### PR TITLE
Show resize cursor when hovering over guides in preview panel

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/GuideCursorResolver.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/GuideCursorResolver.cs
@@ -1,0 +1,55 @@
+using Avalonia.Input;
+using System;
+
+namespace AnimationEditor.App.Controls;
+
+/// <summary>
+/// Pure mapping: given guide lines and camera state, returns the cursor type
+/// to show at screen position (px, py). Returns <c>null</c> when no guide is
+/// near the pointer and the platform default cursor should be used.
+/// </summary>
+public static class GuideCursorResolver
+{
+    private const float HitPx     = 4f;
+    private const float RulerSize = 20f;
+
+    /// <summary>
+    /// Returns the <see cref="StandardCursorType"/> appropriate for the pointer
+    /// position, or <c>null</c> if the pointer is not near any guide.
+    /// </summary>
+    /// <param name="px">Pointer X in control (screen) coordinates.</param>
+    /// <param name="py">Pointer Y in control (screen) coordinates.</param>
+    /// <param name="hGuides">Horizontal guide world-Y values.</param>
+    /// <param name="vGuides">Vertical guide world-X values.</param>
+    /// <param name="panX">Current horizontal pan offset.</param>
+    /// <param name="panY">Current vertical pan offset.</param>
+    /// <param name="zoom">Current zoom factor (must be &gt; 0).</param>
+    /// <param name="viewWidth">Control width in pixels.</param>
+    /// <param name="viewHeight">Control height in pixels.</param>
+    public static StandardCursorType? CursorTypeAt(
+        float px, float py,
+        float[] hGuides, float[] vGuides,
+        float panX, float panY, float zoom,
+        float viewWidth, float viewHeight)
+    {
+        if (viewWidth <= RulerSize || viewHeight <= RulerSize || zoom <= 0f)
+            return null;
+
+        // Ruler strips → clicking there creates a new guide, not dragging an existing one.
+        if (px < RulerSize || py < RulerSize)
+            return null;
+
+        float cx = (viewWidth  - RulerSize) / 2f + RulerSize + panX;
+        float cy = (viewHeight - RulerSize) / 2f + RulerSize + panY;
+
+        foreach (float wy in hGuides)
+            if (MathF.Abs(py - (cy + wy * zoom)) < HitPx)
+                return StandardCursorType.SizeNorthSouth;
+
+        foreach (float wx in vGuides)
+            if (MathF.Abs(px - (cx + wx * zoom)) < HitPx)
+                return StandardCursorType.SizeWestEast;
+
+        return null;
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -333,6 +333,25 @@ public class PreviewControl : Control
     private float ScreenToWorldX(float sx) => (sx - GetCenterX()) / _zoom;
 
     /// <summary>
+    /// Returns the cursor type to show when the pointer is at screen position
+    /// (<paramref name="px"/>, <paramref name="py"/>), based on proximity to
+    /// user-placed guides. Returns <c>null</c> when no guide is nearby.
+    /// </summary>
+    public StandardCursorType? GetGuideCursorAt(float px, float py)
+        => GuideCursorResolver.CursorTypeAt(px, py,
+            _hGuides.ToArray(), _vGuides.ToArray(),
+            _panX, _panY, _zoom,
+            (float)Bounds.Width, (float)Bounds.Height);
+
+    private void UpdateHoverCursor(Point pos)
+    {
+        StandardCursorType? cursorType = _draggedGuideIdx >= 0
+            ? (_draggingHGuide ? StandardCursorType.SizeNorthSouth : StandardCursorType.SizeWestEast)
+            : GetGuideCursorAt((float)pos.X, (float)pos.Y);
+        Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
+    }
+
+    /// <summary>
     /// Captures a thread-safe snapshot of collision shapes attached to the currently
     /// selected frame. Shapes are sourced from <see cref="SelectedState.Self.SelectedFrame"/>
     /// so they only appear when a specific frame is pinned (not during free playback).
@@ -382,6 +401,7 @@ public class PreviewControl : Control
         {
             _isPanning    = true;
             _lastMousePt  = pos;
+            Cursor        = Cursor.Default;
             e.Pointer.Capture(this);
             return;
         }
@@ -458,6 +478,8 @@ public class PreviewControl : Control
                 _vGuides[_draggedGuideIdx] = ScreenToWorldX((float)pos.X);
             InvalidateVisual();
         }
+
+        UpdateHoverCursor(pos);
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
@@ -477,10 +499,17 @@ public class PreviewControl : Control
             }
             _draggedGuideIdx = -1;
             InvalidateVisual();
+            UpdateHoverCursor(pos);
         }
 
         _isPanning = false;
         e.Pointer.Capture(null);
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+        Cursor = Cursor.Default;
     }
 
     // ── Inner types ───────────────────────────────────────────────────────────

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideCursorResolverTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideCursorResolverTests.cs
@@ -1,0 +1,196 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Input;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Pure unit tests for <see cref="GuideCursorResolver"/>.
+/// No Avalonia headless infrastructure needed — the resolver contains no UI state.
+///
+/// Camera math (viewWidth=64, viewHeight=64, pan=0, zoom=1):
+///   cx = (64−20)/2 + 20 = 42   (screen X of world origin)
+///   cy = (64−20)/2 + 20 = 42   (screen Y of world origin)
+///   hitPx = 4
+/// </summary>
+public class GuideCursorResolverTests
+{
+    private const float V = 64f;  // view size used across tests
+
+    // ── Positive hit cases ────────────────────────────────────────────────────
+
+    [Fact]
+    public void HoverAtHGuide_ReturnsNorthSouth()
+    {
+        // guide at worldY=0 → screen Y = cy + 0*1 = 42
+        var result = GuideCursorResolver.CursorTypeAt(
+            32f, 42f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Equal(StandardCursorType.SizeNorthSouth, result);
+    }
+
+    [Fact]
+    public void HoverAtVGuide_ReturnsWestEast()
+    {
+        // guide at worldX=0 → screen X = cx + 0*1 = 42
+        var result = GuideCursorResolver.CursorTypeAt(
+            42f, 32f,
+            hGuides: [], vGuides: [0f],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Equal(StandardCursorType.SizeWestEast, result);
+    }
+
+    // ── Near-miss / miss cases ────────────────────────────────────────────────
+
+    [Fact]
+    public void HoverFarFromHGuide_ReturnsNull()
+    {
+        // guide at screen Y=42; hover at Y=50 → |50-42|=8 > hitPx=4
+        var result = GuideCursorResolver.CursorTypeAt(
+            32f, 50f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HoverFarFromVGuide_ReturnsNull()
+    {
+        // guide at screen X=42; hover at X=50 → |50-42|=8 > hitPx=4
+        var result = GuideCursorResolver.CursorTypeAt(
+            50f, 32f,
+            hGuides: [], vGuides: [0f],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NoGuides_ReturnsNull()
+    {
+        var result = GuideCursorResolver.CursorTypeAt(
+            42f, 42f,
+            hGuides: [], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+
+    // ── Ruler-area guard ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void HoverInLeftRuler_ReturnsNull()
+    {
+        // px < RulerSize(20) — clicking there creates a new guide, not dragging
+        var result = GuideCursorResolver.CursorTypeAt(
+            10f, 42f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HoverInTopRuler_ReturnsNull()
+    {
+        // py < RulerSize(20)
+        var result = GuideCursorResolver.CursorTypeAt(
+            42f, 10f,
+            hGuides: [], vGuides: [0f],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+
+    // ── Pan and zoom affect guide screen position ─────────────────────────────
+
+    [Fact]
+    public void PanX_ShiftsVGuideScreenPosition()
+    {
+        // panX=10 → cx = 42+10 = 52; guide at worldX=0 → screen X=52
+        var hitResult = GuideCursorResolver.CursorTypeAt(
+            52f, 32f,
+            hGuides: [], vGuides: [0f],
+            panX: 10f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        var oldResult = GuideCursorResolver.CursorTypeAt(
+            42f, 32f,   // old position without pan
+            hGuides: [], vGuides: [0f],
+            panX: 10f, panY: 0f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Equal(StandardCursorType.SizeWestEast, hitResult);
+        Assert.Null(oldResult);
+    }
+
+    [Fact]
+    public void PanY_ShiftsHGuideScreenPosition()
+    {
+        // panY=10 → cy = 42+10 = 52; guide at worldY=0 → screen Y=52
+        var hitResult = GuideCursorResolver.CursorTypeAt(
+            32f, 52f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 10f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        var oldResult = GuideCursorResolver.CursorTypeAt(
+            32f, 42f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 10f, zoom: 1f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Equal(StandardCursorType.SizeNorthSouth, hitResult);
+        Assert.Null(oldResult);
+    }
+
+    [Fact]
+    public void Zoom_ScalesGuideOffset()
+    {
+        // zoom=2, guide at worldY=5 → screen Y = cy + 5*2 = 42+10 = 52
+        var hitResult = GuideCursorResolver.CursorTypeAt(
+            32f, 52f,
+            hGuides: [5f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 2f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Equal(StandardCursorType.SizeNorthSouth, hitResult);
+    }
+
+    // ── Defensive guards ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ZeroSizedView_ReturnsNull()
+    {
+        var result = GuideCursorResolver.CursorTypeAt(
+            32f, 32f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 1f,
+            viewWidth: 0f, viewHeight: 0f);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ZeroZoom_ReturnsNull()
+    {
+        var result = GuideCursorResolver.CursorTypeAt(
+            32f, 32f,
+            hGuides: [0f], vGuides: [],
+            panX: 0f, panY: 0f, zoom: 0f,
+            viewWidth: V, viewHeight: V);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary

When the mouse hovers over a user-placed guide in the animation preview panel (PreviewControl), the cursor now changes to indicate a draggable guide:

- **Horizontal guide** (drag up/down) → ↕ (SizeNorthSouth)
- **Vertical guide** (drag left/right) → ↔ (SizeWestEast)

The cursor resets to default when:
- The mouse leaves the control (OnPointerExited)
- A pan operation starts (so panning doesn't show a stale resize cursor)
- A guide drag ends and the pointer is no longer over a guide

## Changes

- **GuideCursorResolver.cs** — new pure static class, analogous to HandleCursorMapper, that maps screen-space hover position to a StandardCursorType? given guide world-values and camera state. Includes a ruler-area guard (no cursor change inside the ruler strips where clicking creates new guides, not drags existing ones).
- **PreviewControl.cs** — adds GetGuideCursorAt, private UpdateHoverCursor, OnPointerExited, and wires cursor updates into OnPointerMoved / OnPointerReleased / pan-start.
- **GuideCursorResolverTests.cs** — 12 unit tests covering hits, near-misses, ruler-area guard, pan/zoom offsets, and defensive zero-size/zoom guards.

Closes #123