### PR TITLE
test(AE): enforce no-MonoGame classpath invariant in Core.Tests

### DIFF
--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -34,7 +34,7 @@ public enum TextureCoordinateType
 
 /// <summary>
 /// Deserialized representation of a .achx animation file.
-/// Load with <see cref="FromFile"/> and convert to runtime types with
+/// Load with <see cref="FromFile(string)"/> and convert to runtime types with
 /// <see cref="ToAnimationChainList"/>.
 /// </summary>
 public class AnimationChainListSave
@@ -53,7 +53,7 @@ public class AnimationChainListSave
     /// <summary>The list of animation chains.</summary>
     public List<AnimationChainSave> AnimationChains = new();
 
-    /// <summary>Absolute path of the .achx file. Set automatically by <see cref="FromFile"/>;
+    /// <summary>Absolute path of the .achx file. Set automatically by <see cref="FromFile(string)"/>;
     /// tooling (Animation Editor) sets this directly when the user picks a Save-As path.</summary>
     public string FileName { get; set; } = string.Empty;
 

--- a/src/UI/GumRenderable.cs
+++ b/src/UI/GumRenderable.cs
@@ -96,5 +96,6 @@ public class GumRenderable : IRenderable, IAttachable
         GumRenderBatch.Instance.DrawElement(Visual);
     }
 
+    /// <inheritdoc/>
     public override string ToString() => Visual?.ToString() ?? "No Gum Object";
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- FRB2 marks MonoGame.Framework.DesktopGL PrivateAssets=All to keep it out
-         of the engine NuGet's transitive set. The Animation Editor links FRB2 by
-         project ref and ends up calling APIs whose JIT-resolution pulls in
-         MonoGame.Framework, so we restore the reference here. -->
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ClasspathInvariantTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ClasspathInvariantTests.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Guards the invariant that MonoGame.Framework is absent from the Core.Tests classpath.
+///
+/// The live AE app ships without MonoGame (FRB2's PackageReference carries
+/// PrivateAssets=All), so any FRB2 API path that JIT-resolves a
+/// Microsoft.Xna.Framework.* symbol throws FileNotFoundException in production.
+/// This test proves the test classpath matches that constraint: a failure here
+/// means a FRB2 API called by the AE has a hidden MonoGame JIT-dependency that
+/// must be fixed before it ships.
+/// </summary>
+public class ClasspathInvariantTests
+{
+    [Fact]
+    public void MonoGameFramework_IsNotPresentInClasspath()
+    {
+        Assert.Throws<FileNotFoundException>(() => Assembly.Load("MonoGame.Framework"));
+    }
+}


### PR DESCRIPTION
## Summary

Removes the MonoGame.Framework.DesktopGL workaround package reference from AnimationEditor.Core.Tests.csproj and adds a runtime probe test to permanently enforce the invariant.

## Changes

**AnimationEditor.Core.Tests.csproj** — Remove the MonoGame.Framework.DesktopGL PackageReference (and its explanatory comment). The JIT-time dependency it was papering over was fixed in PRs #176 and #204.

**ClasspathInvariantTests.cs** (new) — One [Fact] that asserts \Assembly.Load(\"MonoGame.Framework\")\ throws \FileNotFoundException\. If this test ever goes red it means a FRB2 API called by the AE has a hidden MonoGame JIT-dependency that would throw at runtime in the live app (which ships without MonoGame thanks to \PrivateAssets=All\).

## Verification

- 837 existing Core.Tests still pass without the MonoGame reference
- New invariant test passes (838 total)

Closes #181