### PR TITLE
ci(#135): run AnimationEditor tests; bump AnimationEditor to net10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,3 +61,14 @@ jobs:
       # headless platform — no display server needed even on the Windows runner.
       - name: Test AnimationEditor.App
         run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity normal
+
+  # Umbrella check that branch protection gates on. Stays named "dotnet test" so the
+  # existing required-status-check entry in the main-protection ruleset keeps matching
+  # after the workflow was split into per-OS jobs. Passes only if every job above passes.
+  test:
+    name: dotnet test
+    runs-on: ubuntu-latest
+    needs: [engine-tests, animationeditor-tests]
+    steps:
+      - name: All test jobs passed
+        run: echo "engine-tests and animationeditor-tests both succeeded"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,21 +11,8 @@ jobs:
     name: dotnet test
     runs-on: ubuntu-latest
     steps:
-      # FlatRedBall2 currently project-references Gum at ..\..\Gum from src/FlatRedBall2.csproj
-      # for in-place iteration. Both repos must be cloned as siblings under $GITHUB_WORKSPACE
-      # so the relative path resolves the same way it does locally. When FRB2 switches back to
-      # the Gum NuGet packages, the Checkout Gum step and the working-directory entries can go.
-      - name: Checkout FlatRedBall2
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          path: FlatRedBall2
-
-      - name: Checkout Gum
-        uses: actions/checkout@v4
-        with:
-          repository: vchelaru/Gum
-          ref: main
-          path: Gum
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -36,29 +23,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('FlatRedBall2/**/*.csproj', 'Gum/**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      # Gum's MonoGameGum.csproj multi-targets net9.0-ios / net9.0-android, neither of
-      # which can be built on a Linux runner (iOS SDK is macOS-only). Gum exposes
-      # ExcludeIOS / ExcludeAndroid escape-hatch properties that drop those TFMs at
-      # evaluation; pass them as global properties so the whole graph evaluates without
-      # the mobile TFMs.
-      - name: Restore engine tests
-        working-directory: FlatRedBall2
-        run: dotnet restore tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj -p:ExcludeIOS=true -p:ExcludeAndroid=true
-
       - name: Test engine
-        working-directory: FlatRedBall2
-        run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --no-restore --verbosity normal -p:ExcludeIOS=true -p:ExcludeAndroid=true
+        run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --verbosity normal
 
       # AnimationEditor.App.Tests references Avalonia.Headless.XUnit, which provides a
       # headless platform — no xvfb / display server needed.
       - name: Test AnimationEditor.Core
-        working-directory: FlatRedBall2
         run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj --verbosity normal
 
       - name: Test AnimationEditor.App
-        working-directory: FlatRedBall2
         run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity normal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: dotnet test
+  engine-tests:
+    name: Engine tests (ubuntu)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,10 +30,34 @@ jobs:
       - name: Test engine
         run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --verbosity normal
 
-      # AnimationEditor.App.Tests references Avalonia.Headless.XUnit, which provides a
-      # headless platform — no xvfb / display server needed.
+  # AnimationEditor still depends on FlatRedBallDesktopGLNet6 (FRB1), whose FileManager
+  # hardcodes Windows backslash paths in SaveText. That makes Save→Load tests fail on
+  # Linux. Run AE tests on windows-latest until the migration to in-tree FRB2 lands
+  # (tracked as a separate issue), at which point this job can move to ubuntu-latest.
+  animationeditor-tests:
+    name: AnimationEditor tests (windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Test AnimationEditor.Core
         run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj --verbosity normal
 
+      # AnimationEditor.App.Tests references Avalonia.Headless.XUnit, which provides a
+      # headless platform — no display server needed even on the Windows runner.
       - name: Test AnimationEditor.App
         run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity normal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,10 +45,20 @@ jobs:
       # ExcludeIOS / ExcludeAndroid escape-hatch properties that drop those TFMs at
       # evaluation; pass them as global properties so the whole graph evaluates without
       # the mobile TFMs.
-      - name: Restore
+      - name: Restore engine tests
         working-directory: FlatRedBall2
         run: dotnet restore tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj -p:ExcludeIOS=true -p:ExcludeAndroid=true
 
-      - name: Test
+      - name: Test engine
         working-directory: FlatRedBall2
         run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --no-restore --verbosity normal -p:ExcludeIOS=true -p:ExcludeAndroid=true
+
+      # AnimationEditor.App.Tests references Avalonia.Headless.XUnit, which provides a
+      # headless platform — no xvfb / display server needed.
+      - name: Test AnimationEditor.Core
+        working-directory: FlatRedBall2
+        run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj --verbosity normal
+
+      - name: Test AnimationEditor.App
+        working-directory: FlatRedBall2
+        run: dotnet test FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity normal

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -56,12 +56,8 @@
   <!-- MonoGame backend -->
   <ItemGroup Condition="'$(Backend)' == 'MonoGame'">
     <PackageReference Include="Apos.Shapes" Version="*" />
-    <!-- Local Gum source link: temporary swap from NuGet to ProjectReference for in-place debugging.
-         Restore the package refs below before publishing. -->
-    <ProjectReference Include="..\..\Gum\MonoGameGum\MonoGameGum.csproj" />
-    <ProjectReference Include="..\..\Gum\Runtimes\GumShapes\MonoGameGumShapes.csproj" />
-    <!--<PackageReference Include="Gum.MonoGame" Version="2026.5.1.1-preview.16" />-->
-    <!--<PackageReference Include="Gum.Shapes.MonoGame" Version="2026.5.1.1-preview.16" />-->
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
+    <PackageReference Include="Gum.Shapes.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -71,11 +67,8 @@
   <!-- KNI backend (Blazor WebAssembly + future mobile targets) -->
   <ItemGroup Condition="'$(Backend)' == 'Kni'">
     <PackageReference Include="Apos.Shapes.KNI" Version="*" />
-    <!-- Local Gum source link (KNI). Restore the package refs below before publishing. -->
-    <ProjectReference Include="..\..\Gum\MonoGameGum\KniGum\KniGum.csproj" />
-    <ProjectReference Include="..\..\Gum\Runtimes\GumShapes\KniGumShapes.csproj" />
-    <!--<PackageReference Include="Gum.KNI" Version="2026.5.1.1-preview.16" />-->
-    <!--<PackageReference Include="Gum.Shapes.KNI" Version="2026.5.1.1-preview.16" />-->
+    <PackageReference Include="Gum.KNI" Version="2026.5.8.1" />
+    <PackageReference Include="Gum.Shapes.KNI" Version="2026.5.8.1" />
     <PackageReference Include="KNI.Extended" Version="6.0.0-preview.*" />
     <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
     <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />


### PR DESCRIPTION
## Summary
- Adds CI gating for the AnimationEditor unit test suites (closes #135).
- Splits the workflow into two jobs: `engine-tests` on `ubuntu-latest`, `animationeditor-tests` on `windows-latest`. Engine tests stay fast on Linux; AE has to run on Windows because its current FRB1 dependency (`FlatRedBallDesktopGLNet6`) hardcodes Windows path semantics in `FileManager.SaveText` and corrupts file IO on Linux. Migration off FRB1 is tracked as #141 — once that lands, the AE job can move back to ubuntu-latest.
- Bumps the four AnimationEditor csprojs from `net8.0` to `net10.0` so the whole repo shares one TFM (CI keeps a single 10.0.x SDK install instead of dual 8/10).
- Swaps the engine's `..\..\Gum\*` ProjectReferences for `Gum.MonoGame` / `Gum.Shapes.MonoGame` / `Gum.KNI` / `Gum.Shapes.KNI` 2026.5.8.1 from NuGet. This drops the awkward sibling-clone-of-Gum dance from the workflow and makes local builds work from inside git worktrees.

## Verified locally
- `tests/FlatRedBall2.Tests` on net10 with Gum-from-NuGet: 1004/1004 passing, builds from inside a worktree.
- `AnimationEditor.Core.Tests` on net10 (Windows): 692/692 passing.
- `AnimationEditor.App.Tests` on net10 (Windows, Avalonia headless): 149/149 passing.

## Action required after merge
The new step names — `Engine tests (ubuntu) / Test engine`, `AnimationEditor tests (windows) / Test AnimationEditor.Core`, `AnimationEditor tests (windows) / Test AnimationEditor.App` — need to be added to `main`'s required status checks in branch protection / repository rulesets. Workflow YAML alone does not gate merges; the names have to be registered in branch protection for failures to actually block merging.

Closes #135