### PR TITLE
Fix #132: Display texture file paths as relative in the property panel

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -143,14 +143,10 @@ public partial class MainWindow : Window
         var frame = SelectedState.Self.SelectedFrame;
         if (frame == null) return;
 
-        string storePath = absolutePath;
-        if (!string.IsNullOrEmpty(ProjectManager.Self.FileName))
-        {
-            string achxFolder = FlatRedBall.IO.FileManager.GetDirectory(ProjectManager.Self.FileName);
-            string rel = Path.GetRelativePath(achxFolder, absolutePath);
-            if (!rel.StartsWith(".."))
-                storePath = rel;
-        }
+        string achxFolder = string.IsNullOrEmpty(ProjectManager.Self.FileName)
+            ? string.Empty
+            : FlatRedBall.IO.FileManager.GetDirectory(ProjectManager.Self.FileName);
+        string storePath = TexturePathHelper.ComputeStorePath(absolutePath, achxFolder);
         AppCommands.Self.SetFrameTextureName(frame, storePath);
         RefreshPropertyPanel();
     }
@@ -442,8 +438,8 @@ public partial class MainWindow : Window
             if (TextureCombo.SelectedItem as string != texPath)
             {
                 _suppressTextureComboChanged = true;
-                TextureCombo.SelectedItem = texPath;
-                _suppressTextureComboChanged = false;
+                try { TextureCombo.SelectedItem = texPath; }
+                finally { _suppressTextureComboChanged = false; }
                 WireframeCtrl.LoadTexture(texPath);
             }
         }
@@ -1261,14 +1257,13 @@ public partial class MainWindow : Window
             }
         }
 
-        // Store relative path when the file lives under the ACHX folder
-        string storePath = resolvedAbsPath;
-        if (!string.IsNullOrEmpty(achxFolder) && Path.IsPathRooted(resolvedAbsPath))
-        {
-            string rel = Path.GetRelativePath(achxFolder, resolvedAbsPath);
-            if (!rel.StartsWith(".."))
-                storePath = rel;
-        }
+        // Store relative path when possible; ../relative paths are allowed for textures
+        // outside the .achx folder so they round-trip correctly.
+        string storePath = string.IsNullOrEmpty(achxFolder)
+            ? resolvedAbsPath
+            : TexturePathHelper.ComputeStorePath(
+                resolvedAbsPath,
+                FlatRedBall.IO.FileManager.GetDirectory(ProjectManager.Self.FileName));
 
         AppCommands.Self.SetFrameTextureName(frame, storePath);
         WireframeCtrl.LoadTexture(resolvedAbsPath);
@@ -1348,7 +1343,8 @@ public partial class MainWindow : Window
                 PropFrameLen.Value   = (decimal)frame.FrameLength;
                 PropRelX.Value       = (decimal)frame.RelativeX;
                 PropRelY.Value       = (decimal)frame.RelativeY;
-                PropTextureName.Text = frame.TextureName ?? "";
+                PropTextureName.Text = TexturePathHelper.ComputeDisplayPath(
+                    frame.TextureName, ProjectManager.Self.FileName);
 
                 var unitType = AppState.Self.UnitType;
                 PropPixelSection.IsVisible = unitType != UnitType.TextureCoordinate;

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TexturePathHelper.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TexturePathHelper.cs
@@ -1,0 +1,58 @@
+using FlatRedBall.IO;
+using System.IO;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Utility methods for converting texture file paths between absolute and relative
+/// forms in the context of an .achx project file.
+/// </summary>
+public static class TexturePathHelper
+{
+    /// <summary>
+    /// Computes the path to store for a texture, relative to the .achx folder when possible.
+    /// Returns a forward-slash relative path — including <c>../</c> paths for textures outside
+    /// the .achx folder on the same drive — or the original absolute path when no relative path
+    /// can be expressed (e.g., the texture is on a different drive).
+    /// </summary>
+    /// <param name="absoluteTexturePath">The absolute path of the texture file.</param>
+    /// <param name="achxFolder">
+    /// The directory of the .achx file, as returned by <see cref="FileManager.GetDirectory"/>.
+    /// If empty, <paramref name="absoluteTexturePath"/> is returned unchanged.
+    /// </param>
+    public static string ComputeStorePath(string absoluteTexturePath, string achxFolder)
+    {
+        if (string.IsNullOrEmpty(achxFolder))
+            return absoluteTexturePath;
+
+        return FileManager.MakeRelative(absoluteTexturePath, achxFolder);
+    }
+
+    /// <summary>
+    /// Computes the path to display for a frame texture. If the stored path is already relative,
+    /// it is returned unchanged. If it is absolute and a relative path can be computed from the
+    /// .achx location, the relative form is returned instead — making the property panel
+    /// friendlier regardless of how the path was originally stored.
+    /// </summary>
+    /// <param name="framePath">
+    /// The <see cref="FlatRedBall.Content.AnimationChain.AnimationFrameSave.TextureName"/> value.
+    /// </param>
+    /// <param name="achxPath">
+    /// The full path to the .achx file, or <see langword="null"/> if the project has not been saved.
+    /// </param>
+    public static string ComputeDisplayPath(string? framePath, string? achxPath)
+    {
+        if (string.IsNullOrEmpty(framePath)) return string.Empty;
+        if (!Path.IsPathRooted(framePath)) return framePath;
+        if (string.IsNullOrEmpty(achxPath)) return framePath;
+
+        string achxFolder = FileManager.GetDirectory(achxPath);
+        if (string.IsNullOrEmpty(achxFolder)) return framePath;
+
+        string rel = FileManager.MakeRelative(framePath, achxFolder);
+
+        // MakeRelative returns the absolute path unchanged when it cannot make a relative
+        // path (e.g., the texture is on a different drive than the .achx).
+        return Path.IsPathRooted(rel) ? framePath : rel;
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
@@ -1,0 +1,122 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TexturePathHelperTests
+{
+    // ── ComputeStorePath ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeStorePath_TextureInAchxFolder_ReturnsSimpleRelative()
+    {
+        string storePath = TexturePathHelper.ComputeStorePath(
+            @"C:\Project\Animations\Hero.png",
+            @"C:\Project\Animations\");
+
+        Assert.Equal("Hero.png", storePath);
+    }
+
+    [Fact]
+    public void ComputeStorePath_TextureInSubfolder_ReturnsSubfolderRelative()
+    {
+        string storePath = TexturePathHelper.ComputeStorePath(
+            @"C:\Project\Animations\Sprites\Hero.png",
+            @"C:\Project\Animations\");
+
+        Assert.Equal("Sprites/Hero.png", storePath);
+    }
+
+    [Fact]
+    public void ComputeStorePath_TextureInSiblingFolder_ReturnsDotDotRelative()
+    {
+        string storePath = TexturePathHelper.ComputeStorePath(
+            @"C:\Project\Content\Hero.png",
+            @"C:\Project\Animations\");
+
+        // Key fix: sibling-folder textures must be stored as "../Content/Hero.png",
+        // not as the absolute path.
+        Assert.Equal("../Content/Hero.png", storePath);
+    }
+
+    [Fact]
+    public void ComputeStorePath_TextureInGrandparentSiblingFolder_ReturnsDotDotRelative()
+    {
+        string storePath = TexturePathHelper.ComputeStorePath(
+            @"C:\OtherProject\Content\Hero.png",
+            @"C:\Project\Animations\");
+
+        Assert.Equal("../../OtherProject/Content/Hero.png", storePath);
+    }
+
+    [Fact]
+    public void ComputeStorePath_EmptyAchxFolder_ReturnsAbsoluteUnchanged()
+    {
+        const string absolute = @"C:\Project\Content\Hero.png";
+        string storePath = TexturePathHelper.ComputeStorePath(absolute, string.Empty);
+
+        Assert.Equal(absolute, storePath);
+    }
+
+    // ── ComputeDisplayPath ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeDisplayPath_AlreadyRelative_ReturnedUnchanged()
+    {
+        string display = TexturePathHelper.ComputeDisplayPath(
+            "../Content/Hero.png",
+            @"C:\Project\Animations\Player.achx");
+
+        Assert.Equal("../Content/Hero.png", display);
+    }
+
+    [Fact]
+    public void ComputeDisplayPath_AbsolutePathInSiblingFolder_ReturnsRelative()
+    {
+        string display = TexturePathHelper.ComputeDisplayPath(
+            @"C:\Project\Content\Hero.png",
+            @"C:\Project\Animations\Player.achx");
+
+        // Absolute paths stored in the .achx should be displayed as relative.
+        Assert.Equal("../Content/Hero.png", display);
+    }
+
+    [Fact]
+    public void ComputeDisplayPath_AbsolutePathInAchxFolder_ReturnsSimpleRelative()
+    {
+        string display = TexturePathHelper.ComputeDisplayPath(
+            @"C:\Project\Animations\Hero.png",
+            @"C:\Project\Animations\Player.achx");
+
+        Assert.Equal("Hero.png", display);
+    }
+
+    [Fact]
+    public void ComputeDisplayPath_NullPath_ReturnsEmpty()
+    {
+        string display = TexturePathHelper.ComputeDisplayPath(
+            null,
+            @"C:\Project\Animations\Player.achx");
+
+        Assert.Equal(string.Empty, display);
+    }
+
+    [Fact]
+    public void ComputeDisplayPath_EmptyPath_ReturnsEmpty()
+    {
+        string display = TexturePathHelper.ComputeDisplayPath(
+            string.Empty,
+            @"C:\Project\Animations\Player.achx");
+
+        Assert.Equal(string.Empty, display);
+    }
+
+    [Fact]
+    public void ComputeDisplayPath_NullAchxPath_ReturnsAbsoluteUnchanged()
+    {
+        const string absolute = @"C:\Project\Content\Hero.png";
+        string display = TexturePathHelper.ComputeDisplayPath(absolute, null);
+
+        Assert.Equal(absolute, display);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the Animation Editor displaying absolute texture paths in the property panel when the .achx file stores them as relative.

## Root Causes Fixed

**1. Storage bug** - BrowseForFrameTexture and OnTextureComboChanged both used a StartsWith("..") guard that forced absolute paths for textures in sibling/parent directories. Picking a texture at ../Content/Hero.png would store C:/Project/Content/Hero.png instead. This is inconsistent with TextureDropProcessor, which correctly uses FileManager.MakeRelative.

**2. Display bug** - RefreshPropertyPanel showed frame.TextureName verbatim. Any path already stored as absolute in the .achx would display as absolute.

## Changes

- **TexturePathHelper** (new class in AnimationEditor.Core/IO/): two static methods:
  - ComputeStorePath: wraps FileManager.MakeRelative to produce forward-slash relative paths including ../relative for sibling/parent directories; falls back to absolute only for cross-drive paths.
  - ComputeDisplayPath: converts absolute stored paths to relative for display; leaves already-relative paths unchanged.
- **MainWindow.axaml.cs**:
  - BrowseForFrameTexture and OnTextureComboChanged: use ComputeStorePath so sibling-folder textures round-trip as ../textures/Hero.png.
  - RefreshPropertyPanel: uses ComputeDisplayPath for PropTextureName.Text.
  - SyncTextureCombo: added try/finally around suppression flag for exception safety.
- **TexturePathHelperTests**: 11 new unit tests covering both methods.

Closes #132
