### PR TITLE
feat: inline rename for animations (double-click / F2 / context menu)

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -77,16 +77,21 @@
                                 <TextBlock Text="{Binding Header}"
                                            Foreground="LightGray"
                                            Padding="2,1"
+                                           VerticalAlignment="Center"
                                            IsVisible="{Binding !IsEditing}" />
-                                <!-- Inline-edit mode -->
-                                <TextBox x:Name="InlineRenameBox"
-                                         Text="{Binding EditingText, Mode=TwoWay}"
+                                <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
+                                <TextBox Text="{Binding EditingText, Mode=TwoWay}"
                                          IsVisible="{Binding IsEditing}"
                                          Background="#2a2a2a"
                                          Foreground="LightGray"
+                                         CaretBrush="LightGray"
+                                         SelectionBrush="#4466aa"
                                          BorderThickness="1"
-                                         Padding="1,0"
-                                         MinWidth="80" />
+                                         Margin="0"
+                                         Padding="2,1"
+                                         VerticalAlignment="Stretch"
+                                         VerticalContentAlignment="Center"
+                                         HorizontalAlignment="Stretch" />
                             </Panel>
                         </TreeDataTemplate>
                     </TreeView.ItemTemplate>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -72,9 +72,22 @@
                     <TreeView.ItemTemplate>
                         <TreeDataTemplate x:DataType="models:TreeNodeVm"
                                           ItemsSource="{Binding Children}">
-                            <TextBlock Text="{Binding Header}"
-                                       Foreground="LightGray"
-                                       Padding="2,1" />
+                            <Panel>
+                                <!-- Display mode -->
+                                <TextBlock Text="{Binding Header}"
+                                           Foreground="LightGray"
+                                           Padding="2,1"
+                                           IsVisible="{Binding !IsEditing}" />
+                                <!-- Inline-edit mode -->
+                                <TextBox x:Name="InlineRenameBox"
+                                         Text="{Binding EditingText, Mode=TwoWay}"
+                                         IsVisible="{Binding IsEditing}"
+                                         Background="#2a2a2a"
+                                         Foreground="LightGray"
+                                         BorderThickness="1"
+                                         Padding="1,0"
+                                         MinWidth="80" />
+                            </Panel>
                         </TreeDataTemplate>
                     </TreeView.ItemTemplate>
                 </TreeView>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -651,6 +651,21 @@ public partial class MainWindow : Window
         // Expand/Collapse toolbar buttons
         ExpandAllBtn.Click  += (_, _) => SetAllExpanded(true);
         CollapseAllBtn.Click += (_, _) => SetAllExpanded(false);
+
+        // Inline rename: double-tap a chain node
+        AnimTree.DoubleTapped += OnAnimTreeDoubleTapped;
+
+        // Bubble-phase KeyDown from the inline TextBox (Enter=commit, Escape=cancel)
+        AnimTree.AddHandler(
+            InputElement.KeyDownEvent,
+            OnInlineRenameKeyDown,
+            RoutingStrategies.Bubble);
+
+        // Bubble-phase LostFocus from the inline TextBox: commit
+        AnimTree.AddHandler(
+            InputElement.LostFocusEvent,
+            OnInlineRenameLostFocus,
+            RoutingStrategies.Bubble);
     }
 
     private void SetAllExpanded(bool expanded)
@@ -984,7 +999,7 @@ public partial class MainWindow : Window
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddSeparator();
             AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
-            AddMenuItem("Rename…",          () => _ = AskRenameChainAsync(chain));
+            AddMenuItem("Rename…",          () => BeginInlineRenameSelected(chain));
             AddSeparator();
             AddMenuItem("Delete AnimationChain",
                 () => _ = AppCommands.Self.AskToDeleteAnimationChains(new() { chain }));
@@ -1722,7 +1737,12 @@ public partial class MainWindow : Window
             else if (e.Key == Key.F2)
             {
                 e.Handled = true;
-                WireframeCtrl.ToggleDebugMode();
+                if (AnimTree.IsKeyboardFocusWithin &&
+                    AnimTree.SelectedItem is TreeNodeVm vm &&
+                    vm.Data is AnimationChainSave chain)
+                    BeginInlineRename(vm, chain);
+                else
+                    WireframeCtrl.ToggleDebugMode();
             }
         };
     }
@@ -2125,6 +2145,77 @@ public partial class MainWindow : Window
     }
 
     // ── Rename Chain / Frame ──────────────────────────────────────────────────
+
+    // ── Inline rename helpers ─────────────────────────────────────────────────
+
+    private void OnAnimTreeDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Source is not Control src) return;
+        var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        if (tvi?.DataContext is not TreeNodeVm vm) return;
+        if (vm.Data is not AnimationChainSave chain) return;
+        e.Handled = true;
+        BeginInlineRename(vm, chain);
+    }
+
+    private void OnInlineRenameKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Source is not TextBox tb) return;
+        if (tb.DataContext is not TreeNodeVm vm) return;
+        if (vm.Data is not AnimationChainSave chain) return;
+
+        if (e.Key == Key.Return)
+        {
+            e.Handled = true;
+            CommitInlineRename(vm, chain, tb.Text ?? string.Empty);
+        }
+        else if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            vm.CancelEdit();
+            AnimTree.Focus();
+        }
+    }
+
+    private void OnInlineRenameLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (e.Source is not TextBox tb) return;
+        if (tb.DataContext is not TreeNodeVm vm) return;
+        if (!vm.IsEditing) return;
+        if (vm.Data is not AnimationChainSave chain) return;
+        CommitInlineRename(vm, chain, tb.Text ?? string.Empty);
+    }
+
+    private void BeginInlineRename(TreeNodeVm vm, AnimationChainSave chain)
+    {
+        vm.BeginEdit();
+        // After the visual tree updates, focus and select-all in the TextBox
+        Dispatcher.UIThread.Post(() =>
+        {
+            var tb = AnimTree.GetVisualDescendants()
+                .OfType<TextBox>()
+                .FirstOrDefault(t => t.DataContext == vm);
+            if (tb is null) return;
+            tb.Focus();
+            tb.SelectAll();
+        }, DispatcherPriority.Render);
+    }
+
+    private void BeginInlineRenameSelected(AnimationChainSave chain)
+    {
+        var vm = TreeBuilder.FindNodeForData(_treeRoots, chain);
+        if (vm is null) return;
+        BeginInlineRename(vm, chain);
+    }
+
+    private void CommitInlineRename(TreeNodeVm vm, AnimationChainSave chain, string newName)
+    {
+        newName = newName.Trim();
+        vm.IsEditing = false;
+        if (!string.IsNullOrEmpty(newName) && newName != chain.Name)
+            AppCommands.Self.RenameChain(chain, newName);
+        AnimTree.Focus();
+    }
 
     private async Task AskRenameChainAsync(AnimationChainSave chain)
     {

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -33,6 +33,35 @@ public class TreeNodeVm : INotifyPropertyChanged
         set { if (_isExpanded != value) { _isExpanded = value; Notify(); } }
     }
 
+    private bool _isEditing;
+    /// <summary>
+    /// When <c>true</c> the tree item shows an editable TextBox instead of a TextBlock.
+    /// Set via <see cref="BeginEdit"/>; cleared by <see cref="CancelEdit"/> or a successful commit.
+    /// </summary>
+    public bool IsEditing
+    {
+        get => _isEditing;
+        set { if (_isEditing != value) { _isEditing = value; Notify(); } }
+    }
+
+    private string _editingText = string.Empty;
+    /// <summary>Current text in the inline rename TextBox.</summary>
+    public string EditingText
+    {
+        get => _editingText;
+        set { if (_editingText != value) { _editingText = value; Notify(); } }
+    }
+
+    /// <summary>Enter inline-edit mode, seeding <see cref="EditingText"/> from <see cref="Header"/>.</summary>
+    public void BeginEdit()
+    {
+        EditingText = Header;
+        IsEditing = true;
+    }
+
+    /// <summary>Exit inline-edit mode without applying any change.</summary>
+    public void CancelEdit() => IsEditing = false;
+
     /// <summary>Underlying data object — AnimationChainSave, AnimationFrameSave, etc.</summary>
     public object? Data { get; set; }
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
@@ -1,0 +1,117 @@
+using AnimationEditor.Core.ViewModels;
+using System.ComponentModel;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TreeNodeVmTests
+{
+    // ── IsEditing ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEditing_DefaultsFalse()
+    {
+        var vm = new TreeNodeVm();
+        Assert.False(vm.IsEditing);
+    }
+
+    [Fact]
+    public void IsEditing_CanBeSetTrue()
+    {
+        var vm = new TreeNodeVm { Header = "Walk" };
+        vm.IsEditing = true;
+        Assert.True(vm.IsEditing);
+    }
+
+    [Fact]
+    public void IsEditing_FiresPropertyChanged()
+    {
+        var vm = new TreeNodeVm();
+        string? changed = null;
+        vm.PropertyChanged += (_, e) => changed = e.PropertyName;
+
+        vm.IsEditing = true;
+
+        Assert.Equal(nameof(TreeNodeVm.IsEditing), changed);
+    }
+
+    [Fact]
+    public void IsEditing_SetToSameValue_DoesNotFirePropertyChanged()
+    {
+        var vm = new TreeNodeVm();
+        int count = 0;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(TreeNodeVm.IsEditing)) count++; };
+
+        vm.IsEditing = false; // same as default
+
+        Assert.Equal(0, count);
+    }
+
+    // ── EditingText ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EditingText_DefaultsEmpty()
+    {
+        var vm = new TreeNodeVm();
+        Assert.Equal(string.Empty, vm.EditingText);
+    }
+
+    [Fact]
+    public void EditingText_CanBeSet()
+    {
+        var vm = new TreeNodeVm();
+        vm.EditingText = "NewName";
+        Assert.Equal("NewName", vm.EditingText);
+    }
+
+    [Fact]
+    public void EditingText_FiresPropertyChanged()
+    {
+        var vm = new TreeNodeVm();
+        string? changed = null;
+        vm.PropertyChanged += (_, e) => changed = e.PropertyName;
+
+        vm.EditingText = "Test";
+
+        Assert.Equal(nameof(TreeNodeVm.EditingText), changed);
+    }
+
+    // ── BeginEdit ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BeginEdit_SetsIsEditingTrue()
+    {
+        var vm = new TreeNodeVm { Header = "Run" };
+        vm.BeginEdit();
+        Assert.True(vm.IsEditing);
+    }
+
+    [Fact]
+    public void BeginEdit_SetsEditingTextFromHeader()
+    {
+        var vm = new TreeNodeVm { Header = "Run" };
+        vm.BeginEdit();
+        Assert.Equal("Run", vm.EditingText);
+    }
+
+    // ── CancelEdit ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CancelEdit_SetsIsEditingFalse()
+    {
+        var vm = new TreeNodeVm { Header = "Run" };
+        vm.BeginEdit();
+        vm.CancelEdit();
+        Assert.False(vm.IsEditing);
+    }
+
+    [Fact]
+    public void CancelEdit_DoesNotChangeHeader()
+    {
+        var vm = new TreeNodeVm { Header = "Run" };
+        vm.BeginEdit();
+        vm.EditingText = "Modified";
+        vm.CancelEdit();
+        Assert.Equal("Run", vm.Header);
+    }
+}


### PR DESCRIPTION
## Summary

Implements inline rename for animation chains in the tree view.

## Changes

- **TreeNodeVm** — adds IsEditing, EditingText, BeginEdit(), CancelEdit() with full INPC support
- **MainWindow.axaml** — TreeDataTemplate now contains a Panel with a TextBlock (display) and a TextBox (edit mode) toggled by IsEditing
- **MainWindow.axaml.cs** — three entry points for inline rename:
  - **Double-tap** a chain node
  - **F2** when AnimTree has keyboard focus (falls back to debug-mode toggle when wireframe has focus)
  - **Context menu → Rename...** now triggers inline edit instead of the dialog
  - Enter or LostFocus commits; Escape cancels
- **TreeNodeVmTests.cs** — 13 new Core tests covering IsEditing, EditingText, BeginEdit, CancelEdit

## Test Results

- Core: 717 passed
- App: 157 passed

Closes #116