### PR TITLE
AE: pre-select first chain on load to fix wireframe flash

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -134,6 +134,7 @@ namespace AnimationEditor.Core.CommandsAndState
             }
 
             _undoManager.Clear();
+            _selectedState.SelectedChain = _pm.AnimationChainListSave?.AnimationChains.FirstOrDefault();
             RefreshTreeViewRequested?.Invoke();
             _ioManager.LoadAndApplyCompanionFileFor(fileName);
             RefreshWireframeRequested?.Invoke();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
@@ -1,0 +1,144 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies that <see cref="IAppCommands.LoadAnimationChain"/> pre-selects the
+/// first chain after loading so the wireframe panel shows content immediately
+/// instead of flashing then clearing.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class AppCommandsLoadTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir = new();
+    private readonly TestServices _ctx = TestHelpers.SetupFreshAcls();
+
+    public void Dispose() => _dir.Dispose();
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string WriteAchx(params string[] chainNames)
+    {
+        var path = Path.Combine(_dir.Path, "test.achx");
+        var acls = new AnimationChainListSave();
+        foreach (var name in chainNames)
+            acls.AnimationChains.Add(new AnimationChainSave { Name = name });
+        acls.Save(path);
+        return path;
+    }
+
+    private string WriteAchxWithFrame(string chainName, string textureName)
+    {
+        var path = Path.Combine(_dir.Path, "test.achx");
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = textureName, FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    // ── First-chain pre-selection ─────────────────────────────────────────────
+
+    [Fact]
+    public void LoadAnimationChain_WithChains_SetsSelectedChainToFirst()
+    {
+        var path = WriteAchx("Walk", "Run");
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(_ctx.SelectedState.SelectedChain);
+        Assert.Equal("Walk", _ctx.SelectedState.SelectedChain!.Name);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_WithChains_DoesNotSelectSecondChain()
+    {
+        var path = WriteAchx("Walk", "Run");
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotEqual("Run", _ctx.SelectedState.SelectedChain?.Name);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_WithSingleChainAndFrame_SetsSelectedChain()
+    {
+        var path = WriteAchxWithFrame("Idle", "hero.png");
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(_ctx.SelectedState.SelectedChain);
+        Assert.Equal("Idle", _ctx.SelectedState.SelectedChain!.Name);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_EmptyAcls_SelectedChainIsNull()
+    {
+        var path = WriteAchx(); // zero chains
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.Null(_ctx.SelectedState.SelectedChain);
+    }
+
+    // ── Frame is cleared ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadAnimationChain_SelectedFrameIsNull()
+    {
+        // Pre-populate a frame selection
+        var priorChain = new AnimationChainSave { Name = "Prior" };
+        var priorFrame = new AnimationFrameSave { FrameLength = 0.1f };
+        priorChain.Frames.Add(priorFrame);
+        _ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(priorChain);
+        _ctx.SelectedState.SelectedFrame = priorFrame;
+
+        var path = WriteAchx("NewWalk");
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.Null(_ctx.SelectedState.SelectedFrame);
+    }
+
+    // ── Event-ordering regression guard ──────────────────────────────────────
+
+    /// <summary>
+    /// SelectedChain must be set BEFORE RefreshWireframeRequested fires so
+    /// the wireframe sees the correct chain and does not clear the display.
+    /// </summary>
+    [Fact]
+    public void LoadAnimationChain_SelectedChainIsSetBeforeWireframeRefresh()
+    {
+        var path = WriteAchx("Idle");
+        AnimationChainSave? observedDuringRefresh = null;
+        _ctx.AppCommands.RefreshWireframeRequested += () =>
+            observedDuringRefresh = _ctx.SelectedState.SelectedChain;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(observedDuringRefresh);
+        Assert.Equal("Idle", observedDuringRefresh!.Name);
+    }
+
+    /// <summary>
+    /// SelectedChain must be set BEFORE RefreshTreeViewRequested fires so
+    /// any tree subscriber can reflect the selection immediately.
+    /// </summary>
+    [Fact]
+    public void LoadAnimationChain_SelectedChainIsSetBeforeTreeRefresh()
+    {
+        var path = WriteAchx("Walk");
+        AnimationChainSave? observedDuringRefresh = null;
+        _ctx.AppCommands.RefreshTreeViewRequested += () =>
+            observedDuringRefresh = _ctx.SelectedState.SelectedChain;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(observedDuringRefresh);
+        Assert.Equal("Walk", observedDuringRefresh!.Name);
+    }
+}


### PR DESCRIPTION
## Summary

After LoadAnimationChain loads a .achx file, SelectedChain was never assigned, leaving the selection null. The wireframe re-evaluates from SelectedChain; with null selection the panel clears after the brief initial render — producing the visible flash.

## Fix

In AppCommands.LoadAnimationChain, assign SelectedChain to cls.AnimationChains.FirstOrDefault() **before** firing RefreshTreeViewRequested and RefreshWireframeRequested. This ensures every refresh subscriber sees the correct selection immediately.

Setting SelectedChain through the property setter already clears SelectedFrame, SelectedRectangle, and SelectedCircle, so no separate Reset() call is needed.

## Tests

8 new Core tests in AppCommandsLoadTests.cs:
- First chain is selected after load (two-chain file)
- Second chain is NOT selected
- Chain with frames: selection is set
- Empty ACLS: SelectedChain is null (safe FirstOrDefault() path)
- SelectedFrame is null after load (cleared by property setter)
- **Event-ordering guard**: SelectedChain is set before RefreshWireframeRequested fires (direct regression test)
- **Event-ordering guard**: SelectedChain is set before RefreshTreeViewRequested fires

All 847 Core + 238 App tests pass.

Closes #182