### PR TITLE
Move resize handles outside selected frame bounds

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -193,9 +193,10 @@ public class WireframeControl : Control
                 canvas.DrawLine(textureDest.Left, y, textureDest.Right, y, paint);
         }
 
+        private const float Hs = 5f;  // Handle half-size: handles are drawn this far outside the frame edge
+
         private static void DrawHandles(SKCanvas canvas, SKRect sr)
         {
-            const float Hs = 5f;
             using var fill = new SKPaint { Color = SKColors.White, Style = SKPaintStyle.Fill };
             using var stroke = new SKPaint { Color = SKColors.DodgerBlue, Style = SKPaintStyle.Stroke, StrokeWidth = 1f };
 
@@ -210,14 +211,14 @@ public class WireframeControl : Control
         private static IEnumerable<SKPoint> HandlePoints(SKRect r)
         {
             float cx = r.MidX, cy = r.MidY;
-            yield return new SKPoint(r.Left, r.Top);
-            yield return new SKPoint(cx, r.Top);
-            yield return new SKPoint(r.Right, r.Top);
-            yield return new SKPoint(r.Left, cy);
-            yield return new SKPoint(r.Right, cy);
-            yield return new SKPoint(r.Left, r.Bottom);
-            yield return new SKPoint(cx, r.Bottom);
-            yield return new SKPoint(r.Right, r.Bottom);
+            yield return new SKPoint(r.Left  - Hs, r.Top    - Hs);  // TopLeft
+            yield return new SKPoint(cx,           r.Top    - Hs);  // TopCenter
+            yield return new SKPoint(r.Right + Hs, r.Top    - Hs);  // TopRight
+            yield return new SKPoint(r.Left  - Hs, cy);             // MidLeft
+            yield return new SKPoint(r.Right + Hs, cy);             // MidRight
+            yield return new SKPoint(r.Left  - Hs, r.Bottom + Hs);  // BotLeft
+            yield return new SKPoint(cx,           r.Bottom + Hs);  // BotCenter
+            yield return new SKPoint(r.Right + Hs, r.Bottom + Hs);  // BotRight
         }
 
         private static SKRect ToScreen(SKRect r, RenderSnapshot s)
@@ -1562,7 +1563,8 @@ public class WireframeControl : Control
 
         var kind = DragHandleHitTester.GetHandleAt(
             (float)pos.X, (float)pos.Y,
-            sr.Left, sr.Top, sr.Right, sr.Bottom);
+            sr.Left, sr.Top, sr.Right, sr.Bottom,
+            handleOffset: 5f);  // matches Hs: handles drawn outside the frame by this amount
 
         return kind == HandleKind.None ? (null, HandleKind.None) : (sel, kind);
     }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleHitTester.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleHitTester.cs
@@ -19,24 +19,29 @@ public static class DragHandleHitTester
     /// <param name="right">Right edge of the rectangle in screen space.</param>
     /// <param name="bottom">Bottom edge of the rectangle in screen space.</param>
     /// <param name="hitRadius">Half-size of the hit area around each handle point.</param>
+    /// <param name="handleOffset">
+    /// Distance each handle center is pushed outward from the frame edge.
+    /// Pass the same value used when drawing the handles so hit-testing aligns with rendering.
+    /// </param>
     public static HandleKind GetHandleAt(
         float ptX, float ptY,
         float left, float top, float right, float bottom,
-        float hitRadius = 7f)
+        float hitRadius = 7f,
+        float handleOffset = 0f)
     {
         float cx = (left + right)  / 2f;
         float cy = (top  + bottom) / 2f;
 
         (float X, float Y, HandleKind Kind)[] handles =
         {
-            (left,  top,    HandleKind.TopLeft),
-            (cx,    top,    HandleKind.TopCenter),
-            (right, top,    HandleKind.TopRight),
-            (left,  cy,     HandleKind.MidLeft),
-            (right, cy,     HandleKind.MidRight),
-            (left,  bottom, HandleKind.BotLeft),
-            (cx,    bottom, HandleKind.BotCenter),
-            (right, bottom, HandleKind.BotRight),
+            (left  - handleOffset, top    - handleOffset, HandleKind.TopLeft),
+            (cx,                   top    - handleOffset, HandleKind.TopCenter),
+            (right + handleOffset, top    - handleOffset, HandleKind.TopRight),
+            (left  - handleOffset, cy,                   HandleKind.MidLeft),
+            (right + handleOffset, cy,                   HandleKind.MidRight),
+            (left  - handleOffset, bottom + handleOffset, HandleKind.BotLeft),
+            (cx,                   bottom + handleOffset, HandleKind.BotCenter),
+            (right + handleOffset, bottom + handleOffset, HandleKind.BotRight),
         };
 
         foreach (var (hx, hy, kind) in handles)

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
@@ -60,11 +60,12 @@ public class WireframeHandlesAndBorderTests
     // ── Wireframe resize handles ──────────────────────────────────────────────
 
     /// <summary>
-    /// When a frame is selected the top-left handle box (centred at screen (0,0)
-    /// for a full-texture frame at camera(0,0,1)) fills pixels near (2,2) white.
+    /// When a frame is selected the top-left handle box sits OUTSIDE the frame bounds (issue #114).
+    /// Frame at UV 0.125→0.875 on a 64×64 texture → screen rect (8,8,56,56) at camera(0,0,1).
+    /// TopLeft handle centre = (8−5, 8−5) = (3, 3); pixel (3,3) should be white.
     /// </summary>
     [AvaloniaFact]
-    public void WireframeHandles_SelectedFrame_WhiteHandlePixel_AtTopLeftCornerInterior()
+    public void WireframeHandles_SelectedFrame_TopLeftHandleIsOutsideFrame()
     {
         ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -73,40 +74,47 @@ public class WireframeHandlesAndBorderTests
         {
             var png = WriteSolidPng(dir, SKColors.Black);
 
-            // Full-texture frame (UV 0→1)
+            // Inner frame: UV 0.125→0.875 (8px margin on 64×64 texture)
             var frame = new AnimationFrameSave
             {
                 TextureName = png, FrameLength = 0.1f,
-                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                LeftCoordinate = 0.125f, TopCoordinate = 0.125f,
+                RightCoordinate = 0.875f, BottomCoordinate = 0.875f,
                 ShapeCollectionSave = new ShapeCollectionSave()
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
             ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
-            SelectedState.Self.SelectedFrame = frame;   // ← frame is SELECTED
+            SelectedState.Self.SelectedFrame = frame;
 
             var ctrl = new WireframeControl();
             ctrl.LoadTexture(png);
             ctrl.RefreshFrames();
-            ctrl.SetCamera(0, 0, 1);  // texture fills (0,0,64,64); TL handle centred at (0,0)
+            ctrl.SetCamera(0, 0, 1);  // screen rect = (8,8,56,56); TL handle at (3,3)
 
             using var bm = ctrl.RenderToBitmap(64, 64);
 
-            // Handle box at TL: SKRect(-5,-5,5,5) → interior at (2,2) is white fill
-            var px = bm.GetPixel(2, 2);
+            // TopLeft handle: centre (3,3), box (-2,-2,8,8) → pixel (3,3) is white fill
+            var px = bm.GetPixel(3, 3);
             Assert.True(px.Red > 200 && px.Green > 200 && px.Blue > 200,
-                $"Top-left handle interior (2,2) should be white; R={px.Red} G={px.Green} B={px.Blue}");
+                $"Top-left handle (3,3) should be white (outside frame); R={px.Red} G={px.Green} B={px.Blue}");
+
+            // Frame interior corner at (9,9) should be black texture (no handle overlap)
+            var interior = bm.GetPixel(9, 9);
+            Assert.True(interior.Red < 100 && interior.Green < 100 && interior.Blue < 100,
+                $"Frame interior (9,9) should be black texture, not handle; R={interior.Red} G={interior.Green} B={interior.Blue}");
         }
         finally { Directory.Delete(dir, recursive: true); }
     }
 
     /// <summary>
-    /// The middle-left handle is centred at screen (0, 32) for a full-texture
-    /// frame at camera(0,0,1) on a 64×64 canvas.  Pixel (2, 32) should be white.
+    /// The middle-left handle sits outside the frame bounds (issue #114).
+    /// Frame at UV 0.125→0.875 on 64×64 → screen rect (8,8,56,56).
+    /// MidLeft handle centre = (8−5, 32) = (3, 32); pixel (3,32) should be white.
     /// </summary>
     [AvaloniaFact]
-    public void WireframeHandles_SelectedFrame_WhiteHandlePixel_AtMiddleLeftInterior()
+    public void WireframeHandles_SelectedFrame_MidLeftHandleIsOutsideFrame()
     {
         ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -118,7 +126,8 @@ public class WireframeHandlesAndBorderTests
             var frame = new AnimationFrameSave
             {
                 TextureName = png, FrameLength = 0.1f,
-                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                LeftCoordinate = 0.125f, TopCoordinate = 0.125f,
+                RightCoordinate = 0.875f, BottomCoordinate = 0.875f,
                 ShapeCollectionSave = new ShapeCollectionSave()
             };
             var chain = new AnimationChainSave { Name = "Test" };
@@ -134,10 +143,10 @@ public class WireframeHandlesAndBorderTests
 
             using var bm = ctrl.RenderToBitmap(64, 64);
 
-            // ML handle centred at (0,32): box (-5,27,5,37) → pixel (2,32) white
-            var px = bm.GetPixel(2, 32);
+            // MidLeft handle: centre (3, 32), box (-2,27,8,37) → pixel (3,32) is white fill
+            var px = bm.GetPixel(3, 32);
             Assert.True(px.Red > 200 && px.Green > 200 && px.Blue > 200,
-                $"Middle-left handle interior (2,32) should be white; R={px.Red} G={px.Green} B={px.Blue}");
+                $"Mid-left handle (3,32) should be white (outside frame); R={px.Red} G={px.Green} B={px.Blue}");
         }
         finally { Directory.Delete(dir, recursive: true); }
     }
@@ -186,6 +195,7 @@ public class WireframeHandlesAndBorderTests
     /// <summary>
     /// Selecting a frame and then deselecting it (setting SelectedFrame = null)
     /// should make the handles disappear on the next render.
+    /// Uses UV 0.125→0.875 so the TopLeft handle lands at (3,3) within a 64×64 canvas.
     /// </summary>
     [AvaloniaFact]
     public void WireframeHandles_SelectThenDeselect_HandleDisappears()
@@ -197,10 +207,12 @@ public class WireframeHandlesAndBorderTests
         {
             var png = WriteSolidPng(dir, SKColors.Black);
 
+            // Inner frame: handles land inside the 64×64 canvas (TL handle at (3,3))
             var frame = new AnimationFrameSave
             {
                 TextureName = png, FrameLength = 0.1f,
-                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                LeftCoordinate = 0.125f, TopCoordinate = 0.125f,
+                RightCoordinate = 0.875f, BottomCoordinate = 0.875f,
                 ShapeCollectionSave = new ShapeCollectionSave()
             };
             var chain = new AnimationChainSave { Name = "Test" };
@@ -212,11 +224,11 @@ public class WireframeHandlesAndBorderTests
             ctrl.LoadTexture(png);
             ctrl.SetCamera(0, 0, 1);
 
-            // Select frame → handles visible
+            // Select frame → TopLeft handle visible at (3,3)
             SelectedState.Self.SelectedFrame = frame;
             ctrl.RefreshFrames();
             using var bmSelected = ctrl.RenderToBitmap(64, 64);
-            var pxSelected = bmSelected.GetPixel(2, 2);
+            var pxSelected = bmSelected.GetPixel(3, 3);
             Assert.True(pxSelected.Red > 200,
                 $"Handle should be visible when frame selected; R={pxSelected.Red}");
 
@@ -224,7 +236,7 @@ public class WireframeHandlesAndBorderTests
             SelectedState.Self.SelectedFrame = null;
             ctrl.RefreshFrames();
             using var bmDeselected = ctrl.RenderToBitmap(64, 64);
-            var pxDeselected = bmDeselected.GetPixel(2, 2);
+            var pxDeselected = bmDeselected.GetPixel(3, 3);
             Assert.True(pxDeselected.Red < 100,
                 $"Handle should vanish when frame deselected; R={pxDeselected.Red}");
         }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
@@ -101,6 +101,49 @@ public class DragHandleHitTesterTests
         // all handles coincide at (50,50); TopLeft is checked first
         Assert.NotEqual(HandleKind.None, result);
     }
+
+    // ── Handle offset (issue #114: handles sit outside the frame) ─────────────
+
+    [Fact]
+    public void GetHandleAt_WithHandleOffset_TopLeftHandleIsOutsideFrameBounds()
+    {
+        // With handleOffset=5, TopLeft moves from (10,10) to (5,5).
+        // Clicking at (3,3) is outside the frame AND within hitRadius(7) of (5,5).
+        var result = DragHandleHitTester.GetHandleAt(3f, 3f, 10f, 10f, 110f, 110f, handleOffset: 5f);
+        Assert.Equal(HandleKind.TopLeft, result);
+    }
+
+    [Fact]
+    public void GetHandleAt_WithHandleOffset_BotRightHandleIsOutsideFrameBounds()
+    {
+        // With handleOffset=5, BotRight moves from (110,110) to (115,115).
+        var result = DragHandleHitTester.GetHandleAt(115f, 115f, 10f, 10f, 110f, 110f, handleOffset: 5f);
+        Assert.Equal(HandleKind.BotRight, result);
+    }
+
+    [Fact]
+    public void GetHandleAt_WithHandleOffset_TopCenterHandleIsAboveFrame()
+    {
+        // With handleOffset=5, TopCenter moves from (60,10) to (60,5).
+        var result = DragHandleHitTester.GetHandleAt(60f, 3f, 10f, 10f, 110f, 110f, handleOffset: 5f);
+        Assert.Equal(HandleKind.TopCenter, result);
+    }
+
+    [Fact]
+    public void GetHandleAt_WithHandleOffset_MidLeftHandleIsLeftOfFrame()
+    {
+        // With handleOffset=5, MidLeft moves from (10,60) to (5,60).
+        var result = DragHandleHitTester.GetHandleAt(3f, 60f, 10f, 10f, 110f, 110f, handleOffset: 5f);
+        Assert.Equal(HandleKind.MidLeft, result);
+    }
+
+    [Fact]
+    public void GetHandleAt_WithHandleOffset_FrameInteriorIsStillMove()
+    {
+        // With handleOffset=5, clicking inside the frame body still gives Move.
+        var result = DragHandleHitTester.GetHandleAt(60f, 60f, 10f, 10f, 110f, 110f, handleOffset: 5f);
+        Assert.Equal(HandleKind.Move, result);
+    }
 }
 
 [Collection("SequentialSingletons")]


### PR DESCRIPTION
Handles were previously centered exactly on the frame edges. This PR moves them to sit outside the frame by their draw half-size (5px), matching the Gum editor behavior.

## Changes
- \DragHandleHitTester.GetHandleAt\: new \handleOffset\ parameter (default \