### PR TITLE
CI: run dotnet test on PRs and pushes to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: dotnet test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --no-restore --verbosity normal


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml` — first CI workflow in the repo.
- Runs `dotnet test tests/FlatRedBall2.Tests/` on every PR targeting `main` and on direct pushes to `main`. Fails on any test failure or build error.
- Uses `actions/checkout@v4` + `actions/setup-dotnet@v4` with .NET 10 SDK (matches `TargetFramework` in `src/FlatRedBall2.csproj`). NuGet packages cached via `actions/cache@v4` keyed on `**/*.csproj` hashes.

Tracks the "CI: GitHub Action..." item in `design/TODOS.md`. Branch-protection setup is a manual follow-up (instructions in the PR thread).

## Test plan
- [ ] This PR itself triggers the workflow and it passes (549 tests green).
- [ ] After merge, configure branch protection on `main` to require the `dotnet test` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)