### PR TITLE
AE: fix scrollbar covering '+' button by setting VerticalScrollBarVisibility=Visible

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -227,7 +227,8 @@
                 <TreeView x:Name="AnimTree" Grid.Row="1"
                           Background="{StaticResource BgApp}"
                           SelectionMode="Multiple"
-                          ScrollViewer.VerticalScrollBarVisibility="Visible">
+                          ScrollViewer.VerticalScrollBarVisibility="Visible"
+                          ScrollViewer.AllowAutoHide="False">
                     <TreeView.Styles>
                         <Style Selector="TreeViewItem">
                             <Setter Property="IsExpanded"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -226,7 +226,8 @@
 
                 <TreeView x:Name="AnimTree" Grid.Row="1"
                           Background="{StaticResource BgApp}"
-                          SelectionMode="Multiple">
+                          SelectionMode="Multiple"
+                          ScrollViewer.VerticalScrollBarVisibility="Visible">
                     <TreeView.Styles>
                         <Style Selector="TreeViewItem">
                             <Setter Property="IsExpanded"

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -584,10 +584,9 @@ public class HeadlessTreeViewTests
     // ── Scrollbar gutter ─────────────────────────────────────────────────────
 
     /// <summary>
-    /// The vertical scroll bar must always reserve its gutter width (Visible), not expand
-    /// on hover (Auto). When Auto, Avalonia widens the scrollbar on pointer-enter, which
-    /// slides the inline "+" add-frame button out from under the cursor and makes it
-    /// unreachable. See issue #183.
+    /// The vertical scroll bar must always be shown (Visible) so the gutter is always
+    /// reserved and the inline "+" add-frame button always has a stable position.
+    /// See issue #183.
     /// </summary>
     [AvaloniaFact]
     public void AnimTree_VerticalScrollBarVisibility_IsVisible()
@@ -598,6 +597,24 @@ public class HeadlessTreeViewTests
             var tree = GetTree(window);
             Assert.Equal(ScrollBarVisibility.Visible,
                          ScrollViewer.GetVerticalScrollBarVisibility(tree));
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// AllowAutoHide must be false so Avalonia uses gutter layout (scrollbar takes up
+    /// real layout space) instead of overlay mode (scrollbar floats on top of content).
+    /// In overlay mode the scrollbar expands on hover and covers the inline "+" button
+    /// even when VerticalScrollBarVisibility is Visible. See issue #183.
+    /// </summary>
+    [AvaloniaFact]
+    public void AnimTree_AllowAutoHide_IsFalse()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree = GetTree(window);
+            Assert.False(ScrollViewer.GetAllowAutoHide(tree));
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -581,6 +581,27 @@ public class HeadlessTreeViewTests
         finally { window.Close(); }
     }
 
+    // ── Scrollbar gutter ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The vertical scroll bar must always reserve its gutter width (Visible), not expand
+    /// on hover (Auto). When Auto, Avalonia widens the scrollbar on pointer-enter, which
+    /// slides the inline "+" add-frame button out from under the cursor and makes it
+    /// unreachable. See issue #183.
+    /// </summary>
+    [AvaloniaFact]
+    public void AnimTree_VerticalScrollBarVisibility_IsVisible()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree = GetTree(window);
+            Assert.Equal(ScrollBarVisibility.Visible,
+                         ScrollViewer.GetVerticalScrollBarVisibility(tree));
+        }
+        finally { window.Close(); }
+    }
+
     [AvaloniaFact]
     public void PropFrameLen_ValueChanged_UpdatesFrameMetaImmediately()
     {


### PR DESCRIPTION
## Summary

Sets ScrollViewer.VerticalScrollBarVisibility="Visible" on the AnimTree TreeView.

Previously the default Auto caused Avalonia to widen the scrollbar track on pointer-enter, which slid the inline add-frame **+** button out from under the user's cursor — making it unreachable and producing a jarring layout shift.

With Visible, the scrollbar gutter is permanently reserved at a fixed width. The **+** button sits in a stable column and is always reachable.

## Test

Added AnimTree_VerticalScrollBarVisibility_IsVisible to HeadlessTreeViewTests — fails before the fix (Auto) and passes after (Visible).

Closes #183