### PR TITLE
Add YAML frontmatter to all skills, new engine-overview skill, agent …

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -17,9 +17,10 @@ In either case, your job is to produce a focused code change that implements the
 # Before editing
 
 1. Read `.claude/code-style.md` and enforce every rule it contains. All code you write or modify must comply. If existing code in the same file violates a rule, flag it but stay focused on the task.
-2. Read the relevant files and surrounding code. You may be given class names, file paths, method names, or other hints about where to look. Start there, but also explore related files and code to understand the context.
-3. Look for existing patterns and conventions in the codebase — check 2-3 nearby files.
-4. Search for all usages of any symbol you plan to change.
+2. **Invoke relevant skills** for the subsystem you're working in — CLAUDE.md lists all available skills. For new game projects, start with `engine-overview`.
+3. Read the relevant files and surrounding code. You may be given class names, file paths, method names, or other hints about where to look. Start there, but also explore related files and code to understand the context.
+4. Look for existing patterns and conventions in the codebase — check 2-3 nearby files or an existing sample under `samples/`.
+5. Search for all usages of any symbol you plan to change.
 
 # After editing
 
@@ -50,4 +51,7 @@ Add XML doc comments only on **public-facing members** where the behavior is **n
 
 # High-Level Project Structure
 
-TODO: Document the project structure here.
+See CLAUDE.md "Engine Structure" for the full file tree. Key directories:
+- `src/` — Engine library
+- `samples/` — Working game samples (reference these for patterns before inventing new ones)
+- `tests/FlatRedBall2.Tests/` — xUnit + Shouldly

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -19,7 +19,7 @@ In either case, your job is to produce a focused code change that implements the
 1. Read `.claude/code-style.md` and enforce every rule it contains. All code you write or modify must comply. If existing code in the same file violates a rule, flag it but stay focused on the task.
 2. **Invoke relevant skills** for the subsystem you're working in — CLAUDE.md lists all available skills. For new game projects, start with `engine-overview`.
 3. Read the relevant files and surrounding code. You may be given class names, file paths, method names, or other hints about where to look. Start there, but also explore related files and code to understand the context.
-4. Look for existing patterns and conventions in the codebase — check 2-3 nearby files or an existing sample under `samples/`.
+4. Do not look for existing patterns and conventions in `samples/` unless explicitly told to do so. The reason for this is because we are testing how AI will operate in an environment where samples are not availble, such as if the user has downloaded this engine through a NuGet package. Therefore we want the agent to behave as if no samples are available.
 5. Search for all usages of any symbol you plan to change.
 
 # After editing

--- a/.claude/agents/game-designer.md
+++ b/.claude/agents/game-designer.md
@@ -88,7 +88,7 @@ When you have enough information (or the user signals they are ready), produce a
 
 **Save to**: `.claude/designs/<game-name>-design.md` (derive the name from the conversation)
 
-**Open it** with: `start "" "<path>"` via Bash so the user can review it immediately.
+**Tell the user** the full file path so they can open and review it.
 
 ## GDD Structure
 
@@ -128,4 +128,8 @@ When you have enough information (or the user signals they are ready), produce a
 
 Keep the GDD concise — highlights and key decisions only. The goal is a document a coder or product manager can pick up and act on, not a dissertation.
 
-After saving and opening the file, ask: "Does this capture what you're going for, or should we adjust anything before we start designing the mechanics in detail?"
+After saving, ask: "Does this capture what you're going for, or should we adjust anything before we start designing the mechanics in detail?"
+
+# Handoff
+
+When the user is happy with the GDD, explicitly state: **"Hand off to product-manager agent for task breakdown."**

--- a/.claude/agents/game-designer.md
+++ b/.claude/agents/game-designer.md
@@ -88,7 +88,7 @@ When you have enough information (or the user signals they are ready), produce a
 
 **Save to**: `.claude/designs/<game-name>-design.md` (derive the name from the conversation)
 
-**Tell the user** the full file path so they can open and review it.
+**Open it** with: `start "" "<path>"` via Bash so the user can review it immediately. Do not rely on the user being able to copy a file out - if claude is run through Visual Studio then the copy/paste behavior is unreliable, so instead we open the file directly for them.
 
 ## GDD Structure
 
@@ -128,8 +128,4 @@ When you have enough information (or the user signals they are ready), produce a
 
 Keep the GDD concise — highlights and key decisions only. The goal is a document a coder or product manager can pick up and act on, not a dissertation.
 
-After saving, ask: "Does this capture what you're going for, or should we adjust anything before we start designing the mechanics in detail?"
-
-# Handoff
-
-When the user is happy with the GDD, explicitly state: **"Hand off to product-manager agent for task breakdown."**
+After saving, ask: "Does this capture what you're going for, or should we adjust anything before we start designing the mechanics in detail?".

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -32,7 +32,7 @@ When creating design documents:
 - Use descriptive filenames like `feature-name-design.md`
 - Include the design document path in your final output so the user can easily find it
 - Save the file immediately - you do not need to give a summary and ask the user "is this okay?" before saving. You can ask for feedback after saving.
-- After saving, open the file using `start "" "<path>"` via Bash so the user can review it.
+- After saving, tell the user the full file path so they can open it.
 - Do not provide a lengthy design document in the final output. Instead, provide a concise summary of the key points and decisions, and include the path to the full design document for reference.
 
 ## Scope: Product Design, Not Technical Implementation
@@ -57,5 +57,20 @@ You are a **product manager**, not an engineer or technical designer. Focus on h
 
 **Example of appropriate scope:**
 
+> "Create a `ScoreManager` class in `src/` that tracks score per player, exposes a read-only score, and resets on screen transition. The coder should reference the `entities-and-factories` and `screens` skills for lifecycle integration."
 
 Let engineers figure out the technical details during implementation.
+
+# Engine Skill Awareness
+
+When breaking down game development tasks, reference skill names from CLAUDE.md's skill list in your task descriptions. This helps the coder agent load the right context immediately.
+
+Instead of: "Implement player movement"
+Write: "Create Player entity (see `entities-and-factories`) with keyboard input (see `input-system`), set velocity in CustomActivity (see `physics-and-movement`)"
+
+Instead of: "Add collision"
+Write: "Wire collision between player and walls using `AddCollisionRelationship` with `MoveFirstOnCollision` (see `collision-relationships`)"
+
+# Handoff
+
+When your task breakdown is complete, explicitly state: **"Hand off to coder agent for implementation."** If the task needs a game design first, state: **"Hand off to game-designer agent first."**

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -32,7 +32,7 @@ When creating design documents:
 - Use descriptive filenames like `feature-name-design.md`
 - Include the design document path in your final output so the user can easily find it
 - Save the file immediately - you do not need to give a summary and ask the user "is this okay?" before saving. You can ask for feedback after saving.
-- After saving, tell the user the full file path so they can open it.
+- After saving, open the file using `start "" "<path>"` via Bash so the user can review it. Do not simply output the file path because if the user is using Claude through a terminal in Visual Studio, copying is unreliable.
 - Do not provide a lengthy design document in the final output. Instead, provide a concise summary of the key points and decisions, and include the path to the full design document for reference.
 
 ## Scope: Product Design, Not Technical Implementation

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,7 +1,7 @@
 ---
 name: qa
 description: Reviews changes for correctness, edge cases, and regressions; proposes tests and checks.
-tools: Read, Grep, Glob, Edit, Write, Bash
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a skeptical, thorough code reviewer. Your job is to find what's wrong or fragile — not to fix it. You think in edge cases, race conditions, and "what happens when this is null." You trust nothing and verify everything.

--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -16,4 +16,9 @@ Incremental refactoring is preferred over large rewrites. If you need to make a 
 
 # Project-Specific Patterns
 
-TODO: Document project-specific patterns and conventions here as they are discovered.
+- **No static state** — only `FlatRedBallService.Default` is static. Everything else flows through `Engine` on entities or directly on screens.
+- **Factory pattern** — all entities are created via `Factory<T>`. Never bypass this with `new MyEntity()`.
+- **`internal` access** — `InternalsVisibleTo` exposes internals to `FlatRedBall2.Tests`. Use `internal` for engine implementation details, `public` for game-code-facing APIs.
+- **Shape types** — `AxisAlignedRectangle`, `Circle`, `Polygon`. All implement both `IRenderable` and `ICollidable`.
+- **Lifecycle hooks** — `CustomInitialize`, `CustomActivity`, `CustomDestroy` on both `Entity` and `Screen`. Don't add new virtual methods without good reason.
+- **Collision dispatch** — `CollisionDispatcher` is `internal static`. Shape-pair resolution uses concrete type matching, not polymorphism.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
       "Read(//c/git/FlatRedBall/Engines/FlatRedBallXNA/FlatRedBall/Screens/**)",
       "Read(//c/git/Gum/MonoGameGum/**)",
       "Read(//c/git/FlatRedBall/Engines/FlatRedBallXNA/FlatRedBall/**)",
-      "Read(//c/git/FlatRedBall/Engines/FlatRedBallXNA/FlatRedBall/Graphics/**)"
+      "Read(//c/git/FlatRedBall/Engines/FlatRedBallXNA/FlatRedBall/Graphics/**)",
+      "Read(//c/git/FlatRedBall2/**)"
     ]
   }
 }

--- a/.claude/skills/camera/SKILL.md
+++ b/.claude/skills/camera/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: camera
+description: "Camera in FlatRedBall2. Use when working with camera setup, background color, world bounds, window resolution, scrolling, screen shake, coordinate conversion between world and screen space, or Camera.TargetWidth/TargetHeight. Trigger on any camera-related question including viewport, following a player, or screen boundaries."
+---
+
 # Camera in FlatRedBall2
 
 Every `Screen` has a `Camera` property. Access it directly — no initialization required.
@@ -24,11 +29,10 @@ World coordinates are **centered at the origin**:
 - X ∈ [−TargetWidth/2, TargetWidth/2]  →  [−640, 640]
 - Y ∈ [−TargetHeight/2, TargetHeight/2]  →  [−360, 360]
 
-Y+ is **up**. The top of the screen is Y = +360, the bottom is Y = −360.
+Y+ is **up** (see `physics-and-movement`). Top = +360, bottom = −360.
 
 ```csharp
-// Place a wall at the bottom of the screen
-wall.Y = -Camera.TargetHeight / 2f;  // -360
+wall.Y = -Camera.TargetHeight / 2f;  // bottom of screen
 ```
 
 ## Window Resolution

--- a/.claude/skills/collision-relationships/SKILL.md
+++ b/.claude/skills/collision-relationships/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: collision-relationships
+description: "Collision Relationships in FlatRedBall2. Use when working with AddCollisionRelationship, MoveFirstOnCollision, BounceOnCollision, MoveBothOnCollision, CollisionOccurred events, collision response, collision setup, mass/elasticity, or entity-vs-entity collision. Trigger on any collision-related question."
+---
+
 # Collision Relationships in FlatRedBall2
 
 `Screen.AddCollisionRelationship<A,B>` registers a pair of collidable groups. Each frame, after physics runs, every entity in group A is tested against every entity in group B. If they overlap, the configured response fires.
@@ -7,22 +12,20 @@
 Call `AddCollisionRelationship` inside `Screen.CustomInitialize` after creating your factories:
 
 ```csharp
-public class GameScreen : Screen
-{
-    private Factory<Player> _playerFactory = null!;
-    private Factory<Wall>   _wallFactory   = null!;
-
-    public override void CustomInitialize()
-    {
-        _playerFactory = new Factory<Player>(this);
-        _wallFactory   = new Factory<Wall>(this);
-
-        // Solid collision: player is pushed out, walls stay fixed
-        AddCollisionRelationship<Player, Wall>(_playerFactory, _wallFactory)
-            .MoveFirstOnCollision();
-    }
-}
+AddCollisionRelationship<Player, Wall>(_playerFactory, _wallFactory)
+    .MoveFirstOnCollision();
 ```
+
+## Self-Collision (Same List)
+
+To collide entities within the same list (e.g., enemies pushing each other apart):
+
+```csharp
+AddCollisionRelationship<Enemy>(_enemyFactory)
+    .MoveBothOnCollision(firstMass: 1f, secondMass: 1f);
+```
+
+This single-list overload iterates unique pairs only — no duplicate checks or self-collision.
 
 ## Fluent Modifiers
 
@@ -30,41 +33,12 @@ public class GameScreen : Screen
 |--------|--------|
 | `.MoveFirstOnCollision()` | A gets pushed out, B stays fixed. Use for player vs. solid walls. |
 | `.MoveSecondOnCollision()` | B gets pushed out, A stays fixed. |
-| `.MoveBothOnCollision(firstMass, secondMass)` | Both objects share the separation weighted by mass. Equal masses = 50/50 split. |
-| `.BounceOnCollision(firstMass, secondMass, elasticity)` | Reflects A's velocity off B using impulse physics. Separates positions automatically. |
-
-### BounceOnCollision — Mass Semantics
-
-```csharp
-// Signature:
-BounceOnCollision(float firstMass = 1f, float secondMass = 1f, float elasticity = 1f)
-```
-
-- **`firstMass = 0f`** — A (the ball) is fully displaced; B (the wall) stays fixed. Use this for a ball bouncing off immovable walls.
-- **`secondMass = 0f`** — B is fully displaced; A stays fixed. Rarely used for bounce.
-- **`elasticity = 1.0f`** — perfectly elastic (no energy loss). `0.9f` = 10% energy loss per bounce, ball slowly settles.
-
-```csharp
-// Ball bounces off immovable walls — ball moves, walls don't
-AddCollisionRelationship(_balls, _walls)
-    .BounceOnCollision(firstMass: 0f, secondMass: 1f, elasticity: 0.9f);
-
-// Two-body elastic bounce (equal masses exchange velocities)
-AddCollisionRelationship(_bulletsA, _bulletsB)
-    .BounceOnCollision(firstMass: 1f, secondMass: 1f, elasticity: 1.0f);
-```
-
-> **Note:** `BounceOnCollision` only adjusts the velocity of A (the first group). B's velocity is unchanged when `firstMass == 0f`. `AdjustVelocityFrom` requires both objects to be `Entity` instances — it has no effect if either is a bare shape.
+| `.MoveBothOnCollision(firstMass, secondMass)` | Both objects share the separation weighted by mass. |
+| `.BounceOnCollision(firstMass, secondMass, elasticity)` | Reflects A's velocity off B using impulse physics. `firstMass: 0f` = A moves, B fixed (common for walls). |
 
 ## Responding to Collision Events
 
-`CollisionOccurred` covers three broad categories of use:
-
-- **Physics customization** — read or override velocity/position after the engine's response has been applied
-- **Entity logic** — deal damage, destroy entities, update state
-- **Triggers** — detect when an entity enters a region, with no physics response at all
-
-The event fires once per overlapping pair per frame, **after** position separation and velocity adjustment have already been applied. Whatever you set on the entities in this handler is what carries into the next frame.
+`CollisionOccurred` fires once per overlapping pair per frame, **after** position separation and velocity adjustment have been applied.
 
 ### Entity logic
 
@@ -80,32 +54,23 @@ AddCollisionRelationship<Bullet, Enemy>(_bullets, _enemies)
 
 ### Physics customization
 
-Because the event fires after the engine's response, you can override velocity to layer custom behavior on top of the built-in bounce:
+Override velocity after the engine's response:
 
 ```csharp
 AddCollisionRelationship(_balls, _paddles)
     .BounceOnCollision(firstMass: 0f, secondMass: 1f)
     .CollisionOccurred += (ball, paddle) =>
     {
-        // BounceOnCollision already reflected the velocity.
-        // Override here to apply custom logic on top.
         ball.VelocityX = /* custom value */;
         ball.VelocityY = /* custom value */;
     };
 ```
 
-### Triggers
+### Triggers (no physics response)
 
-A trigger is an invisible entity used purely to detect when something enters a region — no physics response needed. Omit the fluent physics modifier entirely and handle everything in `CollisionOccurred`:
+Omit the fluent modifier entirely:
 
 ```csharp
-// DeathZone entity: AxisAlignedRectangle child, Visible = false
-var zone = _deathZoneFactory.Create();
-zone.X = 0;
-zone.Y = -Camera.TargetHeight / 2f - 40f;  // just below screen bottom
-zone.Rectangle.Width  = Camera.TargetWidth;
-zone.Rectangle.Height = 80f;
-
 AddCollisionRelationship(_balls, _deathZoneFactory)
     .CollisionOccurred += (ball, _) =>
     {
@@ -114,58 +79,37 @@ AddCollisionRelationship(_balls, _deathZoneFactory)
     };
 ```
 
-Other trigger examples: end-of-level zones, score regions, checkpoint areas.
+## Execution Order
 
-## How Entity-vs-Entity Collision Works
-
-`CollisionDispatcher` resolves collisions between concrete shape types (AABB vs AABB, Circle vs Circle, AABB vs Circle). When two entities collide, the dispatcher iterates their shape children and finds matching pairs.
-
-For example, if `Player` has an `AxisAlignedRectangle` child and `Wall` has an `AxisAlignedRectangle` child, the dispatcher runs **AABB vs AABB** overlap and separation between those shapes. The parent entity's position is updated as a result.
-
-Supported pairs:
-- `AxisAlignedRectangle` vs `AxisAlignedRectangle`
-- `Circle` vs `Circle`
-- `AxisAlignedRectangle` vs `Circle` (and the reverse)
-- `Polygon` vs `Polygon`
+Collision runs after physics and before `CustomActivity` — by the time game logic runs, entities are already separated from any overlapping collision partner. See `engine-overview` for the full frame loop.
 
 ## Important: ShapeCollection as B Does Not Work
 
-Passing a `ShapeCollection` as the second argument to `AddCollisionRelationship` hits the wildcard dispatch path and returns zero separation. **Use entity factories instead.** If you need reusable wall geometry, create a `Wall` entity class and a `Factory<Wall>`, then configure dimensions after `Create()`:
-
-```csharp
-// Correct — wall entities
-AddCollisionRelationship<Player, Wall>(_playerFactory, _wallFactory)
-    .MoveFirstOnCollision();
-
-// Wrong — ShapeCollection as B returns zero separation
-// AddCollisionRelationship<Player, ShapeCollection>(...) — do not do this
-```
-
-## Execution Order Each Frame
-
-1. Physics update — `X += VelocityX*dt`, `Y += VelocityY*dt`, etc.
-2. Collision resolution — all registered relationships run; positions are corrected
-3. `CustomActivity(time)` — game logic runs with already-corrected positions
-
-This means by the time `CustomActivity` executes, the entity is already separated from any overlapping collision partner.
+Passing a `ShapeCollection` as the second argument hits the wildcard dispatch path and returns zero separation. **Use entity factories instead.**
 
 ## Common Pitfalls
 
-- **Relationship not registered** — `AddCollisionRelationship` must be called from `CustomInitialize`. Relationships registered after the screen is running are still processed, but is unusual.
-- **Both sides move when only one should** — Use `.MoveFirstOnCollision()` (player pushed, walls fixed) rather than `.MoveBothOnCollision()` for solid terrain.
-- **Nothing happens on collision** — Confirm both entities have visible, correctly-sized shape children. The dispatcher only works with shape children, not the entity's own X/Y directly.
-- **Player tunnels through thin walls at high speed** — FlatRedBall2 uses discrete (not continuous) collision detection. Keep velocities and wall thicknesses reasonable, or split fast movement into sub-steps.
-- **Don't use a `DiedThisFrame` flag on enemies — destroy them directly in `CollisionOccurred`**. The execution order is: collision → entity `CustomActivity` → screen `CustomActivity`. Any flag set by collision is reset at the top of `CustomActivity` before the screen ever sees it. Instead, check health and call `Destroy()` right in the callback:
+- **Both sides move when only one should** — Use `.MoveFirstOnCollision()` for solid terrain.
+- **Nothing happens on collision** — Confirm both entities have visible, correctly-sized shape children.
+- **Player tunnels through thin walls** — Discrete collision detection; keep velocities reasonable.
+- **Don't use a `DiedThisFrame` flag** — The frame order is collision → entity `CustomActivity` → screen `CustomActivity`. A flag set during collision is stale by the time the screen reads it. Instead, destroy entities directly in `CollisionOccurred` and detect cleared groups via `_factory.Instances.Count == 0`.
+
+## BounceOnCollision — Mass Semantics
 
 ```csharp
-AddCollisionRelationship<Bullet, Enemy>(_bullets, _enemies)
-    .CollisionOccurred += (bullet, enemy) =>
-    {
-        bullet.Destroy();
-        enemy.TakeHit();          // decrements health
-        if (enemy.Health <= 0)
-            enemy.Destroy();      // destroy here, not via a flag the screen polls
-    };
+BounceOnCollision(float firstMass = 1f, float secondMass = 1f, float elasticity = 1f)
 ```
 
-The screen can then detect the enemy is gone by checking `_enemyFactory.Instances.Count == 0` rather than polling a flag on the entity.
+- **`firstMass = 0f`** — A is fully displaced; B stays fixed. Use for ball vs. immovable walls.
+- **`secondMass = 0f`** — B is fully displaced; A stays fixed. Rarely used.
+- **`elasticity = 1.0f`** — perfectly elastic. `0.9f` = 10% energy loss per bounce.
+
+> **Note:** `BounceOnCollision` only adjusts A's velocity. B is unchanged when `firstMass == 0f`.
+
+## Entity-vs-Entity Dispatch
+
+`CollisionDispatcher` resolves concrete shape pairs. Supported:
+- `AxisAlignedRectangle` vs `AxisAlignedRectangle`
+- `Circle` vs `Circle`
+- `AxisAlignedRectangle` vs `Circle` (and reverse)
+- `Polygon` vs `Polygon`

--- a/.claude/skills/content-and-assets/SKILL.md
+++ b/.claude/skills/content-and-assets/SKILL.md
@@ -1,55 +1,158 @@
+---
+name: content-and-assets
+description: "Content and Assets in FlatRedBall2. Use when working with loading textures, fonts, sprites, content pipeline, .mgcb setup, or ContentManagerService. Also trigger when the user asks about displaying text (use Gum Labels) or graphics without custom art (use Shapes)."
+---
+
 # Content and Assets in FlatRedBall2
 
-> **Status: Under Construction.** The content pipeline (`ContentManagerService.Load<T>()`, `.mgcb` setup, custom textures, custom fonts) is not yet documented and the workflow is not finalized. The guidance below covers what works today.
+## Decision: Shapes, Sprites, or Gum?
+
+| Need | Use | Content files required? |
+|------|-----|------------------------|
+| Simple geometry (paddles, walls, bullets) | Shapes (`AxisAlignedRectangle`, `Circle`, `Polygon`) | No |
+| Textured game objects (ships, characters) | `Sprite` with `Texture2D` | Yes (`.mgcb` pipeline) |
+| On-screen text (scores, labels, menus) | Gum `Label` or `TextRuntime` | No (default font auto-loaded) |
 
 ## Text / Fonts — Use Gum Labels
 
-Do not load `SpriteFont` manually. Gum's default font is loaded automatically by `FlatRedBallService.Initialize` — no `.mgcb` setup required.
+Gum's default font is loaded automatically — no `.mgcb` setup required. See the `gum-integration` skill for Label examples and full layout details.
 
-For any on-screen text (scores, labels, menus, game-over messages), use a Gum `Label`:
+## Graphics Without Art — Use Shapes
 
-```csharp
-using Gum.Forms.Controls;
-
-var scoreLabel = new Label();
-scoreLabel.Text = "0";
-scoreLabel.X = 20;   // screen pixels from left
-scoreLabel.Y = 20;   // screen pixels from TOP (Gum is Y-down)
-AddGum(scoreLabel);
-
-// Update each frame in CustomActivity:
-scoreLabel.Text = _score.ToString();
-```
-
-See `gum-integration.md` for full Label and layout details.
-
-## Graphics — Use Shapes Instead of Sprites
-
-For games that don't need photographic art, shapes are the right choice. They require no content files and are ready to use immediately.
+Shapes require no content files and are ready to use immediately.
 
 ```csharp
-// Paddle / wall — axis-aligned rectangle
-var rect = new AxisAlignedRectangle
-{
-    Width = 20,
-    Height = 120,
-    Color = Color.White,
-    Visible = true,
-};
+var rect = new AxisAlignedRectangle { Width = 20, Height = 120, Color = Color.White, Visible = true };
 AddChild(rect);
-
-// Ball — circle
-var circle = new Circle
-{
-    Radius = 10,
-    Color = Color.White,
-    Visible = true,
-};
-AddChild(circle);
 ```
 
-See `shapes.md` for all shape types, visual properties, and gotchas.
+See the `shapes` skill for all shape types and visual properties.
 
-## Custom Textures / Sprites — Not Yet Supported
+## Sprites and Textures
 
-Loading a `Texture2D` via `ContentManager.Load<Texture2D>("path")` and rendering it through `Sprite` is plumbed but not documented or tested end-to-end. Do not rely on it until this skill is updated.
+Load textures via MonoGame's content pipeline and render them with `Sprite`.
+
+### Loading a Texture
+
+```csharp
+// Inside an Entity's CustomInitialize:
+var texture = Engine.ContentManager.Load<Texture2D>("ship_0001");
+```
+
+The string is the asset name (filename without extension) as defined in the `.mgcb` file. The `Content/` prefix is set by `Game1.Content.RootDirectory`.
+
+### Creating a Sprite
+
+```csharp
+var sprite = new Sprite
+{
+    Texture = texture,
+    TextureScale = 1.5f,   // 1.5x the texture's pixel size
+    IsVisible = true,       // note: IsVisible, not Visible (unlike shapes)
+};
+AddChild(sprite);
+```
+
+### TextureScale vs Explicit Sizing
+
+`TextureScale` (default `1f`) controls how sprite dimensions are derived:
+
+- **Non-null (default)** — `Width = textureWidth * TextureScale`, `Height = textureHeight * TextureScale`. Setting `Width`/`Height` directly is a no-op while `TextureScale` is set.
+- **Null** — explicit mode. Set `TextureScale = null` first, then set `Width`/`Height` freely.
+
+```csharp
+// Pixel-art 2x upscale:
+sprite.TextureScale = 2f;
+
+// Explicit size (ignores texture dimensions):
+sprite.TextureScale = null;
+sprite.Width = 100;
+sprite.Height = 50;
+```
+
+### Sprite Sheets (SourceRectangle)
+
+Use `SourceRectangle` to render a sub-region of a texture:
+
+```csharp
+sprite.SourceRectangle = new Rectangle(0, 0, 32, 32);  // top-left 32x32 tile
+```
+
+When `TextureScale` is non-null, dimensions are recalculated from the source rectangle size.
+
+### Sprite Properties
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| `IsVisible` | `true` | Different from shapes which use `Visible` and default to `false` |
+| `Color` | `Color.White` | Tint color — `White` means no tint |
+| `Alpha` | `1f` | Opacity (0 = transparent, 1 = opaque) |
+| `Rotation` | `0` | Uses `Angle` type, same as entities |
+| `FlipHorizontal` | `false` | Mirror horizontally |
+| `FlipVertical` | `false` | Mirror vertically |
+
+### Cleanup
+
+```csharp
+sprite.Destroy();   // removes from parent entity
+```
+
+## Content Pipeline Setup (.mgcb)
+
+To use textures, you need a `Content/Content.mgcb` file in your sample project.
+
+### 1. Create the Content directory and `.mgcb` file
+
+```
+samples/YourSample/Content/Content.mgcb
+```
+
+Minimal `.mgcb` content:
+
+```
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/$(Platform)
+/intermediateDir:obj/$(Platform)
+/platform:DesktopGL
+/config:
+/profile:Reach
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#
+```
+
+### 2. Add a texture
+
+Place the `.png` file in `Content/`, then add an entry to the `.mgcb`:
+
+```
+#begin mysprite.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:mysprite.png
+```
+
+### 3. Load in code
+
+```csharp
+var tex = Engine.ContentManager.Load<Texture2D>("mysprite");  // no extension
+```
+
+## Gotchas
+
+- **`IsVisible` on Sprite vs `Visible` on shapes** — Sprites use `IsVisible` (default `true`). Shapes use `Visible` (default `false`). Mixing them up is a common source of invisible objects.
+- **`TextureScale` wins over explicit `Width`/`Height`** — If you set `Width` and it doesn't take effect, check that `TextureScale` is `null`.
+- **Content not found at runtime** — Verify the asset name matches the `.mgcb` entry (case-sensitive on Linux), and that `Content.RootDirectory = "Content"` is set in `Game1`.
+- **ACHX animations are stubbed** — `Sprite.PlayAnimation` is a no-op. Animation is not yet implemented.
+- **Each screen gets its own ContentManager** — assets are unloaded when the screen transitions. Re-load textures in each screen's `CustomInitialize` if needed.

--- a/.claude/skills/engine-overview/SKILL.md
+++ b/.claude/skills/engine-overview/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: engine-overview
+description: "Engine overview for FlatRedBall2. Start here for any game development task. Covers what the engine does automatically vs what game code must implement, the frame loop, bootstrapping, and known stubs. Trigger when starting a new game, needing to understand the engine architecture, or unsure how FlatRedBall2 works."
+---
+
+# FlatRedBall2 Engine Overview
+
+FlatRedBall2 is a 2D game engine built on MonoGame. It provides physics, collision, rendering, input, and UI (via Gum) out of the box. Game code creates Screens, Entities, and wires them together.
+
+## What the Engine Does Automatically
+
+- **Physics**: `pos += vel*dt + acc*(dt^2/2)`, `vel += acc*dt`, `vel -= vel*drag*dt` — every frame, for every entity
+- **Collision resolution**: All registered `CollisionRelationship` pairs are tested and resolved after physics
+- **Rendering**: Everything in `Screen.RenderList` is drawn, sorted by Layer + Z
+- **Input polling**: `InputManager` updates keyboard, mouse, and gamepad state each frame
+- **Gum UI updates**: Click/hover/focus events routed to all active Gum elements
+- **Screen transitions**: Old screen torn down, new screen initialized — entities, factories, Gum elements all cleaned up automatically
+- **Camera**: Initialized from window viewport; transforms world coordinates to screen
+
+## What Game Code Must Implement
+
+- **Entity subclasses** — override `CustomInitialize` (add shapes, input) and `CustomActivity` (per-frame logic)
+- **Screen subclasses** — override `CustomInitialize` (create factories, entities, collision relationships, UI)
+- **Collision relationships** — call `AddCollisionRelationship` in screen's `CustomInitialize`
+- **Game1.cs** — initialize `FlatRedBallService.Default`, call `Update`/`Draw` each frame
+
+## Frame Loop Order
+
+Each frame runs in this order:
+
+1. **Screen transition** (if pending) — old screen destroyed, new screen initialized
+2. **Input update** — keyboard, mouse, gamepad polled
+3. **Gum update** — UI input events routed
+4. **Physics** — entity positions updated from velocity/acceleration/drag
+5. **Collision** — registered relationships resolved; positions corrected
+6. **Entity `CustomActivity`** — each entity's per-frame logic
+7. **Screen `CustomActivity`** — screen-level logic (sees post-collision, post-entity state)
+8. **Draw** — all renderables in `RenderList` drawn
+
+## Bootstrapping a Game
+
+```csharp
+// Game1.cs
+protected override void Initialize()
+{
+    base.Initialize();
+    FlatRedBallService.Default.Initialize(this);
+    FlatRedBallService.Default.Start<GameplayScreen>();
+}
+
+protected override void Update(GameTime gameTime)
+{
+    if (Keyboard.GetState().IsKeyDown(Keys.Escape)) Exit();
+    FlatRedBallService.Default.Update(gameTime);
+    base.Update(gameTime);
+}
+
+protected override void Draw(GameTime gameTime)
+{
+    FlatRedBallService.Default.Draw();
+    base.Draw(gameTime);
+}
+```
+
+## Key Design Rules
+
+- **Y+ is up** in world space. Camera flips Y for screen rendering.
+- **Always use `Factory<T>`** to create entities — never `new MyEntity()`. Factory sets `Engine`, registers with the screen, and enables `GetFactory<T>()`.
+- **No static state** — only `FlatRedBallService.Default` is static. Everything else is accessed via `Engine` on entities or directly on screens.
+- **Shapes default to `Visible = false`** — always set `Visible = true`.
+- **`Entity.Engine`**: Use `CustomInitialize`, not the constructor — `Engine` is null until Factory injects it.
+
+## Complete Screen Example
+
+A minimal but complete screen showing factory + entity + collision + input wired together:
+
+```csharp
+public class GameScreen : Screen
+{
+    private Factory<Player> _playerFactory = null!;
+    private Factory<Wall> _wallFactory = null!;
+
+    public override void CustomInitialize()
+    {
+        _playerFactory = new Factory<Player>(this);
+        _wallFactory = new Factory<Wall>(this);
+
+        _playerFactory.Create();
+
+        // Bottom wall
+        var wall = _wallFactory.Create();
+        wall.X = 0; wall.Y = -Camera.TargetHeight / 2f;
+        wall.Rectangle.Width = Camera.TargetWidth; wall.Rectangle.Height = 40;
+
+        AddCollisionRelationship<Player, Wall>(_playerFactory, _wallFactory)
+            .MoveFirstOnCollision();
+    }
+
+    public override void CustomActivity(FrameTime time)
+    {
+        // Screen-level logic here — runs after entities and collision
+    }
+}
+```
+
+## Sub-Systems (accessed via `Engine.*`)
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `InputManager` | `InputManager` | Keyboard, cursor, gamepads |
+| `ContentManager` | `ContentManagerService` | Load textures, fonts via `.mgcb` pipeline |
+| `Random` | `GameRandom` | Seeded random with helpers (`Between`, `RadialVector2`) |
+| `TimeManager` | `TimeManager` | Frame timing, async delays |
+| `AudioManager` | `AudioManager` | **Stub — throws NotImplementedException** |
+| `DebugRenderer` | `DebugRenderer` | **Stub — all draw methods are no-ops** |
+
+## Which Skill to Read Next
+
+| Task | Skill |
+|------|-------|
+| Create a new sample project | `sample-project-setup` |
+| Set up screens and transitions | `screens` |
+| Create entities with shapes | `entities-and-factories` |
+| Load textures and use sprites | `content-and-assets` |
+| Set up collision | `collision-relationships` |
+| Handle input | `input-system` |
+| Physics and movement | `physics-and-movement` |
+| Platformer mechanics | `platformer-movement` |
+| Camera setup | `camera` |
+| UI/HUD with Gum | `gum-integration` |
+| Timers and cooldowns | `timing` |
+| Level layouts | `levels` |
+| Shapes (no-art visuals) | `shapes` |

--- a/.claude/skills/entities-and-factories/SKILL.md
+++ b/.claude/skills/entities-and-factories/SKILL.md
@@ -1,10 +1,13 @@
+---
+name: entities-and-factories
+description: "Entities and Factories in FlatRedBall2. Use when working with Entity subclasses, Factory<T>, spawning/creating/destroying entities, entity lifecycle, AddChild, shape children, CustomInitialize/CustomActivity, or Engine.GetFactory<T>(). Trigger on any entity creation, destruction, or factory question."
+---
+
 # Entities and Factories in FlatRedBall2
 
 An `Entity` is the base class for all game objects. It owns position, velocity, acceleration, drag, and a list of child shapes for collision and rendering. `Factory<T>` manages creating, tracking, and destroying entity instances from within a Screen.
 
 ## Creating an Entity Subclass
-
-Subclass `Entity` and override the lifecycle hooks:
 
 ```csharp
 using FlatRedBall2;
@@ -16,20 +19,17 @@ using Microsoft.Xna.Framework.Input;
 public class Player : Entity
 {
     private KeyboardInput2D _movement = null!;
-
     public AxisAlignedRectangle Rectangle { get; private set; } = null!;
 
     public override void CustomInitialize()
     {
-        // Engine is already set here — safe to access Engine.InputManager
         Rectangle = new AxisAlignedRectangle
         {
-            Width = 40,
-            Height = 40,
+            Width = 40, Height = 40,
             Color = new Color(80, 140, 255, 220),
             Visible = true,
         };
-        AddChild(Rectangle);   // auto-adds to RenderList because Engine is set
+        AddChild(Rectangle);
 
         _movement = new KeyboardInput2D(
             Engine.InputManager.Keyboard,
@@ -49,28 +49,25 @@ public class Player : Entity
 
 1. `Factory<T>.Create()` — allocates the entity, sets `Engine`, calls `AddEntity` on the screen
 2. `CustomInitialize()` — called immediately after; add shape children and initialize input here
-3. Each frame: physics update (`X += VelocityX*dt`, etc.) → collision resolution → `CustomActivity(time)`
+3. Each frame: physics update → collision resolution → `CustomActivity(time)`
 
 ## Shape Children
 
 All three shape types can be attached with `AddChild`:
 
 ```csharp
-// AxisAlignedRectangle — cannot rotate
 var rect = new AxisAlignedRectangle { Width = 40, Height = 40, Visible = true };
 AddChild(rect);
 
-// Circle
 var circle = new Circle { Radius = 20, Visible = true };
 AddChild(circle);
 
-// Polygon — supports rotation
 var poly = Polygon.CreateRectangle(40, 40);
 poly.Visible = true;
 AddChild(poly);
 ```
 
-Shape position is relative to the parent entity's position. A child at `X = 0, Y = 0` renders at the entity's center.
+Shape position is relative to the parent entity's position.
 
 ## Using Factory&lt;T&gt; from a Screen
 
@@ -81,11 +78,9 @@ public class GameScreen : Screen
 
     public override void CustomInitialize()
     {
-        _playerFactory = new Factory<Player>(this);  // pass the screen
-
-        var player = _playerFactory.Create();        // entity is ready to use
-        player.X = 100;
-        player.Y = 50;
+        _playerFactory = new Factory<Player>(this);
+        var player = _playerFactory.Create();
+        player.X = 100; player.Y = 50;
     }
 }
 ```
@@ -94,172 +89,64 @@ public class GameScreen : Screen
 
 ## Inspecting the Factory
 
-`Factory<T>.Instances` exposes the live list as `IReadOnlyList<T>`, available for any read purpose — counting, querying, or iterating to update state:
+`Factory<T>.Instances` exposes the live list as `IReadOnlyList<T>`:
 
 ```csharp
-// Count surviving enemies
 int remaining = _enemyFactory.Instances.Count;
-
-// Iterate to update state
-for (int i = 0; i < _enemyFactory.Instances.Count; i++)
-    _enemyFactory.Instances[i].UpdateHealthBar();
-
-// Detect when a group is fully cleared
 if (_brickFactory.Instances.Count == 0)
     MoveToScreen<NextLevelScreen>();
 ```
 
 ## Configuring Entities After Create()
 
-`Create()` returns the entity instance. You can set position and shape dimensions after creation:
+`Create()` returns the entity instance. Set position and shape dimensions after creation:
 
 ```csharp
-private void SpawnWall(float x, float y, float w, float h)
-{
-    var wall = _wallFactory.Create();
-    wall.X = x;
-    wall.Y = y;
-    wall.Rectangle.Width = w;    // Rectangle is a public property on the entity
-    wall.Rectangle.Height = h;
-}
+var wall = _wallFactory.Create();
+wall.X = x; wall.Y = y;
+wall.Rectangle.Width = w;
+wall.Rectangle.Height = h;
 ```
 
 ## Always Use Factory — Even for Single Instances
 
-Even when you only ever need one of an entity (e.g., a single ball in Pong), create it through a `Factory<T>`. This keeps:
-
-- **Lifecycle consistent** — `CustomInitialize` is called the same way whether there's one or fifty instances.
-- **Collision consistent** — `AddCollisionRelationship` takes `IEnumerable<A>` and `IEnumerable<B>`. A `Factory<T>` implements `IEnumerable<T>`, so ball-vs-paddles is just factory-vs-factory with no special cases.
-- **`Engine.GetFactory<T>()` works** — other entities can spawn or reference the ball's factory without a direct reference.
-
-```csharp
-// Correct — always through Factory, even for one ball
-private Factory<Ball> _ballFactory = null!;
-
-public override void CustomInitialize()
-{
-    _ballFactory = new Factory<Ball>(this);
-    var ball = _ballFactory.Create();
-    ball.X = 0; ball.Y = 0;
-
-    // Collision: same pattern regardless of how many balls
-    AddCollisionRelationship<Ball, Paddle>(_ballFactory, _paddleFactory)
-        .BounceOnCollision(firstMass: 0f, secondMass: 1f);
-}
-```
-
-Avoid creating entities with `new Ball()` or `Screen.Register`. Those bypass the factory and break `Engine.GetFactory<T>()` and the collision system.
+Even for a single entity (e.g., one ball in Pong), create it through `Factory<T>`. This keeps lifecycle, collision (`IEnumerable<T>`), and `Engine.GetFactory<T>()` all working consistently.
 
 ## Spawning Entities from Within Another Entity
 
-Entities can spawn other entities without receiving a factory reference. Call `Engine.GetFactory<T>()` — it returns the factory registered for that type. The factory is registered automatically when `new Factory<T>(screen)` is called in the screen's `CustomInitialize`.
-
 ```csharp
-// Player.cs — spawns a Ball on Space press, no factory field needed
+// Player.cs — spawns a Ball on Space press
 public override void CustomActivity(FrameTime time)
 {
     if (Engine.InputManager.Keyboard.WasKeyPressed(Keys.Space))
     {
         var ball = Engine.GetFactory<Ball>().Create();
-        ball.X = X;
-        ball.Y = Y;
+        ball.X = X; ball.Y = Y;
         ball.VelocityY = 300f;
     }
 }
 ```
 
-`GetFactory<T>()` throws `InvalidOperationException` if no factory for `T` has been created yet — check that the screen calls `new Factory<Ball>(this)` before any entity tries to spawn one.
+`GetFactory<T>()` throws `InvalidOperationException` if no factory for `T` exists yet.
 
 ## Destroying Entities
 
-Call `Destroy()` directly on any entity to remove it from the game. It removes itself from its factory, the screen's update list, and clears all child shapes:
-
 ```csharp
-enemy.Destroy();
-bullet.Destroy();
+enemy.Destroy();   // removes from factory, screen, and clears child shapes
 ```
 
-`factory.Destroy(entity)` is equivalent — prefer whichever is more readable at the call site.
-
-## Destroy and Spawn (Death Effects)
-
-When an entity should trigger a visual effect on destruction, destroy it immediately and spawn a separate effect entity at the same position. Do not try to play an effect on the dying entity — once destroyed it is removed from the game.
-
-```csharp
-AddCollisionRelationship<Bullet, Enemy>(_bullets, _enemies)
-    .CollisionOccurred += (bullet, enemy) =>
-    {
-        var explosion = Engine.GetFactory<Explosion>().Create();
-        explosion.X = enemy.X;
-        explosion.Y = enemy.Y;
-        enemy.Destroy();
-        bullet.Destroy();
-    };
-```
-
-The effect entity manages its own lifetime in `CustomActivity`:
-
-```csharp
-public class Explosion : Entity
-{
-    private float _lifetime = 0.5f;
-
-    public override void CustomActivity(FrameTime time)
-    {
-        _lifetime -= time.DeltaSeconds;
-        if (_lifetime <= 0f)
-            Destroy();
-    }
-}
-```
-
-## Particle Effects
-
-> **Future:** A dedicated particle tool is planned. For now, spawn short-lived entities that destroy themselves after a set duration — the same pattern as death effects, applied in quantity.
-
-A particle entity tracks its own remaining lifetime and destroys itself when it expires:
-
-```csharp
-public class Particle : Entity
-{
-    private float _lifetime;
-
-    public void Launch(float lifetimeSeconds)
-    {
-        _lifetime = lifetimeSeconds;
-    }
-
-    public override void CustomActivity(FrameTime time)
-    {
-        _lifetime -= time.DeltaSeconds;
-        if (_lifetime <= 0f)
-            Destroy();
-    }
-}
-```
-
-Spawn a burst from any entity that has access to the factory:
-
-```csharp
-var factory = Engine.GetFactory<Particle>();
-for (int i = 0; i < 12; i++)
-{
-    var p = factory.Create();
-    p.X = X;
-    p.Y = Y;
-    p.Velocity = Engine.Random.RadialVector2(60f, 180f);
-    p.Launch(lifetimeSeconds: Engine.Random.Between(0.3f, 0.8f));
-}
-```
-
-Visual variety comes from randomizing velocity, color, size, and lifetime across the burst. Fading can be approximated by scaling the shape's alpha in `CustomActivity` based on remaining lifetime fraction.
+`factory.Destroy(entity)` is equivalent.
 
 ## Common Pitfalls
 
-- **Avoid naming fields/constants the same as `Entity` members.** Names like `Acceleration`, `Velocity`, `Position`, and `Drag` already exist on `Entity`. Declaring a field or constant with the same name in a subclass shadows the inherited member and causes compiler warnings. Prefer names like `AccelForce`, `MoveSpeed`, or `MaxSpeed`.
+- **Avoid naming fields/constants the same as `Entity` members.** `Acceleration`, `Velocity`, `Drag` already exist on `Entity` — shadowing them causes warnings.
+- **`Engine` is null in the constructor** — see `engine-overview` Key Design Rules. Use `CustomInitialize` instead.
+- **Shapes default `Visible = false`** — see `shapes` skill. Always set `Visible = true`.
+- **`AddChild` only auto-registers to `RenderList` if `Engine` is set** — Factory sets `Engine` before `CustomInitialize`, so `AddChild` works correctly there.
+- **`_movement` must be initialized once, not every frame** — create input objects in `CustomInitialize`.
+- **Always use `Factory<T>`, never `new MyEntity()`** — bypassing Factory breaks `Engine.GetFactory<T>()` and collision relationships.
 
+## Reference Files
 
-- **`Engine` is null in the entity constructor** — Do not call `AddChild` or access `Engine.InputManager` in the constructor. Use `CustomInitialize` instead.
-- **`Visible` defaults to `false` on shapes** — Always set `Visible = true` or the shape won't render.
-- **`AddChild` only auto-registers to `RenderList` if `Engine` is set** — Factory sets `Engine` before calling `CustomInitialize`, so `AddChild` inside `CustomInitialize` works correctly. If you create entities outside of Factory, call `screen.Register(entity)` first.
-- **`_movement` must be initialized once, not every frame** — Create input objects in `CustomInitialize` and store them as fields. Creating them in `CustomActivity` is wasteful and allocates every frame.
+For advanced patterns (death effects, particles, spawning from entities), see:
+- `references/patterns.md` — Death effects, particle effects, configuring entities after Create()

--- a/.claude/skills/entities-and-factories/references/patterns.md
+++ b/.claude/skills/entities-and-factories/references/patterns.md
@@ -1,0 +1,52 @@
+# Entity Patterns Reference
+
+## Configuring Entities After Create()
+
+`Create()` returns the entity instance. Set position and shape dimensions after creation:
+
+```csharp
+private void SpawnWall(float x, float y, float w, float h)
+{
+    var wall = _wallFactory.Create();
+    wall.X = x; wall.Y = y;
+    wall.Rectangle.Width = w;
+    wall.Rectangle.Height = h;
+}
+```
+
+## Destroy and Spawn (Death Effects)
+
+When an entity should trigger a visual effect on destruction, destroy it immediately and spawn a separate effect entity at the same position. Do not try to play an effect on the dying entity — once destroyed it is removed from the game.
+
+```csharp
+AddCollisionRelationship<Bullet, Enemy>(_bullets, _enemies)
+    .CollisionOccurred += (bullet, enemy) =>
+    {
+        var explosion = Engine.GetFactory<Explosion>().Create();
+        explosion.X = enemy.X;
+        explosion.Y = enemy.Y;
+        enemy.Destroy();
+        bullet.Destroy();
+    };
+```
+
+The effect entity manages its own lifetime — see the `timing` skill for the self-destruct pattern.
+
+## Particle Effects
+
+> **Future:** A dedicated particle tool is planned. For now, spawn short-lived entities using the entity lifetime pattern from the `timing` skill.
+
+Spawn a burst from any entity:
+
+```csharp
+var factory = Engine.GetFactory<Particle>();
+for (int i = 0; i < 12; i++)
+{
+    var p = factory.Create();
+    p.X = X; p.Y = Y;
+    p.Velocity = Engine.Random.RadialVector2(60f, 180f);
+    p.Launch(lifetimeSeconds: Engine.Random.Between(0.3f, 0.8f));
+}
+```
+
+Visual variety comes from randomizing velocity, color, size, and lifetime.

--- a/.claude/skills/gum-integration/SKILL.md
+++ b/.claude/skills/gum-integration/SKILL.md
@@ -1,20 +1,17 @@
+---
+name: gum-integration
+description: "Gum Integration in FlatRedBall2. Use when working with UI, HUD, menus, buttons, labels, text display, StackPanel, Panel, layout, Gum Forms controls, AddGum, screen-space vs world-space UI, or any Gum-related question. Also trigger when user asks about displaying text on screen."
+---
+
 # Gum Integration in FlatRedBall2
 
-## Overview
-
-Gum is FlatRedBall2's UI system, backed by the `Gum.MonoGame` NuGet package. It is **automatically initialized** by `FlatRedBallService.Initialize` — no setup required in `Game1`. Gum elements render interleaved with game-world objects via the same Layer/Z sort used by sprites and shapes.
-
-Key types live in `FlatRedBall2.UI`:
-- `GumRenderable` — wraps a Gum `GraphicalUiElement` as an `IRenderable` (internal implementation detail — users do not construct this directly)
-- `GumRenderBatch` — the `IRenderBatch` that drives Gum's draw pass (internal, singleton)
+Gum is FlatRedBall2's UI system, backed by the `Gum.MonoGame` NuGet package. It is **automatically initialized** by `FlatRedBallService.Initialize` — no setup required.
 
 ## Two Levels of Gum API
 
-Choose the right level for your use case:
+**FrameworkElement controls (high-level, preferred)**: `Button`, `Label`, `TextBox`, `CheckBox`, `StackPanel`, `Panel`, etc. from `Gum.Forms.Controls`. These have built-in functionality — click events, hover, focus, keyboard navigation, layout.
 
-**FrameworkElement controls (high-level, preferred)**: `Button`, `Label`, `TextBox`, `CheckBox`, `StackPanel`, `Panel`, etc. from `Gum.Forms.Controls`. These have built-in functionality — click events, hover, focus, keyboard navigation, layout. Pass directly to `AddGum(control)`.
-
-**GraphicalUiElement visuals (low-level)**: The raw visual tree. Pass directly to `AddGum(visual)`. Use only when Forms controls do not expose what you need — for example, `TextRuntime` for a custom `FontSize` that `Label` does not surface.
+**GraphicalUiElement visuals (low-level)**: The raw visual tree. Use only when Forms controls do not expose what you need — for example, `TextRuntime` for a custom `FontSize` that `Label` does not surface.
 
 **Rule: prefer FrameworkElement. Drop to visuals only when necessary.**
 
@@ -33,106 +30,9 @@ button.Click += (_, _) => Debug.WriteLine("clicked");
 AddGum(button);   // pass FrameworkElement directly
 ```
 
-## Layout
+## AddGum / RemoveGum
 
-Gum has a full layout engine. Prefer layout over hard-coded pixel coordinates so your UI adapts to different sizes and content.
-
-### Positioning Units (XUnits / YUnits)
-
-`X` and `Y` default to pixels from the top-left corner of the parent (or screen). Change `XUnits`/`YUnits` to reposition relative to other edges or the center:
-
-| Unit | Meaning |
-|---|---|
-| `PixelsFromSmall` (default) | Pixels from left (X) or top (Y) |
-| `PixelsFromLarge` | Pixels inward from right (X) or bottom (Y) |
-| `PixelsFromMiddle` | Pixels from horizontal/vertical center |
-| `Percentage` | Percentage of parent size (0–100) |
-
-```csharp
-label.XUnits = GeneralUnitType.PixelsFromLarge;
-label.X = 20;   // 20px from the right edge
-```
-
-### Size Units (WidthUnits / HeightUnits)
-
-| Unit | Meaning |
-|---|---|
-| `Absolute` (default) | Fixed pixel size |
-| `RelativeToParent` | Parent size + offset (0 = match parent; -20 = 20px smaller) |
-| `PercentageOfParent` | Percentage of parent size (100 = full parent) |
-| `RelativeToChildren` | Sizes to wrap children + offset (0 = tight wrap) |
-
-```csharp
-label.WidthUnits = DimensionUnitType.RelativeToParent;
-label.Width = 0;   // same width as parent
-```
-
-### Anchor and Dock
-
-`Anchor` and `Dock` are convenience helpers that set units for you:
-
-```csharp
-// Anchor — pins to a corner/edge/center of the parent
-label.Anchor(Anchor.BottomRight);   // bottom-right corner; X/Y offset inward from there
-
-// Dock — stretches to fill the parent in one or both dimensions
-panel.Dock(Dock.Fill);             // fill parent entirely
-panel.Dock(Dock.FillHorizontally); // full width, auto height
-panel.Dock(Dock.SizeToChildren);   // shrink-wrap content (default for Panel)
-```
-
-`Anchor` and `Dock` are in `Gum.Wireframe` namespace.
-
-### StackPanel — Automatic Stacking
-
-`StackPanel` stacks children vertically (default) or horizontally with optional spacing. No manual X/Y positioning needed for children.
-
-```csharp
-using Gum.Forms.Controls;
-
-var menu = new StackPanel();
-menu.Spacing = 8;
-menu.Anchor(Anchor.Center);   // center the panel on screen
-
-menu.AddChild(new Button { Text = "Start" });
-menu.AddChild(new Button { Text = "Options" });
-menu.AddChild(new Button { Text = "Quit" });
-
-AddGum(menu);
-```
-
-For horizontal layout:
-```csharp
-var toolbar = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
-```
-
-### Panel — Absolute Positioning Container
-
-`Panel` is the base of `StackPanel`. Use it to group controls with manual positioning, or as a root for mixed layouts. It defaults to `Dock.SizeToChildren`.
-
-```csharp
-var hud = new Panel();
-hud.Dock(Dock.Fill);
-
-var scoreLabel = new Label { Text = "0" };
-scoreLabel.Anchor(Anchor.TopRight);
-scoreLabel.X = -20;   // 20px from right
-scoreLabel.Y = 20;
-
-hud.AddChild(scoreLabel);
-AddGum(hud);
-```
-
-## GumRenderable (Low-Level)
-
-`GumRenderable` is an internal implementation detail — the screen creates it for you. You never construct it directly. Simply pass any `GraphicalUiElement` to `AddGum`:
-
-```csharp
-var text = new TextRuntime { Text = "Score", FontSize = 48 };
-AddGum(text);
-```
-
-## Screen.AddGum / RemoveGum
+`AddGum` registers the element for rendering **and** per-frame input updates (cursor, clicks, hover, keyboard). All Forms controls work out of the box — no additional input wiring needed.
 
 Always use `AddGum` instead of adding directly to `RenderList`:
 
@@ -145,25 +45,9 @@ RemoveGum(textRuntime);
 
 **Do not call `button.AddToRoot()`** — this bypasses the FRB2 render-order system.
 
-## Render Ordering (Layer / Z)
-
-Gum elements sort into `Screen.RenderList` by Layer + Z, exactly like sprites and shapes.
-
-| Setting | Effect |
-|---|---|
-| `Layer = null` (default) | Drawn last — on top of all world objects. Right for HUDs and menus. |
-| `z: 50f` parameter | Control ordering among multiple Gum elements or between Gum and sprites |
-| `Layer` on a named Layer | Place on a named Layer for explicit interleaving with game world |
-
-Pass Z at the call site:
-```csharp
-AddGum(bgPanel, z: 0f);
-AddGum(hudPanel, z: 100f);
-```
-
 ## Displaying Text (HUD, Score, Labels)
 
-**Option A — `Label` (preferred FrameworkElement)**:
+**Option A — `Label` (preferred)**:
 
 ```csharp
 var scoreLabel = new Label();
@@ -177,7 +61,7 @@ AddGum(scoreLabel);
 scoreLabel.Text = _score.ToString();
 ```
 
-**Option B — `TextRuntime` (low-level visual)**: Use only when you need `FontSize`, `FontScale`, etc. not exposed by `Label`.
+**Option B — `TextRuntime` (low-level)**: Use only when you need `FontSize`, `FontScale`, etc. not exposed by `Label`.
 
 ```csharp
 using MonoGameGum.GueDeriving;   // TextRuntime lives here, NOT Gum.Wireframe
@@ -186,66 +70,38 @@ var scoreText = new TextRuntime { Text = "0", FontSize = 48 };
 AddGum(scoreText);
 ```
 
-**Coordinate gotcha (screen-space)**: Gum X/Y are screen pixels, Y-down from the top-left corner — opposite of the game world (Y-up, centered). Use `Anchor`/`Dock` to avoid hard-coding pixel positions.
+## Render Ordering (Layer / Z)
 
-**Coordinate gotcha (world-space)**: When using `entity.AddGum`, the entity's `X/Y` are world coordinates (Y-up). The conversion to screen pixels happens automatically. Do not manually set `Visual.X/Y` on a world-space Gum element — it will be overwritten each frame.
-
-## Input / Interactivity
-
-`AddGum` automatically registers the element for per-frame input updates (cursor, clicks, hover, keyboard). All Gum Forms controls work out of the box.
+| Setting | Effect |
+|---|---|
+| `Layer = null` (default) | Drawn last — on top of all world objects. Right for HUDs and menus. |
+| `z: 50f` parameter | Control ordering among multiple Gum elements or between Gum and sprites |
 
 ```csharp
-var button = new Button();
-button.Click += (_, _) => MoveToScreen<GameScreen>();
-AddGum(button);
+AddGum(bgPanel, z: 0f);
+AddGum(hudPanel, z: 100f);
 ```
-
-## Screen Transitions
-
-Gum is fully cleaned up on every screen transition — no manual teardown needed:
-- `Screen._gumRenderables` is abandoned with the old Screen object
-- `GumService.Default.Root.Children` is cleared in `FlatRedBallService.ActivateScreen`
-
-**There is no way to persist Gum elements across screen transitions.** Add them fresh in each screen's `CustomInitialize`.
-
-## Gotchas
-
-- **Namespace**: `TextRuntime` is in `MonoGameGum.GueDeriving` — not `Gum.Wireframe`. Forms controls are in `Gum.Forms.Controls`. `Anchor`/`Dock` enums are in `Gum.Wireframe`. FRB2's wrapper types are in `FlatRedBall2.UI`.
-- **`GumRenderBatch`** is the FRB2 `IRenderBatch` wrapper. Do not confuse it with Gum's own `RenderingLibrary.Graphics.GumBatch`.
-- **Initialize order**: Do not create Gum elements before `FlatRedBallService.Initialize` is called.
-- **`AddToRoot()` is NOT the FRB2 pattern**. Use `AddGum` instead.
 
 ## Screen-Space vs World-Space
 
-### Screen-Space (default)
+**Screen-space (default)**: `Screen.AddGum` places elements in Gum's native coordinate system (pixels, Y-down, origin top-left). Use for HUDs, menus.
 
-`Screen.AddGum` places the element in screen space — Gum's native coordinate system (pixels, Y-down, origin top-left). Use this for HUDs, menus, and any UI that should stay fixed on screen regardless of where the camera is.
+**World-space**: `Entity.AddGum` places a Gum element at the entity's world position. It follows the entity and shifts when the camera pans. The visual is automatically removed when the entity is destroyed.
 
-```csharp
-// In Screen.CustomInitialize():
-var scoreLabel = new Label { Text = "0" };
-scoreLabel.Anchor(Anchor.TopRight);
-AddGum(scoreLabel);   // screen-space — stays in corner as camera moves
-```
+## Gotchas
 
-### World-Space (entity-attached)
+- **Namespace**: `TextRuntime` is in `MonoGameGum.GueDeriving`. Forms controls are in `Gum.Forms.Controls`. `Anchor`/`Dock` enums are in `Gum.Wireframe`.
+- **Gum coordinates are screen pixels, Y-down** — opposite of the game world (Y-up, centered). Use `Anchor`/`Dock` to avoid hard-coding pixel positions.
+- **Initialize order**: Do not create Gum elements before `FlatRedBallService.Initialize`.
+- **`AddToRoot()` is NOT the FRB2 pattern**. Use `AddGum` instead.
+- **No persistence across screen transitions** — Gum elements are fully cleaned up. Add them fresh in each screen's `CustomInitialize`.
+- **World-space Gum**: Do not manually set `Visual.X/Y` on an entity-attached Gum element — it will be overwritten each frame.
 
-`Entity.AddGum` places a Gum element at the entity's world position. Each frame, `AbsoluteX/Y` is converted through the camera to screen pixels — so the visual follows the entity as it moves, and shifts when the camera pans.
+## Pattern: Transient World-Space Text (e.g., Floating Score)
 
-```csharp
-// In a custom Entity.CustomInitialize():
-var label = new TextRuntime { Text = "Enemy", FontSize = 24 };
-AddGum(label);   // world-space — follows this entity
-```
-
-The visual is automatically removed when the entity is destroyed. `RemoveGum` is available if you need to detach it earlier.
-
-### Pattern: Transient World-Space Text (e.g., Floating Score)
-
-For text that spawns at a world position, animates, and then disappears (like "+100" after hitting an enemy), create a short-lived entity that owns the animation:
+Create a short-lived entity that owns a Gum visual at its world position:
 
 ```csharp
-// User-defined in game code — not a FlatRedBall2 type:
 class ScoreFloater : Entity
 {
     private float _lifetime;
@@ -266,11 +122,40 @@ class ScoreFloater : Entity
     }
 }
 
-// Spawn at the hit position:
-var floater = Factory<ScoreFloater>.Create();
-floater.X = hitX;
-floater.Y = hitY;
-floater.Score = 100;
+// Spawn: var floater = Engine.GetFactory<ScoreFloater>().Create();
 ```
 
-Physics (velocity, drag, acceleration) move the entity in world space, and the Gum visual follows automatically. No manual screen-coordinate math is needed.
+Physics moves the entity; the Gum visual follows automatically.
+
+## Layout Essentials
+
+### Anchor and Dock
+
+`Anchor` and `Dock` (in `Gum.Wireframe`) are the primary layout tools:
+
+```csharp
+label.Anchor(Anchor.BottomRight);   // pin to corner; X/Y offset inward from there
+panel.Dock(Dock.Fill);              // fill parent entirely
+panel.Dock(Dock.SizeToChildren);    // shrink-wrap content (default for Panel)
+```
+
+### StackPanel
+
+Stacks children vertically (default) or horizontally with optional spacing:
+
+```csharp
+var menu = new StackPanel();
+menu.Spacing = 8;
+menu.Anchor(Anchor.Center);
+
+menu.AddChild(new Button { Text = "Start" });
+menu.AddChild(new Button { Text = "Quit" });
+AddGum(menu);
+```
+
+For horizontal: `new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 }`.
+
+## Reference Files
+
+For detailed positioning/size units (XUnits, YUnits, WidthUnits, HeightUnits) and Panel documentation, see:
+- `references/layout.md` — Full unit tables and additional layout patterns

--- a/.claude/skills/gum-integration/references/layout.md
+++ b/.claude/skills/gum-integration/references/layout.md
@@ -1,0 +1,87 @@
+# Gum Layout Reference
+
+## Positioning Units (XUnits / YUnits)
+
+`X` and `Y` default to pixels from the top-left corner of the parent (or screen). Change `XUnits`/`YUnits` to reposition relative to other edges or the center:
+
+| Unit | Meaning |
+|---|---|
+| `PixelsFromSmall` (default) | Pixels from left (X) or top (Y) |
+| `PixelsFromLarge` | Pixels inward from right (X) or bottom (Y) |
+| `PixelsFromMiddle` | Pixels from horizontal/vertical center |
+| `Percentage` | Percentage of parent size (0–100) |
+
+```csharp
+label.XUnits = GeneralUnitType.PixelsFromLarge;
+label.X = 20;   // 20px from the right edge
+```
+
+## Size Units (WidthUnits / HeightUnits)
+
+| Unit | Meaning |
+|---|---|
+| `Absolute` (default) | Fixed pixel size |
+| `RelativeToParent` | Parent size + offset (0 = match parent; -20 = 20px smaller) |
+| `PercentageOfParent` | Percentage of parent size (100 = full parent) |
+| `RelativeToChildren` | Sizes to wrap children + offset (0 = tight wrap) |
+
+```csharp
+label.WidthUnits = DimensionUnitType.RelativeToParent;
+label.Width = 0;   // same width as parent
+```
+
+## Anchor and Dock
+
+`Anchor` and `Dock` are convenience helpers that set units for you:
+
+```csharp
+// Anchor — pins to a corner/edge/center of the parent
+label.Anchor(Anchor.BottomRight);   // bottom-right corner; X/Y offset inward from there
+
+// Dock — stretches to fill the parent in one or both dimensions
+panel.Dock(Dock.Fill);             // fill parent entirely
+panel.Dock(Dock.FillHorizontally); // full width, auto height
+panel.Dock(Dock.SizeToChildren);   // shrink-wrap content (default for Panel)
+```
+
+`Anchor` and `Dock` are in `Gum.Wireframe` namespace.
+
+## StackPanel — Automatic Stacking
+
+`StackPanel` stacks children vertically (default) or horizontally with optional spacing. No manual X/Y positioning needed for children.
+
+```csharp
+using Gum.Forms.Controls;
+
+var menu = new StackPanel();
+menu.Spacing = 8;
+menu.Anchor(Anchor.Center);   // center the panel on screen
+
+menu.AddChild(new Button { Text = "Start" });
+menu.AddChild(new Button { Text = "Options" });
+menu.AddChild(new Button { Text = "Quit" });
+
+AddGum(menu);
+```
+
+For horizontal layout:
+```csharp
+var toolbar = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
+```
+
+## Panel — Absolute Positioning Container
+
+`Panel` is the base of `StackPanel`. Use it to group controls with manual positioning, or as a root for mixed layouts. It defaults to `Dock.SizeToChildren`.
+
+```csharp
+var hud = new Panel();
+hud.Dock(Dock.Fill);
+
+var scoreLabel = new Label { Text = "0" };
+scoreLabel.Anchor(Anchor.TopRight);
+scoreLabel.X = -20;   // 20px from right
+scoreLabel.Y = 20;
+
+hud.AddChild(scoreLabel);
+AddGum(hud);
+```

--- a/.claude/skills/input-system/SKILL.md
+++ b/.claude/skills/input-system/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: input-system
+description: "Input System in FlatRedBall2. Use when working with keyboard, mouse, cursor, gamepad, touch input, key bindings, or input handling. Covers IKeyboard, ICursor, IGamepad, KeyboardInput2D, KeyboardPressableInput, GamepadInput2D, GamepadPressableInput, and I2DInput/IPressableInput interfaces."
+---
+
 # Input System in FlatRedBall2
 
 All input is accessed through `Engine.InputManager` from inside an entity. The input manager exposes keyboard, cursor (mouse/touch), and up to four gamepads.
@@ -117,13 +122,11 @@ var jumpButton = new GamepadPressableInput(
 if (jumpButton.WasJustPressed) { /* jump */ }
 ```
 
-> **Note:** `GamepadPressableInput.WasJustPressed` and `WasJustReleased` currently always return `false` (stub implementation). Use `IGamepad.WasButtonJustPressed` directly for reliable pressed/released detection.
-
 ## Best Practices
 
 - **Create input objects once in `CustomInitialize`, not in `CustomActivity`.** Constructing them every frame allocates garbage and is wasteful.
-- **`Engine` is not available in the entity constructor** — always initialize input in `CustomInitialize`.
-- **Y+ is up** — `KeyboardInput2D` already accounts for this. Up key → `Y = +1`. Multiply by positive speed to move upward.
+- **`Engine` is not available in the constructor** — see `engine-overview` Key Design Rules. Always initialize input in `CustomInitialize`.
+- **Y+ is up** — `KeyboardInput2D` already accounts for this. Up key → `Y = +1`.
 - **Check `ICursor.WorldPosition` for click-to-move logic** — it returns coordinates in the same world space as entity positions.
 
 ## Common Pitfalls

--- a/.claude/skills/levels/SKILL.md
+++ b/.claude/skills/levels/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: levels
+description: "Level Data in FlatRedBall2. Use when working with level layouts, tile grids, level progression, loading level data, parsing maps, or transitioning between levels. Covers grid-based string layouts, record-based placement, and level advancement patterns."
+---
+
 # Level Data in FlatRedBall2
 
 Level layouts are defined in code, in a dedicated file separate from screen logic. This keeps data easy to scan and edit without touching game logic.

--- a/.claude/skills/physics-and-movement/SKILL.md
+++ b/.claude/skills/physics-and-movement/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: physics-and-movement
+description: "Physics and Movement in FlatRedBall2. Use when working with velocity, acceleration, drag, gravity, kinematic movement, projectiles, rotation-based thrust, or coordinate system (Y+ up). Also covers GameRandom helpers for randomized spawning. Trigger on any physics or movement question."
+---
+
 # Physics and Movement in FlatRedBall2
 
 ## Coordinate System
@@ -69,9 +74,7 @@ Drag does *not* affect acceleration — only velocity. A falling entity with dra
 
 ## Update Order Each Frame
 
-1. **Physics** — position and velocity updated from acceleration/drag
-2. **Collision** — overlapping pairs separated; bounce impulses applied
-3. **CustomActivity** — game logic sees already-corrected positions
+See `engine-overview` for the full 8-step frame loop. The key point: **Physics → Collision → CustomActivity** — game logic sees already-corrected positions.
 
 ## Common Patterns
 

--- a/.claude/skills/platformer-movement/SKILL.md
+++ b/.claude/skills/platformer-movement/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: platformer-movement
+description: "Platformer Movement in FlatRedBall2. Use when implementing platformer mechanics including jumping, ground detection, PlatformerBehavior, PlatformerValues, double jump, air control, variable-height jumps, or side-scrolling movement. Trigger on any platformer-related question."
+---
+
 # Platformer Movement
 
 ## Overview

--- a/.claude/skills/sample-project-setup/SKILL.md
+++ b/.claude/skills/sample-project-setup/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sample-project-setup
+description: "Sample Project Setup for FlatRedBall2. Use when creating a new sample project, setting up a .csproj, configuring MonoGame content pipeline, or troubleshooting 'Cannot find a manifest file' / 'dotnet-mgcb does not exist' build errors. Covers the complete checklist for new sample projects."
+---
+
 # Sample Project Setup
 
 How to create a new sample project (`.csproj`) under `samples/`. Follow this checklist exactly — two of these steps are easy to forget and cause hard-to-diagnose build failures.

--- a/.claude/skills/screens/SKILL.md
+++ b/.claude/skills/screens/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: screens
+description: "Screens in FlatRedBall2. Use when working with screen lifecycle, screen transitions, MoveToScreen, passing data between screens, CustomInitialize/CustomActivity/CustomDestroy, or starting the first screen. Trigger on any screen management or game state transition question."
+---
+
 # Screens in FlatRedBall2
 
 A `Screen` is the top-level container for a game state — a level, a menu, a game-over sequence. Each screen owns its entities, collision relationships, Gum UI, and camera. Only one screen is active at a time.
@@ -34,14 +39,10 @@ public class GameScreen : Screen
 
 ## Lifecycle Order Each Frame
 
-1. **Physics** — entity positions updated from velocity/acceleration
-2. **Collision** — registered relationships resolved; positions corrected
-3. **Entity `CustomActivity`** — each entity's own logic runs first (context-free)
-4. **Screen `CustomActivity`** — screen-level logic runs after all entities have updated; can react to the updated entity state
+See `engine-overview` for the full 8-step frame loop. Key ordering for screens:
 
-The screen's `CustomActivity` always runs *after* all entity `CustomActivity` calls.
-
-`CustomInitialize` runs once when the screen is activated, before the first frame.
+- Entity `CustomActivity` runs **before** Screen `CustomActivity` — the screen always sees post-entity, post-collision state.
+- `CustomInitialize` runs once when the screen is activated, before the first frame.
 
 ## What's Available on a Screen
 

--- a/.claude/skills/shapes/SKILL.md
+++ b/.claude/skills/shapes/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: shapes
+description: "Working with Shapes in FlatRedBall2. Use when working with AxisAlignedRectangle, Circle, Polygon, shape creation, visibility, color, IsFilled, OutlineThickness, or visual properties of shapes. Also covers RepositionDirections for one-way platforms and tile grids. Trigger on any shape-related question."
+---
+
 # Working with Shapes in FlatRedBall2
 
 FlatRedBall2 has three built-in shape types: `AxisAlignedRectangle`, `Circle`, and `Polygon`. All shapes implement both `IRenderable` and `ICollidable`, so they handle both drawing and collision.
@@ -13,24 +18,13 @@ FlatRedBall2 has three built-in shape types: `AxisAlignedRectangle`, `Circle`, a
 ## Step 1: Create a Shape
 
 ```csharp
-var rect = new AxisAlignedRectangle
-{
-    X = 0, Y = 0,
-    Width = 64, Height = 64,
-};
-
-var circle = new Circle
-{
-    X = 100, Y = 0,
-    Radius = 32,
-};
+var rect = new AxisAlignedRectangle { X = 0, Y = 0, Width = 64, Height = 64 };
+var circle = new Circle { X = 100, Y = 0, Radius = 32 };
 
 // Polygon factory methods:
 var poly = Polygon.CreateRectangle(64, 64);         // rotatable rectangle
-var custom = Polygon.FromPoints(new[] {             // arbitrary shape
-    new Vector2(0, 0),
-    new Vector2(50, 0),
-    new Vector2(25, 40),
+var custom = Polygon.FromPoints(new[] {
+    new Vector2(0, 0), new Vector2(50, 0), new Vector2(25, 40),
 });
 ```
 
@@ -38,124 +32,51 @@ var custom = Polygon.FromPoints(new[] {             // arbitrary shape
 
 Shapes default to `Visible = false`. **Always set `Visible = true`** or the shape won't render.
 
-```csharp
-rect.Visible = true;
-```
-
 ## Step 3: Add to the Render Pipeline
 
-Shapes must be added to `Screen.RenderList` to be drawn each frame.
-
-### Option A — Directly on the Screen
-
-Add the shape to `RenderList` inside `CustomInitialize`:
-
+**Option A — Directly on the Screen**: Add to `RenderList` in `CustomInitialize`:
 ```csharp
-public class GameScreen : Screen
-{
-    public override void CustomInitialize()
-    {
-        var rect = new AxisAlignedRectangle
-        {
-            X = 0, Y = 0,
-            Width = 120, Height = 80,
-            Visible = true,
-        };
-
-        RenderList.Add(rect);   // <-- required
-    }
-}
+RenderList.Add(rect);
 ```
 
-### Option B — Attached to an Entity
+**Option B — Attached to an Entity**: `entity.AddChild(shape)` auto-adds to `RenderList` (as long as `Engine` is set).
 
-Calling `entity.AddChild(shape)` automatically adds the shape to `RenderList` (as long as the entity is registered with a screen). The shape's position is relative to the entity.
-
-```csharp
-public class Player : Entity
-{
-    public Circle Hitbox { get; } = new Circle { Radius = 24, Visible = true };
-
-    public override void CustomInitialize()
-    {
-        AddChild(Hitbox);  // registered to RenderList automatically
-    }
-}
-```
-
-> **Note:** `AddChild` only auto-registers if the entity already has an `Engine` reference (i.e., it was registered via `Screen.Register` or created via `Factory` before `AddChild` is called). If you call `AddChild` in an entity's constructor before registration, add the shape to `RenderList` manually.
+> **Note:** `AddChild` only auto-registers if the entity already has an `Engine` reference (via `Factory` or `Screen.Register`).
 
 ## Visual Properties
-
-All shape types share these visual properties:
 
 ```csharp
 var rect = new AxisAlignedRectangle
 {
-    // Color: RGBA, 0-255 each. Default is semi-transparent white.
-    Color = new Color(220, 60, 60, 200),   // red, mostly opaque
-
-    // IsFilled: true = solid fill, false = outline only
-    IsFilled = false,
-
-    // OutlineThickness: line width in pixels (used when IsFilled = false,
-    // or for Polygon where fill = thicker outline)
-    OutlineThickness = 3f,
-
+    Color = new Color(220, 60, 60, 200),   // RGBA
+    IsFilled = false,                       // true = solid fill, false = outline
+    OutlineThickness = 3f,                  // line width in pixels
     Visible = true,
 };
 ```
 
-> **Polygon note:** `Polygon` always draws as an outline (no fill triangulation yet). Setting `IsFilled = true` on a Polygon doubles the `OutlineThickness` to approximate a filled look.
+> **Polygon note:** `Polygon` always draws as an outline (no fill triangulation yet). `IsFilled = true` doubles `OutlineThickness` to approximate a filled look.
 
 ## Cleanup
 
-Call `Destroy()` when you're done with a shape. This removes it from its parent entity and clears references.
-
 ```csharp
-rect.Destroy();
+rect.Destroy();   // removes from parent entity and clears references
 ```
 
-For shapes added directly to `RenderList` (not via `AddChild`), also remove them manually:
-
-```csharp
-RenderList.Remove(rect);
-rect.Destroy();
-```
-
-## RepositionDirections (AxisAlignedRectangle only)
-
-`RepositionDirections` controls which sides of a rectangle act as solid collision surfaces. Collisions that would push an object in a suppressed direction are ignored entirely.
-
-Default is `RepositionDirections.All` (all four sides solid).
-
-```csharp
-// One-way platform: only the top surface is solid.
-platform.Rectangle.RepositionDirections = RepositionDirections.Up;
-
-// Remove interior sides from adjacent tiles to prevent "snagging" at seams.
-// (Ball grazing the edge between two side-by-side bricks gets deflected into the seam
-//  instead of bouncing off the top. Removing interior sides fixes this.)
-leftTile.Rectangle.RepositionDirections  = RepositionDirections.Up | RepositionDirections.Down | RepositionDirections.Left;
-rightTile.Rectangle.RepositionDirections = RepositionDirections.Up | RepositionDirections.Down | RepositionDirections.Right;
-```
-
-Values can be combined with `|` and removed with `&= ~`:
-```csharp
-brick.Rectangle.RepositionDirections &= ~RepositionDirections.Right; // remove right side
-brick.Rectangle.RepositionDirections |= RepositionDirections.Right;  // restore right side
-```
-
-> **Naming conflict:** `Gum.Forms.Controls` also defines a `RepositionDirections` type (for UI layout). If you import both namespaces, add a using alias to resolve the ambiguity:
-> ```csharp
-> using RepositionDirections = FlatRedBall2.Collision.RepositionDirections;
-> ```
-
-**Dynamic tile grids:** When a tile is destroyed, its neighbors' RepositionDirections must be updated to expose the sides that now face open space. Track the grid in a `Dictionary<(int col, int row), AxisAlignedRectangle>` and restore directions on destroy — see `GameScreen.RestoreNeighborDirections` in the sample for a reference implementation.
+For shapes added directly to `RenderList` (not via `AddChild`), also call `RenderList.Remove(rect)`.
 
 ## Common Pitfalls
 
 - **Shape is invisible** — forgot `Visible = true`. Default is `false`.
-- **Shape is not drawn** — forgot `RenderList.Add(shape)` (or `AddChild` before entity was registered).
-- **Shape position looks wrong** — remember Y+ is **up** in world space. A shape at `Y = 100` is *above* center.
-- **Polygon not rotating** — use `Polygon`, not `AxisAlignedRectangle`. Only `Polygon` has a `Rotation` property.
+- **Shape is not drawn** — forgot `RenderList.Add(shape)` or `AddChild` before entity was registered.
+- **Shape position looks wrong** — Y+ is up (see `physics-and-movement`).
+- **Polygon not rotating** — use `Polygon`, not `AxisAlignedRectangle`.
+
+## RepositionDirections (AxisAlignedRectangle only)
+
+Controls which sides of a rectangle act as solid collision surfaces. Use for one-way platforms (`RepositionDirections.Up` = only top is solid) and removing interior sides from adjacent tiles to prevent seam snagging.
+
+Default is `RepositionDirections.All`. Values combine with `|` and `&= ~`.
+
+For detailed usage and dynamic tile grids, see:
+- `references/reposition-directions.md` — Full examples, dynamic grids, Gum naming conflict workaround

--- a/.claude/skills/shapes/references/reposition-directions.md
+++ b/.claude/skills/shapes/references/reposition-directions.md
@@ -1,0 +1,29 @@
+# RepositionDirections Reference (AxisAlignedRectangle only)
+
+`RepositionDirections` controls which sides of a rectangle act as solid collision surfaces. Collisions that would push an object in a suppressed direction are ignored entirely.
+
+Default is `RepositionDirections.All` (all four sides solid).
+
+```csharp
+// One-way platform: only the top surface is solid.
+platform.Rectangle.RepositionDirections = RepositionDirections.Up;
+
+// Remove interior sides from adjacent tiles to prevent "snagging" at seams.
+leftTile.Rectangle.RepositionDirections  = RepositionDirections.Up | RepositionDirections.Down | RepositionDirections.Left;
+rightTile.Rectangle.RepositionDirections = RepositionDirections.Up | RepositionDirections.Down | RepositionDirections.Right;
+```
+
+Values can be combined with `|` and removed with `&= ~`:
+```csharp
+brick.Rectangle.RepositionDirections &= ~RepositionDirections.Right; // remove right side
+brick.Rectangle.RepositionDirections |= RepositionDirections.Right;  // restore right side
+```
+
+> **Naming conflict:** `Gum.Forms.Controls` also defines a `RepositionDirections` type (for UI layout). If you import both namespaces, add a using alias:
+> ```csharp
+> using RepositionDirections = FlatRedBall2.Collision.RepositionDirections;
+> ```
+
+## Dynamic Tile Grids
+
+When a tile is destroyed, its neighbors' RepositionDirections must be updated to expose the sides that now face open space. Track the grid in a `Dictionary<(int col, int row), AxisAlignedRectangle>` and restore directions on destroy — see `GameScreen.RestoreNeighborDirections` in the sample for a reference implementation.

--- a/.claude/skills/timing/SKILL.md
+++ b/.claude/skills/timing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: timing
+description: "Timing in FlatRedBall2. Use when working with cooldowns, timers, delays, entity lifetimes, self-destruct, repeating events, or FrameTime.DeltaSeconds. Covers cooldown gates, repeating timers, and entity lifetime patterns."
+---
+
 # Timing in FlatRedBall2
 
 The engine provides `FrameTime` to every `CustomActivity` call. Use `time.DeltaSeconds` (a `float`) to drive all time-based logic — cooldowns, repeating events, and entity lifetimes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,11 @@
 
 ## What Is This?
 
-FlatRedBall2 is a 2D game engine/framework written in C# on .NET, built on top of MonoGame. It integrates Gum (UI) and Tiled (level editing) as dependencies. The project is currently in the architecture/design phase — see `ARCHITECTURE.md` for the full design.
+FlatRedBall2 is a 2D game engine/framework written in C# on .NET, built on top of MonoGame. It integrates Gum (UI) and Tiled (level editing) as dependencies.
 
 ## Key Files
 
 - Main project: `src/FlatRedBall2.csproj` (MonoGame.Framework.DesktopGL 3.8.*)
-- Architecture spec: `design/ARCHITECTURE.md`
 - Code style: `.claude/code-style.md`
 - Deferred items: `design/TODOS.md`
 - Test project: `tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj`
@@ -17,27 +16,6 @@ FlatRedBall2 is a 2D game engine/framework written in C# on .NET, built on top o
 ```
 dotnet build src/FlatRedBall2.csproj
 dotnet test tests/FlatRedBall2.Tests/
-```
-
-## Engine Structure
-
-```
-src/
-  Math/Angle.cs
-  FrameTime.cs, IAttachable.cs, Entity.cs, Screen.cs, Factory.cs
-  TimeManager.cs, ContentManagerService.cs, FlatRedBallService.cs
-  Rendering/    IRenderable.cs, IRenderBatch.cs, Layer.cs, Camera.cs, Sprite.cs
-  Rendering/Batches/   WorldSpaceBatch.cs, ScreenSpaceBatch.cs
-  Collision/    ICollidable.cs, AxisAlignedRectangle.cs, Circle.cs, Polygon.cs
-               ShapeCollection.cs, CollisionDispatcher.cs, CollisionRelationship.cs
-  Input/        (15 files: interfaces + implementations)
-  Audio/        AudioManager.cs (stub — throws NotImplementedException)
-  Diagnostics/  BatchBreakInfo.cs, RenderDiagnostics.cs, DebugRenderer.cs (stub)
-  UI/           GumRenderBatch.cs, GumRenderable.cs (implemented)
-  Tiled/        TiledMapLayerRenderable.cs, TiledCollisionGenerator.cs (stubs)
-  Game1.cs      (wired to FlatRedBallService.Default)
-tests/FlatRedBall2.Tests/
-  BounceTests.cs
 ```
 
 ## Available Skills
@@ -62,18 +40,17 @@ Invoke these with the Skill tool when working on specific topics:
 - **Physics**: Second-order kinematic — `pos += vel*dt + acc*(dt²/2)`, `vel += acc*dt`, `vel -= vel*drag*dt`
 - **Y-axis**: World space Y+ up; Camera transform flips Y for screen-space rendering
 - **No static state**: Only `FlatRedBallService.Default` is static
-- **Entity.Engine**: `internal set` — injected by Factory or Screen.Register before `CustomInitialize`; throws `InvalidOperationException` if accessed before injection
+- **Entity.Engine**: `internal set` — injected by Factory before `CustomInitialize`; throws `InvalidOperationException` if accessed before injection
 - **InternalsVisibleTo**: `FlatRedBall2.Tests` accesses internal members (PhysicsUpdate, AddEntity, etc.)
-- **CollisionDispatcher**: `internal static` class in `FlatRedBall2.Collision` namespace
+- **CollisionDispatcher**: `internal static` class — shape-pair resolution uses concrete type matching
 
 ## Known Stubs (Not Yet Implemented)
 
-These APIs exist but are not functional — do not attempt to use them:
+Do not attempt to use these — they exist as API placeholders:
 - Audio: All methods throw `NotImplementedException`
 - ACHX animations: `Sprite.PlayAnimation` is a no-op
 - DebugRenderer: All draw methods are no-ops
 - Tiled integration: `TiledMapLayerRenderable`/`TiledCollisionGenerator` are stubs
-- `GamepadPressableInput.WasJustPressed/Released`: always returns false
 
 ## AI-Usability Goals
 

--- a/design/TODOS.md
+++ b/design/TODOS.md
@@ -44,12 +44,9 @@ This document tracks features and systems intentionally deferred from the initia
 - `TiledMapLayerRenderable.Draw` renders a tile layer using MonoGame.Extended's tile renderer
 - `TiledCollisionGenerator.Generate` reads tile properties and emits `AxisAlignedRectangle` shapes into a `ShapeCollection`
 
-## Same-List Collision
+## ~~Same-List Collision~~ (COMPLETED)
 
-**Status**: Not implemented — `CollisionRelationship` only handles two different lists
-**What's needed**:
-- `AddCollisionRelationship<T>(IEnumerable<T> list)` overload for self-vs-self collision
-- Pair iteration: `for i in 0..n, for j in i+1..n` to avoid duplicate pairs and self-collision
+**Status**: Implemented — `Screen.AddCollisionRelationship<A>(IEnumerable<A> list)` overload exists in `Screen.cs`.
 
 ## Camera Pixel-Perfect Mode
 
@@ -80,10 +77,6 @@ This document tracks features and systems intentionally deferred from the initia
 - `TopDownBehavior` component following the same `Update(entity, time)` pattern as `PlatformerBehavior`
 - Skill file at `.claude/skills/top-down-movement/SKILL.md`
 
-## GamepadPressableInput WasJustPressed / WasJustReleased
+## ~~GamepadPressableInput WasJustPressed / WasJustReleased~~ (COMPLETED)
 
-**Status**: Returns `false` — previous state tracking not implemented
-**What's needed**:
-- Expose `WasButtonPressed(Buttons)` and `WasButtonReleased(Buttons)` on `IGamepad`
-- Update `Gamepad` implementation to track previous frame state (already done internally, needs interface exposure)
-- Update `GamepadPressableInput` to use these methods
+**Status**: Implemented — `GamepadPressableInput` delegates to `IGamepad.WasButtonJustPressed`/`WasButtonJustReleased`.


### PR DESCRIPTION
…improvements

- Add YAML frontmatter (name + description) to all 13 existing skills for proper triggering
- New engine-overview skill: frame loop, bootstrapping, key design rules, complete screen example, sub-systems table, skill routing
- Agent improvements: handoff instructions (game-designer → PM → coder), PM now references skill names in task breakdowns, QA tools corrected, coder invokes skills before editing, refactoring-specialist patterns filled in
- CLAUDE.md trimmed: removed duplicated engine structure tree, updated stubs
- content-and-assets expanded with Sprite/Texture/mgcb pipeline docs
- Skills trimmed with detailed content extracted to reference files (layout.md, reposition-directions.md, patterns.md)
- TODOS.md: marked same-list collision and GamepadPressableInput as completed

Co-Authored-By: Claude Opus 4.6