### PR TITLE
Remove Unicode icons from Play/Pause/Stop buttons and EM dash from About dialog

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -248,22 +248,7 @@
                                     Margin="0,0,0,0"
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Zoom out to previous preset" />
-                            <Separator Margin="8,0" />
-                            <Button x:Name="StopBtn" Content="Stop" Height="24"
-                                    Padding="6,0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Margin="0,0,2,0" ToolTip.Tip="Stop / Reset" />
-                            <Button x:Name="PlayBtn" Content="Play" Height="24"
-                                    Padding="6,0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Margin="0,0,2,0" ToolTip.Tip="Play" />
-                            <Button x:Name="PauseBtn" Content="Pause" Height="24"
-                                    Padding="6,0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Margin="0,0,12,0" ToolTip.Tip="Pause" />
+
                             <TextBlock Text="Speed:" VerticalAlignment="Center"
                                        Margin="0,0,4,0" Foreground="LightGray" />
                             <TextBox x:Name="SpeedInput"

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -249,18 +249,18 @@
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Zoom out to previous preset" />
                             <Separator Margin="8,0" />
-                            <Button x:Name="StopBtn" Content="⏹" Width="28" Height="24"
-                                    Padding="0"
+                            <Button x:Name="StopBtn" Content="Stop" Height="24"
+                                    Padding="6,0"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Margin="0,0,2,0" ToolTip.Tip="Stop / Reset" />
-                            <Button x:Name="PlayBtn" Content="▶" Width="28" Height="24"
-                                    Padding="0"
+                            <Button x:Name="PlayBtn" Content="Play" Height="24"
+                                    Padding="6,0"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Margin="0,0,2,0" ToolTip.Tip="Play" />
-                            <Button x:Name="PauseBtn" Content="⏸" Width="28" Height="24"
-                                    Padding="0"
+                            <Button x:Name="PauseBtn" Content="Pause" Height="24"
+                                    Padding="6,0"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Margin="0,0,12,0" ToolTip.Tip="Pause" />

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -521,7 +521,7 @@ public partial class MainWindow : Window
             Height = 130,
             Content = new TextBlock
             {
-                Text = "AnimationEditor — Avalonia Port\n© FlatRedBall Contributors",
+                Text = "AnimationEditor: Avalonia Port\n© FlatRedBall Contributors",
                 Margin = new Avalonia.Thickness(16),
                 TextWrapping = Avalonia.Media.TextWrapping.Wrap
             }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1505,9 +1505,6 @@ public partial class MainWindow : Window
 
     private void WirePlaybackControls()
     {
-        StopBtn.Click  += (_, _) => PreviewCtrl.StopPlayback();
-        PlayBtn.Click  += (_, _) => PreviewCtrl.Play();
-        PauseBtn.Click += (_, _) => PreviewCtrl.Pause();
         SpeedInput.LostFocus += (_, _) => ApplySpeedFromInput();
         SpeedUpBtn.Click   += (_, _) =>
         {


### PR DESCRIPTION
Closes #117

## Changes

- **Play/Pause/Stop buttons**: Replaced Unicode icons with plain text labels (Stop, Play, Pause).
- **About dialog**: Replaced the EM dash with a colon.