### PR TITLE
feat: chain-drag — select chain node to move all frames as one unit

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -369,6 +369,10 @@ public class WireframeControl : Control
     private SKPoint _dragStartWorld;
     private SKRect _dragStartBounds;
 
+    // Chain-drag state: set when the user drags the composite chain bounding rect
+    private bool _draggingChain;
+    private readonly List<(FrameRect Rect, SKRect StartBounds)> _chainDragStarts = new();
+
     // Before-UV snapshot captured at drag start for undo recording
     private float _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB;
 
@@ -413,6 +417,12 @@ public class WireframeControl : Control
 
     /// <summary>Fired after a frame's UV coords have been updated by dragging a handle.</summary>
     public event Action<AnimationFrameSave>? FrameRegionChanged;
+
+    /// <summary>
+    /// Fired after all frames in a chain have been translated by dragging the chain's
+    /// composite bounding rect on the wireframe. The payload is the chain whose frames moved.
+    /// </summary>
+    public event Action<AnimationChainSave>? ChainRegionChanged;
 
     /// <summary>
     /// Fired on every pointer move while dragging a handle (live update).
@@ -999,6 +1009,37 @@ public class WireframeControl : Control
     }
 
     /// <summary>
+    /// Simulates a complete chain-drag gesture: translates all frames of the currently-selected
+    /// chain from <paramref name="startScreenX"/>,<paramref name="startScreenY"/> to
+    /// <paramref name="endScreenX"/>,<paramref name="endScreenY"/> in screen space.
+    /// <para>
+    /// Drives the same <see cref="ApplyChainDrag"/> code path as real pointer events,
+    /// writes updated UV coordinates back to every frame, and fires
+    /// <see cref="ChainRegionChanged"/>. No-op when no chain is selected, no frames
+    /// are visible, or no texture is loaded.
+    /// </para>
+    /// </summary>
+    public void SimulateChainDrag(
+        float startScreenX, float startScreenY,
+        float endScreenX,   float endScreenY)
+    {
+        var chain = SelectedState.Self.SelectedChain;
+        if (chain is null || _bitmap is null || _frameRects.Count == 0) return;
+
+        _draggingChain = true;
+        _chainDragStarts.Clear();
+        foreach (var fr in _frameRects)
+            _chainDragStarts.Add((fr, fr.Bounds));
+        _dragStartWorld = ScreenToTexture(startScreenX, startScreenY);
+
+        ApplyChainDrag(new Point(endScreenX, endScreenY));
+
+        ChainRegionChanged?.Invoke(chain);
+        _draggingChain = false;
+        _chainDragStarts.Clear();
+    }
+
+    /// <summary>
     /// Test-only: starts a middle-mouse pan gesture with the anchor at the given
     /// <b>viewport-space</b> position. Call <see cref="SimulatePanMove"/> one or more
     /// times to continue the drag, then <see cref="SimulatePanEnd"/> when done.
@@ -1175,6 +1216,10 @@ public class WireframeControl : Control
             snap.OriginTexX = sel.Bounds.MidX - sel.Frame.RelativeX * offMult;
             snap.OriginTexY = sel.Bounds.MidY + sel.Frame.RelativeY * offMult;
         }
+        else if (SelectedState.Self.SelectedChain != null && _frameRects.Count > 0)
+        {
+            snap.SelectedHandleBounds = ComputeChainBoundingRect();
+        }
 
         return snap;
     }
@@ -1227,14 +1272,27 @@ public class WireframeControl : Control
             var (hitFrame, hitHandle) = HitTestHandle(pos);
             if (hitHandle != HandleKind.None)
             {
-                _draggingRect = hitFrame;
-                _draggingHandle = hitHandle;
-                _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
-                _dragStartBounds = hitFrame!.Bounds;
-                _dragBeforeL = hitFrame.Frame.LeftCoordinate;
-                _dragBeforeT = hitFrame.Frame.TopCoordinate;
-                _dragBeforeR = hitFrame.Frame.RightCoordinate;
-                _dragBeforeB = hitFrame.Frame.BottomCoordinate;
+                if (hitFrame != null)
+                {
+                    // Single-frame drag
+                    _draggingRect = hitFrame;
+                    _draggingHandle = hitHandle;
+                    _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
+                    _dragStartBounds = hitFrame.Bounds;
+                    _dragBeforeL = hitFrame.Frame.LeftCoordinate;
+                    _dragBeforeT = hitFrame.Frame.TopCoordinate;
+                    _dragBeforeR = hitFrame.Frame.RightCoordinate;
+                    _dragBeforeB = hitFrame.Frame.BottomCoordinate;
+                }
+                else
+                {
+                    // Chain drag: move all chain frames together
+                    _draggingChain = true;
+                    _chainDragStarts.Clear();
+                    foreach (var fr in _frameRects)
+                        _chainDragStarts.Add((fr, fr.Bounds));
+                    _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
+                }
                 e.Pointer.Capture(this);
                 return;
             }
@@ -1363,6 +1421,12 @@ public class WireframeControl : Control
             return;
         }
 
+        if (_draggingChain)
+        {
+            ApplyChainDrag(pos);
+            return;
+        }
+
         UpdateHoverCursor(pos);
 
         // Update hover preview for magic-wand / grid-snap
@@ -1398,6 +1462,16 @@ public class WireframeControl : Control
                 _draggingRect.Frame.RightCoordinate, _draggingRect.Frame.BottomCoordinate));
             _draggingRect = null;
             _draggingHandle = HandleKind.None;
+            e.Pointer.Capture(null);
+        }
+
+        if (_draggingChain)
+        {
+            var chain = SelectedState.Self.SelectedChain;
+            if (chain != null)
+                ChainRegionChanged?.Invoke(chain);
+            _draggingChain = false;
+            _chainDragStarts.Clear();
             e.Pointer.Capture(null);
         }
     }
@@ -1548,6 +1622,53 @@ public class WireframeControl : Control
         InvalidateVisual();
     }
 
+    private void ApplyChainDrag(Point pos)
+    {
+        if (!_draggingChain || _bitmap is null) return;
+
+        var world = ScreenToTexture((float)pos.X, (float)pos.Y);
+        float dx = world.X - _dragStartWorld.X;
+        float dy = world.Y - _dragStartWorld.Y;
+
+        // Snap to integer pixel; upgrade to grid-size snap when the grid is on.
+        int snapSize = (_showGrid && _gridSize > 0) ? _gridSize : 1;
+        dx = MathF.Round(dx / snapSize) * snapSize;
+        dy = MathF.Round(dy / snapSize) * snapSize;
+
+        float texW = _bitmap.Width;
+        float texH = _bitmap.Height;
+
+        foreach (var (fr, startBounds) in _chainDragStarts)
+        {
+            float newL = startBounds.Left   + dx;
+            float newT = startBounds.Top    + dy;
+            float newR = startBounds.Right  + dx;
+            float newB = startBounds.Bottom + dy;
+
+            fr.Bounds = new SKRect(newL, newT, newR, newB);
+            fr.Frame.LeftCoordinate   = newL / texW;
+            fr.Frame.TopCoordinate    = newT / texH;
+            fr.Frame.RightCoordinate  = newR / texW;
+            fr.Frame.BottomCoordinate = newB / texH;
+        }
+
+        InvalidateVisual();
+    }
+
+    private SKRect ComputeChainBoundingRect()
+    {
+        float l = float.MaxValue, t = float.MaxValue;
+        float r = float.MinValue, b = float.MinValue;
+        foreach (var fr in _frameRects)
+        {
+            l = MathF.Min(l, fr.Bounds.Left);
+            t = MathF.Min(t, fr.Bounds.Top);
+            r = MathF.Max(r, fr.Bounds.Right);
+            b = MathF.Max(b, fr.Bounds.Bottom);
+        }
+        return new SKRect(l, t, r, b);
+    }
+
     private void UpdatePreview(Point pos)
     {
         if (_bitmap is null) { ClearPreview(); return; }
@@ -1579,16 +1700,35 @@ public class WireframeControl : Control
     private (FrameRect? frame, HandleKind handle) HitTestHandle(Point pos)
     {
         var sel = _frameRects.FirstOrDefault(f => f.IsSelected);
-        if (sel is null) return (null, HandleKind.None);
+        if (sel != null)
+        {
+            var sr = ToScreen(sel.Bounds);
 
-        var sr = ToScreen(sel.Bounds);
+            var kind = DragHandleHitTester.GetHandleAt(
+                (float)pos.X, (float)pos.Y,
+                sr.Left, sr.Top, sr.Right, sr.Bottom,
+                handleOffset: 5f);  // matches Hs: handles drawn outside the frame by this amount
 
-        var kind = DragHandleHitTester.GetHandleAt(
-            (float)pos.X, (float)pos.Y,
-            sr.Left, sr.Top, sr.Right, sr.Bottom,
-            handleOffset: 5f);  // matches Hs: handles drawn outside the frame by this amount
+            return kind == HandleKind.None ? (null, HandleKind.None) : (sel, kind);
+        }
 
-        return kind == HandleKind.None ? (null, HandleKind.None) : (sel, kind);
+        // Chain selected (no individual frame): test against the composite bounding rect.
+        // All hits are treated as Move since resizing the group is not supported.
+        if (SelectedState.Self.SelectedChain != null && _frameRects.Count > 0)
+        {
+            var chainRect = ComputeChainBoundingRect();
+            var sr = ToScreen(chainRect);
+
+            var kind = DragHandleHitTester.GetHandleAt(
+                (float)pos.X, (float)pos.Y,
+                sr.Left, sr.Top, sr.Right, sr.Bottom,
+                handleOffset: 5f);
+
+            if (kind != HandleKind.None)
+                return (null, HandleKind.Move);
+        }
+
+        return (null, HandleKind.None);
     }
 
     private void TrySelectFrameAtPoint(SKPoint worldPt)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -284,9 +284,15 @@ public partial class MainWindow : Window
     private void WireWireframeControl()
     {
         WireframeCtrl.FrameRegionChanged     += OnFrameRegionChanged;
+        WireframeCtrl.ChainRegionChanged     += OnChainRegionChanged;
         WireframeCtrl.FrameLiveUpdated       += OnFrameLiveUpdated;
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
         WireframeCtrl.ZoomChanged            += SyncZoomCombo;
+    }
+
+    private void OnChainRegionChanged(AnimationChainSave chain)
+    {
+        ApplicationEvents.Self.RaiseAnimationChainsChanged();
     }
 
     private void OnFrameLiveUpdated(AnimationFrameSave frame)

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
@@ -1,0 +1,183 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+using SkiaSharp;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Integration tests for the chain-drag feature: when an AnimationChain (not an individual frame)
+/// is selected in the tree view, dragging the wireframe bounding rect moves all frames of the
+/// chain together as one unit.
+/// </summary>
+public class WireframeChainDragTests
+{
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName               = null;
+        SelectedState.Self.SelectedChain           = null;
+        SelectedState.Self.SelectedFrame           = null;
+        SelectedState.Self.SelectedNodes           = new List<object>();
+        AppCommands.Self.DoOnUiThread              = a => a();
+        AppCommands.Self.FileDialogService         = NullFileDialogService.Instance;
+        AppState.Self.OffsetMultiplier             = 1f;
+    }
+
+    private static string WriteSolidPng(string dir, SKColor color, int size = 64,
+                                         string name = "sprite.png")
+    {
+        var path = System.IO.Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        System.IO.File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// Builds a WireframeControl with a 64×64 texture, a chain of two frames, and the chain
+    /// selected (no individual frame selected). Camera is at (0,0,1) so texture pixels == screen pixels.
+    ///
+    /// Frame A: top-left quarter  — UV (0.00, 0.00, 0.50, 0.50) → pixels (0, 0, 32, 32)
+    /// Frame B: top-right quarter — UV (0.50, 0.00, 1.00, 0.50) → pixels (32, 0, 64, 32)
+    /// </summary>
+    private static (WireframeControl ctrl, AnimationChainSave chain,
+                    AnimationFrameSave frameA, AnimationFrameSave frameB, string dir)
+        BuildCtrlWithChainSelected()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.DarkGray, name: "sprite.png");
+
+        var frameA = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0f,   TopCoordinate    = 0f,
+            RightCoordinate  = 0.5f, BottomCoordinate = 0.5f,
+            ShapeCollectionSave = new ShapeCollectionSave(),
+        };
+        var frameB = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0.5f, TopCoordinate    = 0f,
+            RightCoordinate  = 1.0f, BottomCoordinate = 0.5f,
+            ShapeCollectionSave = new ShapeCollectionSave(),
+        };
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        // Select the chain — no individual frame selected
+        SelectedState.Self.SelectedChain = chain;
+
+        var ctrl = new WireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.RefreshFrames();
+
+        return (ctrl, chain, frameA, frameB, dir);
+    }
+
+    // ── All frames translate together ─────────────────────────────────────────
+
+    /// <summary>
+    /// Dragging the chain +16px right and +16px down shifts every frame's UV coords
+    /// by the same pixel delta. Frame sizes (UV width / height) must not change.
+    ///
+    /// Before: frameA pixel bounds (0,0,32,32), frameB (32,0,64,32).
+    /// After +16px right, +16px down:
+    ///   frameA → (16,16,48,48) → UV L=0.25, T=0.25, R=0.75, B=0.75
+    ///   frameB → (48,16,80,48) → UV L=0.75, T=0.25, R=1.25, B=0.75 (values may exceed 1 — no clamping)
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateChainDrag_WithTwoFrames_AllFramesTranslatedByDelta()
+    {
+        ResetSingletons();
+        var (ctrl, _, frameA, frameB, dir) = BuildCtrlWithChainSelected();
+        try
+        {
+            // Pre-drag frame sizes
+            float widthA  = frameA.RightCoordinate  - frameA.LeftCoordinate;   // 0.5
+            float heightA = frameA.BottomCoordinate - frameA.TopCoordinate;    // 0.5
+            float widthB  = frameB.RightCoordinate  - frameB.LeftCoordinate;   // 0.5
+            float heightB = frameB.BottomCoordinate - frameB.TopCoordinate;    // 0.5
+
+            // Drag start inside the composite bounding rect; +16px right, +16px down
+            ctrl.SimulateChainDrag(startScreenX: 16f, startScreenY: 8f,
+                                   endScreenX:   32f, endScreenY:   24f);
+
+            // Both frames must have moved +16px in each axis (UV delta = 16/64 = 0.25)
+            Assert.Equal(0.25f, frameA.LeftCoordinate,   precision: 4);
+            Assert.Equal(0.25f, frameA.TopCoordinate,    precision: 4);
+            Assert.Equal(0.75f, frameB.LeftCoordinate,   precision: 4);
+            Assert.Equal(0.25f, frameB.TopCoordinate,    precision: 4);
+
+            // Frame sizes must be preserved
+            Assert.Equal(widthA,  frameA.RightCoordinate  - frameA.LeftCoordinate,  precision: 4);
+            Assert.Equal(heightA, frameA.BottomCoordinate - frameA.TopCoordinate,   precision: 4);
+            Assert.Equal(widthB,  frameB.RightCoordinate  - frameB.LeftCoordinate,  precision: 4);
+            Assert.Equal(heightB, frameB.BottomCoordinate - frameB.TopCoordinate,   precision: 4);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    // ── ChainRegionChanged event fires ────────────────────────────────────────
+
+    /// <summary>
+    /// SimulateChainDrag must fire ChainRegionChanged with the moved chain
+    /// so that MainWindow can save and raise AnimationChainsChanged.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateChainDrag_FiresChainRegionChangedWithCorrectChain()
+    {
+        ResetSingletons();
+        var (ctrl, chain, _, _, dir) = BuildCtrlWithChainSelected();
+        try
+        {
+            AnimationChainSave? notified = null;
+            ctrl.ChainRegionChanged += c => notified = c;
+
+            ctrl.SimulateChainDrag(startScreenX: 0f, startScreenY: 0f,
+                                   endScreenX:   8f, endScreenY:   0f);
+
+            Assert.NotNull(notified);
+            Assert.Same(chain, notified);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    // ── Safety: no chain selected ─────────────────────────────────────────────
+
+    /// <summary>
+    /// SimulateChainDrag must be a safe no-op when no chain is selected.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateChainDrag_NoChainSelected_NoException()
+    {
+        ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black);
+        try
+        {
+            var ctrl = new WireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.SetCamera(0f, 0f, 1f);
+            // No chain selected → must not throw
+            ctrl.SimulateChainDrag(0f, 0f, 8f, 8f);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
@@ -232,8 +232,9 @@ public class WireframeHandlesAndBorderTests
             Assert.True(pxSelected.Red > 200,
                 $"Handle should be visible when frame selected; R={pxSelected.Red}");
 
-            // Deselect frame → handles gone
+            // Deselect frame AND chain → handles gone completely
             SelectedState.Self.SelectedFrame = null;
+            SelectedState.Self.SelectedChain = null;
             ctrl.RefreshFrames();
             using var bmDeselected = ctrl.RenderToBitmap(64, 64);
             var pxDeselected = bmDeselected.GetPixel(3, 3);


### PR DESCRIPTION
Closes #118

## Summary

When an animation chain is selected in the tree view (not an individual frame), the wireframe panel now shows a composite bounding rect with handles around all the chain's frames. Dragging anywhere on that rect translates every frame's UV coordinates by the same pixel delta, effectively remapping the entire animation row on a sprite sheet in one operation.

## Changes

### \WireframeControl.cs\
- **New event** \ChainRegionChanged: Action<AnimationChainSave>?\ — fires after a chain drag completes
- **New public method** \SimulateChainDrag\ — drives the chain drag code path from tests
- **New private methods** \ApplyChainDrag\ and \ComputeChainBoundingRect\
- **\BuildSnapshot\** — when chain is selected with no individual frame, sets \SelectedHandleBounds\ to the chain bounding rect so handles are rendered
- **\HitTestHandle\** — extended to hit-test the chain bounding rect; all hits map to \HandleKind.Move\ (resize of a group is not supported)
- **\OnPointerPressed/Moved/Released\** — extended to start/apply/complete chain drag

### \MainWindow.axaml.cs\
- Subscribes \ChainRegionChanged → RaiseAnimationChainsChanged\ for auto-save

### \WireframeChainDragTests.cs\ (new)
3 tests:
- \SimulateChainDrag_WithTwoFrames_AllFramesTranslatedByDelta\ — both frames move by the same UV delta, sizes preserved
- \SimulateChainDrag_FiresChainRegionChangedWithCorrectChain\ — event fires with the correct chain payload
- \SimulateChainDrag_NoChainSelected_NoException\ — safe no-op guard

### \WireframeHandlesAndBorderTests.cs\
- Updated \SelectThenDeselect\ test: clearing only \SelectedFrame\ while keeping \SelectedChain\ now correctly shows chain handles (new feature). Test now also clears \SelectedChain\ to verify the \
o-handles\ state.