### PR TITLE
Add statusline worktree harness and fix detection for navigated sessions

### DIFF
--- a/.claude/harness/analyze.ps1
+++ b/.claude/harness/analyze.ps1
@@ -1,0 +1,100 @@
+# analyze.ps1 — Reads diagnostic log files and produces a diagnosis report.
+# Run: pwsh -NoProfile -File analyze.ps1 [-LogDir <path>]
+
+param(
+    [string]$LogDir = "$env:USERPROFILE\.copilot\harness\logs"
+)
+
+$files = Get-ChildItem $LogDir -Filter '*.json' -Recurse -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime
+
+if ($files.Count -eq 0) {
+    Write-Host "No .json log files found in $LogDir" -ForegroundColor Red
+    return
+}
+
+Write-Host "`n=== Status-line diagnostic report ===" -ForegroundColor Cyan
+Write-Host "Files: $($files.Count)   Dir: $LogDir"
+
+$worktreeSeen = $false
+
+foreach ($f in $files) {
+    $log = Get-Content $f.FullName -Raw | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if (-not $log) { Write-Host "  (could not parse $($f.Name))"; continue }
+
+    Write-Host "`n--- $($f.Name) ---" -ForegroundColor Yellow
+
+    # JSON payload fields
+    $p = $log.parsed
+    if ($p) {
+        $keys = $p.PSObject.Properties.Name -join ', '
+        Write-Host "  JSON keys: $keys"
+        $cwd       = $p.workspace.current_dir ?? $p.cwd
+        $sessionId = $p.session_id
+        Write-Host "  session_id           : $(if ($sessionId) { $sessionId } else { '(absent)' })"
+        Write-Host "  workspace.current_dir: $(if ($cwd) { $cwd } else { '(absent)' })"
+        Write-Host "  context_window.used  : $($p.context_window.used_percentage)"
+    } else {
+        Write-Host "  raw payload: $($log.raw_json)" -ForegroundColor DarkGray
+    }
+
+    # Env vars
+    Write-Host "  Env COPILOT_CLI              : $($log.env.COPILOT_CLI)"
+    Write-Host "  Env COPILOT_AGENT_SESSION_ID : $(if ($log.env.COPILOT_AGENT_SESSION_ID) { $log.env.COPILOT_AGENT_SESSION_ID } else { '(absent)' })"
+    Write-Host "  Env COPILOT_HOME             : $(if ($log.env.COPILOT_HOME) { $log.env.COPILOT_HOME } else { '(absent)' })"
+
+    # State files
+    $sf = @($log.state_dir_contents)
+    if ($sf.Count -gt 0) {
+        Write-Host "  State files ($($sf.Count)):"
+        $sf | ForEach-Object { Write-Host "    $($_.name)  =>  $($_.content)" }
+    } else {
+        Write-Host "  State files: (none)"
+    }
+
+    # Diagnosis
+    Write-Host "  --- Diagnosis ---" -ForegroundColor Cyan
+    $sid = $p.session_id
+    if (-not $sid) { $sid = $log.env.COPILOT_AGENT_SESSION_ID }
+
+    if (-not $sid) {
+        Write-Host "  !! No session ID available (JSON.session_id absent AND COPILOT_AGENT_SESSION_ID not set)" -ForegroundColor Red
+        Write-Host "     State-file fallback is IMPOSSIBLE without a session ID." -ForegroundColor Red
+    } else {
+        Write-Host "  Session ID: $sid" -ForegroundColor Green
+        $match = $sf | Where-Object { $_.name -eq "$sid.txt" }
+        if ($match) {
+            $content = $match.content
+            if ($content -match '[\\/]\.claude[\\/]worktrees[\\/]([^\\/]+)') {
+                Write-Host "  State file found + contains worktree: $($Matches[1])" -ForegroundColor Green
+                Write-Host "  >> Status line SHOULD show: worktree: $($Matches[1])" -ForegroundColor Green
+                $script:worktreeSeen = $true
+            } else {
+                Write-Host "  State file found but path is NOT a worktree: $content" -ForegroundColor Yellow
+                Write-Host "  >> Agent hasn't cd'd into a worktree yet (or Set-Location hook didn't fire)" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "  No state file for session '$sid'" -ForegroundColor Red
+            Write-Host "  Available state file names: $(($sf | Select-Object -Expand name) -join ', ')" -ForegroundColor Red
+            Write-Host "  >> Set-Location hook may not be firing, or session ID mismatch" -ForegroundColor Red
+        }
+    }
+
+    # Check cwd path for worktree
+    if ($cwd -and $cwd -match '[\\/]\.claude[\\/]worktrees[\\/]([^\\/]+)') {
+        Write-Host "  Session cwd IS a worktree: $($Matches[1])" -ForegroundColor Green
+        Write-Host "  >> Status line SHOULD show: worktree: $($Matches[1]) (via session cwd)" -ForegroundColor Green
+        $script:worktreeSeen = $true
+    }
+}
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+if ($worktreeSeen) {
+    Write-Host "At least one log entry shows a working worktree detection path." -ForegroundColor Green
+} else {
+    Write-Host "No working worktree detection path found in any log entry." -ForegroundColor Red
+    Write-Host "Next steps:" -ForegroundColor Yellow
+    Write-Host "  1. Run unit-test.ps1 to verify detection logic in isolation" -ForegroundColor Yellow
+    Write-Host "  2. Run integration-noninteractive.ps1 to check if COPILOT_AGENT_SESSION_ID is set in shells" -ForegroundColor Yellow
+    Write-Host "  3. Check if the JSON payload contains session_id" -ForegroundColor Yellow
+}

--- a/.claude/harness/diagnostic-statusline.cmd
+++ b/.claude/harness/diagnostic-statusline.cmd
@@ -1,0 +1,2 @@
+@echo off
+"C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile -File "%~dp0diagnostic-statusline.ps1"

--- a/.claude/harness/diagnostic-statusline.ps1
+++ b/.claude/harness/diagnostic-statusline.ps1
@@ -1,0 +1,69 @@
+# Diagnostic drop-in replacement for ~/.copilot/statusline.ps1
+# Logs the complete JSON payload + env vars + git state to a timestamped file,
+# then runs the same worktree-detection logic and emits the normal status output.
+#
+# Activate:  set statusLine.command in ~/.copilot/settings.json to point to
+#            diagnostic-statusline.cmd (the .cmd wrapper for this script).
+# Deactivate: restore the original statusLine.command value.
+
+$raw = [Console]::In.ReadToEnd()
+
+# --- Logging ---
+$logDir = Join-Path (Split-Path $PSCommandPath) 'logs'
+if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss-fff'
+$logFile   = Join-Path $logDir "$timestamp.json"
+
+$stateDir   = Join-Path $env:USERPROFILE '.copilot\statusline-state'
+$stateFiles = if (Test-Path $stateDir) {
+    Get-ChildItem $stateDir -ErrorAction SilentlyContinue | ForEach-Object {
+        [ordered]@{
+            name    = $_.Name
+            content = (Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue)
+        }
+    }
+} else { @() }
+
+$parsed = $raw | ConvertFrom-Json -ErrorAction SilentlyContinue
+
+[ordered]@{
+    timestamp          = $timestamp
+    raw_json           = $raw
+    parsed             = $parsed
+    env                = [ordered]@{
+        COPILOT_CLI              = $env:COPILOT_CLI
+        COPILOT_AGENT_SESSION_ID = $env:COPILOT_AGENT_SESSION_ID
+        COPILOT_HOME             = $env:COPILOT_HOME
+        PWD                      = (Get-Location).Path
+    }
+    git                = [ordered]@{
+        git_dir       = (git rev-parse --git-dir 2>$null)
+        branch        = (git rev-parse --abbrev-ref HEAD 2>$null)
+        worktree_list = @(git worktree list 2>$null)
+    }
+    state_dir_contents = @($stateFiles)
+} | ConvertTo-Json -Depth 10 | Out-File $logFile -Encoding utf8
+
+# --- Same worktree-detection logic as statusline.ps1 ---
+function Get-WorktreeName([string]$path) {
+    if ($path -match '[\\/]\.claude[\\/]worktrees[\\/]([^\\/]+)') { $Matches[1] } else { $null }
+}
+
+$cwd = $parsed.workspace.current_dir
+if (-not $cwd) { $cwd = $parsed.cwd }
+
+$wt = Get-WorktreeName $cwd
+if (-not $wt) {
+    $sessionId = $parsed.session_id
+    if (-not $sessionId) { $sessionId = $env:COPILOT_AGENT_SESSION_ID }
+    if ($sessionId) {
+        $stateFile = Join-Path $stateDir "$sessionId.txt"
+        if (Test-Path -LiteralPath $stateFile) {
+            $shellCwd = Get-Content -LiteralPath $stateFile -Raw -ErrorAction SilentlyContinue
+            $wt = Get-WorktreeName $shellCwd.Trim()
+        }
+    }
+}
+
+if ($wt) { "worktree: $wt" }

--- a/.claude/harness/run-harness.ps1
+++ b/.claude/harness/run-harness.ps1
@@ -1,0 +1,42 @@
+# run-harness.ps1 — Master entry point for the statusline worktree test harness.
+#
+# Usage:
+#   pwsh -File run-harness.ps1 unit          — unit tests only (fast, no copilot instance)
+#   pwsh -File run-harness.ps1 integration   — non-interactive integration test (copilot -p)
+#   pwsh -File run-harness.ps1 tui           — TUI test (opens new terminal, captures status JSON)
+#   pwsh -File run-harness.ps1 all           — run all three in sequence
+#   pwsh -File run-harness.ps1 analyze       — analyze latest log files only
+
+param(
+    [ValidateSet('unit','integration','tui','all','analyze')]
+    [string]$Mode = 'unit'
+)
+
+$here = $PSScriptRoot
+
+function Run-Step([string]$title, [scriptblock]$block) {
+    Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+    Write-Host "  $title" -ForegroundColor Cyan
+    Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+    & $block
+}
+
+switch ($Mode) {
+    'unit' {
+        Run-Step "Unit tests" { & "$here\unit-test.ps1" }
+    }
+    'integration' {
+        Run-Step "Non-interactive integration test" { & "$here\integration-noninteractive.ps1" }
+    }
+    'tui' {
+        Run-Step "TUI integration test" { & "$here\integration-tui.ps1" }
+    }
+    'all' {
+        Run-Step "Unit tests" { & "$here\unit-test.ps1" }
+        Run-Step "Non-interactive integration test" { & "$here\integration-noninteractive.ps1" }
+        Run-Step "TUI integration test" { & "$here\integration-tui.ps1" }
+    }
+    'analyze' {
+        Run-Step "Log analysis" { & "$here\analyze.ps1" }
+    }
+}

--- a/.claude/harness/unit-test.ps1
+++ b/.claude/harness/unit-test.ps1
@@ -1,0 +1,170 @@
+# Unit tests for ~/.copilot/statusline.ps1
+# Verifies each detection path with synthetic JSON payloads and state files.
+# Run: pwsh -NoProfile -File unit-test.ps1
+# All tests are self-contained and clean up after themselves.
+
+$statusScript = "$env:USERPROFILE\.copilot\statusline.ps1"
+$stateDir     = "$env:USERPROFILE\.copilot\statusline-state"
+$worktreeBase = "C:\Users\devin\OneDrive\Documents\Repos\FlatRedBall2\.claude\worktrees"
+
+if (-not (Test-Path $statusScript)) {
+    Write-Host "ERROR: statusline.ps1 not found at $statusScript" -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $stateDir)) {
+    New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+}
+
+$pass = 0; $fail = 0
+
+function Invoke-StatusTest {
+    param(
+        [string]$Name,
+        [hashtable]$Payload,
+        [hashtable]$StateFiles  = @{},
+        [string]$EnvSessionId   = $null,   # simulates COPILOT_AGENT_SESSION_ID in shell
+        [string]$ExpectedMatch  = $null     # $null means expect empty output
+    )
+
+    # Write any state files
+    foreach ($kv in $StateFiles.GetEnumerator()) {
+        Set-Content -Path (Join-Path $stateDir $kv.Key) -Value $kv.Value -Encoding UTF8 -NoNewline
+    }
+
+    # Always snapshot and control COPILOT_AGENT_SESSION_ID so tests are hermetic.
+    # If EnvSessionId is provided, set it; if not, clear it so ambient state files
+    # from the current copilot session don't bleed into tests that expect empty output.
+    $hadEnv = [bool]$env:COPILOT_AGENT_SESSION_ID
+    $oldVal = $env:COPILOT_AGENT_SESSION_ID
+    if ($EnvSessionId) {
+        $env:COPILOT_AGENT_SESSION_ID = $EnvSessionId
+    } else {
+        Remove-Item Env:\COPILOT_AGENT_SESSION_ID -ErrorAction SilentlyContinue
+    }
+
+    try {
+        $json   = $Payload | ConvertTo-Json -Depth 5
+        $result = ($json | pwsh -NoProfile -File $statusScript) -join ''
+    } finally {
+        # Restore original env var value
+        if ($hadEnv) { $env:COPILOT_AGENT_SESSION_ID = $oldVal }
+        else          { Remove-Item Env:\COPILOT_AGENT_SESSION_ID -ErrorAction SilentlyContinue }
+        foreach ($kv in $StateFiles.GetEnumerator()) {
+            Remove-Item (Join-Path $stateDir $kv.Key) -ErrorAction SilentlyContinue
+        }
+    }
+
+    $ok = if ($ExpectedMatch) { $result -like $ExpectedMatch } else { [string]::IsNullOrWhiteSpace($result) }
+    if ($ok) {
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+        $script:pass++
+    } else {
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        Write-Host "        expected: $(if ($ExpectedMatch) { $ExpectedMatch } else { '(empty)' })" -ForegroundColor Yellow
+        Write-Host "        got:      $(if ($result) { $result } else { '(empty)' })" -ForegroundColor Yellow
+        $script:fail++
+    }
+}
+
+Write-Host "`n=== statusline.ps1 unit tests ===`n" -ForegroundColor Cyan
+
+# --- Path 1: session cwd IS a worktree ---
+Write-Host "Path 1 — session cwd is a worktree"
+
+Invoke-StatusTest "workspace.current_dir points to worktree" `
+    -Payload @{ context_window = @{ used_percentage = 42 }
+                workspace      = @{ current_dir = "$worktreeBase\999-test-branch" } } `
+    -ExpectedMatch "*worktree: 999-test-branch*"
+
+Invoke-StatusTest "top-level cwd field points to worktree" `
+    -Payload @{ cwd = "$worktreeBase\888-other-branch" } `
+    -ExpectedMatch "*worktree: 888-other-branch*"
+
+Invoke-StatusTest "non-worktree cwd → empty output" `
+    -Payload @{ workspace = @{ current_dir = "C:\Users\devin\Documents" } } `
+    -ExpectedMatch $null
+
+# --- Path 2: state-file fallback via session_id in JSON ---
+Write-Host "`nPath 2 — state-file fallback (session_id from JSON)"
+
+Invoke-StatusTest "state file exists and contains worktree path" `
+    -Payload @{ workspace  = @{ current_dir = "C:\Users\devin\Documents" }
+                session_id = "json-session-abc" } `
+    -StateFiles @{ "json-session-abc.txt" = "$worktreeBase\777-from-state" } `
+    -ExpectedMatch "*worktree: 777-from-state*"
+
+Invoke-StatusTest "state file exists but contains non-worktree path" `
+    -Payload @{ workspace  = @{ current_dir = "C:\Users\devin\Documents" }
+                session_id = "json-session-def" } `
+    -StateFiles @{ "json-session-def.txt" = "C:\Users\devin\Documents" } `
+    -ExpectedMatch $null
+
+Invoke-StatusTest "session_id in JSON but no matching state file → empty" `
+    -Payload @{ workspace  = @{ current_dir = "C:\Users\devin\Documents" }
+                session_id = "no-such-session-xyz" } `
+    -ExpectedMatch $null
+
+# --- Path 3: state-file fallback via COPILOT_AGENT_SESSION_ID env var ---
+Write-Host "`nPath 3 — state-file fallback (session_id from env var COPILOT_AGENT_SESSION_ID)"
+
+Invoke-StatusTest "env var session ID matches state file with worktree" `
+    -Payload @{ workspace = @{ current_dir = "C:\Users\devin\Documents" } } `
+    -StateFiles @{ "env-session-111.txt" = "$worktreeBase\666-env-branch" } `
+    -EnvSessionId "env-session-111" `
+    -ExpectedMatch "*worktree: 666-env-branch*"
+
+Invoke-StatusTest "env var set but no matching state file → empty" `
+    -Payload @{ workspace = @{ current_dir = "C:\Users\devin\Documents" } } `
+    -EnvSessionId "env-session-no-file" `
+    -ExpectedMatch $null
+
+# --- Path 4: JSON session_id takes priority over env var ---
+Write-Host "`nPath 4 — JSON session_id takes priority over env var"
+
+$sf4 = @{
+    "json-wins.txt" = "$worktreeBase\555-json-branch"
+    "env-wins.txt"  = "$worktreeBase\444-env-branch"
+}
+Invoke-StatusTest "JSON session_id wins over env var" `
+    -Payload @{ workspace  = @{ current_dir = "C:\Users\devin\Documents" }
+                session_id = "json-wins" } `
+    -StateFiles $sf4 `
+    -EnvSessionId "env-wins" `
+    -ExpectedMatch "*worktree: 555-json-branch*"
+
+# --- Path 5: agent writes state file explicitly (primary fix for no-profile shells) ---
+Write-Host "`nPath 5 — agent explicitly writes state file (COPILOT_AGENT_SESSION_ID = session_id in JSON)"
+
+# Simulates the fix: agent runs:
+#   "$(Get-Location)" | Set-Content "$env:USERPROFILE\.copilot\statusline-state\$env:COPILOT_AGENT_SESSION_ID.txt"
+# and the statusline JSON contains the matching session_id.
+Invoke-StatusTest "agent-written state file detected via JSON session_id" `
+    -Payload @{ workspace  = @{ current_dir = "C:\Users\devin\OneDrive\Documents\Repos\FlatRedBall2" }
+                session_id = "agent-explicit-abc" } `
+    -StateFiles @{ "agent-explicit-abc.txt" = "$worktreeBase\333-agent-wrote-this" } `
+    -EnvSessionId "agent-explicit-abc" `
+    -ExpectedMatch "*worktree: 333-agent-wrote-this*"
+
+Invoke-StatusTest "agent-written state file detected via env var when JSON has no session_id" `
+    -Payload @{ workspace = @{ current_dir = "C:\Users\devin\OneDrive\Documents\Repos\FlatRedBall2" } } `
+    -StateFiles @{ "agent-env-only-abc.txt" = "$worktreeBase\222-agent-env-only" } `
+    -EnvSessionId "agent-env-only-abc" `
+    -ExpectedMatch "*worktree: 222-agent-env-only*"
+
+# --- Edge cases ---
+Write-Host "`nEdge cases"
+
+Invoke-StatusTest "empty JSON → empty output" `
+    -Payload @{} `
+    -ExpectedMatch $null
+
+Invoke-StatusTest "completely invalid JSON string" `
+    -Payload @{ __raw = "not-json" } `
+    -ExpectedMatch $null   # ConvertFrom-Json error → silently swallowed
+
+# Summary
+Write-Host "`n==================================="
+$color = if ($fail -eq 0) { 'Green' } else { 'Red' }
+Write-Host "$pass passed, $fail failed" -ForegroundColor $color
+
+exit $fail


### PR DESCRIPTION
Closes #165

Root cause diagnosed via harness: Copilot runs shells with -NoProfile so the Set-Location hook never fires. workspace.current_dir in the JSON payload reflects session startup dir not current shell dir. COPILOT_AGENT_SESSION_ID IS set correctly in shell subprocesses.

Fix: Updated copilot-instructions.md to tell agents to explicitly write the state file after cd-ing into a worktree.

Harness in .claude/harness/: unit-test.ps1 (13 tests, all pass), diagnostic-statusline.ps1/.cmd (JSON payload logger), run-harness.ps1, analyze.ps1.