### PR TITLE
test: close #179 — add corrupt-file coverage to ProjectManagerLoadTests

### DIFF
--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
@@ -1,12 +1,19 @@
 using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
 using System.IO;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
 
-public class ProjectManagerLoadTests
+public class ProjectManagerLoadTests : IDisposable
 {
+    private readonly TestHelpers.TempDir _dir = new();
+
+    public void Dispose() => _dir.Dispose();
+
+    // ── Missing file ─────────────────────────────────────────────────────────
+
     [Fact]
     public void LoadAnimationChain_MissingFile_ThrowsFileNotFoundException()
     {
@@ -26,5 +33,33 @@ public class ProjectManagerLoadTests
         catch (FileNotFoundException) { }
 
         Assert.Null(pm.AnimationChainListSave);
+    }
+
+    // ── Corrupt file ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadAnimationChain_CorruptFile_ThrowsException()
+    {
+        var pm = new ProjectManager();
+        var path = Path.Combine(_dir.Path, "corrupt.achx");
+        File.WriteAllText(path, "this is not valid xml");
+
+        Assert.ThrowsAny<Exception>(
+            () => pm.LoadAnimationChain(new FilePath(path)));
+    }
+
+    [Fact]
+    public void LoadAnimationChain_CorruptFile_DoesNotChangeAnimationChainListSave()
+    {
+        var pm = new ProjectManager();
+        var sentinel = new AnimationChainListSave();
+        pm.AnimationChainListSave = sentinel;
+        var path = Path.Combine(_dir.Path, "corrupt2.achx");
+        File.WriteAllText(path, "this is not valid xml");
+
+        try { pm.LoadAnimationChain(new FilePath(path)); }
+        catch { }
+
+        Assert.Same(sentinel, pm.AnimationChainListSave);
     }
 }


### PR DESCRIPTION
## Summary

The silent swallow in \ProjectManager.LoadAnimationChain\ was already reverted and the \LoadFailed\ event was already wired through the UI as part of PR #178 (merged via PR #202). Issue #179 was not listed in that commit's \Closes\ trailer so it remained open.

## What this PR adds

Extends \ProjectManagerLoadTests\ with two corrupt-file cases that directly verify the no-swallow guarantee **at the \ProjectManager\ level**:

- \LoadAnimationChain_CorruptFile_ThrowsException\ — the XML parse exception must propagate, not be swallowed
- \LoadAnimationChain_CorruptFile_DoesNotChangeAnimationChainListSave\ — project state is left unchanged when the load fails

The missing-file and corrupt-file cases at the \AppCommands\ level were already covered by \AppCommandsLoadFailureTests\ (8 cases).

## Test plan

- [x] \dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ --filter ProjectManagerLoad\ — 4/4 pass

Closes #179