### PR TITLE
fix(#108): cursor reflects frame handle/body under pointer

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/HandleCursorMapper.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/HandleCursorMapper.cs
@@ -1,0 +1,26 @@
+using AnimationEditor.Core.Rendering;
+using Avalonia.Input;
+
+namespace AnimationEditor.App.Controls;
+
+/// <summary>
+/// Pure mapping from a hit-tested <see cref="HandleKind"/> to the Avalonia
+/// <see cref="StandardCursorType"/> the wireframe should display while
+/// hovering. Returns <c>null</c> when the platform default cursor should be used.
+/// </summary>
+public static class HandleCursorMapper
+{
+    public static StandardCursorType? CursorTypeFor(HandleKind kind) => kind switch
+    {
+        HandleKind.Move      => StandardCursorType.SizeAll,
+        HandleKind.TopLeft   => StandardCursorType.TopLeftCorner,
+        HandleKind.BotRight  => StandardCursorType.BottomRightCorner,
+        HandleKind.TopRight  => StandardCursorType.TopRightCorner,
+        HandleKind.BotLeft   => StandardCursorType.BottomLeftCorner,
+        HandleKind.MidLeft or
+        HandleKind.MidRight  => StandardCursorType.SizeWestEast,
+        HandleKind.TopCenter or
+        HandleKind.BotCenter => StandardCursorType.SizeNorthSouth,
+        _                    => null,
+    };
+}

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1345,9 +1345,31 @@ public class WireframeControl : Control
             return;
         }
 
+        UpdateHoverCursor(pos);
+
         // Update hover preview for magic-wand / grid-snap
         UpdatePreview(pos);
     }
+
+    private void UpdateHoverCursor(Point pos)
+    {
+        var (_, hitHandle) = HitTestHandle(pos);
+        Cursor = CursorFor(hitHandle);
+    }
+
+    private static Cursor CursorFor(HandleKind kind) => kind switch
+    {
+        HandleKind.Move        => new Cursor(StandardCursorType.SizeAll),
+        HandleKind.TopLeft     => new Cursor(StandardCursorType.TopLeftCorner),
+        HandleKind.BotRight    => new Cursor(StandardCursorType.BottomRightCorner),
+        HandleKind.TopRight    => new Cursor(StandardCursorType.TopRightCorner),
+        HandleKind.BotLeft     => new Cursor(StandardCursorType.BottomLeftCorner),
+        HandleKind.MidLeft or
+        HandleKind.MidRight    => new Cursor(StandardCursorType.SizeWestEast),
+        HandleKind.TopCenter or
+        HandleKind.BotCenter   => new Cursor(StandardCursorType.SizeNorthSouth),
+        _                      => Cursor.Default,
+    };
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
@@ -1371,6 +1393,7 @@ public class WireframeControl : Control
     protected override void OnPointerExited(PointerEventArgs e)
     {
         base.OnPointerExited(e);
+        Cursor = Cursor.Default;
         if (_showPreview) { _showPreview = false; InvalidateVisual(); }
     }
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1354,22 +1354,11 @@ public class WireframeControl : Control
     private void UpdateHoverCursor(Point pos)
     {
         var (_, hitHandle) = HitTestHandle(pos);
-        Cursor = CursorFor(hitHandle);
+        var cursorType = HandleCursorMapper.CursorTypeFor(hitHandle);
+        Cursor = cursorType is null
+            ? Cursor.Default
+            : new Cursor(cursorType.Value);
     }
-
-    private static Cursor CursorFor(HandleKind kind) => kind switch
-    {
-        HandleKind.Move        => new Cursor(StandardCursorType.SizeAll),
-        HandleKind.TopLeft     => new Cursor(StandardCursorType.TopLeftCorner),
-        HandleKind.BotRight    => new Cursor(StandardCursorType.BottomRightCorner),
-        HandleKind.TopRight    => new Cursor(StandardCursorType.TopRightCorner),
-        HandleKind.BotLeft     => new Cursor(StandardCursorType.BottomLeftCorner),
-        HandleKind.MidLeft or
-        HandleKind.MidRight    => new Cursor(StandardCursorType.SizeWestEast),
-        HandleKind.TopCenter or
-        HandleKind.BotCenter   => new Cursor(StandardCursorType.SizeNorthSouth),
-        _                      => Cursor.Default,
-    };
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HandleCursorMapperTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HandleCursorMapperTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.Rendering;
+using Avalonia.Input;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class HandleCursorMapperTests
+{
+    [Theory]
+    [InlineData(HandleKind.Move,      StandardCursorType.SizeAll)]
+    [InlineData(HandleKind.TopLeft,   StandardCursorType.TopLeftCorner)]
+    [InlineData(HandleKind.TopRight,  StandardCursorType.TopRightCorner)]
+    [InlineData(HandleKind.BotLeft,   StandardCursorType.BottomLeftCorner)]
+    [InlineData(HandleKind.BotRight,  StandardCursorType.BottomRightCorner)]
+    [InlineData(HandleKind.MidLeft,   StandardCursorType.SizeWestEast)]
+    [InlineData(HandleKind.MidRight,  StandardCursorType.SizeWestEast)]
+    [InlineData(HandleKind.TopCenter, StandardCursorType.SizeNorthSouth)]
+    [InlineData(HandleKind.BotCenter, StandardCursorType.SizeNorthSouth)]
+    public void Maps_each_handle_kind_to_the_expected_cursor(HandleKind kind, StandardCursorType expected)
+    {
+        Assert.Equal(expected, HandleCursorMapper.CursorTypeFor(kind));
+    }
+
+    [Fact]
+    public void None_returns_null_meaning_platform_default()
+    {
+        Assert.Null(HandleCursorMapper.CursorTypeFor(HandleKind.None));
+    }
+}


### PR DESCRIPTION
## Summary
- Wireframe editor now updates `Cursor` on pointer move based on `DragHandleHitTester` output: `SizeAll` over the selected frame's body, the matching directional resize cursor over each of the 8 handles, default elsewhere.
- Cursor resets to default on `PointerExited`.

Closes #108

## Test plan
- [x] Open the animation editor, select a frame.
- [x] Hover the body — cursor becomes the move (+) cursor.
- [x] Hover each of the 8 handles — cursor becomes N-S, E-W, NW-SE, NE-SW as appropriate.
- [x] Move off the control — cursor returns to default.
- [x] Drag still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)