### PR TITLE
feat: extract OpenAchxWorkflow to Core for testability

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -117,13 +117,6 @@ public partial class MainWindow : Window
 
         // File dialog service
         _appCommands.FileDialogService = new Services.AvaloniaFileDialogService(this);
-        _appCommands.SaveAsCompleted  += path =>
-        {
-            _appSettings.AddFile(new FilePath(path));
-            SaveSettingsFile();
-            RefreshRecentFiles();
-            UpdateTitle();
-        };
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
@@ -132,7 +125,15 @@ public partial class MainWindow : Window
         _appCommands.RefreshAnimationFrameDisplayRequested += () => { };
         // RefreshWireframeRequested is handled by WireframeControl directly
 
-        _events.AchxLoaded               += HandleAchxLoaded;
+        _events.CurrentFileChanged     += path => Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _appSettings.AddFile(new FilePath(path));
+            SaveSettingsFile();
+            RefreshRecentFiles();
+            UpdateTitle();
+        });
+        _events.AvailableTexturesChanged += () => Dispatcher.UIThread.InvokeAsync(RefreshTextureCombo);
+
         _events.AnimationChainsChanged    += HandleAnimationChainsChanged;
         _selectedState.SelectionChanged   += HandleSelectionChanged;
     }
@@ -377,17 +378,6 @@ public partial class MainWindow : Window
     }
 
     // ── Core event handlers ───────────────────────────────────────────────────
-
-    private void HandleAchxLoaded(string fileName)
-    {
-        _appCommands.LoadAnimationChain(fileName);   // triggers RefreshTreeViewRequested
-
-        _appSettings.AddFile(new FilePath(fileName));
-        SaveSettingsFile();
-        RefreshRecentFiles();
-        UpdateTitle();
-        RefreshTextureCombo();
-    }
 
     private void HandleAnimationChainsChanged()
     {
@@ -1739,7 +1729,7 @@ public partial class MainWindow : Window
     private void LoadAnimationFile(string fileName)
     {
         if (!string.IsNullOrEmpty(fileName))
-            _events.CallAchxLoaded(fileName);
+            _appCommands.OpenAchxWorkflow(fileName);
     }
 
     private void UpdateTitle()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -98,6 +98,17 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         public event Action<string>? SaveAsCompleted;
 
+        // ── Open workflow ─────────────────────────────────────────────────────────
+
+        /// <inheritdoc cref="IAppCommands.OpenAchxWorkflow"/>
+        public void OpenAchxWorkflow(string path)
+        {
+            LoadAnimationChain(path);
+            _events.CallAchxLoaded(path);
+            _events.RaiseCurrentFileChanged(path);
+            _events.RaiseAvailableTexturesChanged();
+        }
+
         // -------------------------------------------------------------------------
 
         public void LoadAnimationChain(string fileName)
@@ -142,7 +153,8 @@ namespace AnimationEditor.Core.CommandsAndState
         /// <summary>
         /// Show a Save-As file picker via <see cref="FileDialogService"/>, save the
         /// current animation chain list to the chosen path, update
-        /// <see cref="ProjectManager.FileName"/>, and fire <see cref="SaveAsCompleted"/>.
+        /// <see cref="ProjectManager.FileName"/>, and fire <see cref="SaveAsCompleted"/>
+        /// and <see cref="IApplicationEvents.CurrentFileChanged"/>.
         /// Does nothing if the user cancels the dialog.
         /// </summary>
         public async Task SaveCurrentAnimationChainListAsync()
@@ -156,6 +168,7 @@ namespace AnimationEditor.Core.CommandsAndState
             _pm.FileName = path;
             _ioManager.DeleteRecoveryFile();
             SaveAsCompleted?.Invoke(path);
+            _events.RaiseCurrentFileChanged(path);
         }
 
         public void DeleteAnimationChains(List<AnimationChainSave> animationChains)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ApplicationEvents.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ApplicationEvents.cs
@@ -12,6 +12,8 @@ namespace AnimationEditor.Core.CommandsAndState
         public event Action<AARectSave>? AfterAxisAlignedRectangleChanged;
         public event Action<CircleSave>? AfterCircleChanged;
         public event Action? AnimationChainsChanged;
+        public event Action<string>? CurrentFileChanged;
+        public event Action? AvailableTexturesChanged;
 
         public void RaiseAfterAxisAlignedRectangleChanged(AARectSave rectangle) =>
             AfterAxisAlignedRectangleChanged?.Invoke(rectangle);
@@ -33,5 +35,11 @@ namespace AnimationEditor.Core.CommandsAndState
 
         public void CallWireframeTextureChange() =>
             WireframeTextureChange?.Invoke();
+
+        public void RaiseCurrentFileChanged(string path) =>
+            CurrentFileChanged?.Invoke(path);
+
+        public void RaiseAvailableTexturesChanged() =>
+            AvailableTexturesChanged?.Invoke();
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -27,6 +27,12 @@ namespace AnimationEditor.Core.CommandsAndState
 
         // ── Methods ───────────────────────────────────────────────────────────
 
+        /// <summary>
+        /// Full open workflow: loads the .achx, fires <c>AchxLoaded</c> (post-load),
+        /// then fires <c>CurrentFileChanged</c> and <c>AvailableTexturesChanged</c>
+        /// so the UI can update its title, recent-files list, and texture combo.
+        /// </summary>
+        void OpenAchxWorkflow(string path);
         void LoadAnimationChain(string fileName);
         void RefreshTreeNode(AnimationChainSave animationChain);
         void RefreshTreeNode(AnimationFrameSave animationFrame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IApplicationEvents.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IApplicationEvents.cs
@@ -8,10 +8,15 @@ namespace AnimationEditor.Core.CommandsAndState
         event Action AfterZoomChange;
         event Action WireframePanning;
         event Action WireframeTextureChange;
+        /// <summary>Fired by <c>AppCommands.OpenAchxWorkflow</c> after the .achx is fully loaded.</summary>
         event Action<string> AchxLoaded;
         event Action<AARectSave> AfterAxisAlignedRectangleChanged;
         event Action<CircleSave> AfterCircleChanged;
         event Action AnimationChainsChanged;
+        /// <summary>Fired after the active file path changes (open or save-as). Carries the new path.</summary>
+        event Action<string> CurrentFileChanged;
+        /// <summary>Fired when texture references in the loaded project may have changed.</summary>
+        event Action AvailableTexturesChanged;
 
         void RaiseAfterAxisAlignedRectangleChanged(AARectSave rectangle);
         void RaiseAfterCircleChanged(CircleSave circle);
@@ -20,5 +25,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void CallAfterZoomChange();
         void CallAfterWireframePanning();
         void CallWireframeTextureChange();
+        void RaiseCurrentFileChanged(string path);
+        void RaiseAvailableTexturesChanged();
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
@@ -104,6 +104,34 @@ public class AppCommandsSaveAsTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_WhenPathReturned_FiresCurrentFileChangedWithPath()
+    {
+        var target = Path.Combine(_dir.Path, "out.achx");
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.FileDialogService = new StubFileDialogService(target);
+        ctx.ProjectManager.AnimationChainListSave = ctx.Acls;
+        string? received = null;
+        ctx.ApplicationEvents.CurrentFileChanged += p => received = p;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal(target, received);
+    }
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_WhenDialogCancelled_DoesNotFireCurrentFileChanged()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.FileDialogService = new StubFileDialogService(null);
+        bool fired = false;
+        ctx.ApplicationEvents.CurrentFileChanged += _ => fired = true;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.False(fired);
+    }
+
+    [Fact]
     public async Task SaveCurrentAnimationChainListAsync_SavedFile_ContainsChainData()
     {
         var target = Path.Combine(_dir.Path, "data.achx");
@@ -119,6 +147,7 @@ public class AppCommandsSaveAsTests : IDisposable
         Assert.Contains("Run", xml);
     }
 }
+
 
 /// <summary>Test double that returns a pre-configured path (or null) from every dialog.</summary>
 internal sealed class StubFileDialogService : IFileDialogService

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
@@ -1,0 +1,152 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Paths;
+using FlatRedBall2.Animation.Content;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies that <see cref="IAppCommands.OpenAchxWorkflow"/> correctly sequences
+/// the open flow (load data, notify WireframeCtrl/PreviewCtrl via AchxLoaded,
+/// then raise CurrentFileChanged and AvailableTexturesChanged for the UI layer)
+/// — all without any Avalonia dependency.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class OpenAchxWorkflowTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir;
+    private readonly TestServices _ctx;
+
+    public OpenAchxWorkflowTests()
+    {
+        _dir = new TestHelpers.TempDir();
+        _ctx = TestHelpers.SetupFreshAcls();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string WriteMinimalAchx(string chainName = "Idle")
+    {
+        var path = Path.Combine(_dir.Path, "test.achx");
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = chainName });
+        acls.Save(path);
+        return path;
+    }
+
+    // ── Data loading ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenAchxWorkflow_WithValidFile_LoadsChainIntoProjectManager()
+    {
+        var path = WriteMinimalAchx("Walk");
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.NotNull(_ctx.ProjectManager.AnimationChainListSave);
+        Assert.Single(_ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        Assert.Equal("Walk", _ctx.ProjectManager.AnimationChainListSave.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public void OpenAchxWorkflow_WithValidFile_SetsProjectManagerFileName()
+    {
+        var path = WriteMinimalAchx();
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.Equal(new FilePath(path), new FilePath(_ctx.ProjectManager.FileName!));
+    }
+
+    // ── Event ordering ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenAchxWorkflow_AchxLoadedFiresAfterDataIsLoaded()
+    {
+        var path = WriteMinimalAchx("Run");
+        FilePath? fileNameAtNotification = null;
+        _ctx.ApplicationEvents.AchxLoaded += _ =>
+            fileNameAtNotification = _ctx.ProjectManager.FileName;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        // AchxLoaded fires after LoadAnimationChain sets the FileName
+        Assert.Equal(new FilePath(path), fileNameAtNotification);
+    }
+
+    [Fact]
+    public void OpenAchxWorkflow_WithValidFile_FiresAchxLoadedWithPath()
+    {
+        var path = WriteMinimalAchx();
+        string? received = null;
+        _ctx.ApplicationEvents.AchxLoaded += p => received = p;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.Equal(new FilePath(path), new FilePath(received!));
+    }
+
+    // ── CurrentFileChanged ────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenAchxWorkflow_WithValidFile_FiresCurrentFileChangedWithPath()
+    {
+        var path = WriteMinimalAchx();
+        string? received = null;
+        _ctx.ApplicationEvents.CurrentFileChanged += p => received = p;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.Equal(new FilePath(path), new FilePath(received!));
+    }
+
+    [Fact]
+    public void OpenAchxWorkflow_CurrentFileChangedFiresAfterDataIsLoaded()
+    {
+        var path = WriteMinimalAchx("Jump");
+        FilePath? fileNameAtNotification = null;
+        _ctx.ApplicationEvents.CurrentFileChanged += _ =>
+            fileNameAtNotification = _ctx.ProjectManager.FileName;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.Equal(new FilePath(path), fileNameAtNotification);
+    }
+
+    // ── AvailableTexturesChanged ───────────────────────────────────────────────
+
+    [Fact]
+    public void OpenAchxWorkflow_WithValidFile_FiresAvailableTexturesChanged()
+    {
+        var path = WriteMinimalAchx();
+        bool fired = false;
+        _ctx.ApplicationEvents.AvailableTexturesChanged += () => fired = true;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.True(fired);
+    }
+
+    // ── Non-existent file (graceful no-op) ────────────────────────────────────
+
+    [Fact]
+    public void OpenAchxWorkflow_WithNonExistentFile_StillFiresCurrentFileChangedAndAvailableTextures()
+    {
+        // Pre-existing behaviour: LoadAnimationChain silently skips when file is
+        // absent, but the UI still receives the events (keeps parity with old HandleAchxLoaded).
+        var path = Path.Combine(_dir.Path, "ghost.achx");
+        bool currentFileFired = false;
+        bool texturesFired = false;
+        _ctx.ApplicationEvents.CurrentFileChanged += _ => currentFileFired = true;
+        _ctx.ApplicationEvents.AvailableTexturesChanged += () => texturesFired = true;
+
+        _ctx.AppCommands.OpenAchxWorkflow(path);
+
+        Assert.True(currentFileFired);
+        Assert.True(texturesFired);
+    }
+}


### PR DESCRIPTION
Closes #177

## Summary

Moves the multi-step open-file sequence out of \MainWindow.HandleAchxLoaded\ into \AppCommands.OpenAchxWorkflow\ so it can be unit-tested without Avalonia.

## Changes

**Core (new logic):**
- \IApplicationEvents\ / \ApplicationEvents\: added \CurrentFileChanged\ and \AvailableTexturesChanged\ domain events
- \IAppCommands\: added \OpenAchxWorkflow(string path)\ 
- \AppCommands.OpenAchxWorkflow\: loads chain → fires \AchxLoaded\ (now truly post-load) → raises \CurrentFileChanged\ + \AvailableTexturesChanged\
- \AppCommands.SaveCurrentAnimationChainListAsync\: also raises \CurrentFileChanged\ so the title updates after save-as

**App (thin wiring only):**
- \MainWindow.LoadAnimationFile\: delegates to \_appCommands.OpenAchxWorkflow\
- \MainWindow.WireAppCommands\: subscribes to the two new events (Dispatcher-wrapped); drops old \HandleAchxLoaded\ subscription
- \MainWindow.HandleAchxLoaded\: **deleted**

**Tests:**
- \OpenAchxWorkflowTests.cs\ — 8 new tests: data loading, \AchxLoaded\ fires after data is loaded, \CurrentFileChanged\ fires after data is loaded, \AvailableTexturesChanged\, non-existent file graceful behaviour
- \AppCommandsSaveAsTests.cs\ — 3 new tests for \CurrentFileChanged\ on save-as