### PR TITLE
chore: gitignore /run.ps1 to prevent double terminal launches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ CLAUDE.local.md
 /design/edc
 /out
 
+# Per-issue launch script — created fresh by the agent for each issue worktree.
+# Never commit: each issue needs its own content and a tracked version would
+# reappear as a stale "previous issue" file in every new worktree.
+/run.ps1
+
 # Sample folders intentionally excluded from source control
 /samples/auto
 /samples/SlopesSample

--- a/run.ps1
+++ b/run.ps1
@@ -1,2 +1,0 @@
-$appDir = Join-Path $PSScriptRoot "tools\AnimationEditorAvalonia\src\AnimationEditor.App"
-Start-Process wt -ArgumentList "new-tab --title `"Issue #177 - AnimationEditor`" -d `"$appDir`""


### PR DESCRIPTION
## Problem

\un.ps1\ is a per-issue helper script the agent writes into the worktree root before launching a titled Windows Terminal tab. Because it was git-tracked, every new worktree inherited the **previous issue's** content — causing a second terminal to open alongside the fresh one (one from the stale version, one from the newly-written version).

## Fix

- Add \/run.ps1\ to \.gitignore\ with an explanatory comment
- \git rm --cached run.ps1\ to stop tracking it

Going forward the agent always **creates** \un.ps1\ fresh for each issue worktree rather than updating a pre-existing stale copy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>