### PR TITLE
Snap preview guides to pixel boundary on place and drag

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -28,4 +28,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AnimationEditor.Core\AnimationEditor.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AnimationEditor.App.Tests" />
+  </ItemGroup>
 </Project>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -325,12 +325,65 @@ public class PreviewControl : Control
 
     // ── Guide helpers ─────────────────────────────────────────────────────────
 
-    private float GetCenterX() => (float)((Bounds.Width  - RulerSize) / 2f + RulerSize + _panX);
-    private float GetCenterY() => (float)((Bounds.Height - RulerSize) / 2f + RulerSize + _panY);
+    private float GetCenterX(float? width  = null) => ((width  ?? (float)Bounds.Width)  - RulerSize) / 2f + RulerSize + _panX;
+    private float GetCenterY(float? height = null) => ((height ?? (float)Bounds.Height) - RulerSize) / 2f + RulerSize + _panY;
     private float WorldToScreenY(float wy) => GetCenterY() + wy * _zoom;
     private float WorldToScreenX(float wx) => GetCenterX() + wx * _zoom;
-    private float ScreenToWorldY(float sy) => (sy - GetCenterY()) / _zoom;
-    private float ScreenToWorldX(float sx) => (sx - GetCenterX()) / _zoom;
+    private float ScreenToWorldY(float sy, float? height = null) => (sy - GetCenterY(height)) / _zoom;
+    private float ScreenToWorldX(float sx, float? width  = null) => (sx - GetCenterX(width))  / _zoom;
+
+    // Guides snap to the nearest integer (pixel boundary) in world space.
+    private static float SnapToPixel(float world) => MathF.Round(world, MidpointRounding.AwayFromZero);
+
+    // ── Test helpers (internal) ───────────────────────────────────────────────
+
+    /// <summary>Horizontal guide world-Y values; exposed for headless tests.</summary>
+    internal IReadOnlyList<float> HGuides => _hGuides;
+
+    /// <summary>Vertical guide world-X values; exposed for headless tests.</summary>
+    internal IReadOnlyList<float> VGuides => _vGuides;
+
+    /// <summary>
+    /// Simulates a ruler-click that creates a horizontal guide at <paramref name="screenY"/>
+    /// within a control of height <paramref name="controlHeight"/>. Applies the same
+    /// snap-to-pixel logic as the live pointer handler.
+    /// </summary>
+    internal void SimulateAddHGuide(float screenY, float controlHeight)
+    {
+        _hGuides.Add(SnapToPixel(ScreenToWorldY(screenY, controlHeight)));
+        InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Simulates a ruler-click that creates a vertical guide at <paramref name="screenX"/>
+    /// within a control of width <paramref name="controlWidth"/>. Applies the same
+    /// snap-to-pixel logic as the live pointer handler.
+    /// </summary>
+    internal void SimulateAddVGuide(float screenX, float controlWidth)
+    {
+        _vGuides.Add(SnapToPixel(ScreenToWorldX(screenX, controlWidth)));
+        InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Simulates dragging horizontal guide at <paramref name="idx"/> to
+    /// <paramref name="screenY"/>. Applies snap-to-pixel.
+    /// </summary>
+    internal void SimulateDragHGuide(int idx, float screenY, float controlHeight)
+    {
+        _hGuides[idx] = SnapToPixel(ScreenToWorldY(screenY, controlHeight));
+        InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Simulates dragging vertical guide at <paramref name="idx"/> to
+    /// <paramref name="screenX"/>. Applies snap-to-pixel.
+    /// </summary>
+    internal void SimulateDragVGuide(int idx, float screenX, float controlWidth)
+    {
+        _vGuides[idx] = SnapToPixel(ScreenToWorldX(screenX, controlWidth));
+        InvalidateVisual();
+    }
 
     /// <summary>
     /// Captures a thread-safe snapshot of collision shapes attached to the currently
@@ -391,7 +444,7 @@ public class PreviewControl : Control
         // Click in left ruler strip → create horizontal guide
         if (px < RulerSize && py >= RulerSize)
         {
-            float wy = ScreenToWorldY(py);
+            float wy = SnapToPixel(ScreenToWorldY(py));
             _hGuides.Add(wy);
             _draggedGuideIdx = _hGuides.Count - 1;
             _draggingHGuide  = true;
@@ -403,7 +456,7 @@ public class PreviewControl : Control
         // Click in top ruler strip → create vertical guide
         if (py < RulerSize && px >= RulerSize)
         {
-            float wx = ScreenToWorldX(px);
+            float wx = SnapToPixel(ScreenToWorldX(px));
             _vGuides.Add(wx);
             _draggedGuideIdx = _vGuides.Count - 1;
             _draggingHGuide  = false;
@@ -453,9 +506,9 @@ public class PreviewControl : Control
         if (_draggedGuideIdx >= 0)
         {
             if (_draggingHGuide)
-                _hGuides[_draggedGuideIdx] = ScreenToWorldY((float)pos.Y);
+                _hGuides[_draggedGuideIdx] = SnapToPixel(ScreenToWorldY((float)pos.Y));
             else
-                _vGuides[_draggedGuideIdx] = ScreenToWorldX((float)pos.X);
+                _vGuides[_draggedGuideIdx] = SnapToPixel(ScreenToWorldX((float)pos.X));
             InvalidateVisual();
         }
     }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideSnapToPixelTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideSnapToPixelTests.cs
@@ -1,0 +1,204 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests that user-created guides snap to the nearest pixel boundary (integer
+/// world coordinate) when placed or dragged.
+///
+/// Coordinate system recap:
+///   world X/Y = pixel offset from the animation origin.
+///   At zoom=2, default pan (0,0), 64×64 control:
+///     cx = cy = (64-20)/2 + 20 + 0 = 42
+///     screenX/Y 43 → world = (43-42)/2 = 0.5 → snapped to 1
+///     snapped guide renders at screen 42 + 1*2 = 44
+///
+/// User-created guide colour: SKColor(0, 200, 255, 200) — cyan.
+/// After alpha-blending over the background (30,30,30):
+///   Blue ≈ 206, Red ≈ 7  → assert Blue > Red to detect guide pixels.
+/// </summary>
+public class GuideSnapToPixelTests
+{
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName = null;
+        SelectedState.Self.SelectedChain = null;
+        SelectedState.Self.SelectedFrame = null;
+        SelectedState.Self.SelectedNodes = new System.Collections.Generic.List<object>();
+        AppCommands.Self.DoOnUiThread = a => a();
+        AppCommands.Self.FileDialogService = NullFileDialogService.Instance;
+        AppState.Self.OffsetMultiplier = 1f;
+    }
+
+    // ── Horizontal guide (HGuide) world-Y storage ─────────────────────────────
+
+    /// <summary>
+    /// At zoom=2, screenY=43 maps to worldY=0.5; must snap to 1.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_AtFractionalScreenY_SnapsToNearestPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200); // zoom=2 produces easy-to-reason fractional worlds
+
+        // centerY = (64-20)/2 + 20 = 42; (43-42)/2 = 0.5 → snapped to 1
+        ctrl.SimulateAddHGuide(screenY: 43f, controlHeight: 64f);
+
+        Assert.Single(ctrl.HGuides);
+        Assert.Equal(1f, ctrl.HGuides[0]);
+    }
+
+    /// <summary>
+    /// At zoom=2, screenY=44 maps to worldY=1.0 (exact integer); must store 1.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_AtExactPixelScreenY_StoresIntegerUnchanged()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        // (44-42)/2 = 1.0 — already integer
+        ctrl.SimulateAddHGuide(screenY: 44f, controlHeight: 64f);
+
+        Assert.Single(ctrl.HGuides);
+        Assert.Equal(1f, ctrl.HGuides[0]);
+    }
+
+    /// <summary>
+    /// Negative fractional: screenY=41 → worldY = (41-42)/2 = -0.5 → snapped to -1
+    /// (MidpointRounding.AwayFromZero rounds half-integers away from zero).
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_AtNegativeFractionalScreenY_SnapsAwayFromZero()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        // (41-42)/2 = -0.5 → snapped to -1 (AwayFromZero, not banker's 0)
+        ctrl.SimulateAddHGuide(screenY: 41f, controlHeight: 64f);
+
+        Assert.Single(ctrl.HGuides);
+        Assert.Equal(-1f, ctrl.HGuides[0]);
+    }
+
+    // ── Vertical guide (VGuide) world-X storage ───────────────────────────────
+
+    /// <summary>
+    /// At zoom=2, screenX=43 maps to worldX=0.5; must snap to 1.
+    /// </summary>
+    [AvaloniaFact]
+    public void VGuide_AtFractionalScreenX_SnapsToNearestPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        ctrl.SimulateAddVGuide(screenX: 43f, controlWidth: 64f);
+
+        Assert.Single(ctrl.VGuides);
+        Assert.Equal(1f, ctrl.VGuides[0]);
+    }
+
+    // ── Drag snapping ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dragging an existing guide to a fractional screen position must also snap.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_Drag_SnapsToNearestPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        // Place guide at integer world 0 (screenY=42 → worldY=0)
+        ctrl.SimulateAddHGuide(screenY: 42f, controlHeight: 64f);
+        Assert.Equal(0f, ctrl.HGuides[0]);
+
+        // Drag to fractional position: screenY=43 → worldY=0.5 → snapped to 1
+        ctrl.SimulateDragHGuide(idx: 0, screenY: 43f, controlHeight: 64f);
+
+        Assert.Equal(1f, ctrl.HGuides[0]);
+    }
+
+    /// <summary>
+    /// Dragging a vertical guide to a fractional screen position must snap.
+    /// </summary>
+    [AvaloniaFact]
+    public void VGuide_Drag_SnapsToNearestPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        ctrl.SimulateAddVGuide(screenX: 42f, controlWidth: 64f);
+        Assert.Equal(0f, ctrl.VGuides[0]);
+
+        ctrl.SimulateDragVGuide(idx: 0, screenX: 43f, controlWidth: 64f);
+
+        Assert.Equal(1f, ctrl.VGuides[0]);
+    }
+
+    // ── Rendering: guide appears at snapped pixel, not fractional position ─────
+
+    /// <summary>
+    /// A vertical guide placed at screenX=43 (worldX=0.5 unsnapped, 1 snapped) at
+    /// zoom=2 must render at screen X=44 (cx 42 + 1*2), not X=43 (cx 42 + 0.5*2).
+    /// Cyan user guides have Blue > Red after blending over the dark background.
+    /// </summary>
+    [AvaloniaFact]
+    public void VGuide_SnappedWorldX1_RendersAtExpectedScreenPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        ctrl.SimulateAddVGuide(screenX: 43f, controlWidth: 64f);
+
+        using var bm = ctrl.RenderToBitmap(64, 64);
+
+        // Sample at y=25 to stay above the origin crosshair (cy=42)
+        var atSnapped   = bm.GetPixel(44, 25);   // world=1 → screen 44  (should be cyan)
+        var atUnsnapped = bm.GetPixel(43, 25);   // world=0.5 → screen 43 (must be background)
+
+        Assert.True(atSnapped.Blue > atSnapped.Red,
+            $"Guide should render at x=44 (snapped world=1); B={atSnapped.Blue} R={atSnapped.Red}");
+        Assert.True(atUnsnapped.Blue <= atUnsnapped.Red + 10,
+            $"x=43 (unsnapped) should be background; B={atUnsnapped.Blue} R={atUnsnapped.Red}");
+    }
+
+    /// <summary>
+    /// A horizontal guide placed at screenY=43 (worldY=0.5 unsnapped, 1 snapped) at
+    /// zoom=2 must render at screen Y=44, not Y=43.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_SnappedWorldY1_RendersAtExpectedScreenPixel()
+    {
+        ResetSingletons();
+        var ctrl = new PreviewControl();
+        ctrl.SetZoomPercent(200);
+
+        ctrl.SimulateAddHGuide(screenY: 43f, controlHeight: 64f);
+
+        using var bm = ctrl.RenderToBitmap(64, 64);
+
+        // Sample at x=25 to stay left of the origin crosshair (cx=42)
+        var atSnapped   = bm.GetPixel(25, 44);
+        var atUnsnapped = bm.GetPixel(25, 43);
+
+        Assert.True(atSnapped.Blue > atSnapped.Red,
+            $"Guide should render at y=44 (snapped world=1); B={atSnapped.Blue} R={atSnapped.Red}");
+        Assert.True(atUnsnapped.Blue <= atUnsnapped.Red + 10,
+            $"y=43 (unsnapped) should be background; B={atUnsnapped.Blue} R={atUnsnapped.Red}");
+    }
+}


### PR DESCRIPTION
Fixes #124

## What changed
Guides in the animation preview panel now snap to the nearest pixel boundary (integer world coordinate) when:
- **Created** — by clicking in a ruler strip
- **Dragged** — while repositioning an existing guide

Previously the stored world coordinate was a raw float from the screen-to-world conversion, which caused guides to sit between pixels at most zoom levels.

## How it works
- Added a \SnapToPixel\ helper: \MathF.Round(world, MidpointRounding.AwayFromZero)\
- Applied in \OnPointerPressed\ (guide creation) and \OnPointerMoved\ (drag)
- Generalised \GetCenterX/Y\ and \ScreenToWorldX/Y\ to accept an optional explicit dimension, enabling headless test helpers that work without a live \Bounds\ from the layout system

## Tests
- Added \GuideSnapToPixelTests.cs\ — 8 new \[AvaloniaFact]\ tests covering:
  - Fractional screen → integer world on creation (H and V guides)
  - Exact-pixel creation stores integer unchanged
  - Negative half-pixel snaps away from zero (validates \AwayFromZero\ rounding)
  - Drag also snaps (H and V)
  - Rendered pixel appears at the snapped position, not the unsnapped one (2 bitmap tests)
- All 168 existing tests continue to pass

Closes #124