### PR TITLE
Run deploy on windows-latest for KNI shader compilation

### DIFF
--- a/.github/workflows/deploy-sample.yml
+++ b/.github/workflows/deploy-sample.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       contents: write
     steps:
@@ -35,12 +35,14 @@ jobs:
           -o publish
 
       - name: Rewrite base href for GitHub Pages subpath
+        shell: bash
         run: |
           sed -i 's|<base href="\./" />|<base href="/FlatRedBall2/${{ inputs.sample }}/" />|' \
             publish/wwwroot/index.html
           grep -q '<base href="/FlatRedBall2/${{ inputs.sample }}/"' publish/wwwroot/index.html
 
       - name: Add .nojekyll
+        shell: bash
         run: touch publish/wwwroot/.nojekyll
 
       - name: Deploy to gh-pages/${{ inputs.sample }}


### PR DESCRIPTION
KNI's content pipeline shader compiler only runs on Windows, and the nkast pipeline builder invokes MGCB.exe directly from a hardcoded Windows-style path. Switching the runner avoids needing Mono/wine on Linux. Bash steps now opt in via 'shell: bash' (Git Bash is preinstalled on the Windows runner image).