### PR TITLE
Add click-to-select for collision shapes in preview panel

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -229,6 +229,13 @@ public class PreviewControl : Control
     public void SimulateRightClick(float x, float y) => TryRemoveGuideAt(x, y);
 
     /// <summary>
+    /// Test-only: simulates a left-click on the canvas at (<paramref name="px"/>, <paramref name="py"/>)
+    /// and selects the topmost collision shape under the cursor, if any.
+    /// Mirrors the shape-selection code path in <see cref="OnPointerPressed"/>.
+    /// </summary>
+    internal void SimulateCanvasClick(float px, float py) => TrySelectShapeAt(px, py);
+
+    /// <summary>
     /// Test-only: simulates a single mouse-wheel zoom event toward the given
     /// control-space point. Mirrors <see cref="OnPointerWheelChanged"/> so
     /// headless tests can drive the same code path without synthesising
@@ -513,6 +520,54 @@ public class PreviewControl : Control
         return false;
     }
 
+    /// <summary>
+    /// Selects the topmost collision shape under (<paramref name="px"/>, <paramref name="py"/>)
+    /// in screen space. Circles are checked before rectangles because they are rendered on top.
+    /// Within each type, shapes are iterated in reverse render order so the last-drawn (topmost)
+    /// shape wins when two shapes overlap.
+    /// Returns <c>true</c> if a shape was selected.
+    /// </summary>
+    private bool TrySelectShapeAt(float px, float py)
+    {
+        var frame = SelectedState.Self.SelectedFrame;
+        if (frame?.ShapeCollectionSave is null) return false;
+        if (px < RulerSize || py < RulerSize) return false;
+
+        float cx = GetCenterX();
+        float cy = GetCenterY();
+        float om = AppState.Self.OffsetMultiplier * _zoom;
+        const float tolerance = 5f;
+
+        // Circles are rendered after rects (on top), so check circles first.
+        var circles = frame.ShapeCollectionSave.CircleSaves;
+        for (int i = circles.Count - 1; i >= 0; i--)
+        {
+            var c = circles[i];
+            float sx = cx + c.X * om;
+            float sy = cy - c.Y * om;
+            if (PreviewShapeHitTester.HitsCircle(px, py, sx, sy, c.Radius * om, tolerance))
+            {
+                SelectedState.Self.SelectedCircle = c;
+                return true;
+            }
+        }
+
+        var rects = frame.ShapeCollectionSave.AxisAlignedRectangleSaves;
+        for (int i = rects.Count - 1; i >= 0; i--)
+        {
+            var r = rects[i];
+            float sx = cx + r.X * om;
+            float sy = cy - r.Y * om;
+            if (PreviewShapeHitTester.HitsRect(px, py, sx, sy, r.ScaleX * om, r.ScaleY * om, tolerance))
+            {
+                SelectedState.Self.SelectedRectangle = r;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
@@ -594,6 +649,9 @@ public class PreviewControl : Control
                 return;
             }
         }
+
+        // No guide hit — try to select a collision shape.
+        TrySelectShapeAt(px, py);
     }
 
     protected override void OnPointerMoved(PointerEventArgs e)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -929,16 +929,16 @@ public partial class MainWindow : Window
 
     private void SyncTreeSelection()
     {
-        var selFrame = SelectedState.Self.SelectedFrame;
-        var selChain = SelectedState.Self.SelectedChain;
+        // Shapes are more specific than frames — prefer them so clicking a circle or
+        // rect in the tree (or preview panel) keeps the shape node highlighted.
+        object? sel = (object?)SelectedState.Self.SelectedCircle
+                   ?? SelectedState.Self.SelectedRectangle
+                   ?? SelectedState.Self.SelectedFrame
+                   ?? (object?)SelectedState.Self.SelectedChain;
 
-        TreeNodeVm? target = selFrame is not null
-            ? TreeBuilder.FindNodeForData(_treeRoots, selFrame)
-            : selChain is not null
-                ? TreeBuilder.FindNodeForData(_treeRoots, selChain)
-                : null;
+        var target = sel is not null ? TreeBuilder.FindNodeForData(_treeRoots, sel) : null;
 
-        if (target is not null && AnimTree.SelectedItem != target)
+        if (target is not null && !ReferenceEquals(AnimTree.SelectedItem, target))
             AnimTree.SelectedItem = target;
     }
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/PreviewShapeHitTester.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/PreviewShapeHitTester.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Pure, SkiaSharp-free hit-tester for collision shapes in the preview panel.
+/// All coordinates are in screen space (already transformed from world space).
+/// </summary>
+public static class PreviewShapeHitTester
+{
+    /// <summary>
+    /// Returns <c>true</c> if the click point is inside or within
+    /// <paramref name="tolerance"/> pixels of a circle's edge.
+    /// </summary>
+    public static bool HitsCircle(
+        float ptX, float ptY,
+        float centerX, float centerY,
+        float screenRadius,
+        float tolerance = 5f)
+    {
+        float dx = ptX - centerX;
+        float dy = ptY - centerY;
+        float limit = screenRadius + tolerance;
+        return dx * dx + dy * dy <= limit * limit;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the click point is inside or within
+    /// <paramref name="tolerance"/> pixels of an axis-aligned rectangle's edge.
+    /// </summary>
+    public static bool HitsRect(
+        float ptX, float ptY,
+        float centerX, float centerY,
+        float halfW, float halfH,
+        float tolerance = 5f)
+    {
+        return MathF.Abs(ptX - centerX) <= halfW + tolerance
+            && MathF.Abs(ptY - centerY) <= halfH + tolerance;
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -118,7 +118,9 @@ public static class TreeBuilder
             {
                 if (acls is null || !acls.AnimationChains.Any(c => c.Frames.Contains(frame)))
                     return true; // stale — recognised type, but don't corrupt state
-                if (SelectedState.Self.SelectedFrame != frame)
+                // Re-assign even when the same frame is already selected if a shape is
+                // selected, so that SelectedFrame.set clears SelectedCircle/SelectedRectangle.
+                if (SelectedState.Self.SelectedFrame != frame || SelectedState.Self.SelectedShape != null)
                     SelectedState.Self.SelectedFrame = frame;
                 return true;
             }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -418,6 +418,89 @@ public class HeadlessTreeViewTests
         finally { window.Close(); }
     }
 
+    // ── Tree selection sync with shapes ───────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SelectCircle_TreeViewHighlightsCircleNode_NotFrameNode()
+    {
+        var window = CreateWindow();
+        try
+        {
+            // Arrange: chain → frame → circle in ProjectManager
+            var circle = new CircleSave { Name = "CircleInstance", Radius = 8f };
+            var frame  = new AnimationFrameSave
+            {
+                TextureName         = "Tex.png",
+                ShapeCollectionSave = new ShapeCollectionSave()
+            };
+            frame.ShapeCollectionSave.CircleSaves.Add(circle);
+            var chain  = new AnimationChainSave { Name = "Run" };
+            chain.Frames.Add(frame);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
+            ProjectManager.Self.FileName = "test.achx";
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            // First select the frame (simulates the normal tree-click flow)
+            SelectedState.Self.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var tree = GetTree(window);
+            var roots = GetRoots(tree);
+            var frameNode  = roots[0].Children[0];          // chain → frame
+            var circleNode = frameNode.Children[0];          // frame → circle
+
+            Assert.Same(frameNode,  tree.SelectedItem);
+
+            // Act: select the circle (e.g. from tree click or preview click)
+            SelectedState.Self.SelectedCircle = circle;
+            Dispatcher.UIThread.RunJobs();
+
+            // Assert: tree must highlight the circle node, not the frame node
+            Assert.Same(circleNode, tree.SelectedItem);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void SelectRect_TreeViewHighlightsRectNode_NotFrameNode()
+    {
+        var window = CreateWindow();
+        try
+        {
+            var rect  = new AxisAlignedRectangleSave { Name = "HitBox" };
+            var frame = new AnimationFrameSave
+            {
+                TextureName         = "Tex.png",
+                ShapeCollectionSave = new ShapeCollectionSave()
+            };
+            frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+            var chain = new AnimationChainSave { Name = "Idle" };
+            chain.Frames.Add(frame);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
+            ProjectManager.Self.FileName = "test.achx";
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            SelectedState.Self.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var tree     = GetTree(window);
+            var frameNode = GetRoots(tree)[0].Children[0];
+            var rectNode  = frameNode.Children[0];
+
+            Assert.Same(frameNode, tree.SelectedItem);
+
+            SelectedState.Self.SelectedRectangle = rect;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Same(rectNode, tree.SelectedItem);
+        }
+        finally { window.Close(); }
+    }
+
     [AvaloniaFact]
     public void InlineAddFrameBtn_Click_AddsFrameToChain_AndSelectsIt()
     {

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
@@ -1,0 +1,178 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Content.Math.Geometry;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Integration tests that verify clicking on the preview canvas selects the
+/// collision shape under the cursor. Issue #130.
+/// </summary>
+public class PreviewCircleSelectionTests
+{
+    // Control size used for all tests.
+    private const float W = 400f;
+    private const float H = 300f;
+
+    // RulerSize from PreviewControl — must match the const there.
+    private const float RulerSize = 20f;
+
+    // Expected canvas center at zoom=1, pan=0 for a W×H control.
+    private const float CX = (W - RulerSize) / 2f + RulerSize;   // 210
+    private const float CY = (H - RulerSize) / 2f + RulerSize;   // 160
+
+    private static void ResetSingletons()
+    {
+        ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
+        ProjectManager.Self.FileName               = null;
+        SelectedState.Self.SelectedChain           = null;
+        SelectedState.Self.SelectedFrame           = null;
+        SelectedState.Self.SelectedNodes           = new List<object>();
+        AppCommands.Self.DoOnUiThread              = a => a();
+        AppCommands.Self.ConfirmAsync              = (_, _) => System.Threading.Tasks.Task.FromResult(true);
+        AppCommands.Self.FileDialogService         = NullFileDialogService.Instance;
+        AppState.Self.OffsetMultiplier             = 1f;
+    }
+
+    private static PreviewControl MakeControl()
+    {
+        var ctrl = new PreviewControl();
+        ctrl.Measure(new Size(W, H));
+        ctrl.Arrange(new Rect(0, 0, W, H));
+        return ctrl;
+    }
+
+    private static AnimationFrameSave MakeFrameWithCircle(float worldX, float worldY, float radius, out CircleSave circle)
+    {
+        circle = new CircleSave { X = worldX, Y = worldY, Radius = radius };
+        var frame = new AnimationFrameSave
+        {
+            ShapeCollectionSave = new ShapeCollectionSave()
+        };
+        frame.ShapeCollectionSave.CircleSaves.Add(circle);
+        return frame;
+    }
+
+    // ── Circle selection ─────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_SelectsCircle_WhenClickAtCenter()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        var frame = MakeFrameWithCircle(0f, 0f, radius: 8f, out var circle);
+        SelectedState.Self.SelectedFrame = frame;
+
+        // At world (0,0), screen center is exactly (CX, CY).
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Same(circle, SelectedState.Self.SelectedCircle);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_SelectsCircle_WhenClickInsideRadius()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        // Circle at world (10, 5), radius 20 → screen center (220, 155).
+        var frame = MakeFrameWithCircle(10f, 5f, radius: 20f, out var circle);
+        SelectedState.Self.SelectedFrame = frame;
+
+        // Click 5px right of the screen center — still inside radius.
+        ctrl.SimulateCanvasClick(CX + 10f + 5f, CY - 5f);
+
+        Assert.Same(circle, SelectedState.Self.SelectedCircle);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_DoesNotSelectCircle_WhenClickFarAway()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        var frame = MakeFrameWithCircle(0f, 0f, radius: 8f, out _);
+        SelectedState.Self.SelectedFrame = frame;
+
+        // Click 100px away from the circle center — well outside radius+tolerance.
+        ctrl.SimulateCanvasClick(CX + 100f, CY + 100f);
+
+        Assert.Null(SelectedState.Self.SelectedCircle);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_DoesNothing_WhenNoFrameSelected()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        // No frame selected — TrySelectShapeAt must not throw.
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Null(SelectedState.Self.SelectedCircle);
+        Assert.Null(SelectedState.Self.SelectedRectangle);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_DoesNothing_WhenClickInRulerStrip()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        var frame = MakeFrameWithCircle(0f, 0f, radius: 200f, out _);
+        SelectedState.Self.SelectedFrame = frame;
+
+        // Click in the ruler area (px < RulerSize) — must be ignored.
+        ctrl.SimulateCanvasClick(5f, CY);
+
+        Assert.Null(SelectedState.Self.SelectedCircle);
+    }
+
+    // ── Rect selection ───────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_SelectsRect_WhenClickAtRectCenter()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        var rect = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 15f, ScaleY = 10f };
+        var frame = new AnimationFrameSave { ShapeCollectionSave = new ShapeCollectionSave() };
+        frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+        SelectedState.Self.SelectedFrame = frame;
+
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Same(rect, SelectedState.Self.SelectedRectangle);
+    }
+
+    // ── Priority: circle over rect ───────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_SelectsCircle_WhenCircleAndRectOverlap()
+    {
+        ResetSingletons();
+        var ctrl = MakeControl();
+
+        // Both at origin — circle is rendered on top (drawn after rect), so it wins.
+        var rect   = new AxisAlignedRectangleSave { X = 0f, Y = 0f, ScaleX = 30f, ScaleY = 30f };
+        var circle = new CircleSave              { X = 0f, Y = 0f, Radius = 20f };
+        var frame  = new AnimationFrameSave { ShapeCollectionSave = new ShapeCollectionSave() };
+        frame.ShapeCollectionSave.AxisAlignedRectangleSaves.Add(rect);
+        frame.ShapeCollectionSave.CircleSaves.Add(circle);
+        SelectedState.Self.SelectedFrame = frame;
+
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Same(circle, SelectedState.Self.SelectedCircle);
+        Assert.Null(SelectedState.Self.SelectedRectangle);
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PreviewShapeHitTesterTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PreviewShapeHitTesterTests.cs
@@ -1,0 +1,104 @@
+using AnimationEditor.Core.Rendering;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PreviewShapeHitTester"/> — the pure, SkiaSharp-free
+/// hit-tester that backs click-to-select for circles and rectangles in the preview panel.
+/// Issue #130.
+/// </summary>
+public class PreviewShapeHitTesterTests
+{
+    // ── Circle ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HitsCircle_ReturnsTrue_WhenClickAtCenter()
+    {
+        Assert.True(PreviewShapeHitTester.HitsCircle(100f, 100f, 100f, 100f, screenRadius: 20f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsTrue_WhenClickInsideRadius()
+    {
+        // 15px from center, radius=20 → inside
+        Assert.True(PreviewShapeHitTester.HitsCircle(115f, 100f, 100f, 100f, screenRadius: 20f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsTrue_WhenClickWithinTolerance()
+    {
+        // 23px from center, radius=20, tolerance=5 → 23 ≤ 25
+        Assert.True(PreviewShapeHitTester.HitsCircle(123f, 100f, 100f, 100f, screenRadius: 20f, tolerance: 5f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsFalse_WhenClickBeyondRadiusPlusTolerance()
+    {
+        // 30px from center, radius=20, tolerance=5 → 30 > 25
+        Assert.False(PreviewShapeHitTester.HitsCircle(130f, 100f, 100f, 100f, screenRadius: 20f, tolerance: 5f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsFalse_WhenClickFarAway()
+    {
+        Assert.False(PreviewShapeHitTester.HitsCircle(300f, 300f, 100f, 100f, screenRadius: 10f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsTrue_WhenClickOnEdgeExactly()
+    {
+        // 20px from center, radius=20, no tolerance override → exactly on edge
+        Assert.True(PreviewShapeHitTester.HitsCircle(120f, 100f, 100f, 100f, screenRadius: 20f, tolerance: 0f));
+    }
+
+    [Fact]
+    public void HitsCircle_ReturnsFalse_WhenZeroRadius_AndClickOutsideTolerance()
+    {
+        // radius=0, tolerance=5 → must be within 5px of center
+        Assert.False(PreviewShapeHitTester.HitsCircle(106f, 100f, 100f, 100f, screenRadius: 0f, tolerance: 5f));
+    }
+
+    // ── Rect ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HitsRect_ReturnsTrue_WhenClickAtCenter()
+    {
+        Assert.True(PreviewShapeHitTester.HitsRect(100f, 100f, 100f, 100f, halfW: 30f, halfH: 20f));
+    }
+
+    [Fact]
+    public void HitsRect_ReturnsTrue_WhenClickInsideBounds()
+    {
+        // (120, 110): 20px right, 10px down from center → within halfW=30, halfH=20
+        Assert.True(PreviewShapeHitTester.HitsRect(120f, 110f, 100f, 100f, halfW: 30f, halfH: 20f));
+    }
+
+    [Fact]
+    public void HitsRect_ReturnsTrue_WhenClickWithinToleranceX()
+    {
+        // 33px right of center, halfW=30, tolerance=5 → 33 ≤ 35
+        Assert.True(PreviewShapeHitTester.HitsRect(133f, 100f, 100f, 100f, halfW: 30f, halfH: 20f, tolerance: 5f));
+    }
+
+    [Fact]
+    public void HitsRect_ReturnsFalse_WhenClickBeyondToleranceX()
+    {
+        // 36px right of center, halfW=30, tolerance=5 → 36 > 35
+        Assert.False(PreviewShapeHitTester.HitsRect(136f, 100f, 100f, 100f, halfW: 30f, halfH: 20f, tolerance: 5f));
+    }
+
+    [Fact]
+    public void HitsRect_ReturnsFalse_WhenClickBeyondToleranceY()
+    {
+        // 26px below center, halfH=20, tolerance=5 → 26 > 25
+        Assert.False(PreviewShapeHitTester.HitsRect(100f, 126f, 100f, 100f, halfW: 30f, halfH: 20f, tolerance: 5f));
+    }
+
+    [Fact]
+    public void HitsRect_ReturnsTrue_WhenClickOnEdgeExactly()
+    {
+        // 30px right of center, halfW=30, tolerance=0 → exactly on edge
+        Assert.True(PreviewShapeHitTester.HitsRect(130f, 100f, 100f, 100f, halfW: 30f, halfH: 20f, tolerance: 0f));
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -312,9 +312,48 @@ public class TreeBuilderSingletonTests
     }
 
     /// <summary>
-    /// Regression test for Bug #2: clicking a chain after a frame was selected must clear
-    /// SelectedFrame so the context menu (and preview) reflect the chain, not the old frame.
+    /// Regression: clicking the parent frame after a shape is selected must clear the shape.
+    /// Without the fix, the guard `if (SelectedFrame != frame)` short-circuits and never
+    /// clears SelectedCircle.
     /// </summary>
+    [Fact]
+    public void RouteNodeSelection_FrameAlreadySelected_WithCircle_ClearsCircle()
+    {
+        var acls  = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(acls, "Run", frameCount: 1);
+        var frame = chain.Frames[0];
+        var circle = new CircleSave { Name = "C" };
+
+        // Select the frame first, then a shape (SelectedCircle.set does not clear SelectedFrame)
+        SelectedState.Self.SelectedFrame  = frame;
+        SelectedState.Self.SelectedCircle = circle;
+        Assert.Same(circle, SelectedState.Self.SelectedCircle);
+
+        // Re-click the same frame node — must clear the circle
+        TreeBuilder.RouteNodeSelection(new TreeNodeVm { Data = frame });
+
+        Assert.Null(SelectedState.Self.SelectedCircle);
+        Assert.Same(frame, SelectedState.Self.SelectedFrame);
+    }
+
+    [Fact]
+    public void RouteNodeSelection_FrameAlreadySelected_WithRect_ClearsRect()
+    {
+        var acls  = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(acls, "Idle", frameCount: 1);
+        var frame = chain.Frames[0];
+        var rect  = new AxisAlignedRectangleSave { Name = "HitBox" };
+
+        SelectedState.Self.SelectedFrame     = frame;
+        SelectedState.Self.SelectedRectangle = rect;
+        Assert.Same(rect, SelectedState.Self.SelectedRectangle);
+
+        TreeBuilder.RouteNodeSelection(new TreeNodeVm { Data = frame });
+
+        Assert.Null(SelectedState.Self.SelectedRectangle);
+        Assert.Same(frame, SelectedState.Self.SelectedFrame);
+    }
+
     [Fact]
     public void RouteNodeSelection_ChainAfterFrame_ClearsSelectedFrame()
     {


### PR DESCRIPTION
## Summary

Fixes #130 — users can now click circles (and axis-aligned rectangles) in the preview panel to select them, even when they sit under an animation frame sprite.

## Changes

**AnimationEditor.Core/Rendering/PreviewShapeHitTester.cs** (new)
- Pure static class with \HitsCircle\ and \HitsRect\ — no SkiaSharp dependency, fully unit-testable.

**AnimationEditor.App/Controls/PreviewControl.cs**
- \TrySelectShapeAt(px, py)\: checks circles first (rendered on top), then rects, both in reverse render order so the topmost shape wins when overlapping. Guards against ruler-strip clicks (\px/py < RulerSize\). Called from \OnPointerPressed\ after guide hit-tests fall through.
- \SimulateCanvasClick(px, py)\: \internal\ test helper, mirrors the same code path.

## Tests

- **13 pure \[Fact]\ tests** in \AnimationEditor.Core.Tests/PreviewShapeHitTesterTests.cs\
- **7 \[AvaloniaFact]\ integration tests** in \AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs\

All 795 Core tests + 208 App tests pass.

Closes #130