### PR TITLE
Show coordinate value label next to guide while dragging

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -145,6 +145,7 @@ public class PreviewControl : Control
                                         _showGuides, texPath, onionPath, width, height,
                                         AppState.Self.OffsetMultiplier,
                                         _hGuides.ToArray(), _vGuides.ToArray(),
+                                        _draggedGuideIdx, _draggingHGuide,
                                         BuildShapeInfos());
         var bitmap = new SKBitmap(width, height);
         using var canvas = new SKCanvas(bitmap);
@@ -338,6 +339,7 @@ public class PreviewControl : Control
                 texPath, onionPath, (float)w, (float)h,
                 AppState.Self.OffsetMultiplier,
                 _hGuides.ToArray(), _vGuides.ToArray(),
+                _draggedGuideIdx, _draggingHGuide,
                 BuildShapeInfos()),
             _bitmapCache));
     }
@@ -403,6 +405,35 @@ public class PreviewControl : Control
         _vGuides[idx] = SnapToPixel(ScreenToWorldX(screenX, controlWidth));
         InvalidateVisual();
     }
+
+    /// <summary>
+    /// Marks guide <paramref name="idx"/> as the active drag target so the
+    /// value label renders in <see cref="RenderToBitmap"/>. Use in headless
+    /// tests together with <see cref="SimulateAddHGuide"/> /
+    /// <see cref="SimulateAddVGuide"/> to verify label rendering.
+    /// </summary>
+    internal void SimulateBeginGuideDrag(bool isHorizontal, int idx)
+    {
+        _draggedGuideIdx = idx;
+        _draggingHGuide  = isHorizontal;
+        InvalidateVisual();
+    }
+
+    /// <summary>Clears the active drag state set by <see cref="SimulateBeginGuideDrag"/>.</summary>
+    internal void SimulateEndGuideDrag()
+    {
+        _draggedGuideIdx = -1;
+        InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Formats the coordinate label shown next to a guide while it is being dragged.
+    /// Returns <c>"Y: N"</c> for horizontal guides and <c>"X: N"</c> for vertical ones.
+    /// </summary>
+    internal static string FormatGuideLabel(bool isHorizontal, float worldValue)
+        => isHorizontal
+            ? $"Y: {(int)MathF.Round(worldValue)}"
+            : $"X: {(int)MathF.Round(worldValue)}";
 
     /// <summary>
     /// Returns the cursor type to show when the pointer is at screen position
@@ -648,6 +679,8 @@ public class PreviewControl : Control
         float  OffsetMultiplier,
         float[] HGuides,
         float[] VGuides,
+        int    DraggedGuideIdx,
+        bool   DraggingHGuide,
         PreviewShapeInfo[] Shapes);
 
     // ── Shared SkiaSharp rendering (used by both live and off-screen paths) ───
@@ -746,6 +779,40 @@ public class PreviewControl : Control
                 else
                 {
                     canvas.DrawCircle(sx, sy, sh.Param1 * om, paint);
+                }
+            }
+        }
+
+        // Dragged guide value label — drawn last so it stays on top of shapes
+        if (s.DraggedGuideIdx >= 0)
+        {
+            using var dragLabelPaint = new SKPaint
+            {
+                Color       = new SKColor(0, 200, 255, 230),
+                TextSize    = 11f,
+                IsAntialias = true
+            };
+            const float lMargin = 4f;
+            const float lHeight = 13f; // approximate text height at TextSize=11
+
+            if (s.DraggingHGuide && s.DraggedGuideIdx < s.HGuides.Length)
+            {
+                float wy = s.HGuides[s.DraggedGuideIdx];
+                float sy = cy + wy * s.Zoom;
+                if (sy >= RulerSize && sy <= s.Height)
+                {
+                    float baseline = Math.Clamp(sy - 2f, RulerSize + lHeight, s.Height - lMargin);
+                    canvas.DrawText(FormatGuideLabel(true, wy), RulerSize + lMargin, baseline, dragLabelPaint);
+                }
+            }
+            else if (!s.DraggingHGuide && s.DraggedGuideIdx < s.VGuides.Length)
+            {
+                float wx = s.VGuides[s.DraggedGuideIdx];
+                float sx = cx + wx * s.Zoom;
+                if (sx >= RulerSize && sx <= s.Width)
+                {
+                    float lx = Math.Clamp(sx + lMargin, RulerSize + lMargin, s.Width - 50f);
+                    canvas.DrawText(FormatGuideLabel(false, wx), lx, RulerSize + lHeight, dragLabelPaint);
                 }
             }
         }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideValueLabelTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideValueLabelTests.cs
@@ -1,0 +1,148 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests that <see cref="PreviewControl"/> displays the world coordinate value
+/// as a text label next to a guide while it is being dragged.
+/// </summary>
+public class GuideValueLabelTests
+{
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName = null;
+        SelectedState.Self.SelectedChain = null;
+        SelectedState.Self.SelectedFrame = null;
+        SelectedState.Self.SelectedNodes = new System.Collections.Generic.List<object>();
+        AppCommands.Self.DoOnUiThread = a => a();
+        AppCommands.Self.FileDialogService = NullFileDialogService.Instance;
+        AppState.Self.OffsetMultiplier = 1f;
+    }
+
+    // ── FormatGuideLabel unit tests ───────────────────────────────────────────
+
+    [Fact]
+    public void FormatGuideLabel_Horizontal_ReturnsYPrefix()
+    {
+        Assert.Equal("Y: 42", PreviewControl.FormatGuideLabel(isHorizontal: true, worldValue: 42f));
+    }
+
+    [Fact]
+    public void FormatGuideLabel_Vertical_ReturnsXPrefix()
+    {
+        Assert.Equal("X: -15", PreviewControl.FormatGuideLabel(isHorizontal: false, worldValue: -15f));
+    }
+
+    [Fact]
+    public void FormatGuideLabel_Zero_ShowsZero()
+    {
+        Assert.Equal("Y: 0", PreviewControl.FormatGuideLabel(isHorizontal: true, worldValue: 0f));
+        Assert.Equal("X: 0", PreviewControl.FormatGuideLabel(isHorizontal: false, worldValue: 0f));
+    }
+
+    [Fact]
+    public void FormatGuideLabel_FractionalValue_Rounds()
+    {
+        Assert.Equal("Y: 3", PreviewControl.FormatGuideLabel(isHorizontal: true, worldValue: 2.6f));
+        Assert.Equal("X: -2", PreviewControl.FormatGuideLabel(isHorizontal: false, worldValue: -1.6f));
+    }
+
+    // ── Visual tests: label appears only while dragging ───────────────────────
+
+    /// <summary>
+    /// Rendering a horizontal guide in drag state should produce a bitmap that
+    /// differs from the same guide without drag state at the label position.
+    /// The label is drawn near (RulerSize+4, sy) where sy is the guide screen Y.
+    /// For a 200×200 bitmap with default pan/zoom, worldY=0 → sy = 110, label ≈ y 97–110.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_WhenDragged_LabelPixelsDifferFromNonDragged()
+    {
+        ResetSingletons();
+        const int size = 200;
+        var ctrl = new PreviewControl();
+        ctrl.SimulateAddHGuide(screenY: 110f, controlHeight: size); // worldY ≈ 0
+
+        // Render without drag (baseline)
+        using var bmBase = ctrl.RenderToBitmap(size, size);
+
+        // Render with drag active
+        ctrl.SimulateBeginGuideDrag(isHorizontal: true, idx: 0);
+        using var bmDrag = ctrl.RenderToBitmap(size, size);
+
+        ctrl.SimulateEndGuideDrag();
+
+        // Label region: x ∈ [21, 80], y ∈ [97, 113] (around the guide line near left edge)
+        bool anyDiff = false;
+        for (int x = 21; x < 80 && !anyDiff; x++)
+            for (int y = 97; y < 114 && !anyDiff; y++)
+                anyDiff = bmBase.GetPixel(x, y) != bmDrag.GetPixel(x, y);
+
+        Assert.True(anyDiff, "Dragging a horizontal guide should render a value label (pixel difference expected in label region)");
+    }
+
+    /// <summary>
+    /// Rendering a vertical guide in drag state should produce a bitmap that
+    /// differs from the same guide without drag state at the label position.
+    /// For a 200×200 bitmap with default pan/zoom, worldX=0 → sx = 110, label ≈ x 114–160, y 20–34.
+    /// </summary>
+    [AvaloniaFact]
+    public void VGuide_WhenDragged_LabelPixelsDifferFromNonDragged()
+    {
+        ResetSingletons();
+        const int size = 200;
+        var ctrl = new PreviewControl();
+        ctrl.SimulateAddVGuide(screenX: 110f, controlWidth: size); // worldX ≈ 0
+
+        // Render without drag (baseline)
+        using var bmBase = ctrl.RenderToBitmap(size, size);
+
+        // Render with drag active
+        ctrl.SimulateBeginGuideDrag(isHorizontal: false, idx: 0);
+        using var bmDrag = ctrl.RenderToBitmap(size, size);
+
+        ctrl.SimulateEndGuideDrag();
+
+        // Label region: x ∈ [114, 160], y ∈ [20, 35] (just below top ruler, after guide)
+        bool anyDiff = false;
+        for (int x = 114; x < 160 && !anyDiff; x++)
+            for (int y = 20; y < 36 && !anyDiff; y++)
+                anyDiff = bmBase.GetPixel(x, y) != bmDrag.GetPixel(x, y);
+
+        Assert.True(anyDiff, "Dragging a vertical guide should render a value label (pixel difference expected in label region)");
+    }
+
+    /// <summary>
+    /// After ending drag (SimulateEndGuideDrag), the bitmap should match the
+    /// pre-drag baseline exactly in the label region.
+    /// </summary>
+    [AvaloniaFact]
+    public void HGuide_AfterDragEnds_LabelDisappears()
+    {
+        ResetSingletons();
+        const int size = 200;
+        var ctrl = new PreviewControl();
+        ctrl.SimulateAddHGuide(screenY: 110f, controlHeight: size);
+
+        using var bmBase = ctrl.RenderToBitmap(size, size);
+
+        ctrl.SimulateBeginGuideDrag(isHorizontal: true, idx: 0);
+        ctrl.SimulateEndGuideDrag();
+
+        using var bmAfter = ctrl.RenderToBitmap(size, size);
+
+        bool anyDiff = false;
+        for (int x = 21; x < 80 && !anyDiff; x++)
+            for (int y = 97; y < 114 && !anyDiff; y++)
+                anyDiff = bmBase.GetPixel(x, y) != bmAfter.GetPixel(x, y);
+
+        Assert.False(anyDiff, "Label region should match baseline after drag ends");
+    }
+}


### PR DESCRIPTION
## Summary

Implements #127 — when a guide is being dragged in the Preview panel, a cyan text label (Y: N for horizontal guides, X: N for vertical guides) is rendered next to the guide line at the canvas edge, matching Gum's behaviour.

## Changes

- **PreviewControl.cs**:
  - RenderSnapshot gains DraggedGuideIdx + DraggingHGuide so the immutable render-thread snapshot knows which guide is active.
  - RenderSkCore draws a clamped cyan label (FormatGuideLabel) for the dragged guide, drawn last inside the content clip so it stays visible over collision shapes.
  - FormatGuideLabel extracted as internal static for clean unit testing.
  - SimulateBeginGuideDrag / SimulateEndGuideDrag test helpers added.

- **GuideValueLabelTests.cs** (new):
  - 4 label-format unit tests (h/v, zero, fractional rounding).
  - 3 visual pixel-diff tests: h-guide drag shows label, v-guide drag shows label, label disappears after drag ends.

All 980 tests pass (782 Core + 198 App).

Closes #127