### PR TITLE
docs: require TDD or explicit explanation for every behavior change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,19 @@ Do not attempt to use these — they exist as API placeholders:
 - DebugRenderer: All draw methods are no-ops
 - Tiled integration: `TileMapCollisions` uses MonoGame.Extended 6.0 preview
 
+## Test-First Discipline (Repo-Wide, Non-Negotiable)
+
+**Every code change that alters behavior must either (a) start with a failing test that the change makes pass, or (b) include an explicit, written explanation of why a test was not feasible.** This applies to the entire repository — engine (`src/`), tools (`FRBDK/`), samples, anything. There is no third option. Silently skipping tests is not allowed.
+
+The `engine-tdd` skill spells out the discipline for `src/`; the same rule applies everywhere else. Hard-to-test surfaces (UI cursor changes, render output, third-party-library wiring) are not exemptions — they are a prompt to **extract the testable core** (a pure mapping function, a state computation, a hit-test) and test that, then leave a thin untested wiring layer.
+
+When (b) applies, the explanation must be in the PR/commit body and must say:
+1. What specifically blocked a test (e.g., "Avalonia `Cursor` exposes no equality on `StandardCursorType`").
+2. What testable core *was* extracted and covered, if any.
+3. What's left untested and why that residue is acceptable.
+
+If you cannot honestly write (1)-(3), the answer is: write the test.
+
 ## AI-Usability Goals
 
 This project serves dual purposes: building a game engine AND evaluating how well AI assistants can work with it. **Game samples are not just games — they are AI usability tests for FlatRedBall2.**


### PR DESCRIPTION
## Summary
Adds a repo-wide rule to `CLAUDE.md`: every behavior-changing code change must either (a) start with a failing test that the change makes pass, or (b) include a written explanation of why a test was not feasible (what blocked it, what testable core was extracted, what residue is acceptable). No third option.

Motivation: the existing `engine-tdd` skill scopes only to `src/`, so work in `FRBDK/`, samples, etc. has been quietly skipping tests. This closes that gap.

## Test plan
- [ ] N/A — docs-only change. (Per the new rule itself, this falls under the "no behavior change" exemption.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)