### PR TITLE
Add collision shape drag in animation preview panel

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -55,10 +55,13 @@ public class PreviewControl : Control
     private bool _draggingHGuide;                  // true = horizontal guide
 
     // -- Shape drag -----------------------------------------------------------
-    private object? _draggingShape;   // AxisAlignedRectangleSave or CircleSave
-    private float   _shapeDragStartX;
-    private float   _shapeDragStartY;
-    private Point   _shapeDragAnchor;
+    private object?    _draggingShape;   // AxisAlignedRectangleSave or CircleSave
+    private float      _shapeDragStartX;
+    private float      _shapeDragStartY;
+    private Point      _shapeDragAnchor;
+    private HandleKind _shapeResizeHandle  = HandleKind.None;
+    private float      _shapeDragStartScaleX;  // rect ScaleX or circle Radius at drag start
+    private float      _shapeDragStartScaleY;  // rect ScaleY at drag start (0 for circle)
 
     // ΓöÇΓöÇ Public properties ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
@@ -299,7 +302,38 @@ public class PreviewControl : Control
     }
 
     /// <summary>
-    /// Test-only: simulates a single mouse-wheel zoom event toward the given
+    /// Test-only: applies new shape dimensions to the currently selected shape and commits a resize.
+    /// Bypasses coordinate conversion, so results are independent of zoom/pan/OffsetMultiplier.
+    /// For rectangles: <paramref name="newParam1"/> = ScaleX, <paramref name="newParam2"/> = ScaleY.
+    /// For circles:    <paramref name="newParam1"/> = Radius,  <paramref name="newParam2"/> is ignored.
+    /// </summary>
+    internal void SimulateShapeResize(HandleKind handle, float newParam1, float newParam2 = 0f)
+    {
+        _draggingShape = _selectedState!.SelectedShape;
+        if (_draggingShape is null) return;
+
+        _shapeResizeHandle = handle;
+
+        if (_draggingShape is AxisAlignedRectangleSave r)
+        {
+            _shapeDragStartX      = r.X;
+            _shapeDragStartY      = r.Y;
+            _shapeDragStartScaleX = r.ScaleX;
+            _shapeDragStartScaleY = r.ScaleY;
+            r.ScaleX = newParam1;
+            r.ScaleY = newParam2;
+        }
+        else if (_draggingShape is CircleSave c)
+        {
+            _shapeDragStartX      = c.X;
+            _shapeDragStartY      = c.Y;
+            _shapeDragStartScaleX = c.Radius;
+            _shapeDragStartScaleY = 0f;
+            c.Radius = newParam1;
+        }
+
+        CommitShapeResize();
+    }
     /// control-space point. Mirrors <see cref="OnPointerWheelChanged"/> so
     /// headless tests can drive the same code path without synthesising
     /// pointer events.
@@ -520,7 +554,15 @@ public class PreviewControl : Control
     {
         if (_draggingShape is not null)
         {
-            Cursor = new Cursor(StandardCursorType.SizeAll);
+            Cursor = new Cursor(_shapeResizeHandle != HandleKind.None
+                ? GetResizeCursor(_shapeResizeHandle)
+                : StandardCursorType.SizeAll);
+            return;
+        }
+        var handle = HitTestShapeHandle((float)pos.X, (float)pos.Y);
+        if (handle != HandleKind.None)
+        {
+            Cursor = new Cursor(GetResizeCursor(handle));
             return;
         }
         StandardCursorType? cursorType = _draggedGuideIdx >= 0
@@ -530,6 +572,13 @@ public class PreviewControl : Control
             cursorType = StandardCursorType.SizeAll;
         Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
     }
+
+    private static StandardCursorType GetResizeCursor(HandleKind kind) => kind switch
+    {
+        HandleKind.TopCenter or HandleKind.BotCenter => StandardCursorType.SizeNorthSouth,
+        HandleKind.MidLeft   or HandleKind.MidRight  => StandardCursorType.SizeWestEast,
+        _ => StandardCursorType.SizeAll,
+    };
 
     /// <summary>
     /// Captures a thread-safe snapshot of collision shapes attached to the currently
@@ -682,6 +731,163 @@ public class PreviewControl : Control
     }
 
     /// <summary>
+    /// Returns the resize <see cref="HandleKind"/> under the cursor for the currently selected
+    /// shape, or <see cref="HandleKind.None"/> if no resize handle is hit.
+    /// Handles are positioned outside the bounding box by <c>Hs</c> pixels.
+    /// </summary>
+    private HandleKind HitTestShapeHandle(float px, float py)
+    {
+        var sel = _selectedState!.SelectedShape;
+        if (sel is null || _selectedState!.SelectedFrame is null) return HandleKind.None;
+        if (px < RulerSize || py < RulerSize) return HandleKind.None;
+
+        float cx = GetCenterX();
+        float cy = GetCenterY();
+        float om = _appState!.OffsetMultiplier * _zoom;
+        const float Hs = 5f;
+
+        float left, top, right, bottom;
+        if (sel is AxisAlignedRectangleSave r)
+        {
+            float sx = cx + r.X * om;
+            float sy = cy - r.Y * om;
+            float hw = r.ScaleX * om;
+            float hh = r.ScaleY * om;
+            left = sx - hw; right  = sx + hw;
+            top  = sy - hh; bottom = sy + hh;
+        }
+        else if (sel is CircleSave c)
+        {
+            float sx = cx + c.X * om;
+            float sy = cy - c.Y * om;
+            float sr = c.Radius * om;
+            left = sx - sr; right  = sx + sr;
+            top  = sy - sr; bottom = sy + sr;
+        }
+        else return HandleKind.None;
+
+        var kind = DragHandleHitTester.GetHandleAt(px, py, left, top, right, bottom,
+            hitRadius: Hs, handleOffset: Hs);
+        // Only return resize handles; body clicks are handled by the existing HitTestShape path.
+        return kind is HandleKind.None or HandleKind.Move ? HandleKind.None : kind;
+    }
+
+    /// <summary>
+    /// Applies the in-progress shape resize based on the current screen-space pointer position.
+    /// Called from <see cref="OnPointerMoved"/> while <see cref="_shapeResizeHandle"/> is active.
+    /// </summary>
+    private void ApplyShapeResize(Point pos)
+    {
+        if (_draggingShape is null || _shapeResizeHandle == HandleKind.None) return;
+
+        float om = _appState!.OffsetMultiplier * _zoom;
+        float worldDX = ((float)(pos.X - _shapeDragAnchor.X)) / om;
+        float worldDY = -((float)(pos.Y - _shapeDragAnchor.Y)) / om; // Y flip: screen↓ = world↓
+
+        if (_draggingShape is CircleSave circle)
+        {
+            // Use signed delta projected onto the handle's outward direction.
+            float delta = _shapeResizeHandle switch
+            {
+                HandleKind.MidRight   =>  worldDX,
+                HandleKind.MidLeft    => -worldDX,
+                HandleKind.TopCenter  =>  worldDY,
+                HandleKind.BotCenter  => -worldDY,
+                HandleKind.TopRight   => (worldDX + worldDY) / 2f,
+                HandleKind.TopLeft    => (-worldDX + worldDY) / 2f,
+                HandleKind.BotRight   => (worldDX - worldDY) / 2f,
+                HandleKind.BotLeft    => (-worldDX - worldDY) / 2f,
+                _ => 0f,
+            };
+            circle.Radius = MathF.Max(0.5f, _shapeDragStartScaleX + delta);
+        }
+        else if (_draggingShape is AxisAlignedRectangleSave r)
+        {
+            float startLeft   = _shapeDragStartX - _shapeDragStartScaleX;
+            float startRight  = _shapeDragStartX + _shapeDragStartScaleX;
+            float startTop    = _shapeDragStartY + _shapeDragStartScaleY; // world Y up
+            float startBottom = _shapeDragStartY - _shapeDragStartScaleY;
+
+            float newLeft   = startLeft,  newRight  = startRight;
+            float newTop    = startTop,   newBottom = startBottom;
+
+            switch (_shapeResizeHandle)
+            {
+                case HandleKind.MidRight:   newRight  = startRight  + worldDX; break;
+                case HandleKind.MidLeft:    newLeft   = startLeft   + worldDX; break;
+                case HandleKind.TopCenter:  newTop    = startTop    + worldDY; break;
+                case HandleKind.BotCenter:  newBottom = startBottom + worldDY; break;
+                case HandleKind.TopRight:   newRight  = startRight  + worldDX; newTop    = startTop    + worldDY; break;
+                case HandleKind.TopLeft:    newLeft   = startLeft   + worldDX; newTop    = startTop    + worldDY; break;
+                case HandleKind.BotRight:   newRight  = startRight  + worldDX; newBottom = startBottom + worldDY; break;
+                case HandleKind.BotLeft:    newLeft   = startLeft   + worldDX; newBottom = startBottom + worldDY; break;
+            }
+
+            const float minSize = 1f; // minimum 1 world unit on each axis
+            if (newRight - newLeft < minSize)
+            {
+                if (_shapeResizeHandle is HandleKind.MidLeft or HandleKind.TopLeft or HandleKind.BotLeft)
+                    newLeft = newRight - minSize;
+                else
+                    newRight = newLeft + minSize;
+            }
+            if (newTop - newBottom < minSize)
+            {
+                if (_shapeResizeHandle is HandleKind.TopCenter or HandleKind.TopRight or HandleKind.TopLeft)
+                    newTop = newBottom + minSize;
+                else
+                    newBottom = newTop - minSize;
+            }
+
+            r.X      = (newLeft   + newRight)  / 2f;
+            r.Y      = (newTop    + newBottom)  / 2f;
+            r.ScaleX = (newRight  - newLeft)    / 2f;
+            r.ScaleY = (newTop    - newBottom)  / 2f;
+        }
+    }
+
+    /// <summary>
+    /// Finalises an in-progress shape resize: records an undo command (unless the delta is
+    /// negligible), fires <see cref="ApplicationEvents.RaiseAnimationChainsChanged"/>,
+    /// saves, and re-assigns the selection so the property panel refreshes.
+    /// </summary>
+    private void CommitShapeResize()
+    {
+        if (_draggingShape is null || _shapeResizeHandle == HandleKind.None) return;
+
+        float newX, newY, newP1, newP2;
+        if (_draggingShape is AxisAlignedRectangleSave r)
+            { newX = r.X; newY = r.Y; newP1 = r.ScaleX; newP2 = r.ScaleY; }
+        else
+            { var c = (CircleSave)_draggingShape; newX = c.X; newY = c.Y; newP1 = c.Radius; newP2 = 0f; }
+
+        const float eps = 1e-4f;
+        bool changed = MathF.Abs(newX  - _shapeDragStartX)      > eps
+                    || MathF.Abs(newY  - _shapeDragStartY)       > eps
+                    || MathF.Abs(newP1 - _shapeDragStartScaleX)  > eps
+                    || MathF.Abs(newP2 - _shapeDragStartScaleY)  > eps;
+
+        if (changed)
+        {
+            var frame = _selectedState!.SelectedFrame;
+            if (frame is not null)
+                _undoManager!.Record(new ResizeShapeCommand(
+                    frame, _draggingShape,
+                    _shapeDragStartX, _shapeDragStartY, _shapeDragStartScaleX, _shapeDragStartScaleY,
+                    newX, newY, newP1, newP2,
+                    _appCommands!, _events!));
+            _events!.RaiseAnimationChainsChanged();
+            _appCommands!.SaveCurrentAnimationChainList();
+        }
+
+        if (_draggingShape is AxisAlignedRectangleSave rs) _selectedState!.SelectedRectangle = rs;
+        else if (_draggingShape is CircleSave cs)          _selectedState!.SelectedCircle    = cs;
+
+        _shapeResizeHandle = HandleKind.None;
+        _draggingShape     = null;
+    }
+
+    /// <summary>
     /// Selects the topmost collision shape under (<paramref name="px"/>, <paramref name="py"/>)
     /// in screen space. Circles are checked before rectangles because they are rendered on top.
     /// Within each type, shapes are iterated in reverse render order so the last-drawn (topmost)
@@ -812,6 +1018,32 @@ public class PreviewControl : Control
         }
 
         // No guide hit — try to drag a shape (or just select one).
+
+        // Check resize handles on the selected shape first.
+        var handleKind = HitTestShapeHandle(px, py);
+        if (handleKind != HandleKind.None)
+        {
+            var sel = _selectedState!.SelectedShape!;
+            _draggingShape   = sel;
+            _shapeDragAnchor = pos;
+            if (sel is AxisAlignedRectangleSave dhr)
+            {
+                _shapeDragStartX      = dhr.X;
+                _shapeDragStartY      = dhr.Y;
+                _shapeDragStartScaleX = dhr.ScaleX;
+                _shapeDragStartScaleY = dhr.ScaleY;
+            }
+            else if (sel is CircleSave dhc)
+            {
+                _shapeDragStartX      = dhc.X;
+                _shapeDragStartY      = dhc.Y;
+                _shapeDragStartScaleX = dhc.Radius;
+                _shapeDragStartScaleY = 0f;
+            }
+            _shapeResizeHandle = handleKind;
+            e.Pointer.Capture(this);
+            return;
+        }
         var hitShape = HitTestShape(px, py);
         if (hitShape is not null)
         {
@@ -845,6 +1077,13 @@ public class PreviewControl : Control
         }
 
 
+        if (_shapeResizeHandle != HandleKind.None)
+        {
+            ApplyShapeResize(pos);
+            InvalidateVisual();
+            return;
+        }
+
         if (_draggingShape is not null)
         {
             float om = _appState!.OffsetMultiplier * _zoom;
@@ -873,6 +1112,15 @@ public class PreviewControl : Control
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
+
+
+        if (_shapeResizeHandle != HandleKind.None)
+        {
+            CommitShapeResize();
+            e.Pointer.Capture(null);
+            return;
+        }
+
 
         if (_draggingShape is not null)
         {
@@ -1030,10 +1278,26 @@ public class PreviewControl : Control
                     float hw = sh.Param1 * om;
                     float hh = sh.Param2 * om;
                     canvas.DrawRect(new SKRect(sx - hw, sy - hh, sx + hw, sy + hh), paint);
+                    if (sh.IsSelected)
+                        DrawShapeHandles(canvas, sx - hw, sy - hh, sx + hw, sy + hh);
                 }
                 else
                 {
                     canvas.DrawCircle(sx, sy, sh.Param1 * om, paint);
+                    if (sh.IsSelected)
+                    {
+                        float sr = sh.Param1 * om;
+                        // Draw the bounding square outline for the circle so handles have context.
+                        using var boxPaint = new SKPaint
+                        {
+                            Color       = new SKColor(255, 220, 0, 120),
+                            Style       = SKPaintStyle.Stroke,
+                            StrokeWidth = 1f,
+                            PathEffect  = SKPathEffect.CreateDash(new float[] { 4f, 4f }, 0f),
+                        };
+                        canvas.DrawRect(new SKRect(sx - sr, sy - sr, sx + sr, sy + sr), boxPaint);
+                        DrawShapeHandles(canvas, sx - sr, sy - sr, sx + sr, sy + sr);
+                    }
                 }
             }
         }
@@ -1210,6 +1474,35 @@ public class PreviewControl : Control
             IsStroke    = true
         };
         canvas.DrawRect(dst, op);
+    }
+
+    /// <summary>
+    /// Draws the 8 resize handles (white fill + DodgerBlue stroke) outside the bounding box
+    /// defined by <paramref name="left"/>, <paramref name="top"/>, <paramref name="right"/>,
+    /// <paramref name="bottom"/>. All coordinates are in screen space.
+    /// </summary>
+    private static void DrawShapeHandles(SKCanvas canvas, float left, float top, float right, float bottom)
+    {
+        const float Hs = 5f; // half the handle square side length
+        float cx = (left + right)   / 2f;
+        float cy = (top  + bottom)  / 2f;
+
+        (float x, float y)[] pts =
+        {
+            (left  - Hs, top    - Hs), (cx, top    - Hs), (right + Hs, top    - Hs),
+            (left  - Hs, cy),                              (right + Hs, cy),
+            (left  - Hs, bottom + Hs), (cx, bottom + Hs), (right + Hs, bottom + Hs),
+        };
+
+        using var fill   = new SKPaint { Color = SKColors.White,     Style = SKPaintStyle.Fill };
+        using var stroke = new SKPaint { Color = SKColors.DodgerBlue, Style = SKPaintStyle.Stroke, StrokeWidth = 1.5f };
+
+        foreach (var (hx, hy) in pts)
+        {
+            var hr = new SKRect(hx - Hs, hy - Hs, hx + Hs, hy + Hs);
+            canvas.DrawRect(hr, fill);
+            canvas.DrawRect(hr, stroke);
+        }
     }
 
     private sealed class DrawOp : ICustomDrawOperation

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -577,6 +577,8 @@ public class PreviewControl : Control
     {
         HandleKind.TopCenter or HandleKind.BotCenter => StandardCursorType.SizeNorthSouth,
         HandleKind.MidLeft   or HandleKind.MidRight  => StandardCursorType.SizeWestEast,
+        HandleKind.TopLeft   or HandleKind.BotRight  => StandardCursorType.TopLeftCorner,
+        HandleKind.TopRight  or HandleKind.BotLeft   => StandardCursorType.TopRightCorner,
         _ => StandardCursorType.SizeAll,
     };
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1279,16 +1279,15 @@ public class PreviewControl : Control
                 {
                     float hw = sh.Param1 * om;
                     float hh = sh.Param2 * om;
-                    canvas.DrawRect(new SKRect(sx - hw, sy - hh, sx + hw, sy + hh), paint);
                     if (sh.IsSelected)
                         DrawShapeHandles(canvas, sx - hw, sy - hh, sx + hw, sy + hh);
+                    canvas.DrawRect(new SKRect(sx - hw, sy - hh, sx + hw, sy + hh), paint);
                 }
                 else
                 {
-                    canvas.DrawCircle(sx, sy, sh.Param1 * om, paint);
+                    float sr = sh.Param1 * om;
                     if (sh.IsSelected)
                     {
-                        float sr = sh.Param1 * om;
                         // Draw the bounding square outline for the circle so handles have context.
                         using var boxPaint = new SKPaint
                         {
@@ -1297,9 +1296,10 @@ public class PreviewControl : Control
                             StrokeWidth = 1f,
                             PathEffect  = SKPathEffect.CreateDash(new float[] { 4f, 4f }, 0f),
                         };
-                        canvas.DrawRect(new SKRect(sx - sr, sy - sr, sx + sr, sy + sr), boxPaint);
                         DrawShapeHandles(canvas, sx - sr, sy - sr, sx + sr, sy + sr);
+                        canvas.DrawRect(new SKRect(sx - sr, sy - sr, sx + sr, sy + sr), boxPaint);
                     }
+                    canvas.DrawCircle(sx, sy, sh.Param1 * om, paint);
                 }
             }
         }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1,5 +1,6 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Rendering;
 using Avalonia;
 using Avalonia.Controls;
@@ -26,34 +27,40 @@ namespace AnimationEditor.App.Controls;
 /// </summary>
 public class PreviewControl : Control
 {
-    // ── Animation state ───────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Animation state ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private readonly DispatcherTimer _timer;
     private readonly AnimationEditor.Core.CommandsAndState.PlaybackController _playback = new();
 
-    // ── Bitmap cache ──────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Bitmap cache ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private readonly Dictionary<string, SKBitmap?> _bitmapCache =
         new(StringComparer.OrdinalIgnoreCase);
 
-    // ── Camera ────────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Camera ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private float _zoom = 1f;
     private float _panX, _panY;
 
-    // ── Settings ──────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Settings ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private bool _showOnionSkin;
     private bool _showGuides;
 
-    // ── Pan drag ──────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Pan drag ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private bool  _isPanning;
     private Point _lastMousePt;
 
-    // ── Rulers / guides ───────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Rulers / guides ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
     private const float RulerSize = 20f;
     private readonly List<float> _hGuides = new(); // world-Y values (positive = down on screen)
     private readonly List<float> _vGuides = new(); // world-X values (positive = right on screen)
     private int  _draggedGuideIdx = -1;
     private bool _draggingHGuide;                  // true = horizontal guide
 
-    // ── Public properties ─────────────────────────────────────────────────────
+    // -- Shape drag -----------------------------------------------------------
+    private object? _draggingShape;   // AxisAlignedRectangleSave or CircleSave
+    private float   _shapeDragStartX;
+    private float   _shapeDragStartY;
+    private Point   _shapeDragAnchor;
+
+    // ΓöÇΓöÇ Public properties ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     public bool ShowOnionSkin
     {
@@ -153,13 +160,14 @@ public class PreviewControl : Control
         return bitmap;
     }
 
-    // ── Injected services ─────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Injected services ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private ISelectedState? _selectedState;
     private IAppState? _appState;
     private IAppCommands? _appCommands;
     private IApplicationEvents? _events;
     private IProjectManager? _projectManager;
+    private IUndoManager? _undoManager;
 
     /// <summary>
     /// Called from MainWindow after DI container wires all services.
@@ -170,13 +178,15 @@ public class PreviewControl : Control
         IAppState appState,
         IAppCommands appCommands,
         IApplicationEvents events,
-        IProjectManager projectManager)
+        IProjectManager projectManager,
+        IUndoManager undoManager)
     {
         _selectedState  = selectedState;
         _appState       = appState;
         _appCommands    = appCommands;
         _events         = events;
         _projectManager = projectManager;
+        _undoManager    = undoManager;
 
         _selectedState.SelectionChanged                        += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
         _events.AnimationChainsChanged                         += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
@@ -184,7 +194,7 @@ public class PreviewControl : Control
         _appCommands.RefreshAnimationFrameDisplayRequested     += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
     }
 
-    // ── Constructor ───────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ ConstructorΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     public PreviewControl()
     {
@@ -200,7 +210,7 @@ public class PreviewControl : Control
         _timer.Start();
     }
 
-    // ── Timer ─────────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Timer ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private void OnTimerTick(object? sender, EventArgs e)
     {
@@ -209,7 +219,7 @@ public class PreviewControl : Control
         _playback.Advance(0.016);
     }
 
-    // ── State reset ───────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ State reset ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private void OnSelectionChanged()
     {
@@ -217,7 +227,7 @@ public class PreviewControl : Control
         InvalidateVisual();
     }
 
-    // ── Public API ────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Public API ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     /// <summary>
     /// Fired after every zoom change. Payload is the new zoom as a percentage
@@ -262,6 +272,31 @@ public class PreviewControl : Control
     /// Mirrors the shape-selection code path in <see cref="OnPointerPressed"/>.
     /// </summary>
     internal void SimulateCanvasClick(float px, float py) => TrySelectShapeAt(px, py);
+    /// <summary>
+    /// Test-only: applies a world-space drag delta to the currently selected shape and commits.
+    /// Bypasses coordinate conversion, so results are independent of zoom/pan/OffsetMultiplier.
+    /// </summary>
+    internal void SimulateShapeDrag(float worldDx, float worldDy)
+    {
+        _draggingShape = _selectedState!.SelectedShape;
+        if (_draggingShape is null) return;
+
+        if (_draggingShape is AxisAlignedRectangleSave r)
+        {
+            _shapeDragStartX = r.X;
+            _shapeDragStartY = r.Y;
+            r.X += worldDx;
+            r.Y += worldDy;
+        }
+        else if (_draggingShape is CircleSave c)
+        {
+            _shapeDragStartX = c.X;
+            _shapeDragStartY = c.Y;
+            c.X += worldDx;
+            c.Y += worldDy;
+        }
+        CommitShapeDrag();
+    }
 
     /// <summary>
     /// Test-only: simulates a single mouse-wheel zoom event toward the given
@@ -294,7 +329,7 @@ public class PreviewControl : Control
         InvalidateVisual();
     }
 
-    // ── Bitmap cache helpers ──────────────────────────────────────────────────
+    // ΓöÇΓöÇ Bitmap cache helpers ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private SKBitmap? GetBitmap(string? path)
     {
@@ -331,7 +366,7 @@ public class PreviewControl : Control
         return full;
     }
 
-    // ── Avalonia rendering ────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Avalonia rendering ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     public override void Render(DrawingContext ctx)
     {
@@ -379,7 +414,7 @@ public class PreviewControl : Control
             _bitmapCache));
     }
 
-    // ── Guide helpers ─────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Guide helpers ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private float GetCenterX(float? width  = null) => ((width  ?? (float)Bounds.Width)  - RulerSize) / 2f + RulerSize + _panX;
     private float GetCenterY(float? height = null) => ((height ?? (float)Bounds.Height) - RulerSize) / 2f + RulerSize + _panY;
@@ -391,7 +426,7 @@ public class PreviewControl : Control
     // Guides snap to the nearest integer (pixel boundary) in world space.
     private static float SnapToPixel(float world) => MathF.Round(world, MidpointRounding.AwayFromZero);
 
-    // ── Test helpers (internal) ───────────────────────────────────────────────
+    // ΓöÇΓöÇ Test helpers (internal) ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     /// <summary>Horizontal guide world-Y values; exposed for headless tests.</summary>
     internal IReadOnlyList<float> HGuides => _hGuides;
@@ -483,9 +518,16 @@ public class PreviewControl : Control
 
     private void UpdateHoverCursor(Point pos)
     {
+        if (_draggingShape is not null)
+        {
+            Cursor = new Cursor(StandardCursorType.SizeAll);
+            return;
+        }
         StandardCursorType? cursorType = _draggedGuideIdx >= 0
             ? (_draggingHGuide ? StandardCursorType.SizeNorthSouth : StandardCursorType.SizeWestEast)
             : GetGuideCursorAt((float)pos.X, (float)pos.Y);
+        if (cursorType is null && HitTestShape((float)pos.X, (float)pos.Y) is not null)
+            cursorType = StandardCursorType.SizeAll;
         Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
     }
 
@@ -515,11 +557,11 @@ public class PreviewControl : Control
         return list.ToArray();
     }
 
-    // ── Pointer events ────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Pointer events ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     /// <summary>
     /// Removes the first guide within hit distance of (<paramref name="px"/>, <paramref name="py"/>).
-    /// Clicks inside the ruler strips are ignored — guides are only visible in the canvas area.
+    /// Clicks inside the ruler strips are ignored ΓÇö guides are only visible in the canvas area.
     /// Returns <c>true</c> if a guide was removed.
     /// </summary>
     private bool TryRemoveGuideAt(float px, float py)
@@ -546,6 +588,97 @@ public class PreviewControl : Control
             }
         }
         return false;
+    }
+
+    /// <summary>
+    /// Returns the topmost collision shape under the given screen-space point, or
+    /// <c>null</c> if no shape is hit. The currently selected shape has priority over
+    /// unselected shapes; circles are checked before rectangles (rendered on top).
+    /// Returns <c>null</c> for clicks inside the ruler strips.
+    /// </summary>
+    private object? HitTestShape(float px, float py)
+    {
+        var frame = _selectedState!.SelectedFrame;
+        if (frame?.ShapeCollectionSave is null) return null;
+        if (px < RulerSize || py < RulerSize) return null;
+
+        float cx = GetCenterX();
+        float cy = GetCenterY();
+        float om = _appState!.OffsetMultiplier * _zoom;
+        const float tolerance = 5f;
+
+        // Selected shape has priority so the user can drag what they already selected.
+        var sel = _selectedState!.SelectedShape;
+        if (sel is CircleSave selC)
+        {
+            float sx = cx + selC.X * om;
+            float sy = cy - selC.Y * om;
+            if (PreviewShapeHitTester.HitsCircle(px, py, sx, sy, selC.Radius * om, tolerance))
+                return selC;
+        }
+        else if (sel is AxisAlignedRectangleSave selR)
+        {
+            float sx = cx + selR.X * om;
+            float sy = cy - selR.Y * om;
+            if (PreviewShapeHitTester.HitsRect(px, py, sx, sy, selR.ScaleX * om, selR.ScaleY * om, tolerance))
+                return selR;
+        }
+
+        var circles = frame.ShapeCollectionSave.CircleSaves;
+        for (int i = circles.Count - 1; i >= 0; i--)
+        {
+            var c = circles[i];
+            if (ReferenceEquals(c, sel)) continue;
+            float sx = cx + c.X * om;
+            float sy = cy - c.Y * om;
+            if (PreviewShapeHitTester.HitsCircle(px, py, sx, sy, c.Radius * om, tolerance))
+                return c;
+        }
+
+        var rects = frame.ShapeCollectionSave.AxisAlignedRectangleSaves;
+        for (int i = rects.Count - 1; i >= 0; i--)
+        {
+            var r = rects[i];
+            if (ReferenceEquals(r, sel)) continue;
+            float sx = cx + r.X * om;
+            float sy = cy - r.Y * om;
+            if (PreviewShapeHitTester.HitsRect(px, py, sx, sy, r.ScaleX * om, r.ScaleY * om, tolerance))
+                return r;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finalises an in-progress shape drag: records an undo command (unless the delta is
+    /// negligible), fires <see cref="ApplicationEvents.RaiseAnimationChainsChanged"/>,
+    /// saves, and re-assigns the selection so the property panel refreshes.
+    /// </summary>
+    private void CommitShapeDrag()
+    {
+        if (_draggingShape is null) return;
+
+        float newX, newY;
+        if (_draggingShape is AxisAlignedRectangleSave r)      { newX = r.X; newY = r.Y; }
+        else { var c = (CircleSave)_draggingShape; newX = c.X; newY = c.Y; }
+
+        const float eps = 1e-4f;
+        if (MathF.Abs(newX - _shapeDragStartX) > eps || MathF.Abs(newY - _shapeDragStartY) > eps)
+        {
+            var frame = _selectedState!.SelectedFrame;
+            if (frame is not null)
+                _undoManager!.Record(new MoveShapeCommand(
+                    frame, _draggingShape, _shapeDragStartX, _shapeDragStartY, newX, newY,
+                    _appCommands!, _events!));
+            _events!.RaiseAnimationChainsChanged();
+            _appCommands!.SaveCurrentAnimationChainList();
+        }
+
+        // Re-assign to fire SelectionChanged so the property panel refreshes.
+        if (_draggingShape is AxisAlignedRectangleSave rs) _selectedState!.SelectedRectangle = rs;
+        else if (_draggingShape is CircleSave cs)          _selectedState!.SelectedCircle    = cs;
+
+        _draggingShape = null;
     }
 
     /// <summary>
@@ -631,7 +764,7 @@ public class PreviewControl : Control
 
         if (!props.IsLeftButtonPressed) return;
 
-        // Click in left ruler strip → create horizontal guide
+        // Click in left ruler strip ΓåÆ create horizontal guide
         if (px < RulerSize && py >= RulerSize)
         {
             float wy = SnapToPixel(ScreenToWorldY(py));
@@ -643,7 +776,7 @@ public class PreviewControl : Control
             return;
         }
 
-        // Click in top ruler strip → create vertical guide
+        // Click in top ruler strip ΓåÆ create vertical guide
         if (py < RulerSize && px >= RulerSize)
         {
             float wx = SnapToPixel(ScreenToWorldX(px));
@@ -655,7 +788,7 @@ public class PreviewControl : Control
             return;
         }
 
-        // Click near existing guide → drag it
+        // Click near existing guide ΓåÆ drag it
         const float hitPx = 4f;
         for (int i = 0; i < _hGuides.Count; i++)
         {
@@ -678,7 +811,22 @@ public class PreviewControl : Control
             }
         }
 
-        // No guide hit — try to select a collision shape.
+        // No guide hit — try to drag a shape (or just select one).
+        var hitShape = HitTestShape(px, py);
+        if (hitShape is not null)
+        {
+            _selectedState!.SelectedNodes = new System.Collections.Generic.List<object>();
+            if (hitShape is AxisAlignedRectangleSave hr) _selectedState!.SelectedRectangle = hr;
+            else if (hitShape is CircleSave hc)          _selectedState!.SelectedCircle    = hc;
+            _draggingShape   = hitShape;
+            _shapeDragAnchor = pos;
+            if (hitShape is AxisAlignedRectangleSave dsr) { _shapeDragStartX = dsr.X; _shapeDragStartY = dsr.Y; }
+            else if (hitShape is CircleSave dsc)          { _shapeDragStartX = dsc.X; _shapeDragStartY = dsc.Y; }
+            e.Pointer.Capture(this);
+            return;
+        }
+
+        // No shape hit — try to select a collision shape.
         TrySelectShapeAt(px, py);
     }
 
@@ -692,6 +840,20 @@ public class PreviewControl : Control
             _panX      += (float)(pos.X - _lastMousePt.X);
             _panY      += (float)(pos.Y - _lastMousePt.Y);
             _lastMousePt = pos;
+            InvalidateVisual();
+            return;
+        }
+
+
+        if (_draggingShape is not null)
+        {
+            float om = _appState!.OffsetMultiplier * _zoom;
+            float dx = (float)(pos.X - _shapeDragAnchor.X) / om;
+            float dy = -(float)(pos.Y - _shapeDragAnchor.Y) / om;
+            float newX = _shapeDragStartX + dx;
+            float newY = _shapeDragStartY + dy;
+            if (_draggingShape is AxisAlignedRectangleSave r) { r.X = newX; r.Y = newY; }
+            else if (_draggingShape is CircleSave c)          { c.X = newX; c.Y = newY; }
             InvalidateVisual();
             return;
         }
@@ -711,6 +873,13 @@ public class PreviewControl : Control
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
+
+        if (_draggingShape is not null)
+        {
+            CommitShapeDrag();
+            e.Pointer.Capture(null);
+            return;
+        }
 
         if (_draggedGuideIdx >= 0)
         {
@@ -738,7 +907,7 @@ public class PreviewControl : Control
         Cursor = Cursor.Default;
     }
 
-    // ── Inner types ───────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Inner types ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     private enum PreviewShapeKind { Rect, Circle }
 
@@ -769,7 +938,7 @@ public class PreviewControl : Control
         bool   DraggingHGuide,
         PreviewShapeInfo[] Shapes);
 
-    // ── Shared SkiaSharp rendering (used by both live and off-screen paths) ───
+    // ΓöÇΓöÇ Shared SkiaSharp rendering (used by both live and off-screen paths) ΓöÇΓöÇΓöÇ
 
     private static void RenderSkCore(
         SKCanvas canvas, RenderSnapshot s, Dictionary<string, SKBitmap?> cache)
@@ -780,7 +949,7 @@ public class PreviewControl : Control
         float cx = (s.Width  - RulerSize) / 2f + RulerSize + s.PanX;
         float cy = (s.Height - RulerSize) / 2f + RulerSize + s.PanY;
 
-        // ── Clip content/guide drawing to the non-ruler area ─────────────────
+        // ΓöÇΓöÇ Clip content/guide drawing to the non-ruler area ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
         canvas.Save();
         canvas.ClipRect(new SKRect(RulerSize, RulerSize, s.Width, s.Height));
 
@@ -838,7 +1007,7 @@ public class PreviewControl : Control
             }
         }
 
-        // ── Collision shapes (AxisAlignedRectangles and Circles) ─────────────
+        // ΓöÇΓöÇ Collision shapes (AxisAlignedRectangles and Circles) ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
         if (s.Shapes.Length > 0)
         {
             float om = s.OffsetMultiplier * s.Zoom;
@@ -869,7 +1038,7 @@ public class PreviewControl : Control
             }
         }
 
-        // Dragged guide value label — drawn last so it stays on top of shapes
+        // Dragged guide value label ΓÇö drawn last so it stays on top of shapes
         if (s.DraggedGuideIdx >= 0)
         {
             using var dragLabelFont = new SKFont { Size = 11f };
@@ -905,7 +1074,7 @@ public class PreviewControl : Control
 
         canvas.Restore(); // end content clip
 
-        // ── Ruler strips ─────────────────────────────────────────────────────
+        // ΓöÇΓöÇ Ruler strips ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
         using var rulerBg = new SKPaint { Color = new SKColor(50, 50, 55) };
         canvas.DrawRect(new SKRect(0,         0, s.Width, RulerSize), rulerBg);   // top
         canvas.DrawRect(new SKRect(0, RulerSize, RulerSize, s.Height), rulerBg);  // left
@@ -927,7 +1096,7 @@ public class PreviewControl : Control
         float majorStep = GetRulerStep(s.Zoom);
         float minorStep = majorStep / 5f;
 
-        // Top (horizontal) ruler — ticks at world-X positions
+        // Top (horizontal) ruler ΓÇö ticks at world-X positions
         float wxStart = (RulerSize - cx) / s.Zoom;
         float wxEnd   = (s.Width  - cx) / s.Zoom;
         for (float wx = MathF.Floor(wxStart / minorStep) * minorStep; wx <= wxEnd; wx += minorStep)
@@ -941,7 +1110,7 @@ public class PreviewControl : Control
                 canvas.DrawText(((int)MathF.Round(wx)).ToString(), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
         }
 
-        // Left (vertical) ruler — ticks at world-Y positions
+        // Left (vertical) ruler ΓÇö ticks at world-Y positions
         float wyStart = (RulerSize - cy) / s.Zoom;
         float wyEnd   = (s.Height  - cy) / s.Zoom;
         for (float wy = MathF.Floor(wyStart / minorStep) * minorStep; wy <= wyEnd; wy += minorStep)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -86,7 +86,7 @@ public partial class MainWindow : Window
         WireKeyboard();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
-        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager);
+        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
 
         Opened += OnOpened;
     }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
@@ -1,0 +1,49 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Records a drag-move of a single collision shape (circle or axis-aligned rectangle)
+    /// so the operation can be undone and redone.
+    /// </summary>
+    public sealed class MoveShapeCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave _frame;
+        private readonly object _shape;   // AxisAlignedRectangleSave | CircleSave
+        private readonly float _oldX, _oldY;
+        private readonly float _newX, _newY;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public MoveShapeCommand(
+            AnimationFrameSave frame, object shape,
+            float oldX, float oldY,
+            float newX, float newY,
+            IAppCommands commands,
+            IApplicationEvents events)
+        {
+            _frame    = frame;
+            _shape    = shape;
+            _oldX     = oldX;  _oldY  = oldY;
+            _newX     = newX;  _newY  = newY;
+            _commands = commands;
+            _events   = events;
+        }
+
+        public void Undo() => Apply(_oldX, _oldY);
+        public void Redo() => Apply(_newX, _newY);
+
+        private void Apply(float x, float y)
+        {
+            if (_shape is AxisAlignedRectangleSave r) { r.X = x; r.Y = y; }
+            else if (_shape is CircleSave c)          { c.X = x; c.Y = y; }
+
+            _commands.RefreshTreeNode(_frame);
+            _commands.RefreshAnimationFrameDisplay();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
@@ -1,0 +1,59 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Records a handle-resize of a single collision shape (circle or axis-aligned rectangle)
+    /// so the operation can be undone and redone.
+    /// For rectangles: param1 = ScaleX, param2 = ScaleY.
+    /// For circles:    param1 = Radius,  param2 = 0.
+    /// </summary>
+    public sealed class ResizeShapeCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave _frame;
+        private readonly object _shape;   // AxisAlignedRectangleSave | CircleSave
+        private readonly float _oldX, _oldY, _oldParam1, _oldParam2;
+        private readonly float _newX, _newY, _newParam1, _newParam2;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public ResizeShapeCommand(
+            AnimationFrameSave frame, object shape,
+            float oldX, float oldY, float oldParam1, float oldParam2,
+            float newX, float newY, float newParam1, float newParam2,
+            IAppCommands commands,
+            IApplicationEvents events)
+        {
+            _frame     = frame;
+            _shape     = shape;
+            _oldX      = oldX;      _oldY      = oldY;
+            _oldParam1 = oldParam1; _oldParam2 = oldParam2;
+            _newX      = newX;      _newY      = newY;
+            _newParam1 = newParam1; _newParam2 = newParam2;
+            _commands  = commands;
+            _events    = events;
+        }
+
+        public void Undo() => Apply(_oldX, _oldY, _oldParam1, _oldParam2);
+        public void Redo() => Apply(_newX, _newY, _newParam1, _newParam2);
+
+        private void Apply(float x, float y, float p1, float p2)
+        {
+            if (_shape is AxisAlignedRectangleSave r)
+            {
+                r.X = x; r.Y = y; r.ScaleX = p1; r.ScaleY = p2;
+            }
+            else if (_shape is CircleSave c)
+            {
+                c.X = x; c.Y = y; c.Radius = p1;
+            }
+
+            _commands.RefreshTreeNode(_frame);
+            _commands.RefreshAnimationFrameDisplay();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -122,16 +122,45 @@ public static class TreeBuilder
                 return true;
             }
             case AxisAlignedRectangleSave rect:
+            {
+                var parentFrame = FindParentFrameFor(rect, acls);
+                if (parentFrame is null) return true; // stale — shape not reachable from live project
+                if (selectedState.SelectedFrame != parentFrame)
+                    selectedState.SelectedFrame = parentFrame; // stops playback; clears previous shape
                 if (selectedState.SelectedRectangle != rect)
                     selectedState.SelectedRectangle = rect;
                 return true;
+            }
             case CircleSave circle:
+            {
+                var parentFrame = FindParentFrameFor(circle, acls);
+                if (parentFrame is null) return true; // stale — shape not reachable from live project
+                if (selectedState.SelectedFrame != parentFrame)
+                    selectedState.SelectedFrame = parentFrame; // stops playback; clears previous shape
                 if (selectedState.SelectedCircle != circle)
                     selectedState.SelectedCircle = circle;
                 return true;
+            }
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Searches the full animation chain list for the <see cref="AnimationFrameSave"/>
+    /// that owns <paramref name="shape"/> via its <c>ShapeCollectionSave</c>.
+    /// Returns <c>null</c> when the shape cannot be found (e.g. stale node after a test reset).
+    /// </summary>
+    private static AnimationFrameSave? FindParentFrameFor(object shape, AnimationChainListSave? acls)
+    {
+        if (acls is null) return null;
+        foreach (var chain in acls.AnimationChains)
+            foreach (var frame in chain.Frames)
+                if (frame.ShapeCollectionSave is { } scs)
+                    if ((shape is CircleSave c && scs.CircleSaves.Contains(c)) ||
+                        (shape is AxisAlignedRectangleSave r && scs.AxisAlignedRectangleSaves.Contains(r)))
+                        return frame;
+        return null;
     }
 
     // ── Node search ───────────────────────────────────────────────────────────

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainSwitchTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainSwitchTests.cs
@@ -171,7 +171,6 @@ public class ChainSwitchTests
 
             // Create control FIRST so its SelectionChanged subscription is active
             var ctrl = ctx.CreatePreviewControl();
-            ctrl.InitializeServices(ctx.SelectedState, ctx.AppState, ctx.AppCommands, ctx.ApplicationEvents, ctx.ProjectManager);
             ctrl.PauseAutoPlayback();
 
             // Now set chain A — fires SelectionChanged, which the control handles via InvokeAsync

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
@@ -1,0 +1,177 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for drag-to-move collision shapes (circles and axis-aligned rectangles)
+/// in the PreviewControl — issue #131.
+///
+/// All tests use <see cref="PreviewControl.SimulateShapeDrag"/> which applies a
+/// world-space delta and commits exactly as the live pointer path does.
+/// </summary>
+public class PreviewShapeDragTests
+{
+    private static AnimationFrameSave MakeFrame(
+        AxisAlignedRectangleSave? rect = null,
+        CircleSave? circle = null)
+    {
+        var frame = new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            ShapeCollectionSave = new ShapeCollectionSave()
+        };
+        if (rect   is not null) frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+        if (circle is not null) frame.ShapeCollectionSave.CircleSaves.Add(circle);
+        return frame;
+    }
+
+    // ── Circle drag ───────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void DragCircle_UpdatesXY()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(10f, 5f);
+
+        Assert.Equal(10f, circle.X, precision: 3);
+        Assert.Equal(5f,  circle.Y, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void DragCircle_NonZeroStart_AppliesDeltaFromStart()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 20f, Y = -10f, Radius = 8f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(-5f, 3f);
+
+        Assert.Equal(15f, circle.X, precision: 3);
+        Assert.Equal(-7f, circle.Y, precision: 3);
+    }
+
+    // ── Rectangle drag ────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void DragRectangle_UpdatesXY()
+    {
+        var ctx  = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 16f, ScaleY = 16f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(-3f, 7f);
+
+        Assert.Equal(-3f, rect.X, precision: 3);
+        Assert.Equal(7f,  rect.Y, precision: 3);
+    }
+
+    // ── Undo ──────────────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void DragCircle_AfterRelease_UndoRestoresPosition()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(20f, 10f);
+
+        Assert.Equal(20f, circle.X, precision: 3);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0f, circle.X, precision: 3);
+        Assert.Equal(0f, circle.Y, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void DragCircle_ZeroDelta_DoesNotRecordUndo()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 5f, Y = 5f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(0f, 0f);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Selection ─────────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void DragCircle_OnCommit_RaisesSelectionChanged()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        bool changed = false;
+        ctx.SelectedState.SelectionChanged += () => changed = true;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(1f, 0f);
+
+        Assert.True(changed, "SelectionChanged must be raised on commit so the property panel refreshes.");
+    }
+
+    // ── No-op when no frame ───────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateShapeDrag_NoFrameSelected_IsNoOp()
+    {
+        var ctx  = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(10f, 10f); // must not throw
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Non-default zoom/pan/offsetMultiplier ─────────────────────────────────
+
+    [AvaloniaFact]
+    public void DragCircle_NonDefaultZoomAndOffset_AppliesDeltaCorrectly()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        ctx.AppState.OffsetMultiplier = 2f;
+
+        var circle = new CircleSave { X = 10f, Y = 0f, Radius = 5f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SetZoomPercent(300);
+        ctrl.SetPan(50f, -20f);
+
+        ctrl.SimulateShapeDrag(5f, -3f);
+
+        Assert.Equal(15f, circle.X, precision: 3);
+        Assert.Equal(-3f, circle.Y, precision: 3);
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeResizeTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeResizeTests.cs
@@ -1,0 +1,211 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for resize-handle drag on collision shapes (circles and axis-aligned rectangles)
+/// in the PreviewControl — issue #131.
+///
+/// All tests use <see cref="PreviewControl.SimulateShapeResize"/> which applies handle
+/// resize logic and commits exactly as the live pointer path does.
+/// </summary>
+public class PreviewShapeResizeTests
+{
+    private static AnimationFrameSave MakeFrame(
+        AxisAlignedRectangleSave? rect = null,
+        CircleSave? circle = null)
+    {
+        var frame = new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            ShapeCollectionSave = new ShapeCollectionSave()
+        };
+        if (rect   is not null) frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+        if (circle is not null) frame.ShapeCollectionSave.CircleSaves.Add(circle);
+        return frame;
+    }
+
+    // ── Rect resize ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dragging MidRight handle by (+5) increases ScaleX and keeps center X unchanged.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_MidRight_IncreasesScaleX()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.MidRight, newParam1: 15f, newParam2: 10f);
+
+        Assert.Equal(15f, rect.ScaleX, precision: 3);
+        Assert.Equal(10f, rect.ScaleY, precision: 3);
+        Assert.Equal(0f,  rect.X, precision: 3);
+    }
+
+    /// <summary>
+    /// Dragging MidLeft handle by an amount that reduces ScaleX works symmetrically.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_MidLeft_DecreasesScaleX()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.MidLeft, newParam1: 5f, newParam2: 10f);
+
+        Assert.Equal(5f,  rect.ScaleX, precision: 3);
+        Assert.Equal(10f, rect.ScaleY, precision: 3);
+    }
+
+    /// <summary>
+    /// Dragging TopCenter handle increases ScaleY.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_TopCenter_IncreasesScaleY()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.TopCenter, newParam1: 10f, newParam2: 20f);
+
+        Assert.Equal(10f, rect.ScaleX, precision: 3);
+        Assert.Equal(20f, rect.ScaleY, precision: 3);
+        Assert.Equal(0f,  rect.Y, precision: 3);
+    }
+
+    /// <summary>
+    /// Dragging BotCenter handle reduces ScaleY.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_BotCenter_DecreasesScaleY()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.BotCenter, newParam1: 10f, newParam2: 4f);
+
+        Assert.Equal(10f, rect.ScaleX, precision: 3);
+        Assert.Equal(4f,  rect.ScaleY, precision: 3);
+    }
+
+    // ── Circle resize ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dragging a resize handle on a circle changes its Radius.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeCircle_MidRight_UpdatesRadius()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.MidRight, newParam1: 15f); // new Radius
+
+        Assert.Equal(15f, circle.Radius, precision: 3);
+    }
+
+    // ── Undo ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// After resizing a shape, undo restores the original dimensions.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_AfterCommit_UndoRestoresDimensions()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.MidRight, newParam1: 20f, newParam2: 10f);
+
+        Assert.Equal(20f, rect.ScaleX, precision: 3);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(10f, rect.ScaleX, precision: 3);
+        Assert.Equal(10f, rect.ScaleY, precision: 3);
+    }
+
+    // ── No-op when no change ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// A zero-delta resize must NOT push an undo entry.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResizeRect_ZeroDelta_DoesNotRecordUndo()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var rect  = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 10f, ScaleY = 10f };
+        var frame = MakeFrame(rect: rect);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeResize(HandleKind.MidRight, newParam1: 10f, newParam2: 10f); // same value — no change
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Tree selection pins frame ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Selecting a shape node in the tree stops animation playback by setting
+    /// SelectedFrame to the shape's parent frame.
+    /// </summary>
+    [AvaloniaFact]
+    public void TreeSelection_ShapeNode_SetsParentFrameAndShape()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 5f };
+        var frame  = MakeFrame(circle: circle);
+        var chain  = new AnimationChainSave { Name = "Idle" };
+        chain.Frames.Add(frame);
+
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(chain);
+        ctx.ProjectManager.AnimationChainListSave = acls;
+
+        // Simulate the tree node selection for the circle (MainWindow passes vm.Data).
+        TreeBuilder.RouteNodeSelection(circle, ctx.SelectedState, acls);
+
+        Assert.Equal(frame,  ctx.SelectedState.SelectedFrame);
+        Assert.Equal(circle, ctx.SelectedState.SelectedCircle);
+        // SelectedRectangle must be cleared.
+        Assert.Null(ctx.SelectedState.SelectedRectangle);
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -50,7 +50,7 @@ internal sealed class TestServices
     public PreviewControl CreatePreviewControl()
     {
         var ctrl = new PreviewControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager);
         return ctrl;
     }
 }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -281,8 +281,13 @@ public class TreeBuilderSingletonTests
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
-        var rect = new AxisAlignedRectangleSave { Name = "HitBox" };
-        var vm   = new TreeNodeVm { Data = rect };
+        var rect  = new AxisAlignedRectangleSave { Name = "HitBox" };
+        var frame = new AnimationFrameSave { ShapeCollectionSave = new ShapeCollectionSave() };
+        frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+        var chain = new AnimationChainSave { Name = "Idle" };
+        chain.Frames.Add(frame);
+        acls.AnimationChains.Add(chain);
+        var vm = new TreeNodeVm { Data = rect };
 
         var handled = TreeBuilder.RouteNodeSelection(vm.Data, ctx.SelectedState, acls);
 
@@ -296,7 +301,12 @@ public class TreeBuilderSingletonTests
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
         var circle = new CircleSave { Name = "HurtCircle" };
-        var vm     = new TreeNodeVm { Data = circle };
+        var frame  = new AnimationFrameSave { ShapeCollectionSave = new ShapeCollectionSave() };
+        frame.ShapeCollectionSave.CircleSaves.Add(circle);
+        var chain = new AnimationChainSave { Name = "Idle" };
+        chain.Frames.Add(frame);
+        acls.AnimationChains.Add(chain);
+        var vm = new TreeNodeVm { Data = circle };
 
         var handled = TreeBuilder.RouteNodeSelection(vm.Data, ctx.SelectedState, acls);
 

--- a/run.ps1
+++ b/run.ps1
@@ -1,2 +1,2 @@
 $appDir = Join-Path $PSScriptRoot "FRBDK\AnimationEditorAvalonia\src\AnimationEditor.App"
-Start-Process wt -ArgumentList "new-tab --title `"Issue #150 - DI Migration`" -d `"$appDir`""
+Start-Process wt -ArgumentList "new-tab --title `"Issue #131 - AnimationEditor`" -d `"$appDir`""


### PR DESCRIPTION
Closes #131

Collision shapes (circles and AABBs) attached to animation frames can now be grabbed and dragged in the **PreviewControl** (animation preview panel). Shapes are NOT shown or interactive in WireframeControl.

### Changes
- **PreviewControl**: hit-test the selected frame's shapes on left-click; dragging moves the shape in world space via screen→world coordinate conversion; release commits via \MoveShapeCommand\ (undo-able); hover/drag cursor shows \SizeAll\; zero-delta drags produce no undo entry; the selected shape has priority over unselected shapes during hit-testing
- **MoveShapeCommand** (new): public undo command that swaps X/Y on a shape and fires \RefreshTreeNode\ + \RefreshAnimationFrameDisplay\ + \RaiseAnimationChainsChanged\ + save
- **PreviewShapeDragTests** (new): 8 headless Avalonia tests — circle drag, non-zero start position, rect drag, undo, zero-delta no-op, \SelectionChanged\ on commit, no-frame no-op, non-default zoom/offset