### PR TITLE
AE: surface load failures via LoadFailed event

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -124,6 +124,8 @@ public partial class MainWindow : Window
             RefreshRecentFiles();
             UpdateTitle();
         };
+        _appCommands.LoadFailed += (path, ex) =>
+            Dispatcher.UIThread.InvokeAsync(() => ShowLoadFailedDialogAsync(path, ex));
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
@@ -380,7 +382,19 @@ public partial class MainWindow : Window
 
     private void HandleAchxLoaded(string fileName)
     {
-        _appCommands.LoadAnimationChain(fileName);   // triggers RefreshTreeViewRequested
+        bool failed = false;
+        void OnFail(string _, Exception __) => failed = true;
+        _appCommands.LoadFailed += OnFail;
+        try
+        {
+            _appCommands.LoadAnimationChain(fileName);
+        }
+        finally
+        {
+            _appCommands.LoadFailed -= OnFail;
+        }
+
+        if (failed) return;
 
         _appSettings.AddFile(new FilePath(fileName));
         SaveSettingsFile();
@@ -1777,6 +1791,36 @@ public partial class MainWindow : Window
         {
             // File in use — ignore
         }
+    }
+
+    // ── Load-failed error dialog ──────────────────────────────────────────────
+
+    private async Task ShowLoadFailedDialogAsync(string filePath, Exception ex)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var dialog = new Window
+        {
+            Title = "Load Failed",
+            Width = 440,
+            Height = 180,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        var panel = new StackPanel { Margin = new Avalonia.Thickness(16), Spacing = 12 };
+        panel.Children.Add(new TextBlock
+        {
+            Text = $"Could not load '{fileName}':\n{ex.Message}",
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap
+        });
+
+        var okBtn = new Button { Content = "OK", HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right };
+        okBtn.Click += (_, _) => dialog.Close();
+        panel.Children.Add(okBtn);
+
+        dialog.Content = panel;
+        dialog.Closed += (_, _) => { };
+
+        await dialog.ShowDialog(this);
     }
 
     private async Task<bool> ShowConfirmDialogAsync(string message, string title)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -98,12 +98,23 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         public event Action<string>? SaveAsCompleted;
 
+        /// <inheritdoc cref="IAppCommands.LoadFailed"/>
+        public event Action<string, Exception>? LoadFailed;
+
         // -------------------------------------------------------------------------
 
         public void LoadAnimationChain(string fileName)
         {
-            var selectedTextureFilePath = string.Empty;
-            _pm.LoadAnimationChain(new AnimationEditor.Core.Paths.FilePath(fileName));
+            try
+            {
+                _pm.LoadAnimationChain(new AnimationEditor.Core.Paths.FilePath(fileName));
+            }
+            catch (Exception ex)
+            {
+                LoadFailed?.Invoke(fileName, ex);
+                return;
+            }
+
             _undoManager.Clear();
             RefreshTreeViewRequested?.Invoke();
             _ioManager.LoadAndApplyCompanionFileFor(fileName);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -25,6 +25,14 @@ namespace AnimationEditor.Core.CommandsAndState
         event Action RefreshWireframeRequested;
         event Action<string>? SaveAsCompleted;
 
+        /// <summary>
+        /// Fired when <see cref="LoadAnimationChain"/> fails — file not found, corrupt XML,
+        /// or any other engine-side throw. The first argument is the attempted file path;
+        /// the second is the exception. <c>RefreshTreeViewRequested</c> is NOT fired when
+        /// this event fires; project state is left unchanged.
+        /// </summary>
+        event Action<string, Exception>? LoadFailed;
+
         // ── Methods ───────────────────────────────────────────────────────────
 
         void LoadAnimationChain(string fileName);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -37,21 +37,21 @@ namespace AnimationEditor.Core
 
         public void LoadAnimationChain(FilePath fileName)
         {
-            if (fileName.Exists())
-            {
-                var acls = AnimationChainListSave.FromFile(fileName.FullPath);
+            if (!fileName.Exists())
+                throw new FileNotFoundException($"Animation chain file not found: {fileName.FullPath}", fileName.FullPath);
 
-                AddShapeCollectionsToFrames(acls);
+            var acls = AnimationChainListSave.FromFile(fileName.FullPath);
 
-                OnDiskCoordinateType = acls.CoordinateType;
-                NormalizeCoordinatesToUv(acls, fileName.GetDirectoryContainingThis().FullPath);
+            AddShapeCollectionsToFrames(acls);
 
-                AnimationChainListSave = acls;
-                FileName = fileName.FullPath;
+            OnDiskCoordinateType = acls.CoordinateType;
+            NormalizeCoordinatesToUv(acls, fileName.GetDirectoryContainingThis().FullPath);
 
-                if (!string.IsNullOrEmpty(acls.ProjectFile))
-                    TryLoadProjectFile(new FilePath(fileName.GetDirectoryContainingThis().FullPath + acls.ProjectFile));
-            }
+            AnimationChainListSave = acls;
+            FileName = fileName.FullPath;
+
+            if (!string.IsNullOrEmpty(acls.ProjectFile))
+                TryLoadProjectFile(new FilePath(fileName.GetDirectoryContainingThis().FullPath + acls.ProjectFile));
         }
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
@@ -1,0 +1,109 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class AppCommandsLoadFailureTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir = new();
+
+    public void Dispose() => _dir.Dispose();
+
+    // ── Missing file ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_FiresLoadFailed()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        string? capturedPath = null;
+        Exception? capturedEx = null;
+        ctx.AppCommands.LoadFailed += (path, ex) => { capturedPath = path; capturedEx = ex; };
+
+        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+
+        Assert.NotNull(capturedPath);
+        Assert.NotNull(capturedEx);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_FiresLoadFailed_ExactlyOnce()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        int fireCount = 0;
+        ctx.AppCommands.LoadFailed += (_, __) => fireCount++;
+
+        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+
+        Assert.Equal(1, fireCount);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_DoesNotFireRefreshTreeViewRequested()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        bool fired = false;
+        ctx.AppCommands.RefreshTreeViewRequested += () => fired = true;
+
+        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_DoesNotFireRefreshWireframeRequested()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        bool fired = false;
+        ctx.AppCommands.RefreshWireframeRequested += () => fired = true;
+
+        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_DoesNotChangeAnimationChainListSave()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var sentinel = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave = sentinel;
+
+        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+
+        Assert.Same(sentinel, ctx.ProjectManager.AnimationChainListSave);
+    }
+
+    // ── Corrupt file ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadAnimationChain_CorruptFile_FiresLoadFailed()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var badFile = Path.Combine(_dir.Path, "bad.achx");
+        File.WriteAllText(badFile, "this is not valid xml");
+        string? capturedPath = null;
+        ctx.AppCommands.LoadFailed += (path, _) => capturedPath = path;
+
+        ctx.AppCommands.LoadAnimationChain(badFile);
+
+        Assert.NotNull(capturedPath);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_CorruptFile_DoesNotFireRefreshTreeViewRequested()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var badFile = Path.Combine(_dir.Path, "bad2.achx");
+        File.WriteAllText(badFile, "this is not valid xml");
+        bool fired = false;
+        ctx.AppCommands.RefreshTreeViewRequested += () => fired = true;
+
+        ctx.AppCommands.LoadAnimationChain(badFile);
+
+        Assert.False(fired);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.Core;
+using System.IO;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ProjectManagerLoadTests
+{
+    [Fact]
+    public void LoadAnimationChain_MissingFile_ThrowsFileNotFoundException()
+    {
+        var pm = new ProjectManager();
+
+        Assert.Throws<FileNotFoundException>(
+            () => pm.LoadAnimationChain(new FilePath(@"C:\does\not\exist.achx")));
+    }
+
+    [Fact]
+    public void LoadAnimationChain_MissingFile_DoesNotChangeAnimationChainListSave()
+    {
+        var pm = new ProjectManager();
+        pm.AnimationChainListSave = null;
+
+        try { pm.LoadAnimationChain(new FilePath(@"C:\does\not\exist.achx")); }
+        catch (FileNotFoundException) { }
+
+        Assert.Null(pm.AnimationChainListSave);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes load failures that previously propagated raw (or silently no-oped) through AppCommands.LoadAnimationChain.

## Changes

### ProjectManager.LoadAnimationChain
- Replaced the silent if (fileName.Exists()) no-op with 	hrow new FileNotFoundException(...). A missing file now throws explicitly rather than pretending the load succeeded.

### IAppCommands / AppCommands
- Added vent Action<string, Exception>? LoadFailed — fires when load fails (file not found, corrupt XML, or any engine throw).
- LoadAnimationChain wraps only the _pm.LoadAnimationChain(...) call in try/catch; on failure, fires LoadFailed and returns early. Post-load refresh events (RefreshTreeViewRequested, etc.) are **not** raised, leaving project state unchanged.

### MainWindow
- Subscribes to LoadFailed in WireAppCommands and shows a modal error dialog with the file name and exception message.
- HandleAchxLoaded uses a 	ry/finally guard to detect failure and skip adding the file to recent files when load fails.

## Tests
- **AppCommandsLoadFailureTests** (8 cases): missing file fires LoadFailed once, does not fire RefreshTreeViewRequested or RefreshWireframeRequested, does not change AnimationChainListSave; corrupt file fires LoadFailed and does not fire RefreshTreeViewRequested.
- **ProjectManagerLoadTests** (2 cases): missing file throws FileNotFoundException, does not mutate AnimationChainListSave.

Closes #178