### PR TITLE
Move menus into combined custom title bar

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -9,48 +9,113 @@
         x:Class="AnimationEditor.App.MainWindow"
         Title="AnimationEditor"
         Icon="avares://AnimationEditor.App/Assets/icons/achx-icon-256.png"
-        MinWidth="900" MinHeight="600">
+        MinWidth="900" MinHeight="600"
+        WindowDecorations="BorderOnly">
 
     <DockPanel>
-        <!-- ── Top bar: File/Edit/Help menus in a unified header row ── -->
+        <!-- ── Title bar: app icon + name + menus + drag region + window controls ── -->
         <Border DockPanel.Dock="Top"
+                x:Name="TitleBarBorder"
                 Background="{StaticResource BgRail}"
                 BorderBrush="{StaticResource LineBrush}"
                 BorderThickness="0,0,0,1"
                 Height="36">
-            <Menu x:Name="MainMenu"
-                  Background="Transparent"
-                  BorderThickness="0"
-                  VerticalAlignment="Center"
-                  Margin="4,0">
-                <MenuItem Header="_File">
-                    <MenuItem Header="_New"          x:Name="MenuNew"    InputGesture="Ctrl+N" />
-                    <MenuItem Header="_Load..."       x:Name="MenuLoad"   InputGesture="Ctrl+L" />
-                    <MenuItem Header="_Save"          x:Name="MenuSave"   InputGesture="Ctrl+S" />
-                    <MenuItem Header="Save _As..."    x:Name="MenuSaveAs" />
-                    <Separator />
-                    <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
-                </MenuItem>
-                <MenuItem Header="_Edit">
-                    <MenuItem Header="_Undo"            x:Name="MenuUndo"          InputGesture="Ctrl+Z" />
-                    <MenuItem Header="_Redo"            x:Name="MenuRedo"          InputGesture="Ctrl+Y" />
-                    <Separator />
-                    <MenuItem Header="_Copy"            x:Name="MenuCopy"          InputGesture="Ctrl+C" />
-                    <MenuItem Header="_Paste"           x:Name="MenuPaste"         InputGesture="Ctrl+V" />
-                    <Separator />
-                    <MenuItem Header="Resize _Texture…" x:Name="MenuResizeTexture" />
-                </MenuItem>
-                <MenuItem Header="_View">
-                    <MenuItem Header="Wireframe _Zoom In"   InputGesture="Ctrl+OemPlus" />
-                    <MenuItem Header="Wireframe Zoom _Out"  InputGesture="Ctrl+OemMinus" />
-                    <Separator />
-                    <MenuItem Header="Preview Zoom _In"     InputGesture="Ctrl+Shift+OemPlus" />
-                    <MenuItem Header="Preview Zoom O_ut"    InputGesture="Ctrl+Shift+OemMinus" />
-                </MenuItem>
-                <MenuItem Header="_Help">
-                    <MenuItem Header="_About"         x:Name="MenuAbout" />
-                </MenuItem>
-            </Menu>
+            <DockPanel>
+                <!-- Window controls: minimize, maximize, close (right) -->
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Stretch">
+                    <Button x:Name="MinimizeBtn"
+                            Content="−"
+                            Width="46" Height="36"
+                            Padding="0" BorderThickness="0"
+                            Background="Transparent"
+                            Foreground="{StaticResource InkMid}"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            FontSize="16"
+                            ToolTip.Tip="Minimize"
+                            Click="OnMinimizeBtnClick" />
+                    <Button x:Name="MaximizeBtn"
+                            Content="□"
+                            Width="46" Height="36"
+                            Padding="0" BorderThickness="0"
+                            Background="Transparent"
+                            Foreground="{StaticResource InkMid}"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            FontSize="13"
+                            ToolTip.Tip="Maximize / Restore"
+                            Click="OnMaximizeBtnClick" />
+                    <Button x:Name="CloseBtn"
+                            Content="✕"
+                            Width="46" Height="36"
+                            Padding="0" BorderThickness="0"
+                            Background="Transparent"
+                            Foreground="{StaticResource InkMid}"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            FontSize="12"
+                            ToolTip.Tip="Close"
+                            Click="OnCloseBtnClick">
+                        <Button.Styles>
+                            <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                <Setter Property="Background" Value="#c42b1c" />
+                            </Style>
+                        </Button.Styles>
+                    </Button>
+                </StackPanel>
+                <!-- App identity: icon + name (far left, draggable) -->
+                <StackPanel DockPanel.Dock="Left"
+                            Orientation="Horizontal" Spacing="6"
+                            VerticalAlignment="Center" Margin="10,0,4,0"
+                            PointerPressed="OnTitleBarPointerPressed"
+                            DoubleTapped="OnTitleBarDoubleTapped">
+                    <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
+                           Width="16" Height="16" VerticalAlignment="Center" />
+                    <TextBlock Text="AnimationEditor"
+                               FontSize="12"
+                               Foreground="{StaticResource InkMid}"
+                               VerticalAlignment="Center" />
+                </StackPanel>
+                <!-- Menus: File, Edit, View, Help (left, after identity) -->
+                <Menu DockPanel.Dock="Left"
+                      x:Name="MainMenu"
+                      Background="Transparent"
+                      BorderThickness="0"
+                      VerticalAlignment="Center"
+                      Margin="4,0">
+                    <MenuItem Header="_File">
+                        <MenuItem Header="_New"          x:Name="MenuNew"    InputGesture="Ctrl+N" />
+                        <MenuItem Header="_Load..."       x:Name="MenuLoad"   InputGesture="Ctrl+L" />
+                        <MenuItem Header="_Save"          x:Name="MenuSave"   InputGesture="Ctrl+S" />
+                        <MenuItem Header="Save _As..."    x:Name="MenuSaveAs" />
+                        <Separator />
+                        <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
+                    </MenuItem>
+                    <MenuItem Header="_Edit">
+                        <MenuItem Header="_Undo"            x:Name="MenuUndo"          InputGesture="Ctrl+Z" />
+                        <MenuItem Header="_Redo"            x:Name="MenuRedo"          InputGesture="Ctrl+Y" />
+                        <Separator />
+                        <MenuItem Header="_Copy"            x:Name="MenuCopy"          InputGesture="Ctrl+C" />
+                        <MenuItem Header="_Paste"           x:Name="MenuPaste"         InputGesture="Ctrl+V" />
+                        <Separator />
+                        <MenuItem Header="Resize _Texture…" x:Name="MenuResizeTexture" />
+                    </MenuItem>
+                    <MenuItem Header="_View">
+                        <MenuItem Header="Wireframe _Zoom In"   InputGesture="Ctrl+OemPlus" />
+                        <MenuItem Header="Wireframe Zoom _Out"  InputGesture="Ctrl+OemMinus" />
+                        <Separator />
+                        <MenuItem Header="Preview Zoom _In"     InputGesture="Ctrl+Shift+OemPlus" />
+                        <MenuItem Header="Preview Zoom O_ut"    InputGesture="Ctrl+Shift+OemMinus" />
+                    </MenuItem>
+                    <MenuItem Header="_Help">
+                        <MenuItem Header="_About"         x:Name="MenuAbout" />
+                    </MenuItem>
+                </Menu>
+                <!-- Drag region: fills remaining space, handles window move and maximize toggle -->
+                <Border Background="Transparent"
+                        PointerPressed="OnTitleBarPointerPressed"
+                        DoubleTapped="OnTitleBarDoubleTapped" />
+            </DockPanel>
         </Border>
 
         <!-- ── Status bar ── -->

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -5,7 +5,6 @@
         xmlns:controls="clr-namespace:AnimationEditor.App.Controls"
         xmlns:models="clr-namespace:AnimationEditor.Core.ViewModels;assembly=AnimationEditor.Core"
         xmlns:svg="clr-namespace:Avalonia.Svg.Skia;assembly=Svg.Controls.Skia.Avalonia"
-        xmlns:chrome="clr-namespace:Avalonia.Controls.Chrome;assembly=Avalonia.Controls"
         mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
         x:Class="AnimationEditor.App.MainWindow"
         Title="AnimationEditor"
@@ -1017,21 +1016,13 @@
         </Grid>
     </DockPanel>
         <!-- Resize grips — 4px edges + 8px corners, transparent overlays -->
-        <Border Height="4" VerticalAlignment="Top" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeN" />
-        <Border Height="4" VerticalAlignment="Bottom" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeS" />
-        <Border Width="4" HorizontalAlignment="Left" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeW" />
-        <Border Width="4" HorizontalAlignment="Right" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeE" />
-        <Border Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeNW" />
-        <Border Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeNE" />
-        <Border Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeSW" />
-        <Border Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent"
-                chrome:WindowDecorationProperties.ElementRole="ResizeSE" />
+        <Border x:Name="GripN"  Height="4" VerticalAlignment="Top"    Background="Transparent" Cursor="TopSide"         PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripS"  Height="4" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomSide"      PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripW"  Width="4"  HorizontalAlignment="Left"  Background="Transparent" Cursor="LeftSide"        PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripE"  Width="4"  HorizontalAlignment="Right" Background="Transparent" Cursor="RightSide"       PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripNW" Width="8" Height="8" HorizontalAlignment="Left"  VerticalAlignment="Top"    Background="Transparent" Cursor="TopLeftCorner"     PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripNE" Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Top"    Background="Transparent" Cursor="TopRightCorner"    PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripSW" Width="8" Height="8" HorizontalAlignment="Left"  VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomLeftCorner"  PointerPressed="OnResizeGrip" />
+        <Border x:Name="GripSE" Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomRightCorner" PointerPressed="OnResizeGrip" />
     </Grid>
 </Window>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -5,14 +5,16 @@
         xmlns:controls="clr-namespace:AnimationEditor.App.Controls"
         xmlns:models="clr-namespace:AnimationEditor.Core.ViewModels;assembly=AnimationEditor.Core"
         xmlns:svg="clr-namespace:Avalonia.Svg.Skia;assembly=Svg.Controls.Skia.Avalonia"
+        xmlns:chrome="clr-namespace:Avalonia.Controls.Chrome;assembly=Avalonia.Controls"
         mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
         x:Class="AnimationEditor.App.MainWindow"
         Title="AnimationEditor"
         Icon="avares://AnimationEditor.App/Assets/icons/achx-icon-256.png"
         MinWidth="900" MinHeight="600"
-        WindowDecorations="BorderOnly">
+        WindowDecorations="None">
 
-    <DockPanel>
+    <Grid>
+        <DockPanel>
         <!-- ── Title bar: app icon + name + menus + drag region + window controls ── -->
         <Border DockPanel.Dock="Top"
                 x:Name="TitleBarBorder"
@@ -1014,4 +1016,22 @@
             </Grid>
         </Grid>
     </DockPanel>
+        <!-- Resize grips — 4px edges + 8px corners, transparent overlays -->
+        <Border Height="4" VerticalAlignment="Top" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeN" />
+        <Border Height="4" VerticalAlignment="Bottom" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeS" />
+        <Border Width="4" HorizontalAlignment="Left" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeW" />
+        <Border Width="4" HorizontalAlignment="Right" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeE" />
+        <Border Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeNW" />
+        <Border Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Top" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeNE" />
+        <Border Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeSW" />
+        <Border Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Bottom" Background="Transparent"
+                chrome:WindowDecorationProperties.ElementRole="ResizeSE" />
+    </Grid>
 </Window>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -507,6 +507,24 @@ public partial class MainWindow : Window
 
     private void OnCloseBtnClick(object? sender, RoutedEventArgs e) => Close();
 
+    private void OnResizeGrip(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        var edge = (sender as Control)?.Name switch
+        {
+            "GripN"  => WindowEdge.North,
+            "GripS"  => WindowEdge.South,
+            "GripE"  => WindowEdge.East,
+            "GripW"  => WindowEdge.West,
+            "GripNE" => WindowEdge.NorthEast,
+            "GripNW" => WindowEdge.NorthWest,
+            "GripSE" => WindowEdge.SouthEast,
+            "GripSW" => WindowEdge.SouthWest,
+            _        => (WindowEdge?)null,
+        };
+        if (edge.HasValue) BeginResizeDrag(edge.Value, e);
+    }
+
     // ── Menu wiring ───────────────────────────────────────────────────────────
 
     private void WireMenuEvents()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -71,6 +71,7 @@ public partial class MainWindow : Window
         _undoManager = undoManager;
 
         InitializeComponent();
+        PropertyChanged += (_, e) => { if (e.Property == OffScreenMarginProperty) Padding = OffScreenMargin; };
         WireframeCtrl.AttachScrollViewer(WireframeScrollViewer);
 
         WireAppCommands();
@@ -487,6 +488,24 @@ public partial class MainWindow : Window
             WireframeCtrl.LoadTexture(texPath);
         }
     }
+
+    // ── Custom title bar ─────────────────────────────────────────────────────
+
+    private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            BeginMoveDrag(e);
+    }
+
+    private void OnTitleBarDoubleTapped(object? sender, TappedEventArgs e) =>
+        WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+
+    private void OnMinimizeBtnClick(object? sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
+
+    private void OnMaximizeBtnClick(object? sender, RoutedEventArgs e) =>
+        WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+
+    private void OnCloseBtnClick(object? sender, RoutedEventArgs e) => Close();
 
     // ── Menu wiring ───────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Xunit;
 
@@ -6,14 +7,49 @@ namespace AnimationEditor.App.Tests;
 public class MainWindowChromeTests
 {
     [AvaloniaFact]
-    public void MainWindow_DoesNotExtendIntoSystemTitleBar()
+    public void MainWindow_RemovesOsTitleBar()
     {
         var ctx = TestHelpers.BuildServices();
         var window = ctx.CreateMainWindow();
         window.Show();
         try
         {
-            Assert.False(window.ExtendClientAreaToDecorationsHint);
+            Assert.Equal(WindowDecorations.BorderOnly, window.WindowDecorations);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void TitleBar_ContainsMenuAndAppIdentity()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Assert.NotNull(window.FindControl<Border>("TitleBarBorder"));
+            Assert.NotNull(window.FindControl<Menu>("MainMenu"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void TitleBar_HasWindowControlButtons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Assert.NotNull(window.FindControl<Button>("MinimizeBtn"));
+            Assert.NotNull(window.FindControl<Button>("MaximizeBtn"));
+            Assert.NotNull(window.FindControl<Button>("CloseBtn"));
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
@@ -14,7 +14,7 @@ public class MainWindowChromeTests
         window.Show();
         try
         {
-            Assert.Equal(WindowDecorations.BorderOnly, window.WindowDecorations);
+            Assert.Equal(WindowDecorations.None, window.WindowDecorations);
         }
         finally
         {


### PR DESCRIPTION
Closes #199

Replaces the separate menu bar row with a single combined title bar row:
app icon + name + File/Edit/View/Help menus + drag region + min/max/close buttons.

Uses Avalonia 12's WindowDecorations=BorderOnly to remove the OS title bar
while keeping the OS resize frame. All 238 tests pass.