### PR TITLE
Allow negative X/Y frame bounds — frames can extend outside PNG

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1504,8 +1504,7 @@ public class WireframeControl : Control
         var startBounds = new BoundsRect(_dragStartBounds.Left, _dragStartBounds.Top,
                                          _dragStartBounds.Right, _dragStartBounds.Bottom);
 
-        var nb = DragHandleApplier.Apply(_draggingHandle, dx, dy, startBounds,
-                                         _bitmap.Width, _bitmap.Height);
+        var nb = DragHandleApplier.Apply(_draggingHandle, dx, dy, startBounds);
 
         // Snap moved edges to the grid when the grid is enabled
         if (_showGrid && _gridSize > 0)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -380,13 +380,13 @@
                                         <TextBlock Text="X" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropPixelX" Grid.Column="1"
-                                                       Minimum="0" Maximum="16384" Increment="1" />
+                                                       Minimum="-16384" Maximum="16384" Increment="1" />
                                     </Grid>
                                     <Grid ColumnDefinitions="78,*">
                                         <TextBlock Text="Y" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropPixelY" Grid.Column="1"
-                                                       Minimum="0" Maximum="16384" Increment="1" />
+                                                       Minimum="-16384" Maximum="16384" Increment="1" />
                                     </Grid>
                                     <Grid ColumnDefinitions="78,*">
                                         <TextBlock Text="Width" VerticalAlignment="Center"
@@ -407,28 +407,28 @@
                                         <TextBlock Text="Left" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropTcLeft" Grid.Column="1"
-                                                       Minimum="0" Maximum="1"
+                                                       Minimum="-10" Maximum="10"
                                                        Increment="0.001" FormatString="0.0000" />
                                     </Grid>
                                     <Grid ColumnDefinitions="78,*">
                                         <TextBlock Text="Right" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropTcRight" Grid.Column="1"
-                                                       Minimum="0" Maximum="1"
+                                                       Minimum="-10" Maximum="10"
                                                        Increment="0.001" FormatString="0.0000" />
                                     </Grid>
                                     <Grid ColumnDefinitions="78,*">
                                         <TextBlock Text="Top" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropTcTop" Grid.Column="1"
-                                                       Minimum="0" Maximum="1"
+                                                       Minimum="-10" Maximum="10"
                                                        Increment="0.001" FormatString="0.0000" />
                                     </Grid>
                                     <Grid ColumnDefinitions="78,*">
                                         <TextBlock Text="Bottom" VerticalAlignment="Center"
                                                    Foreground="LightGray" FontSize="11" />
                                         <NumericUpDown x:Name="PropTcBottom" Grid.Column="1"
-                                                       Minimum="0" Maximum="1"
+                                                       Minimum="-10" Maximum="10"
                                                        Increment="0.001" FormatString="0.0000" />
                                     </Grid>
                                 </StackPanel>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
@@ -17,14 +17,13 @@ public static class DragHandleApplier
     /// <summary>
     /// Returns the new texture-pixel bounds after dragging <paramref name="handle"/>
     /// by (<paramref name="dx"/>, <paramref name="dy"/>) from <paramref name="startBounds"/>.
-    /// The result is clamped to [0, bitmapWidth] × [0, bitmapHeight] with a minimum
-    /// dimension of 1 pixel on each axis.
+    /// The frame may extend freely outside the bitmap boundaries; only a minimum
+    /// dimension of 1 pixel on each axis is enforced (resize handles only).
     /// </summary>
     public static BoundsRect Apply(
         HandleKind handle,
         float dx, float dy,
-        BoundsRect startBounds,
-        float bitmapWidth, float bitmapHeight)
+        BoundsRect startBounds)
     {
         var b = startBounds;
 
@@ -42,21 +41,15 @@ public static class DragHandleApplier
             _                    => b,
         };
 
-        // Move slides the whole frame as a rigid body — preserve dimensions, slide to wall.
+        // Move slides the whole frame as a rigid body — dimensions already preserved.
         if (handle == HandleKind.Move)
-        {
-            float fw = nb.Right  - nb.Left;
-            float fh = nb.Bottom - nb.Top;
-            float cl = Math.Clamp(nb.Left, 0f, Math.Max(0f, bitmapWidth  - fw));
-            float ct = Math.Clamp(nb.Top,  0f, Math.Max(0f, bitmapHeight - fh));
-            return new(cl, ct, cl + fw, ct + fh);
-        }
+            return nb;
 
-        // Resize handles: clamp each edge independently, enforce minimum 1-pixel size.
-        float l  = Math.Max(0f,           Math.Min(nb.Left,   nb.Right  - 1f));
-        float t  = Math.Max(0f,           Math.Min(nb.Top,    nb.Bottom - 1f));
-        float r  = Math.Min(bitmapWidth,  Math.Max(nb.Right,  nb.Left   + 1f));
-        float bm = Math.Min(bitmapHeight, Math.Max(nb.Bottom, nb.Top    + 1f));
+        // Resize: enforce minimum 1-pixel size; frame may extend outside bitmap.
+        float l  = Math.Min(nb.Left,   nb.Right  - 1f);
+        float t  = Math.Min(nb.Top,    nb.Bottom - 1f);
+        float r  = Math.Max(nb.Right,  nb.Left   + 1f);
+        float bm = Math.Max(nb.Bottom, nb.Top    + 1f);
 
         return new(l, t, r, bm);
     }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
@@ -113,7 +113,7 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_Move_ShiftsAllFourEdges()
     {
-        var result = DragHandleApplier.Apply(HandleKind.Move, 10f, 5f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.Move, 10f, 5f, Rect20x20);
         Assert.Equal(30f, result.Left);
         Assert.Equal(25f, result.Top);
         Assert.Equal(90f, result.Right);
@@ -123,7 +123,7 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_TopLeft_MovesTopAndLeftEdges()
     {
-        var result = DragHandleApplier.Apply(HandleKind.TopLeft, 5f, 5f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.TopLeft, 5f, 5f, Rect20x20);
         Assert.Equal(25f, result.Left);
         Assert.Equal(25f, result.Top);
         Assert.Equal(80f, result.Right);  // unchanged
@@ -133,7 +133,7 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_TopCenter_MovesTopEdgeOnly()
     {
-        var result = DragHandleApplier.Apply(HandleKind.TopCenter, 99f, 5f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.TopCenter, 99f, 5f, Rect20x20);
         Assert.Equal(20f, result.Left);   // unchanged
         Assert.Equal(25f, result.Top);
         Assert.Equal(80f, result.Right);  // unchanged
@@ -143,7 +143,7 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_MidRight_MovesRightEdgeOnly()
     {
-        var result = DragHandleApplier.Apply(HandleKind.MidRight, 10f, 99f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.MidRight, 10f, 99f, Rect20x20);
         Assert.Equal(20f, result.Left);
         Assert.Equal(20f, result.Top);
         Assert.Equal(90f, result.Right);
@@ -153,42 +153,85 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_BotCenter_MovesBottomEdgeOnly()
     {
-        var result = DragHandleApplier.Apply(HandleKind.BotCenter, 99f, 10f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.BotCenter, 99f, 10f, Rect20x20);
         Assert.Equal(90f, result.Bottom); // 80 + dy(10) = 90
         Assert.Equal(20f, result.Left);
         Assert.Equal(80f, result.Right);
         Assert.Equal(20f, result.Top);
     }
 
-    // ── Clamping ──────────────────────────────────────────────────────────────
+    // ── Outside-PNG-bounds dragging (issue #107) ──────────────────────────────
 
     [Fact]
-    public void Apply_ClampsToBitmapRight()
+    public void Apply_Move_AllowsNegativeLeft()
     {
-        // Move to the right by 200 — should be clamped at bitmapWidth=100
-        var result = DragHandleApplier.Apply(HandleKind.Move, 200f, 0f, Rect20x20, 100f, 100f);
-        Assert.True(result.Right <= 100f);
+        // Frame (20,20)→(80,80) dragged 30px left → Left should be -10, not clamped to 0.
+        var result = DragHandleApplier.Apply(HandleKind.Move, -30f, 0f, Rect20x20);
+        Assert.Equal(-10f, result.Left);
+        Assert.Equal(50f,  result.Right);  // width preserved
     }
 
     [Fact]
-    public void Apply_ClampsToBitmapBottom()
+    public void Apply_Move_AllowsFrameBeyondRightBoundary()
     {
-        var result = DragHandleApplier.Apply(HandleKind.Move, 0f, 200f, Rect20x20, 100f, 100f);
-        Assert.True(result.Bottom <= 100f);
+        // Frame (20,20)→(80,80) dragged 40px right → Right=120, not clamped to 100.
+        var result = DragHandleApplier.Apply(HandleKind.Move, 40f, 0f, Rect20x20);
+        Assert.Equal(60f,  result.Left);
+        Assert.Equal(120f, result.Right);
     }
 
     [Fact]
-    public void Apply_ClampsToZeroLeft()
+    public void Apply_Move_AllowsNegativeTop()
     {
-        var result = DragHandleApplier.Apply(HandleKind.Move, -200f, 0f, Rect20x20, 100f, 100f);
-        Assert.True(result.Left >= 0f);
+        // Frame (20,20)→(80,80) dragged 30px up → Top=-10, not clamped to 0.
+        var result = DragHandleApplier.Apply(HandleKind.Move, 0f, -30f, Rect20x20);
+        Assert.Equal(-10f, result.Top);
+        Assert.Equal(50f,  result.Bottom);
     }
+
+    [Fact]
+    public void Apply_MidLeft_AllowsNegativeLeft()
+    {
+        // Drag left edge 30px left from (20,20,80,80) → Left=-10.
+        var result = DragHandleApplier.Apply(HandleKind.MidLeft, -30f, 0f, Rect20x20);
+        Assert.Equal(-10f, result.Left);
+        Assert.Equal(80f,  result.Right);  // unchanged
+    }
+
+    [Fact]
+    public void Apply_MidRight_AllowsRightBeyondBitmapWidth()
+    {
+        // Drag right edge 30px right from (20,20,80,80) → Right=110.
+        var result = DragHandleApplier.Apply(HandleKind.MidRight, 30f, 0f, Rect20x20);
+        Assert.Equal(110f, result.Right);
+        Assert.Equal(20f,  result.Left);   // unchanged
+    }
+
+    [Fact]
+    public void Apply_TopCenter_AllowsNegativeTop()
+    {
+        // Drag top edge 30px up from (20,20,80,80) → Top=-10.
+        var result = DragHandleApplier.Apply(HandleKind.TopCenter, 0f, -30f, Rect20x20);
+        Assert.Equal(-10f, result.Top);
+        Assert.Equal(80f,  result.Bottom); // unchanged
+    }
+
+    [Fact]
+    public void Apply_BotCenter_AllowsBottomBeyondBitmapHeight()
+    {
+        // Drag bottom edge 30px down from (20,20,80,80) → Bottom=110.
+        var result = DragHandleApplier.Apply(HandleKind.BotCenter, 0f, 30f, Rect20x20);
+        Assert.Equal(110f, result.Bottom);
+        Assert.Equal(20f,  result.Top);    // unchanged
+    }
+
+    // ── Minimum-size enforcement ──────────────────────────────────────────────
 
     [Fact]
     public void Apply_EnforcesMinimumWidthOf1()
     {
         // Drag right edge far left to collapse width
-        var result = DragHandleApplier.Apply(HandleKind.MidRight, -200f, 0f, Rect20x20, 100f, 100f);
+        var result = DragHandleApplier.Apply(HandleKind.MidRight, -200f, 0f, Rect20x20);
         Assert.True(result.Right - result.Left >= 1f);
     }
 
@@ -196,7 +239,7 @@ public class DragHandleApplierTests
     public void Apply_EnforcesMinimumHeightOf1()
     {
         // Drag bottom edge far up to collapse height
-        var result = DragHandleApplier.Apply(HandleKind.BotCenter, 0f, -200f, Rect20x20, 100f, 100f);
+        var result = DragHandleApplier.Apply(HandleKind.BotCenter, 0f, -200f, Rect20x20);
         Assert.True(result.Bottom - result.Top >= 1f);
     }
 
@@ -225,7 +268,7 @@ public class DragHandleApplierTests
     [Fact]
     public void Apply_None_LeavesRectUnchanged()
     {
-        var result = DragHandleApplier.Apply(HandleKind.None, 50f, 50f, Rect20x20, 200f, 200f);
+        var result = DragHandleApplier.Apply(HandleKind.None, 50f, 50f, Rect20x20);
         Assert.Equal(Rect20x20, result);
     }
 
@@ -249,7 +292,7 @@ public class DragHandleApplierTests
         //      r = min(32, max(50,41)) = 32
         // Result: Left=40 > Right=32 → inverted rect.
         var result = DragHandleApplier.Apply(HandleKind.Move, 30f, 0f,
-            new BoundsRect(10f, 10f, 20f, 20f), 32f, 32f);
+            new BoundsRect(10f, 10f, 20f, 20f));
 
         Assert.True(result.Left <= result.Right,
             $"BUG: Rect is inverted after Move past right boundary. Left={result.Left}, Right={result.Right}");
@@ -264,7 +307,7 @@ public class DragHandleApplierTests
         //      r = min(32, max(-10,-19)) = min(32,-10) = -10
         // Result: Left=0 > Right=-10 → inverted rect.
         var result = DragHandleApplier.Apply(HandleKind.Move, -30f, 0f,
-            new BoundsRect(10f, 10f, 20f, 20f), 32f, 32f);
+            new BoundsRect(10f, 10f, 20f, 20f));
 
         Assert.True(result.Left <= result.Right,
             $"BUG: Rect is inverted after Move past left boundary. Left={result.Left}, Right={result.Right}");


### PR DESCRIPTION
Closes #107

Removes bitmap-bounds clamping so frame regions can have negative X/Y (left/top) and extend past the right/bottom edge of the source PNG.

**Changes:**
- DragHandleApplier.Apply: drop bitmapWidth/bitmapHeight params; Move returns unclamped nb; resize enforces min 1-pixel only
- WireframeControl: update call site
- MainWindow.axaml: PropPixelX/Y Minimum=-16384; TC controls range -10 to 10
- Tests: 7 new tests, 3 stale clamping tests removed, all call sites updated

✅ 696 tests pass