### PR TITLE
Hide resize handles when animation chain (not frame) is selected

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <!-- MainWindow is DI-only; runtime XAML instantiation is intentionally not supported -->
+    <NoWarn>$(NoWarn);AVLN3001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1286,10 +1286,8 @@ public class WireframeControl : Control
             snap.OriginTexX = sel.Bounds.MidX - sel.Frame.RelativeX * offMult;
             snap.OriginTexY = sel.Bounds.MidY + sel.Frame.RelativeY * offMult;
         }
-        else if (_selectedState?.SelectedChain != null && _frameRects.Count > 0)
-        {
-            snap.SelectedHandleBounds = ComputeChainBoundingRect();
-        }
+        // Chain selected (no individual frame): handles are not rendered.
+        // Move-drag still works via HitTestHandle, which uses _frameRects directly.
 
         return snap;
     }

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
@@ -443,6 +443,56 @@ public class WireframeHandlesAndBorderTests
         }
     }
 
+    // ── Handles hidden when chain (not individual frame) is selected ──────────
+
+    /// <summary>
+    /// When an AnimationChain is selected but no individual frame is selected,
+    /// resize handles must NOT be rendered.  The handle zones around the chain's
+    /// bounding rect should be dark background, not white.
+    ///
+    /// Frame at UV 0.25→0.75 on a 64×64 texture → screen rect (16,16,48,48).
+    /// TopLeft handle centre = (11,11) — must not be white.
+    /// </summary>
+    [AvaloniaFact]
+    public void WireframeHandles_ChainSelected_NoHandlesRendered()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var png = WriteSolidPng(dir, SKColors.DarkGray);
+
+            var frame = new AnimationFrameSave
+            {
+                TextureName = png, FrameLength = 0.1f,
+                LeftCoordinate = 0.25f, TopCoordinate = 0.25f,
+                RightCoordinate = 0.75f, BottomCoordinate = 0.75f,
+                ShapeCollectionSave = new ShapeCollectionSave()
+            };
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            // Chain selected — no individual frame selected
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = null;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.RefreshFrames();
+            ctrl.SetCamera(0, 0, 1);  // screen rect (16,16,48,48); TL handle centre (11,11)
+
+            using var bm = ctrl.RenderToBitmap(64, 64);
+
+            // TL handle centre (11,11) must not be white — handles are only for single-frame selection
+            var px = bm.GetPixel(11, 11);
+            Assert.True(px.Red < 200 && px.Green < 200 && px.Blue < 200,
+                $"TL handle zone (11,11) should be dark when chain (not frame) is selected; R={px.Red} G={px.Green} B={px.Blue}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
     // ── Render with vs without selected frame — different bitmaps ────────────
 
     /// <summary>


### PR DESCRIPTION
## Summary

When an AnimationChain was selected in the tree view, \WireframeControl\ was setting \SelectedHandleBounds\ to the chain's composite bounding rect. This caused \DrawHandles\ to render white resize handles around the selection — even though resizing has no meaning for a multi-frame selection.

## Fix

Remove the \snap.SelectedHandleBounds = ComputeChainBoundingRect()\ assignment in the chain-selected branch. Chain-level move-drag is unaffected because \HitTestHandle\ computes the bounding rect directly from \_frameRects\ at pointer-event time (independent of the snapshot).

## Tests

Added \WireframeHandles_ChainSelected_NoHandlesRendered\ to \WireframeHandlesAndBorderTests\: sets up a chain-selected wireframe, renders to bitmap, and asserts the TL handle zone is not white. Confirmed red (fails before fix, passes after).

Closes #173