### PR TITLE
Add right-click support for removing guides in animation preview panel

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -208,6 +208,25 @@ public class PreviewControl : Control
     /// <summary>Current zoom factor (1.0 = 100 %).</summary>
     public float Zoom => _zoom;
 
+    /// <summary>Test-only: adds a horizontal guide at the given world-Y coordinate.</summary>
+    public void AddHGuide(float worldY) { _hGuides.Add(worldY); InvalidateVisual(); }
+
+    /// <summary>Test-only: adds a vertical guide at the given world-X coordinate.</summary>
+    public void AddVGuide(float worldX) { _vGuides.Add(worldX); InvalidateVisual(); }
+
+    /// <summary>Test-only: returns the number of user-created horizontal guides.</summary>
+    public int HGuideCount => _hGuides.Count;
+
+    /// <summary>Test-only: returns the number of user-created vertical guides.</summary>
+    public int VGuideCount => _vGuides.Count;
+
+    /// <summary>
+    /// Test-only: simulates a right-click at the given control-space point,
+    /// removing any guide within hit distance. Mirrors <see cref="OnPointerPressed"/> so
+    /// headless tests can drive the right-click removal code path without synthesising events.
+    /// </summary>
+    public void SimulateRightClick(float x, float y) => TryRemoveGuideAt(x, y);
+
     /// <summary>
     /// Test-only: simulates a single mouse-wheel zoom event toward the given
     /// control-space point. Mirrors <see cref="OnPointerWheelChanged"/> so
@@ -379,6 +398,37 @@ public class PreviewControl : Control
 
     // ── Pointer events ────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Removes the first guide within hit distance of (<paramref name="px"/>, <paramref name="py"/>).
+    /// Clicks inside the ruler strips are ignored — guides are only visible in the canvas area.
+    /// Returns <c>true</c> if a guide was removed.
+    /// </summary>
+    private bool TryRemoveGuideAt(float px, float py)
+    {
+        if (px < RulerSize || py < RulerSize) return false;
+
+        const float hitPx = 4f;
+        for (int i = 0; i < _hGuides.Count; i++)
+        {
+            if (MathF.Abs(py - WorldToScreenY(_hGuides[i])) < hitPx)
+            {
+                _hGuides.RemoveAt(i);
+                InvalidateVisual();
+                return true;
+            }
+        }
+        for (int i = 0; i < _vGuides.Count; i++)
+        {
+            if (MathF.Abs(px - WorldToScreenX(_vGuides[i])) < hitPx)
+            {
+                _vGuides.RemoveAt(i);
+                InvalidateVisual();
+                return true;
+            }
+        }
+        return false;
+    }
+
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
@@ -403,6 +453,12 @@ public class PreviewControl : Control
             _lastMousePt  = pos;
             Cursor        = Cursor.Default;
             e.Pointer.Capture(this);
+            return;
+        }
+
+        if (props.IsRightButtonPressed)
+        {
+            TryRemoveGuideAt(px, py);
             return;
         }
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideRightClickRemoveTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideRightClickRemoveTests.cs
@@ -1,0 +1,105 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests that right-clicking near a guide in <see cref="PreviewControl"/>
+/// removes it.
+///
+/// The control is arranged to 64×64 before each test so that
+/// <see cref="Control.Bounds"/> matches the explicit size passed to
+/// <see cref="PreviewControl.RenderToBitmap"/>, keeping hit-test and
+/// render coordinate systems consistent.
+///
+/// With Bounds 64×64 and default pan/zoom:
+///   CenterX = (64-20)/2 + 20 = 42
+///   CenterY = (64-20)/2 + 20 = 42
+/// A guide at world position 0 maps to screen position 42 on that axis.
+/// </summary>
+public class GuideRightClickRemoveTests
+{
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName               = null;
+        SelectedState.Self.SelectedChain           = null;
+        SelectedState.Self.SelectedFrame           = null;
+        SelectedState.Self.SelectedNodes           = new System.Collections.Generic.List<object>();
+        AppCommands.Self.DoOnUiThread              = a => a();
+        AppCommands.Self.FileDialogService         = NullFileDialogService.Instance;
+        AppState.Self.OffsetMultiplier             = 1f;
+    }
+
+    private static PreviewControl MakeArrangedControl()
+    {
+        var ctrl = new PreviewControl();
+        ctrl.ShowGuides = true;
+        // Arrange to a known size so GetCenterX/Y match the 64×64 render size.
+        ctrl.Measure(new Size(64, 64));
+        ctrl.Arrange(new Rect(0, 0, 64, 64));
+        return ctrl;
+    }
+
+    // ── Horizontal guide removed ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Right-clicking on a horizontal guide (world Y=0 → screen Y=42)
+    /// must remove it from the guide list.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateRightClick_NearHGuide_HGuideIsRemoved()
+    {
+        ResetSingletons();
+        var ctrl = MakeArrangedControl();
+        ctrl.AddHGuide(0f);    // world Y=0 → screen Y=42
+        Assert.Equal(1, ctrl.HGuideCount);
+
+        ctrl.SimulateRightClick(30f, 42f);  // within hit distance of screen Y=42
+
+        Assert.Equal(0, ctrl.HGuideCount);
+    }
+
+    // ── No removal when click misses all guides ───────────────────────────────
+
+    /// <summary>
+    /// Right-clicking well away from any guide must leave the guide list unchanged.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateRightClick_AwayFromGuide_GuideIsRetained()
+    {
+        ResetSingletons();
+        var ctrl = MakeArrangedControl();
+        ctrl.AddHGuide(0f);    // world Y=0 → screen Y=42
+        Assert.Equal(1, ctrl.HGuideCount);
+
+        ctrl.SimulateRightClick(30f, 20f);  // screen Y=20, dist from guide = 22 > hit threshold
+
+        Assert.Equal(1, ctrl.HGuideCount);
+    }
+
+    // ── Vertical guide removed ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Right-clicking on a vertical guide (world X=0 → screen X=42)
+    /// must remove it from the guide list.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateRightClick_NearVGuide_VGuideIsRemoved()
+    {
+        ResetSingletons();
+        var ctrl = MakeArrangedControl();
+        ctrl.AddVGuide(0f);    // world X=0 → screen X=42
+        Assert.Equal(1, ctrl.VGuideCount);
+
+        ctrl.SimulateRightClick(42f, 30f);  // within hit distance of screen X=42
+
+        Assert.Equal(0, ctrl.VGuideCount);
+    }
+}


### PR DESCRIPTION
## Summary

Right-clicking near a user-created guide line in the animation preview panel now removes it immediately.

## Changes

**PreviewControl.cs**
- Added TryRemoveGuideAt(float px, float py) — extracts the guide hit-test logic into a reusable method; guards against ruler-strip clicks (px/py < RulerSize) so only canvas-area right-clicks can remove a guide
- Wired IsRightButtonPressed in OnPointerPressed to call TryRemoveGuideAt
- Added test-only APIs: AddHGuide, AddVGuide, HGuideCount, VGuideCount, SimulateRightClick

**GuideRightClickRemoveTests.cs** (new)
- SimulateRightClick_NearHGuide_HGuideIsRemoved
- SimulateRightClick_NearVGuide_VGuideIsRemoved
- SimulateRightClick_AwayFromGuide_GuideIsRetained

All 181 tests pass.

Closes #126