### PR TITLE
Snap to pixel on drag even without grid

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1506,9 +1506,9 @@ public class WireframeControl : Control
 
         var nb = DragHandleApplier.Apply(_draggingHandle, dx, dy, startBounds);
 
-        // Snap moved edges to the grid when the grid is enabled
-        if (_showGrid && _gridSize > 0)
-            nb = SnapBoundsToGrid(nb, _draggingHandle, _gridSize);
+        // Always snap to integer pixel; upgrade to grid-size snap when the grid is on.
+        int snapSize = (_showGrid && _gridSize > 0) ? _gridSize : 1;
+        nb = DragHandleApplier.SnapEdges(nb, _draggingHandle, snapSize);
 
         _draggingRect.Bounds = new SKRect(nb.Left, nb.Top, nb.Right, nb.Bottom);
 
@@ -1523,35 +1523,6 @@ public class WireframeControl : Control
         // Live update for the property panel (no save / tree refresh yet)
         FrameLiveUpdated?.Invoke(_draggingRect.Frame);
         InvalidateVisual();
-    }
-
-    /// <summary>
-    /// Snaps only the edges that <paramref name="handle"/> controls to the grid,
-    /// leaving unaffected edges unchanged.
-    /// </summary>
-    private static BoundsRect SnapBoundsToGrid(BoundsRect nb, HandleKind handle, int gridSize)
-    {
-        float Snap(float v) => MathF.Round(v / gridSize) * gridSize;
-
-        float l = nb.Left, t = nb.Top, r = nb.Right, b = nb.Bottom;
-        switch (handle)
-        {
-            case HandleKind.Move:
-                // Preserve size; snap top-left corner
-                float snappedL = Snap(l);
-                float snappedT = Snap(t);
-                return new BoundsRect(snappedL, snappedT,
-                                      snappedL + (r - l), snappedT + (b - t));
-            case HandleKind.TopLeft:   return new BoundsRect(Snap(l), Snap(t), r, b);
-            case HandleKind.TopCenter: return new BoundsRect(l, Snap(t), r, b);
-            case HandleKind.TopRight:  return new BoundsRect(l, Snap(t), Snap(r), b);
-            case HandleKind.MidLeft:   return new BoundsRect(Snap(l), t, r, b);
-            case HandleKind.MidRight:  return new BoundsRect(l, t, Snap(r), b);
-            case HandleKind.BotLeft:   return new BoundsRect(Snap(l), t, r, Snap(b));
-            case HandleKind.BotCenter: return new BoundsRect(l, t, r, Snap(b));
-            case HandleKind.BotRight:  return new BoundsRect(l, t, Snap(r), Snap(b));
-            default:                   return nb;
-        }
     }
 
     private void UpdatePreview(Point pos)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
@@ -55,6 +55,40 @@ public static class DragHandleApplier
     }
 
     /// <summary>
+    /// Snaps only the edges that <paramref name="handle"/> controls to the nearest
+    /// multiple of <paramref name="snapSize"/>, leaving unaffected edges unchanged.
+    /// Pass <paramref name="snapSize"/> = 1 to snap to integer pixels.
+    /// When <paramref name="snapSize"/> is ≤ 0 the bounds are returned unchanged.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="HandleKind.Move"/> the top-left corner is snapped and the
+    /// original width/height is preserved so the frame does not drift in size.
+    /// </remarks>
+    public static BoundsRect SnapEdges(BoundsRect bounds, HandleKind handle, int snapSize)
+    {
+        if (snapSize <= 0) return bounds;
+
+        float Snap(float v) => MathF.Round(v / snapSize) * snapSize;
+
+        float l = bounds.Left, t = bounds.Top, r = bounds.Right, b = bounds.Bottom;
+        return handle switch
+        {
+            HandleKind.Move =>
+                // Preserve size; snap top-left corner only.
+                new BoundsRect(Snap(l), Snap(t), Snap(l) + (r - l), Snap(t) + (b - t)),
+            HandleKind.TopLeft   => new BoundsRect(Snap(l), Snap(t), r, b),
+            HandleKind.TopCenter => new BoundsRect(l, Snap(t), r, b),
+            HandleKind.TopRight  => new BoundsRect(l, Snap(t), Snap(r), b),
+            HandleKind.MidLeft   => new BoundsRect(Snap(l), t, r, b),
+            HandleKind.MidRight  => new BoundsRect(l, t, Snap(r), b),
+            HandleKind.BotLeft   => new BoundsRect(Snap(l), t, r, Snap(b)),
+            HandleKind.BotCenter => new BoundsRect(l, t, r, Snap(b)),
+            HandleKind.BotRight  => new BoundsRect(l, t, Snap(r), Snap(b)),
+            _                    => bounds,
+        };
+    }
+
+    /// <summary>
     /// Converts texture-pixel bounds to UV coordinates (0…1 relative to bitmap dimensions).
     /// Returns (left, top, right, bottom) UV tuple.
     /// </summary>

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
@@ -272,6 +272,65 @@ public class DragHandleApplierTests
         Assert.Equal(Rect20x20, result);
     }
 
+    // ── SnapEdges – pixel snap (snapSize = 1) ────────────────────────────────
+
+    [Fact]
+    public void SnapEdges_Move_SnapsTopLeftToNearestPixelAndPreservesSize()
+    {
+        // Left=20.7, Top=30.3, width=60, height=70
+        // → snapL=21, snapT=30, R=21+60=81, B=30+70=100
+        var input = new BoundsRect(20.7f, 30.3f, 80.7f, 100.3f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.Move, 1);
+        Assert.Equal(21f,  result.Left);
+        Assert.Equal(30f,  result.Top);
+        Assert.Equal(81f,  result.Right);
+        Assert.Equal(100f, result.Bottom);
+    }
+
+    [Fact]
+    public void SnapEdges_MidRight_SnapsRightEdgeOnly()
+    {
+        var input = new BoundsRect(20f, 30f, 80.7f, 100f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.MidRight, 1);
+        Assert.Equal(20f,  result.Left);    // unchanged
+        Assert.Equal(30f,  result.Top);     // unchanged
+        Assert.Equal(81f,  result.Right);   // round(80.7) = 81
+        Assert.Equal(100f, result.Bottom);  // unchanged
+    }
+
+    [Fact]
+    public void SnapEdges_TopCenter_SnapsTopEdgeOnly()
+    {
+        var input = new BoundsRect(20f, 30.6f, 80f, 100f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.TopCenter, 1);
+        Assert.Equal(20f,  result.Left);
+        Assert.Equal(31f,  result.Top);    // round(30.6) = 31
+        Assert.Equal(80f,  result.Right);
+        Assert.Equal(100f, result.Bottom);
+    }
+
+    [Fact]
+    public void SnapEdges_GridSize16_SnapsToGridMultiple()
+    {
+        // TopLeft handle: only Left and Top get snapped
+        // round(20.7/16)*16 = round(1.29)*16 = 16
+        // round(30.3/16)*16 = round(1.89)*16 = 32
+        var input = new BoundsRect(20.7f, 30.3f, 80.7f, 100.3f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.TopLeft, 16);
+        Assert.Equal(16f,    result.Left);
+        Assert.Equal(32f,    result.Top);
+        Assert.Equal(80.7f,  result.Right);   // unchanged
+        Assert.Equal(100.3f, result.Bottom);  // unchanged
+    }
+
+    [Fact]
+    public void SnapEdges_SnapSizeZeroOrNegative_ReturnsUnchanged()
+    {
+        var input = new BoundsRect(20.7f, 30.3f, 80.7f, 100.3f);
+        Assert.Equal(input, DragHandleApplier.SnapEdges(input, HandleKind.Move, 0));
+        Assert.Equal(input, DragHandleApplier.SnapEdges(input, HandleKind.Move, -1));
+    }
+
     // ── Move handle boundary clamping bug ─────────────────────────────────────
     //
     // BUG: when a Move drag carries the entire frame past the right or left


### PR DESCRIPTION
Fixes #112

## Problem
When no grid was checked, dragging to resize or reposition a frame could land on sub-pixel (fractional) coordinates. Only grid mode snapped to whole numbers.

## Fix
- Extracted DragHandleApplier.SnapEdges(bounds, handle, snapSize) into Core — pure snap math that snaps only the handle-controlled edges to the nearest multiple of snapSize.
- ApplyHandleDrag in WireframeControl now **always** snaps with snapSize = 1 (integer pixel) when no grid is active, or snapSize = gridSize when grid is on.
- Removed private SnapBoundsToGrid from WireframeControl (logic lives in Core now).

## Tests
5 new unit tests in DragHandleApplierTests covering pixel-snap and grid-snap via SnapEdges. 701 Core tests pass (up from 696).

Closes #112