### PR TITLE
AE: reset wireframe/preview on File->New and File->Load

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -46,6 +46,7 @@ public partial class MainWindow : Window
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
     private bool _suppressPreviewZoomComboChanged;
+    private bool _suppressTreeSelectionHandling;
 
     private FilePath SettingsFilePath =>
         new FilePath((Path.GetDirectoryName(
@@ -942,6 +943,7 @@ public partial class MainWindow : Window
 
     private void OnTreeSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
+        if (_suppressTreeSelectionHandling) return;
         if (AnimTree.SelectedItem is not TreeNodeVm vm) return;
 
         // Sync multi-select into SelectedState
@@ -958,25 +960,33 @@ public partial class MainWindow : Window
 
     private void RefreshTreeView()
     {
-        var acls = _projectManager.AnimationChainListSave;
-
-        // Preserve expanded chain names before clearing
-        var expanded = TreeBuilder.GetExpandedChainNames(_treeRoots).ToHashSet();
-
-        _treeRoots.Clear();
-
-        if (acls is null) return;
-
-        foreach (var chain in acls.AnimationChains)
+        _suppressTreeSelectionHandling = true;
+        try
         {
-            var node = TreeBuilder.BuildChainNode(chain);
-            // Restore expand state — keep true if no prior state recorded yet
-            node.IsExpanded = expanded.Count == 0 || expanded.Contains(chain.Name);
-            _treeRoots.Add(node);
-        }
+            var acls = _projectManager.AnimationChainListSave;
 
-        // Re-select to keep visual state
-        SyncTreeSelection();
+            // Preserve expanded chain names before clearing
+            var expanded = TreeBuilder.GetExpandedChainNames(_treeRoots).ToHashSet();
+
+            _treeRoots.Clear();
+
+            if (acls is null) return;
+
+            foreach (var chain in acls.AnimationChains)
+            {
+                var node = TreeBuilder.BuildChainNode(chain);
+                // Restore expand state — keep true if no prior state recorded yet
+                node.IsExpanded = expanded.Count == 0 || expanded.Contains(chain.Name);
+                _treeRoots.Add(node);
+            }
+
+            // Re-select to keep visual state
+            SyncTreeSelection();
+        }
+        finally
+        {
+            _suppressTreeSelectionHandling = false;
+        }
     }
 
     private void RefreshChainNode(AnimationChainSave chain)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -559,9 +559,10 @@ public partial class MainWindow : Window
 
     private void OnNewClick(object? sender, RoutedEventArgs e)
     {
-        _projectManager.AnimationChainListSave =
-            new AnimationChainListSave();
+        _projectManager.AnimationChainListSave = new AnimationChainListSave();
         _projectManager.FileName = null;
+        _selectedState.Reset();
+        RefreshTreeView();
         _ = _appCommands.SaveCurrentAnimationChainListAsync();
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -134,6 +134,7 @@ namespace AnimationEditor.Core.CommandsAndState
             }
 
             _undoManager.Clear();
+            _selectedState.Reset();
             RefreshTreeViewRequested?.Invoke();
             _ioManager.LoadAndApplyCompanionFileFor(fileName);
             RefreshWireframeRequested?.Invoke();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ISelectedState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ISelectedState.cs
@@ -23,5 +23,12 @@ namespace AnimationEditor.Core
         string? SelectedTextureName { get; }
         TileMapInformation? SelectedTileMapInformation { get; }
         SelectionSnapshot Snapshot { get; set; }
+
+        /// <summary>
+        /// Clears all selection state (chain, frame, shapes, multi-select) and fires
+        /// <see cref="SelectionChanged"/> once. Call this when the project is reset or
+        /// a new file is loaded so the wireframe and preview stop showing stale content.
+        /// </summary>
+        void Reset();
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
@@ -162,5 +162,17 @@ namespace AnimationEditor.Core
             }
             return null;
         }
+
+        /// <inheritdoc/>
+        public void Reset()
+        {
+            _selectedChain = null;
+            _selectedFrame = null;
+            _selectedRectangle = null;
+            _selectedCircle = null;
+            _selectedNodes = new List<object>();
+            SelectedChains = new List<AnimationChainSave>();
+            SelectionChanged?.Invoke();
+        }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
@@ -98,6 +98,39 @@ public class NewAndLoadResetTests
         finally { window.Close(); }
     }
 
+    /// <summary>
+    /// File → New must reset SelectedChain even when selection was made via the tree.
+    /// In a real window Avalonia fires AnimTree.SelectionChanged when _treeRoots is
+    /// cleared; the handler must not re-apply the stale tree item after Reset().
+    /// </summary>
+    [AvaloniaFact]
+    public void New_ClearsSelection_WhenSelectedViaTree()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+
+            var tree  = window.FindControl<TreeView>("AnimTree")!;
+            var roots = (System.Collections.ObjectModel.ObservableCollection<AnimationEditor.Core.ViewModels.TreeNodeVm>)tree.ItemsSource!;
+            Assert.NotEmpty(roots);
+
+            // Simulate the user clicking the chain node in the tree
+            tree.SelectedItem = roots[0];
+            Dispatcher.UIThread.RunJobs();
+
+            // File → New
+            window.FindControl<MenuItem>("MenuNew")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Null(ctx.SelectedState.SelectedChain);
+            Assert.Null(ctx.SelectedState.SelectedFrame);
+        }
+        finally { window.Close(); }
+    }
+
     // ── File → Load ───────────────────────────────────────────────────────────
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies that File → New and File → Load reset the sprite shown in the
+/// wireframe and the animation playing in the preview by clearing selection.
+/// </summary>
+public class NewAndLoadResetTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static string WriteAchx(string dir, params string[] chainNames)
+    {
+        var path = Path.Combine(dir, "test.achx");
+        var acls = new AnimationChainListSave();
+        foreach (var name in chainNames)
+            acls.AnimationChains.Add(new AnimationChainSave { Name = name });
+        acls.Save(path);
+        return path;
+    }
+
+    // ── File → New ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// File → New must clear the tree so it shows no chains.
+    /// (Regression: OnNewClick was missing RefreshTreeView.)
+    /// </summary>
+    [AvaloniaFact]
+    public void New_ClearsTree()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+
+            window.FindControl<MenuItem>("MenuNew")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+
+            var tree  = window.FindControl<TreeView>("AnimTree")!;
+            var roots = (System.Collections.ObjectModel.ObservableCollection<AnimationEditor.Core.ViewModels.TreeNodeVm>)tree.ItemsSource!;
+            Assert.Empty(roots);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// File → New must reset SelectedChain and SelectedFrame so the wireframe
+    /// and preview stop showing the previous file's sprite and animation.
+    /// </summary>
+    [AvaloniaFact]
+    public void New_ClearsSelection()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "Tex.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame; // simulate a frame being selected
+
+            window.FindControl<MenuItem>("MenuNew")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+
+            Assert.Null(ctx.SelectedState.SelectedChain);
+            Assert.Null(ctx.SelectedState.SelectedFrame);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── File → Load ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Loading a new .achx must clear the old selection so the wireframe and
+    /// preview stop rendering the previous file's sprite/animation.
+    /// </summary>
+    [AvaloniaFact]
+    public void Load_ClearsSelectionBeforePopulatingNewFile()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // Set up an initial chain and select it
+            var oldChain = new AnimationChainSave { Name = "OldWalk" };
+            var oldFrame = new AnimationFrameSave { TextureName = "Old.png", ShapesSave = new ShapesSave() };
+            oldChain.Frames.Add(oldFrame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(oldChain);
+            ctx.SelectedState.SelectedFrame = oldFrame;
+
+            // Load a different .achx
+            var path = WriteAchx(dir, "NewRun");
+            typeof(MainWindow)
+                .GetMethod("LoadAnimationFile", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, [path]);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Null(ctx.SelectedState.SelectedChain);
+            Assert.Null(ctx.SelectedState.SelectedFrame);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After pressing **File → New** or loading a different **.achx**, the wireframe still showed the old sprite and the animation preview kept playing the old chain. Root cause: \_selectedState\ was never cleared, so \WireframeControl.DetermineTexturePath()\ kept resolving the stale frame's texture path and \PreviewControl\ kept playing the stale chain.

Also: **File → New** was missing a \RefreshTreeView()\ call, so the tree was not cleared.

## Fix

**New API:** \ISelectedState.Reset()\ / \SelectedState.Reset()\  
Zeros chain, frame, shapes, and multi-select in one atomic call and fires \SelectionChanged\ once — which causes:
- \WireframeControl.RefreshAll()\ → \DetermineTexturePath()\ → null → \LoadTexture(null)\ → bitmap cleared
- \PreviewControl.OnSelectionChanged()\ → \_playback.SetChain(null)\ → playback stops

**\OnNewClick\** (MainWindow): calls \_selectedState.Reset()\ and \RefreshTreeView()\ before the fire-and-forget save.

**\LoadAnimationChain\** (AppCommands): calls \_selectedState.Reset()\ before \RefreshTreeViewRequested\ fires, so all subscribers rebuild with null selection.

## Tests

3 new \[AvaloniaFact]\ tests in \NewAndLoadResetTests.cs\:

| Test | Covers |
|------|--------|
| \New_ClearsTree\ | Tree is empty after File→New |
| \New_ClearsSelection\ | SelectedChain/Frame are null after File→New |
| \Load_ClearsSelectionBeforePopulatingNewFile\ | Selection is null after loading a different .achx |

All 1078 tests pass.