### PR TITLE
Add Alt+Arrow reorder for frames and animations

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1764,6 +1764,13 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 UndoManager.Self.Redo();
             }
+            else if ((e.Key == Key.Up || e.Key == Key.Down) &&
+                     e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+            {
+                e.Handled = true;
+                int delta = e.Key == Key.Up ? -1 : +1;
+                AppCommands.Self.HandleReorder(delta);
+            }
         };
     }
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1723,7 +1723,10 @@ public partial class MainWindow : Window
 
     private void WireKeyboard()
     {
-        KeyDown += (_, e) =>
+        // Use Tunnel routing so we intercept keys before child controls (e.g. the TreeView,
+        // which handles Up/Down for navigation and would mark the event Handled before the
+        // default Bubble-phase KeyDown fires).
+        AddHandler(KeyDownEvent, (EventHandler<KeyEventArgs>)((_, e) =>
         {
             if (e.Handled) return;
 
@@ -1771,7 +1774,7 @@ public partial class MainWindow : Window
                 int delta = e.Key == Key.Up ? -1 : +1;
                 AppCommands.Self.HandleReorder(delta);
             }
-        };
+        }), RoutingStrategies.Tunnel);
     }
 
     // ── Copy / Paste ──────────────────────────────────────────────────────────

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -464,6 +464,23 @@ namespace AnimationEditor.Core.CommandsAndState
             ApplicationEvents.Self.RaiseAnimationChainsChanged();
         }
 
+        /// <summary>
+        /// Moves the currently-selected frame or chain up (<paramref name="delta"/> = -1)
+        /// or down (<paramref name="delta"/> = +1) in the tree.
+        /// Frame selection takes priority: if a frame is selected its parent chain is used.
+        /// No-op when nothing is selected or when the item is already at the boundary.
+        /// </summary>
+        public void HandleReorder(int delta)
+        {
+            var frame = SelectedState.Self.SelectedFrame;
+            var chain = SelectedState.Self.SelectedChain;
+
+            if (frame is not null && chain is not null)
+                MoveFrame(frame, chain, delta);
+            else if (chain is not null)
+                MoveChain(chain, delta);
+        }
+
         public void FlipFrameHorizontally(AnimationFrameSave frame)
         {
             frame.FlipHorizontal = !frame.FlipHorizontal;

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -1,0 +1,96 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall.Content.AnimationChain;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class AppCommandsReorderTests
+{
+    // ── HandleReorder — chain selected ───────────────────────────────────────
+
+    [Fact]
+    public void HandleReorder_ChainSelected_DeltaPos1_MovesChainDown()
+    {
+        var acls = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(acls, "Walk");
+        var run  = TestHelpers.MakeChain(acls, "Run");
+        SelectedState.Self.SelectedChain = walk;
+
+        AppCommands.Self.HandleReorder(+1);
+
+        Assert.Equal(run,  acls.AnimationChains[0]);
+        Assert.Equal(walk, acls.AnimationChains[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_ChainSelected_DeltaNeg1_MovesChainUp()
+    {
+        var acls = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(acls, "Walk");
+        var run  = TestHelpers.MakeChain(acls, "Run");
+        SelectedState.Self.SelectedChain = run;
+
+        AppCommands.Self.HandleReorder(-1);
+
+        Assert.Equal(run,  acls.AnimationChains[0]);
+        Assert.Equal(walk, acls.AnimationChains[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_ChainSelected_AtTop_DeltaNeg1_IsNoOp()
+    {
+        var acls = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(acls, "Walk");
+        TestHelpers.MakeChain(acls, "Run");
+        SelectedState.Self.SelectedChain = walk;
+
+        AppCommands.Self.HandleReorder(-1);
+
+        Assert.Equal(walk, acls.AnimationChains[0]);
+    }
+
+    // ── HandleReorder — frame selected ───────────────────────────────────────
+
+    [Fact]
+    public void HandleReorder_FrameSelected_DeltaPos1_MovesFrameDown()
+    {
+        var acls  = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 3);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        SelectedState.Self.SelectedFrame = frameA;
+
+        AppCommands.Self.HandleReorder(+1);
+
+        Assert.Equal(frameB, chain.Frames[0]);
+        Assert.Equal(frameA, chain.Frames[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_FrameSelected_DeltaNeg1_MovesFrameUp()
+    {
+        var acls  = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 3);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        SelectedState.Self.SelectedFrame = frameB;
+
+        AppCommands.Self.HandleReorder(-1);
+
+        Assert.Equal(frameB, chain.Frames[0]);
+        Assert.Equal(frameA, chain.Frames[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_NothingSelected_DoesNotThrow()
+    {
+        TestHelpers.SetupFreshAcls();
+        // SelectedChain and SelectedFrame are both null after SetupFreshAcls
+
+        var ex = Record.Exception(() => AppCommands.Self.HandleReorder(+1));
+
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
Closes #119

## Changes

- **AppCommands.HandleReorder(int delta)** — new method in Core that dispatches to MoveFrame when a frame is selected, MoveChain when only a chain is selected, no-op otherwise.
- **WireKeyboard()** — wires Alt+Up → HandleReorder(-1) and Alt+Down → HandleReorder(+1) on the main window, consistent with how Gum, the old AnimationEditor, and code editors work.
- **AppCommandsReorderTests** — 6 failing-first tests covering chain up/down, frame up/down, boundary no-op, and no-selection safety.