### PR TITLE
AnimationEditor: enable TreatWarningsAsErrors and fix all warnings

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/Directory.Build.props
+++ b/FRBDK/AnimationEditorAvalonia/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- All projects under AnimationEditorAvalonia/ must build with zero warnings. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -786,10 +786,10 @@ public class PreviewControl : Control
         // Dragged guide value label — drawn last so it stays on top of shapes
         if (s.DraggedGuideIdx >= 0)
         {
+            using var dragLabelFont = new SKFont { Size = 11f };
             using var dragLabelPaint = new SKPaint
             {
                 Color       = new SKColor(0, 200, 255, 230),
-                TextSize    = 11f,
                 IsAntialias = true
             };
             const float lMargin = 4f;
@@ -802,7 +802,7 @@ public class PreviewControl : Control
                 if (sy >= RulerSize && sy <= s.Height)
                 {
                     float baseline = Math.Clamp(sy - 2f, RulerSize + lHeight, s.Height - lMargin);
-                    canvas.DrawText(FormatGuideLabel(true, wy), RulerSize + lMargin, baseline, dragLabelPaint);
+                    canvas.DrawText(FormatGuideLabel(true, wy), RulerSize + lMargin, baseline, dragLabelFont, dragLabelPaint);
                 }
             }
             else if (!s.DraggingHGuide && s.DraggedGuideIdx < s.VGuides.Length)
@@ -812,7 +812,7 @@ public class PreviewControl : Control
                 if (sx >= RulerSize && sx <= s.Width)
                 {
                     float lx = Math.Clamp(sx + lMargin, RulerSize + lMargin, s.Width - 50f);
-                    canvas.DrawText(FormatGuideLabel(false, wx), lx, RulerSize + lHeight, dragLabelPaint);
+                    canvas.DrawText(FormatGuideLabel(false, wx), lx, RulerSize + lHeight, dragLabelFont, dragLabelPaint);
                 }
             }
         }
@@ -831,10 +831,10 @@ public class PreviewControl : Control
             StrokeWidth = 1f,
             IsAntialias = false
         };
+        using var labelFont = new SKFont { Size = 8f };
         using var labelPaint = new SKPaint
         {
             Color    = new SKColor(190, 190, 195),
-            TextSize = 8f,
             IsAntialias = true
         };
 
@@ -852,7 +852,7 @@ public class PreviewControl : Control
             float tickH = isMajor ? RulerSize * 0.55f : RulerSize * 0.30f;
             canvas.DrawLine(sx, RulerSize - tickH, sx, RulerSize, tickPaint);
             if (isMajor)
-                canvas.DrawText(((int)MathF.Round(wx)).ToString(), sx + 1f, RulerSize - tickH - 1f, labelPaint);
+                canvas.DrawText(((int)MathF.Round(wx)).ToString(), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
         }
 
         // Left (vertical) ruler — ticks at world-Y positions
@@ -870,7 +870,7 @@ public class PreviewControl : Control
                 canvas.Save();
                 canvas.Translate(RulerSize - tickW - 1f, sy);
                 canvas.RotateDegrees(-90f);
-                canvas.DrawText(((int)MathF.Round(wy)).ToString(), 0f, 0f, labelPaint);
+                canvas.DrawText(((int)MathF.Round(wy)).ToString(), 0f, 0f, labelFont, labelPaint);
                 canvas.Restore();
             }
         }
@@ -929,9 +929,11 @@ public class PreviewControl : Control
 
         using var paint = new SKPaint
         {
-            FilterQuality = zoom >= 1 ? SKFilterQuality.None : SKFilterQuality.Low,
-            Color         = new SKColor(255, 255, 255, (byte)(255 * alpha))
+            Color = new SKColor(255, 255, 255, (byte)(255 * alpha))
         };
+        var sampling = zoom >= 1
+            ? new SKSamplingOptions(SKFilterMode.Nearest)
+            : new SKSamplingOptions(SKFilterMode.Linear);
 
         bool flip = FlipScaleCalculator.IsFlipped(frame.FlipHorizontal, frame.FlipVertical);
         if (flip)
@@ -941,7 +943,8 @@ public class PreviewControl : Control
             canvas.Scale(scaleX, scaleY, cx, cy);
         }
 
-        canvas.DrawBitmap(bm, src, dst, paint);
+        using var img = SKImage.FromBitmap(bm);
+        canvas.DrawImage(img, src, dst, sampling, paint);
 
         if (flip) canvas.Restore();
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -100,9 +100,10 @@ public class WireframeControl : Control
                     s.PanY + s.ImageHeight * s.Zoom);
 
                 // Texture image — point sampling when zoomed ≥ 1× for pixel-art fidelity
-                using var imgPaint = new SKPaint();
-                imgPaint.FilterQuality = s.Zoom >= 1f ? SKFilterQuality.None : SKFilterQuality.Low;
-                canvas.DrawImage(s.Image, dest, imgPaint);
+                var sampling = s.Zoom >= 1f
+                    ? new SKSamplingOptions(SKFilterMode.Nearest)
+                    : new SKSamplingOptions(SKFilterMode.Linear);
+                canvas.DrawImage(s.Image, dest, sampling);
 
                 // Outline around whole texture
                 using var outlinePaint = new SKPaint

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1261,9 +1261,7 @@ public partial class MainWindow : Window
         // outside the .achx folder so they round-trip correctly.
         string storePath = string.IsNullOrEmpty(achxFolder)
             ? resolvedAbsPath
-            : TexturePathHelper.ComputeStorePath(
-                resolvedAbsPath,
-                FlatRedBall.IO.FileManager.GetDirectory(ProjectManager.Self.FileName));
+            : TexturePathHelper.ComputeStorePath(resolvedAbsPath, achxFolder);
 
         AppCommands.Self.SetFrameTextureName(frame, storePath);
         WireframeCtrl.LoadTexture(resolvedAbsPath);

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -43,27 +43,27 @@ namespace AnimationEditor.Core.CommandsAndState
         /// <summary>
         /// Request a full tree-view refresh. Raised instead of calling TreeViewManager directly.
         /// </summary>
-        public event Action RefreshTreeViewRequested;
+        public event Action? RefreshTreeViewRequested;
 
         /// <summary>
         /// Request a single chain's tree node to refresh.
         /// </summary>
-        public event Action<AnimationChainSave> RefreshChainNodeRequested;
+        public event Action<AnimationChainSave>? RefreshChainNodeRequested;
 
         /// <summary>
         /// Request a single frame's tree node to refresh.
         /// </summary>
-        public event Action<AnimationFrameSave> RefreshFrameNodeRequested;
+        public event Action<AnimationFrameSave>? RefreshFrameNodeRequested;
 
         /// <summary>
         /// Request the preview/animation-frame display to refresh.
         /// </summary>
-        public event Action RefreshAnimationFrameDisplayRequested;
+        public event Action? RefreshAnimationFrameDisplayRequested;
 
         /// <summary>
         /// Request the wireframe to refresh.
         /// </summary>
-        public event Action RefreshWireframeRequested;
+        public event Action? RefreshWireframeRequested;
 
         /// <summary>
         /// File dialog abstraction. Wired to Avalonia's <c>StorageProvider</c> by the
@@ -105,7 +105,7 @@ namespace AnimationEditor.Core.CommandsAndState
         public void RefreshTreeView() =>
             RefreshTreeViewRequested?.Invoke();
 
-        public void SaveCurrentAnimationChainList(string fileName = null)
+        public void SaveCurrentAnimationChainList(string? fileName = null)
         {
             var target = fileName ?? ProjectManager.Self.FileName;
             if (!string.IsNullOrEmpty(target))
@@ -135,6 +135,7 @@ namespace AnimationEditor.Core.CommandsAndState
         public void DeleteAnimationChains(List<AnimationChainSave> animationChains)
         {
             var acls = ProjectManager.Self.AnimationChainListSave;
+            if (acls == null) return;
 
             // Capture original indices before removal for undo
             var entries = animationChains
@@ -295,9 +296,10 @@ namespace AnimationEditor.Core.CommandsAndState
 
                     if (entries.Length > 0)
                         UndoManager.Self.Record(new DeleteFramesCommand(entries, chain));
+
+                    RefreshChainNodeRequested?.Invoke(chain);
                 }
 
-                RefreshChainNodeRequested?.Invoke(chain);
                 RefreshWireframeRequested?.Invoke();
                 ApplicationEvents.Self.RaiseAnimationChainsChanged();
             }
@@ -807,7 +809,7 @@ namespace AnimationEditor.Core.CommandsAndState
         {
             if (frame == null) return;
             string? oldName = frame.TextureName;
-            frame.TextureName = textureName;
+            frame.TextureName = textureName!;
             RefreshFrameNodeRequested?.Invoke(frame);
             ApplicationEvents.Self.RaiseAnimationChainsChanged();
             UndoManager.Self.Record(new SetFrameTextureNameCommand(frame, oldName, textureName));

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppState.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppState.cs
@@ -14,7 +14,7 @@ namespace AnimationEditor.Core.CommandsAndState
         /// The absolute path of the project (.gluj/.glux) that this .achx belongs to.
         /// When set, the tool won't prompt the user to copy files that are part of the project.
         /// </summary>
-        public string ProjectFolder { get; set; }
+        public string? ProjectFolder { get; set; }
 
         private UnitType _unitType;
         public UnitType UnitType
@@ -52,7 +52,7 @@ namespace AnimationEditor.Core.CommandsAndState
             set => _gridSize = value;
         }
 
-        public AnimationFrameSave CurrentFrame => SelectedState.Self.SelectedFrame;
+        public AnimationFrameSave? CurrentFrame => SelectedState.Self.SelectedFrame;
 
         // ── PL11: Sprite alignment ────────────────────────────────────────────
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ApplicationEvents.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ApplicationEvents.cs
@@ -5,13 +5,13 @@ namespace AnimationEditor.Core.CommandsAndState
 {
     public class ApplicationEvents : Singleton<ApplicationEvents>
     {
-        public event Action AfterZoomChange;
-        public event Action WireframePanning;
-        public event Action WireframeTextureChange;
-        public event Action<string> AchxLoaded;
-        public event Action<AxisAlignedRectangleSave> AfterAxisAlignedRectangleChanged;
-        public event Action<CircleSave> AfterCircleChanged;
-        public event Action AnimationChainsChanged;
+        public event Action? AfterZoomChange;
+        public event Action? WireframePanning;
+        public event Action? WireframeTextureChange;
+        public event Action<string>? AchxLoaded;
+        public event Action<AxisAlignedRectangleSave>? AfterAxisAlignedRectangleChanged;
+        public event Action<CircleSave>? AfterCircleChanged;
+        public event Action? AnimationChainsChanged;
 
         public void RaiseAfterAxisAlignedRectangleChanged(AxisAlignedRectangleSave rectangle) =>
             AfterAxisAlignedRectangleChanged?.Invoke(rectangle);

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
@@ -17,14 +17,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo()
         {
-            _frame.TextureName = _oldName;
+            _frame.TextureName = _oldName!;
             AppCommands.Self.RefreshTreeNode(_frame);
             ApplicationEvents.Self.RaiseAnimationChainsChanged();
         }
 
         public void Redo()
         {
-            _frame.TextureName = _newName;
+            _frame.TextureName = _newName!;
             AppCommands.Self.RefreshTreeNode(_frame);
             ApplicationEvents.Self.RaiseAnimationChainsChanged();
         }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
@@ -9,7 +9,7 @@ namespace AnimationEditor.Core.Data
 
     public class AnimationChainSettingSave
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
         public UnitType UnitType { get; set; }
     }
 

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TileMapInformation.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TileMapInformation.cs
@@ -4,7 +4,7 @@ namespace AnimationEditor.Core.Data
 {
     public class TileMapInformation
     {
-        public string Name;
+        public string? Name;
         public int TileWidth;
         public int TileHeight;
     }
@@ -13,7 +13,7 @@ namespace AnimationEditor.Core.Data
     {
         public List<TileMapInformation> TileMapInfos = new List<TileMapInformation>();
 
-        public TileMapInformation GetTileMapInformation(string fileName)
+        public TileMapInformation? GetTileMapInformation(string fileName)
         {
             foreach (var info in TileMapInfos)
             {

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
@@ -9,7 +9,7 @@ namespace AnimationEditor.Core.IO
     public class IoManager : Singleton<IoManager>
     {
         /// <summary>Raised when saving the companion file fails. The app layer should display the error.</summary>
-        public event Action<string, Exception> SaveFailed;
+        public event Action<string, Exception>? SaveFailed;
 
         private FilePath GetCompanionFileFor(FilePath fileName)
         {
@@ -35,7 +35,7 @@ namespace AnimationEditor.Core.IO
 
             if (!fileToLoad.Exists()) return;
 
-            AESettingsSave loadedInstance = null;
+            AESettingsSave? loadedInstance = null;
             try
             {
                 loadedInstance = FileManager.XmlDeserialize<AESettingsSave>(fileToLoad.FullPath);
@@ -64,6 +64,6 @@ namespace AnimationEditor.Core.IO
 
         /// <summary>Raised after a companion file is loaded. Provides the full settings object
         /// so the UI layer can apply expanded tree nodes, guide lines, etc.</summary>
-        public event Action<AESettingsSave> SettingsLoaded;
+        public event Action<AESettingsSave>? SettingsLoaded;
     }
 }

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ObjectFinder.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ObjectFinder.cs
@@ -5,9 +5,9 @@ namespace AnimationEditor.Core
 {
     public class ObjectFinder : Singleton<ObjectFinder>
     {
-        public AnimationFrameSave GetAnimationFrameContaining(AxisAlignedRectangleSave rectangle)
+        public AnimationFrameSave? GetAnimationFrameContaining(AxisAlignedRectangleSave rectangle)
         {
-            foreach (var chain in ProjectManager.Self.AnimationChainListSave.AnimationChains)
+            foreach (var chain in ProjectManager.Self.AnimationChainListSave?.AnimationChains ?? [])
             {
                 foreach (var frame in chain.Frames)
                 {
@@ -18,9 +18,9 @@ namespace AnimationEditor.Core
             return null;
         }
 
-        public AnimationFrameSave GetAnimationFrameContaining(CircleSave circle)
+        public AnimationFrameSave? GetAnimationFrameContaining(CircleSave circle)
         {
-            foreach (var chain in ProjectManager.Self.AnimationChainListSave.AnimationChains)
+            foreach (var chain in ProjectManager.Self.AnimationChainListSave?.AnimationChains ?? [])
             {
                 foreach (var frame in chain.Frames)
                 {
@@ -31,9 +31,9 @@ namespace AnimationEditor.Core
             return null;
         }
 
-        public AnimationChainSave GetAnimationChainContaining(AnimationFrameSave frame)
+        public AnimationChainSave? GetAnimationChainContaining(AnimationFrameSave frame)
         {
-            foreach (var chain in ProjectManager.Self.AnimationChainListSave.AnimationChains)
+            foreach (var chain in ProjectManager.Self.AnimationChainListSave?.AnimationChains ?? [])
             {
                 foreach (var possibleFrame in chain.Frames)
                 {

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -15,7 +15,7 @@ namespace AnimationEditor.Core
     {
         static TileMapInformationList mTileMapInformationList = new TileMapInformationList();
 
-        public AnimationChainListSave AnimationChainListSave { get; set; }
+        public AnimationChainListSave? AnimationChainListSave { get; set; }
 
         public TileMapInformationList TileMapInformationList
         {
@@ -25,7 +25,7 @@ namespace AnimationEditor.Core
 
         public FilePath[] ReferencedPngs { get; private set; } = new FilePath[0];
 
-        public string FileName { get; set; }
+        public string? FileName { get; set; }
 
         /// <summary>
         /// The coordinate format the .achx should be written with. Set from the loaded
@@ -203,7 +203,7 @@ namespace AnimationEditor.Core
 
             var files = new HashSet<FilePath>();
 
-            void AddRfs(XElement referencedFiles)
+            void AddRfs(XElement? referencedFiles)
             {
                 if (referencedFiles != null)
                 {
@@ -222,7 +222,7 @@ namespace AnimationEditor.Core
                 }
             }
 
-            XElement xElement = null;
+            XElement? xElement = null;
             try
             {
                 xElement = XElement.Load(projectFile.FullPath);

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
@@ -9,26 +9,26 @@ namespace AnimationEditor.Core
 {
     public class SelectionSnapshot
     {
-        public AnimationChainSave AnimationChainSave;
-        public AnimationFrameSave AnimationFrameSave;
+        public AnimationChainSave? AnimationChainSave;
+        public AnimationFrameSave? AnimationFrameSave;
     }
 
     public class SelectedState : Singleton<SelectedState>
     {
-        private AnimationChainSave _selectedChain;
-        private AnimationFrameSave _selectedFrame;
-        private AxisAlignedRectangleSave _selectedRectangle;
-        private CircleSave _selectedCircle;
+        private AnimationChainSave? _selectedChain;
+        private AnimationFrameSave? _selectedFrame;
+        private AxisAlignedRectangleSave? _selectedRectangle;
+        private CircleSave? _selectedCircle;
         private List<object> _selectedNodes = new List<object>();
 
         private SelectionSnapshot mSnapshot = new SelectionSnapshot();
 
-        public event Action SelectionChanged;
+        public event Action? SelectionChanged;
 
-        public AnimationChainListSave AnimationChainListSave =>
+        public AnimationChainListSave? AnimationChainListSave =>
             ProjectManager.Self.AnimationChainListSave;
 
-        public AnimationChainSave SelectedChain
+        public AnimationChainSave? SelectedChain
         {
             get => _selectedChain;
             set
@@ -41,7 +41,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public AnimationFrameSave SelectedFrame
+        public AnimationFrameSave? SelectedFrame
         {
             get => _selectedFrame;
             set
@@ -58,7 +58,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public AxisAlignedRectangleSave SelectedRectangle
+        public AxisAlignedRectangleSave? SelectedRectangle
         {
             get => _selectedRectangle;
             set
@@ -69,7 +69,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public CircleSave SelectedCircle
+        public CircleSave? SelectedCircle
         {
             get => _selectedCircle;
             set
@@ -80,7 +80,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public object SelectedShape => (object)_selectedRectangle ?? _selectedCircle;
+        public object? SelectedShape => (object?)_selectedRectangle ?? _selectedCircle;
 
         public List<AnimationChainSave> SelectedChains { get; set; } = new List<AnimationChainSave>();
 
@@ -115,7 +115,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public string SelectedTextureName
+        public string? SelectedTextureName
         {
             get
             {
@@ -127,7 +127,7 @@ namespace AnimationEditor.Core
             }
         }
 
-        public TileMapInformation SelectedTileMapInformation
+        public TileMapInformation? SelectedTileMapInformation
         {
             get
             {
@@ -147,7 +147,7 @@ namespace AnimationEditor.Core
             set => mSnapshot = value;
         }
 
-        private AnimationChainSave FindChainForFrame(AnimationFrameSave frame)
+        private AnimationChainSave? FindChainForFrame(AnimationFrameSave frame)
         {
             if (AnimationChainListSave == null) return null;
             foreach (var chain in AnimationChainListSave.AnimationChains)

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Singleton.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/Singleton.cs
@@ -2,7 +2,7 @@ namespace AnimationEditor.Core
 {
     public class Singleton<T> where T : new()
     {
-        static T mSelf;
+        static T? mSelf;
 
         public static T Self
         {

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CtrlClickPlainModeTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CtrlClickPlainModeTests.cs
@@ -125,7 +125,7 @@ public class CtrlClickPlainModeTests
             ShapeCollectionSave = new ShapeCollectionSave(),
         };
         chain.Frames.Add(lastFrame);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         SelectedState.Self.SelectedChain = chain;
 
         var ctrl = new WireframeControl();

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -424,7 +424,7 @@ public class GridRenderTests
         };
         chain.Frames.Add(frame);
         ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
 
         SelectedState.Self.SelectedChain = chain;
@@ -481,7 +481,7 @@ public class GridRenderTests
         };
         chain.Frames.Add(frame);
         ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
 
         SelectedState.Self.SelectedChain = chain;
@@ -531,7 +531,7 @@ public class GridRenderTests
         };
         chain.Frames.Add(frame);
         ProjectManager.Self.AnimationChainListSave = new AnimationChainListSave();
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
 
         SelectedState.Self.SelectedChain = chain;

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuidePanTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuidePanTests.cs
@@ -222,7 +222,7 @@ public class GuidePanTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuidePersistenceAcrossChainSwitchTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuidePersistenceAcrossChainSwitchTests.cs
@@ -64,8 +64,8 @@ public class GuidePersistenceAcrossChainSwitchTests
 
         var chainIdle = new AnimationChainSave { Name = "Idle" };
         var chainRun  = new AnimationChainSave { Name = "Run"  };
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainIdle);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainRun);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainIdle);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = new PreviewControl();
         ctrl.ShowGuides = true;
@@ -102,8 +102,8 @@ public class GuidePersistenceAcrossChainSwitchTests
 
         var chainIdle = new AnimationChainSave { Name = "Idle" };
         var chainRun  = new AnimationChainSave { Name = "Run"  };
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainIdle);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainRun);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainIdle);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = new PreviewControl();
         ctrl.ShowGuides = true;
@@ -138,8 +138,8 @@ public class GuidePersistenceAcrossChainSwitchTests
 
         var chainIdle = new AnimationChainSave { Name = "Idle" };
         var chainRun  = new AnimationChainSave { Name = "Run"  };
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainIdle);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainRun);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainIdle);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = new PreviewControl();
         ctrl.ShowGuides = true;
@@ -183,8 +183,8 @@ public class GuidePersistenceAcrossChainSwitchTests
         {
             var chainIdle = new AnimationChainSave { Name = "Idle" };
             var chainRun  = new AnimationChainSave { Name = "Run"  };
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainIdle);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chainRun);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainIdle);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
             var ctrl = new PreviewControl();
             ctrl.ShowGuides = true;

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewLiveUpdateTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewLiveUpdateTests.cs
@@ -91,7 +91,7 @@ public class PreviewLiveUpdateTests
                 ShapeCollectionSave = new ShapeCollectionSave(),
             };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TutorialMainWindowIntegrationTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TutorialMainWindowIntegrationTests.cs
@@ -91,7 +91,7 @@ public class TutorialMainWindowIntegrationTests
             ProjectManager.Self.FileName = achx;
 
             var chain = new AnimationChainSave { Name = "Idle" };
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var wireframe = GetWireframe(window);
@@ -148,7 +148,7 @@ public class TutorialMainWindowIntegrationTests
             ProjectManager.Self.FileName = achx;
 
             var chain = new AnimationChainSave { Name = "Run" };
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var wireframe = GetWireframe(window);
@@ -201,7 +201,7 @@ public class TutorialMainWindowIntegrationTests
             // Deliberately do NOT set ProjectManager.Self.FileName
 
             var chain = new AnimationChainSave { Name = "Idle" };
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var wireframe = GetWireframe(window);
@@ -265,7 +265,7 @@ public class TutorialMainWindowIntegrationTests
             };
             var chain = new AnimationChainSave { Name = "Idle" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
 
             // Load texture BEFORE selecting the frame so BitmapSize is non-zero
             // when RefreshPropertyPanel runs and populates PropPixelX.
@@ -329,7 +329,7 @@ public class TutorialMainWindowIntegrationTests
                 ShapeCollectionSave = new ShapeCollectionSave(),
             };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
 
             ProjectManager.Self.FileName = achx;
             AppCommands.Self.SaveCurrentAnimationChainList(achx);
@@ -378,7 +378,7 @@ public class TutorialMainWindowIntegrationTests
             };
             var chain = new AnimationChainSave { Name = "Idle" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
 
             // Select chain → preview should start playing
             SelectedState.Self.SelectedChain = chain;

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
@@ -177,7 +177,7 @@ public class VisualRenderTests
                 ShapeCollectionSave = new ShapeCollectionSave()
             });
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -215,7 +215,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Run" };
             chain.Frames.Add(frame);
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -352,7 +352,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;   // IsSelected=true → fill alpha=45
 
@@ -415,7 +415,7 @@ public class VisualRenderTests
             chain.Frames.Add(frame0);
             chain.Frames.Add(frame1);
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -436,7 +436,7 @@ public class VisualRenderTests
             SelectedState.Self.SelectedFrame = frame0;
             ctrl.RefreshFrames();
             var selectedRects = ctrl.GetFrameRects();
-            Assert.Equal(1, selectedRects.Count);
+            Assert.Single(selectedRects);
             Assert.True(selectedRects[0].IsSelected, "the selected frame should report IsSelected=true");
             // Bounds should match frame0's UV rect on the 64×64 texture (left half).
             Assert.Equal(0f,  selectedRects[0].Bounds.Left);
@@ -475,7 +475,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Half" };
             chain.Frames.Add(frame);
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;  // selected → fill alpha=45
 
@@ -562,7 +562,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;   // pin to this frame
 
@@ -613,7 +613,7 @@ public class VisualRenderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -667,7 +667,7 @@ public class VisualRenderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -736,7 +736,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame0);
             chain.Frames.Add(frame1);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame1;  // frame0 becomes the onion
 
@@ -796,7 +796,7 @@ public class VisualRenderTests
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame0);
             chain.Frames.Add(frame1);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             // SelectedFrame stays null → playback controller drives frame selection
 
@@ -1078,7 +1078,7 @@ public class VisualRenderTests
                         ShapeCollectionSave = new ShapeCollectionSave()
                     });
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -1120,7 +1120,7 @@ public class VisualRenderTests
                         ShapeCollectionSave = new ShapeCollectionSave()
                     });
 
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
@@ -76,7 +76,7 @@ public class WireframeChainDragTests
         var chain = new AnimationChainSave { Name = "Walk" };
         chain.Frames.Add(frameA);
         chain.Frames.Add(frameB);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
 
         // Select the chain — no individual frame selected

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandleDragTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandleDragTests.cs
@@ -74,7 +74,7 @@ public class WireframeHandleDragTests
         };
         var chain = new AnimationChainSave { Name = "Test" };
         chain.Frames.Add(frame);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         ProjectManager.Self.FileName = System.IO.Path.Combine(dir, "test.achx");
 
         SelectedState.Self.SelectedChain = chain;

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
@@ -84,7 +84,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -132,7 +132,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -173,7 +173,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = null;   // ← NO frame selected
 
@@ -217,7 +217,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -356,7 +356,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -413,7 +413,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -466,7 +466,7 @@ public class WireframeHandlesAndBorderTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = null;
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
@@ -105,7 +105,7 @@ public class WireframeTextureTests
             };
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frame);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
             SelectedState.Self.SelectedFrame = frame;
 
@@ -179,7 +179,7 @@ public class WireframeTextureTests
             var chain = new AnimationChainSave { Name = "Test" };
             chain.Frames.Add(frameRed);
             chain.Frames.Add(frameGreen);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
             SelectedState.Self.SelectedChain = chain;
 
             var ctrl = new WireframeControl();
@@ -256,7 +256,7 @@ public class WireframeTextureTests
             var chain = new AnimationChainSave { Name = "Walk" };
             chain.Frames.Add(frame1);
             chain.Frames.Add(frame2);
-            ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+            ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
 
             var ctrl = new WireframeControl();
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationFrameSaveConditionalSerializationTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationFrameSaveConditionalSerializationTests.cs
@@ -210,7 +210,7 @@ public class AnimationFrameSaveConditionalSerializationTests
     [Fact]
     public void Serialization_WhenShapeCollectionSaveIsNull_OmitsElement()
     {
-        var frame = new AnimationFrameSave { ShapeCollectionSave = null };
+        var frame = new AnimationFrameSave { ShapeCollectionSave = null! };
 
         var xml = SerializeFrame(frame);
 
@@ -236,7 +236,7 @@ public class AnimationFrameSaveConditionalSerializationTests
     [Fact]
     public void ShouldSerializeShapeCollectionSave_Property_WhenNullReturnsFalse()
     {
-        var frame = new AnimationFrameSave { ShapeCollectionSave = null };
+        var frame = new AnimationFrameSave { ShapeCollectionSave = null! };
 
         Assert.False(frame.ShouldSerializeShapeCollectionSave);
     }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameFromPixelBoundsTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameFromPixelBoundsTests.cs
@@ -15,7 +15,7 @@ public class AppCommandsFrameFromPixelBoundsTests
     private static AnimationChainSave MakeChain(string name = "Chain")
     {
         var chain = new AnimationChainSave { Name = name };
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         return chain;
     }
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsNewFileTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsNewFileTests.cs
@@ -16,14 +16,14 @@ public class AppCommandsNewFileTests
     public void NewFile_CreatesEmptyAcls()
     {
         // Arrange – pre-populate
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(
             new AnimationChainSave { Name = "Existing" });
 
         // Act
         AppCommands.Self.NewFile();
 
         Assert.NotNull(ProjectManager.Self.AnimationChainListSave);
-        Assert.Empty(ProjectManager.Self.AnimationChainListSave.AnimationChains);
+        Assert.Empty(ProjectManager.Self.AnimationChainListSave!.AnimationChains);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class AppCommandsNewFileTests
     public void NewFile_ClearsSelectedChain()
     {
         var chain = new AnimationChainSave { Name = "A" };
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         SelectedState.Self.SelectedChain = chain;
 
         AppCommands.Self.NewFile();
@@ -54,7 +54,7 @@ public class AppCommandsNewFileTests
         var chain = new AnimationChainSave { Name = "A" };
         var frame = new AnimationFrameSave { FrameLength = 0.1f };
         chain.Frames.Add(frame);
-        ProjectManager.Self.AnimationChainListSave.AnimationChains.Add(chain);
+        ProjectManager.Self.AnimationChainListSave!.AnimationChains.Add(chain);
         SelectedState.Self.SelectedChain = chain;
         SelectedState.Self.SelectedFrame = frame;
 
@@ -91,6 +91,6 @@ public class AppCommandsNewFileTests
         AppCommands.Self.NewFile();
         AppCommands.Self.NewFile();
 
-        Assert.Empty(ProjectManager.Self.AnimationChainListSave.AnimationChains);
+        Assert.Empty(ProjectManager.Self.AnimationChainListSave!.AnimationChains);
     }
 }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
@@ -13,7 +13,7 @@ public class TextureListBuilderTests
         var acls = new AnimationChainListSave();
         var chain = new AnimationChainSave { Name = "Chain" };
         foreach (var t in textureNames)
-            chain.Frames.Add(new AnimationFrameSave { TextureName = t });
+            chain.Frames.Add(new AnimationFrameSave { TextureName = t! });
         acls.AnimationChains.Add(chain);
         return acls;
     }


### PR DESCRIPTION
## Summary

Resolves #140 by driving the AnimationEditor build to zero warnings, then promoting them to errors.

## Changes

**New file:**
- \FRBDK/AnimationEditorAvalonia/Directory.Build.props\ — sets \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\ for all projects

**AnimationEditor.Core — nullable reference type fixes (CS8618, CS8625, CS8603, CS8604, CS8601, CS8600):**
- \SelectedState.cs\ — all selection fields/properties made nullable; \SelectedShape\ → \object?\
- \AppCommands.cs\ — 5 events → \?\; \DeleteAnimationChains\ guards null ACLS
- \AppState.cs\ — \CurrentFrame\ → \AnimationFrameSave?\
- \ProjectManager.cs\ — \AnimationChainListSave?\, \FileName?\
- \ObjectFinder.cs\ — null-conditional \?.AnimationChains ?? []\ in foreach
- \ApplicationEvents.cs\, \Singleton.cs\, \IoManager.cs\, \AESettingsSave.cs\, \TileMapInformation.cs\, \SetFrameTextureNameCommand.cs\ — miscellaneous nullable fixes

**AnimationEditor.App — SkiaSharp obsolete API fixes (CS0618):**
- \WireframeControl.cs\ — \SKFilterQuality\ → \SKSamplingOptions(SKFilterMode)\
- \PreviewControl.cs\ — \SKPaint.TextSize\ → \SKFont { Size }\ + \DrawText(..., SKFont, SKPaint)\; \DrawBitmap\ → \SKImage.FromBitmap\ + \DrawImage(..., SKSamplingOptions, ...)\
- \MainWindow.axaml.cs\ — use pre-computed \chxFolder\ instead of re-calling \GetDirectory(FileName?)\

**Test projects:**
- All test files: null-forgiving \!\ operator on \AnimationChainListSave\ (always set by \SetupFreshAcls\/\ResetSingletons\)
- \AnimationFrameSaveConditionalSerializationTests.cs\ — \
ull!\ for intentional null tests on FlatRedBall package types
- \TextureListBuilderTests.cs\ — \	!\ for string? passed to non-nullable \TextureName\
- \VisualRenderTests.cs\ — \Assert.Single\ instead of \Assert.Equal(1, ...)\ (xUnit2013)

## Verification

- Build: **0 Warning(s), 0 Error(s)**
- Tests: **793 passed, 0 failed**

Closes #140