### PR TITLE
feat: double-click frame node centres wireframe on that frame

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1178,6 +1178,40 @@ public class WireframeControl : Control
     }
 
     /// <summary>
+    /// Scrolls the wireframe panel so that <paramref name="frame"/>'s region is
+    /// centred in the viewport.  The current zoom level is preserved.
+    /// <para>
+    /// Does nothing when no bitmap is loaded or no ScrollViewer is attached.
+    /// </para>
+    /// </summary>
+    public void CenterOnFrame(AnimationFrameSave frame)
+    {
+        if (_bitmap is null || _scrollViewer is null) return;
+
+        float bmpW = _bitmap.Width;
+        float bmpH = _bitmap.Height;
+
+        float texCX = ((frame.LeftCoordinate + frame.RightCoordinate)  / 2f) * bmpW;
+        float texCY = ((frame.TopCoordinate  + frame.BottomCoordinate) / 2f) * bmpH;
+
+        float vpW = (float)_scrollViewer.Viewport.Width;
+        float vpH = (float)_scrollViewer.Viewport.Height;
+
+        float scrollX = Math.Max(0f, _panX + texCX * _zoom - vpW / 2f);
+        float scrollY = Math.Max(0f, _panY + texCY * _zoom - vpH / 2f);
+
+        // Clamp to the current max scroll so TryApplyPendingScroll's extent guard
+        // does not defer the scroll indefinitely when the frame is near the far edge.
+        if (_scrollViewer.Extent.Width > 0)
+            scrollX = Math.Min(scrollX, (float)Math.Max(0, _scrollViewer.Extent.Width  - vpW));
+        if (_scrollViewer.Extent.Height > 0)
+            scrollY = Math.Min(scrollY, (float)Math.Max(0, _scrollViewer.Extent.Height - vpH));
+
+        CancelPendingScrollApply(x: scrollX, y: scrollY);
+        QueueScrollAfterLayout(scrollX, scrollY);
+    }
+
+    /// <summary>
     /// Returns a snapshot of the frame rectangles currently tracked by the control.
     /// Bounds are in texture-space pixel coordinates; call after
     /// <see cref="RefreshFrames"/> to ensure the list is current.

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -946,18 +946,36 @@ public partial class MainWindow : Window
     /// <summary>
     /// Tunnel-phase PointerPressed: selects the tree node under the pointer on right-click so the
     /// context menu always acts on the item the user actually right-clicked, not the previous selection.
+    /// On left-button double-click over a frame node, centres the wireframe on that frame.
     /// We do NOT set e.Handled so normal selection and context-menu logic continues afterward.
     /// </summary>
     private void OnTreePointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (!e.GetCurrentPoint(AnimTree).Properties.IsRightButtonPressed) return;
+        var props = e.GetCurrentPoint(AnimTree).Properties;
 
-        // e.Source is the innermost visual under the pointer (e.g. the TextBlock in the DataTemplate).
-        // Walk up the visual tree to find the containing TreeViewItem.
-        if (e.Source is not Control src) return;
-        var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
-        if (tvi?.DataContext is TreeNodeVm vm && !ReferenceEquals(AnimTree.SelectedItem, vm))
-            AnimTree.SelectedItem = vm;
+        if (props.IsRightButtonPressed)
+        {
+            // e.Source is the innermost visual under the pointer (e.g. the TextBlock in the DataTemplate).
+            // Walk up the visual tree to find the containing TreeViewItem.
+            if (e.Source is not Control src) return;
+            var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+            if (tvi?.DataContext is TreeNodeVm vm && !ReferenceEquals(AnimTree.SelectedItem, vm))
+                AnimTree.SelectedItem = vm;
+        }
+        else if (props.IsLeftButtonPressed && e.ClickCount == 2)
+        {
+            if (e.Source is not Control src) return;
+            var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+            if (tvi?.DataContext is TreeNodeVm { Data: AnimationFrameSave frame })
+            {
+                // Post at Background priority so we run after the higher-priority
+                // SelectionChanged → RefreshAll dispatch has completed.  This prevents
+                // a same-texture RefreshAll from overwriting our queued scroll.
+                Dispatcher.UIThread.Post(
+                    () => WireframeCtrl.CenterOnFrame(frame),
+                    DispatcherPriority.Background);
+            }
+        }
     }
 
     private void OnTreeContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
@@ -1,0 +1,176 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall.Content.AnimationChain;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for WireframeControl.CenterOnFrame — scrolls the wireframe panel
+/// so the specified frame's region is centred in the viewport.
+/// </summary>
+public class WireframeCenterOnFrameTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName               = null;
+        SelectedState.Self.SelectedChain           = null;
+        SelectedState.Self.SelectedFrame           = null;
+        SelectedState.Self.SelectedNodes           = new System.Collections.Generic.List<object>();
+        AppCommands.Self.DoOnUiThread              = a => a();
+        AppCommands.Self.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        AppCommands.Self.FileDialogService         = NullFileDialogService.Instance;
+        AppState.Self.UnitType                     = UnitType.Pixel;
+    }
+
+    private static string WriteSolidPng(string dir, string name, int width, int height)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(width, height);
+        bm.Erase(SKColors.Blue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    private static T FindCtrl<T>(MainWindow w, string name) where T : Control
+        => w.FindControl<T>(name)
+           ?? throw new InvalidOperationException($"Control '{name}' not found");
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// CenterOnFrame scrolls the wireframe so the frame's centre is in
+    /// the middle of the viewport.  Uses a 500×500 texture at 300% zoom so
+    /// the image overflows and the expected scroll value is positive and not
+    /// clamped to zero for any realistic headless viewport size.
+    /// </summary>
+    [AvaloniaFact]
+    public void CenterOnFrame_FrameAtKnownUV_ScrollsToFrameCenter()
+    {
+        ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // 500×500 so the image overflows at 300% zoom
+            var texPath = WriteSolidPng(dir, "tex.png", 500, 500);
+
+            // Frame with UV centre at (0.7, 0.7) → texture-space pixel centre = (350, 350)
+            float expectedTexCX = 350f;
+            float expectedTexCY = 350f;
+
+            var frame = new AnimationFrameSave
+            {
+                LeftCoordinate   = 0.6f,
+                TopCoordinate    = 0.6f,
+                RightCoordinate  = 0.8f,
+                BottomCoordinate = 0.8f,
+            };
+
+            var window = new MainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+            var sv   = FindCtrl<ScrollViewer>(window, "WireframeScrollViewer");
+
+            ctrl.LoadTexture(texPath);
+            Dispatcher.UIThread.RunJobs();
+
+            // Zoom to 300% so the 500px image (1500px rendered) overflows the viewport,
+            // guaranteeing the expected scroll values are positive.
+            ctrl.SetZoomPercent(300);
+            Dispatcher.UIThread.RunJobs();
+
+            var (panX, panY, zoom) = ctrl.CameraState;
+            double vpW = sv.Viewport.Width;
+            double vpH = sv.Viewport.Height;
+
+            float expectedScrollX = Math.Max(0f, panX + expectedTexCX * zoom - (float)vpW / 2f);
+            float expectedScrollY = Math.Max(0f, panY + expectedTexCY * zoom - (float)vpH / 2f);
+
+            // Sanity: expected scroll must be positive for the test to be meaningful
+            Assert.True(expectedScrollX > 0,
+                $"Test precondition failed: expectedScrollX={expectedScrollX:F1} must be > 0 " +
+                $"(panX={panX:F1} zoom={zoom:F2} vpW={vpW:F1})");
+
+            ctrl.CenterOnFrame(frame);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(Math.Abs(sv.Offset.X - expectedScrollX) < 2.0,
+                $"Scroll X should centre frame; expected≈{expectedScrollX:F1} actual={sv.Offset.X:F1}");
+            Assert.True(Math.Abs(sv.Offset.Y - expectedScrollY) < 2.0,
+                $"Scroll Y should centre frame; expected≈{expectedScrollY:F1} actual={sv.Offset.Y:F1}");
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// CenterOnFrame called with a frame near the far edge of the texture
+    /// must clamp to max scroll and not leave the pending-scroll flag stuck.
+    /// </summary>
+    [AvaloniaFact]
+    public void CenterOnFrame_FrameNearFarEdge_ClampsToMaxScroll()
+    {
+        ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir, "tex.png", 500, 500);
+
+            // Frame at the far corner [0.95, 0.95, 1.0, 1.0] → centre at (487.5, 487.5)
+            var frame = new AnimationFrameSave
+            {
+                LeftCoordinate   = 0.95f,
+                TopCoordinate    = 0.95f,
+                RightCoordinate  = 1.0f,
+                BottomCoordinate = 1.0f,
+            };
+
+            var window = new MainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+            var sv   = FindCtrl<ScrollViewer>(window, "WireframeScrollViewer");
+
+            ctrl.LoadTexture(texPath);
+            Dispatcher.UIThread.RunJobs();
+
+            ctrl.SetZoomPercent(300);
+            Dispatcher.UIThread.RunJobs();
+
+            ctrl.CenterOnFrame(frame);
+            Dispatcher.UIThread.RunJobs();
+
+            // Pending flag must be cleared — scroll was either applied or clamped
+            Assert.False(ctrl.PendingScrollApply,
+                "PendingScrollApply must be false after CenterOnFrame + RunJobs");
+
+            // Scroll must not exceed max
+            double maxScrollX = Math.Max(0, sv.Extent.Width  - sv.Viewport.Width);
+            double maxScrollY = Math.Max(0, sv.Extent.Height - sv.Viewport.Height);
+            Assert.True(sv.Offset.X <= maxScrollX + 1.0,
+                $"Scroll X must not exceed max; offset={sv.Offset.X:F1} max={maxScrollX:F1}");
+            Assert.True(sv.Offset.Y <= maxScrollY + 1.0,
+                $"Scroll Y must not exceed max; offset={sv.Offset.Y:F1} max={maxScrollY:F1}");
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
## Summary

Double-clicking a frame node in the left animation tree now scrolls the wireframe (top) panel so that frame's region is centred in the viewport.

## Changes

### \WireframeControl.CenterOnFrame(AnimationFrameSave)\
Converts the frame's UV coordinates to texture-space pixel centre, computes the scroll offset needed to place it in the middle of the viewport at the current zoom, pre-clamps to maxScroll to avoid an infinite defer in TryApplyPendingScroll, then queues the scroll via CancelPendingScrollApply + QueueScrollAfterLayout.

### \MainWindow.OnTreePointerPressed\
Refactored to handle right-click (existing) and left-button double-click (new) in the same handler. On double-click over a frame node, posts CenterOnFrame at DispatcherPriority.Background so it runs after the higher-priority SelectionChanged → RefreshAll dispatch.

### \WireframeCenterOnFrameTests\
Two new [AvaloniaFact] tests:
- **Happy path** — 500×500 texture at 300% zoom, frame at [0.6, 0.8] × [0.6, 0.8] UV; asserts ScrollViewer.Offset within ±2 px of the expected centre.
- **Far-edge clamp** — frame at [0.95, 1.0] × [0.95, 1.0]; asserts PendingScrollApply is false and offset does not exceed maxScroll.

## Test results
193 tests, 0 failures.

Closes #128