### PR TITLE
Add inline Add Frame button on each animation chain node

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -86,7 +86,7 @@
                     <TreeView.ItemTemplate>
                         <TreeDataTemplate x:DataType="models:TreeNodeVm"
                                           ItemsSource="{Binding Children}">
-                            <Grid ColumnDefinitions="*,Auto">
+                            <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Stretch">
                                 <Panel>
                                     <!-- Display mode -->
                                     <TextBlock Text="{Binding Header}"
@@ -115,7 +115,7 @@
                                         IsVisible="{Binding IsChainNode}"
                                         Width="18" Height="18"
                                         Padding="0"
-                                        Margin="2,0,0,0"
+                                        Margin="4,0,4,0"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         ToolTip.Tip="Add Frame"

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -71,31 +71,56 @@
                             <Setter Property="IsExpanded"
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                         </Style>
+                        <!-- Inline "Add Frame" button: hidden by default, revealed on row hover -->
+                        <Style Selector="Button.add-frame-btn">
+                            <Setter Property="Opacity" Value="0" />
+                            <Setter Property="IsHitTestVisible" Value="False" />
+                            <Setter Property="Focusable" Value="False" />
+                        </Style>
+                        <Style Selector="TreeViewItem:pointerover Button.add-frame-btn">
+                            <Setter Property="Opacity" Value="1" />
+                            <Setter Property="IsHitTestVisible" Value="True" />
+                            <Setter Property="Focusable" Value="True" />
+                        </Style>
                     </TreeView.Styles>
                     <TreeView.ItemTemplate>
                         <TreeDataTemplate x:DataType="models:TreeNodeVm"
                                           ItemsSource="{Binding Children}">
-                            <Panel>
-                                <!-- Display mode -->
-                                <TextBlock Text="{Binding Header}"
-                                           Foreground="LightGray"
-                                           Padding="2,1"
-                                           VerticalAlignment="Center"
-                                           IsVisible="{Binding !IsEditing}" />
-                                <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
-                                <TextBox Text="{Binding EditingText, Mode=TwoWay}"
-                                         IsVisible="{Binding IsEditing}"
-                                         Background="#2a2a2a"
-                                         Foreground="LightGray"
-                                         CaretBrush="LightGray"
-                                         SelectionBrush="#4466aa"
-                                         BorderThickness="1"
-                                         Margin="0"
-                                         Padding="2,1"
-                                         VerticalAlignment="Stretch"
-                                         VerticalContentAlignment="Center"
-                                         HorizontalAlignment="Stretch" />
-                            </Panel>
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Panel>
+                                    <!-- Display mode -->
+                                    <TextBlock Text="{Binding Header}"
+                                               Foreground="LightGray"
+                                               Padding="2,1"
+                                               VerticalAlignment="Center"
+                                               IsVisible="{Binding !IsEditing}" />
+                                    <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
+                                    <TextBox Text="{Binding EditingText, Mode=TwoWay}"
+                                             IsVisible="{Binding IsEditing}"
+                                             Background="#2a2a2a"
+                                             Foreground="LightGray"
+                                             CaretBrush="LightGray"
+                                             SelectionBrush="#4466aa"
+                                             BorderThickness="1"
+                                             Margin="0"
+                                             Padding="2,1"
+                                             VerticalAlignment="Stretch"
+                                             VerticalContentAlignment="Center"
+                                             HorizontalAlignment="Stretch" />
+                                </Panel>
+                                <!-- Inline "Add Frame" button — only visible on chain nodes; shown on hover -->
+                                <Button Grid.Column="1"
+                                        Classes="add-frame-btn"
+                                        Content="+"
+                                        IsVisible="{Binding IsChainNode}"
+                                        Width="18" Height="18"
+                                        Padding="0"
+                                        Margin="2,0,0,0"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        ToolTip.Tip="Add Frame"
+                                        Click="OnAddFrameBtnClick" />
+                            </Grid>
                         </TreeDataTemplate>
                     </TreeView.ItemTemplate>
                 </TreeView>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -696,6 +696,19 @@ public partial class MainWindow : Window
             node.IsExpanded = expanded;
     }
 
+    /// <summary>
+    /// Click handler for the inline "Add Frame" button shown on each chain node in the tree.
+    /// Adds a new frame to the animation chain that owns the clicked button.
+    /// </summary>
+    private void OnAddFrameBtnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn) return;
+        if (btn.DataContext is not TreeNodeVm vm) return;
+        if (vm.Data is not AnimationChainSave chain) return;
+        AppCommands.Self.AddFrame(chain);
+        e.Handled = true;
+    }
+
     private void OnTreeDragOver(object? sender, DragEventArgs e)
     {
         // Use TryGetFiles() — the correct Avalonia 12 API for OS file drops

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -43,7 +43,7 @@ public static class TreeBuilder
     /// <summary>Builds a single chain node with all its frame children.</summary>
     public static TreeNodeVm BuildChainNode(AnimationChainSave chain)
     {
-        var node = new TreeNodeVm { Header = chain.Name, Data = chain, IsExpanded = true };
+        var node = new TreeNodeVm { Header = chain.Name, Data = chain, IsExpanded = true, IsChainNode = true };
         foreach (var frame in chain.Frames)
             node.Children.Add(BuildFrameNode(frame));
         return node;

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -65,5 +65,11 @@ public class TreeNodeVm : INotifyPropertyChanged
     /// <summary>Underlying data object — AnimationChainSave, AnimationFrameSave, etc.</summary>
     public object? Data { get; set; }
 
+    /// <summary>
+    /// True when this node represents an <see cref="FlatRedBall.Content.AnimationChain.AnimationChainSave"/>.
+    /// Used by the tree item template to show the inline Add Frame button only on chain nodes.
+    /// </summary>
+    public bool IsChainNode { get; set; }
+
     public ObservableCollection<TreeNodeVm> Children { get; } = new();
 }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -7,7 +7,9 @@ using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FlatRedBall.Content.AnimationChain;
 using FlatRedBall.Content.Math.Geometry;
 using Xunit;
@@ -68,6 +70,17 @@ public class HeadlessTreeViewTests
             ?? throw new InvalidOperationException("OnTreeContextMenuOpening not found via reflection");
 
         method.Invoke(window, [null, new CancelEventArgs()]);
+    }
+
+    /// <summary>Invokes the private <c>RefreshTreeView</c> method directly.</summary>
+    private static void TriggerRefreshTreeView(MainWindow window)
+    {
+        var method = typeof(MainWindow).GetMethod(
+            "RefreshTreeView",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("RefreshTreeView not found via reflection");
+
+        method.Invoke(window, null);
     }
 
     private static List<string?> ContextMenuHeaders(MainWindow window)
@@ -380,6 +393,60 @@ public class HeadlessTreeViewTests
             var headers = ContextMenuHeaders(window);
             Assert.Contains("Delete AnimationChain", headers);
             Assert.DoesNotContain("Delete Frame", headers);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── TV08: Inline "Add Frame" button on chain nodes ────────────────────────
+
+    [AvaloniaFact]
+    public void ChainNode_AfterRefresh_HasIsChainNodeTrue()
+    {
+        var window = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var roots = GetRoots(GetTree(window));
+            Assert.Single(roots);
+            Assert.True(roots[0].IsChainNode);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineAddFrameBtn_Click_AddsFrameToChain_AndSelectsIt()
+    {
+        var window = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Run" };
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            // Wire SaveCurrentAnimationChainList to a no-op so no file I/O happens
+            AppCommands.Self.DoOnUiThread = a => a();
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            // Find the add-frame button rendered inside the tree visual tree
+            var tree = GetTree(window);
+            var addBtn = tree.GetVisualDescendants()
+                .OfType<Button>()
+                .FirstOrDefault(b => b.Classes.Contains("add-frame-btn") && b.IsVisible);
+
+            Assert.NotNull(addBtn);
+
+            // Simulate a click
+            addBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(chain.Frames);
+            Assert.Same(chain.Frames[0], SelectedState.Self.SelectedFrame);
         }
         finally { window.Close(); }
     }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -108,6 +108,34 @@ public class TreeBuilderPureTests
         Assert.True(node.IsExpanded);
     }
 
+    [Fact]
+    public void BuildChainNode_SetsIsChainNodeTrue()
+    {
+        var chain = new AnimationChainSave { Name = "Jump" };
+        var node = TreeBuilder.BuildChainNode(chain);
+        Assert.True(node.IsChainNode);
+    }
+
+    [Fact]
+    public void BuildFrameNode_HasIsChainNodeFalse()
+    {
+        var frame = new AnimationFrameSave { TextureName = "run1.png" };
+        var node = TreeBuilder.BuildFrameNode(frame);
+        Assert.False(node.IsChainNode);
+    }
+
+    [Fact]
+    public void BuildTree_ChainNodes_HaveIsChainNodeTrue()
+    {
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Walk" });
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Run" });
+
+        var result = TreeBuilder.BuildTree(acls);
+
+        Assert.All(result, n => Assert.True(n.IsChainNode));
+    }
+
     // ── BuildFrameNode & BuildFrameHeader ─────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds a small + button to each animation chain node in the tree view that immediately adds a new frame to that chain.

## Changes

- **TreeNodeVm**: Added IsChainNode property — set to 	rue for chain nodes, alse for frame/shape nodes
- **TreeBuilder.BuildChainNode**: Sets IsChainNode = true
- **MainWindow.axaml**: Tree item template now wraps content in a Grid; the + button (CSS class dd-frame-btn) sits in column 1, visible only for chain nodes. Two styles in TreeView.Styles hide it by default (Opacity=0, IsHitTestVisible=False, Focusable=False) and reveal it when the row is hovered (TreeViewItem:pointerover Button.add-frame-btn)
- **MainWindow.axaml.cs**: OnAddFrameBtnClick handler reads the TreeNodeVm from the button's DataContext, extracts the AnimationChainSave, and calls AppCommands.Self.AddFrame(chain)

## Tests

Five new tests covering:
- BuildChainNode_SetsIsChainNodeTrue
- BuildFrameNode_HasIsChainNodeFalse
- BuildTree_ChainNodes_HaveIsChainNodeTrue
- ChainNode_AfterRefresh_HasIsChainNodeTrue (headless app test)
- InlineAddFrameBtn_Click_AddsFrameToChain_AndSelectsIt (headless app test — simulates click, asserts frame added and selected)

Closes #125