### PR TITLE
fix(AE): diff-update frame children to preserve tree selection and expand state

### DIFF
--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -35,6 +35,15 @@ public class AnimationFrameSave
     /// <summary>The frame's offset along the Y axis.</summary>
     public float RelativeY;
 
+    /// <summary>
+    /// User-visible display label for this frame in the Animation Editor tree.
+    /// Set once on creation for unnamed frames (e.g. "Frame 3") so the label
+    /// survives reorders, copy/paste, and full tree rebuilds.
+    /// Empty for frames loaded from files that pre-date this field; the editor
+    /// falls back to a position-based label in that case.
+    /// </summary>
+    public string Name = string.Empty;
+
     /// <summary>Per-frame shape definitions. Empty by default.</summary>
     public ShapesSave? ShapesSave;
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -282,7 +282,8 @@
                                                    Foreground="{StaticResource Ink}"
                                                    Padding="2,1"
                                                    VerticalAlignment="Center"
-                                                   IsVisible="{Binding !IsEditing}" />
+                                                   IsVisible="{Binding !IsEditing}"
+                                                   DoubleTapped="OnHeaderTextDoubleTapped" />
                                         <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
                                         <TextBox Text="{Binding EditingText, Mode=TwoWay}"
                                                  IsVisible="{Binding IsEditing}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -234,6 +234,33 @@
                             <Setter Property="IsExpanded"
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                         </Style>
+                        <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered. -->
+                        <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">
+                            <Setter Property="Margin" Value="0" />
+                            <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
+                        </Style>
+                        <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
+                            <Setter Property="VerticalAlignment" Value="Stretch" />
+                            <Setter Property="HorizontalAlignment" Value="Stretch" />
+                            <Setter Property="Width" Value="NaN" />
+                            <Setter Property="Height" Value="NaN" />
+                            <Setter Property="Template">
+                                <ControlTemplate>
+                                    <Border Background="Transparent">
+                                        <Path x:Name="ChevronPath"
+                                              Width="12" Height="12"
+                                              Data="{StaticResource TreeViewItemCollapsedChevronPathData}"
+                                              Fill="{DynamicResource TreeViewItemForeground}"
+                                              Stretch="Uniform"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter>
+                        </Style>
+                        <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron:checked /template/ Path#ChevronPath">
+                            <Setter Property="Data" Value="{StaticResource TreeViewItemExpandedChevronPathData}" />
+                        </Style>
                         <!-- Inline "Add Frame" button: hidden by default, revealed on row hover -->
                         <Style Selector="Button.add-frame-btn">
                             <Setter Property="Opacity" Value="0" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -409,11 +409,12 @@
                         <Border Width="1" Height="18" Background="{StaticResource LineBrush}"
                                 Margin="4,0" VerticalAlignment="Center" />
 
-                        <CheckBox x:Name="SnapToGridCheck"
-                                  Foreground="{StaticResource Ink}"
-                                  VerticalAlignment="Center"
-                                  Margin="0,0,4,0"
-                                  ToolTip.Tip="Snap to Grid">
+                        <ToggleButton x:Name="SnapToGridCheck"
+                                      Height="26"
+                                      Foreground="{StaticResource Ink}"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,4,0"
+                                      ToolTip.Tip="Snap to Grid">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <svg:Svg Width="16" Height="16"
                                          Path="avares://AnimationEditor.App/Assets/icons/svg/IconGrid.svg"
@@ -421,7 +422,7 @@
                                          VerticalAlignment="Center" />
                                 <TextBlock Text="Grid" VerticalAlignment="Center" />
                             </StackPanel>
-                        </CheckBox>
+                        </ToggleButton>
 
                         <Border BorderBrush="{StaticResource LineBrush}"
                                 BorderThickness="1" CornerRadius="4" ClipToBounds="True"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -759,11 +759,14 @@ public partial class MainWindow : Window
         // Blank-space double-tap: expand / collapse the node
         AnimTree.DoubleTapped += OnAnimTreeDoubleTapped;
 
-        // Bubble-phase KeyDown from the inline TextBox (Enter=commit, Escape=cancel)
+        // Tunnel-phase KeyDown from the inline TextBox (Enter=commit, Escape=cancel).
+        // Must be Tunnel (not Bubble) so we intercept Enter/Escape BEFORE the event
+        // reaches TreeViewItem.OnKeyDown, which in Avalonia 12.x handles Key.Enter by
+        // toggling IsExpanded — collapsing the chain mid-rename if we arrive too late.
         AnimTree.AddHandler(
             InputElement.KeyDownEvent,
             OnInlineRenameKeyDown,
-            RoutingStrategies.Bubble);
+            RoutingStrategies.Tunnel);
 
         // Bubble-phase LostFocus from the inline TextBox: commit
         AnimTree.AddHandler(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -756,7 +756,7 @@ public partial class MainWindow : Window
         ExpandAllBtn.Click  += (_, _) => SetAllExpanded(true);
         CollapseAllBtn.Click += (_, _) => SetAllExpanded(false);
 
-        // Inline rename: double-tap a chain node
+        // Blank-space double-tap: expand / collapse the node
         AnimTree.DoubleTapped += OnAnimTreeDoubleTapped;
 
         // Bubble-phase KeyDown from the inline TextBox (Enter=commit, Escape=cancel)
@@ -2473,8 +2473,30 @@ public partial class MainWindow : Window
 
     // ── Inline rename helpers ─────────────────────────────────────────────────
 
+    /// <summary>
+    /// Double-tap on the text label of a tree node → inline rename.
+    /// Marks the event handled so it does not bubble to <see cref="OnAnimTreeDoubleTapped"/>.
+    /// </summary>
+    private void OnHeaderTextDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (sender is not Control src) return;
+        var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        if (tvi?.DataContext is not TreeNodeVm vm) return;
+        e.Handled = true;
+
+        if (vm.Data is AnimationChainSave chain)
+            BeginInlineRename(vm, chain.Name);
+        else if (vm.Data is AnimationFrameSave frame)
+            BeginInlineRename(vm, frame.TextureName ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Double-tap on blank space in a tree row (not the text label, not a Button) →
+    /// toggle expand / collapse.
+    /// </summary>
     private void OnAnimTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
+        if (e.Source is Button) return;
         if (e.Source is not Control src) return;
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (tvi?.DataContext is not TreeNodeVm vm) return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -992,15 +992,14 @@ public partial class MainWindow : Window
     private void RefreshChainNode(AnimationChainSave chain)
     {
         var node = FindChainNode(chain);
-        var rebuiltChainNode = TreeBuilder.BuildChainNode(chain);
         if (node is null)
         {
-            _treeRoots.Add(rebuiltChainNode);
+            _treeRoots.Add(TreeBuilder.BuildChainNode(chain));
         }
         else
         {
-            node.Header = rebuiltChainNode.Header;
-            node.Meta   = rebuiltChainNode.Meta;
+            node.Header = chain.Name;
+            node.Meta   = $"{chain.Frames.Count} fr";
             TreeBuilder.SyncFramesInto(node, chain.Frames);
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2496,6 +2496,11 @@ public partial class MainWindow : Window
     /// </summary>
     private void OnAnimTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
+        // If the TextBlock's DoubleTapped handler already handled the event (inline rename),
+        // skip expand/collapse. Belt-and-suspenders: also bail if source is a TextBlock in
+        // case Avalonia gesture routing raises a fresh event instance per subscriber.
+        if (e.Handled) return;
+        if (e.Source is TextBlock) return;
         if (e.Source is Button) return;
         if (e.Source is not Control src) return;
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2486,8 +2486,8 @@ public partial class MainWindow : Window
 
         if (vm.Data is AnimationChainSave chain)
             BeginInlineRename(vm, chain.Name);
-        else if (vm.Data is AnimationFrameSave frame)
-            BeginInlineRename(vm, frame.TextureName ?? string.Empty);
+        else if (vm.Data is AnimationFrameSave)
+            BeginInlineRename(vm, vm.Header);
     }
 
     /// <summary>
@@ -2582,7 +2582,7 @@ public partial class MainWindow : Window
     {
         var vm = TreeBuilder.FindNodeForData(_treeRoots, frame);
         if (vm is null) return;
-        BeginInlineRename(vm, frame.TextureName ?? string.Empty);
+        BeginInlineRename(vm, vm.Header);
     }
 
     private void CommitInlineRename(TreeNodeVm vm, string newName)
@@ -2597,14 +2597,13 @@ public partial class MainWindow : Window
         }
         else if (vm.Data is AnimationFrameSave frame)
         {
-            if (newName != (frame.TextureName ?? string.Empty))
+            // Rename updates frame.Name (the display label) — never frame.TextureName,
+            // which holds the actual texture path and must not be cleared.
+            if (newName != frame.Name)
             {
-                _appCommands.RenameFrame(frame, newName);
-                var frameChain = _objectFinder.GetAnimationChainContaining(frame);
-                if (frameChain is not null) _appCommands.RefreshTreeNode(frameChain);
-                _appCommands.RefreshWireframe();
-                RefreshTextureCombo();
-                _events.RaiseAnimationChainsChanged();
+                frame.Name = newName;
+                _appCommands.RefreshTreeNode(frame);
+                _appCommands.SaveCurrentAnimationChainList();
             }
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -104,13 +104,18 @@ public static class TreeBuilder
         return node;
     }
 
-    /// <summary>Returns the display label for a frame node.</summary>
+    /// <summary>
+    /// Returns the display label for a frame node.
+    /// Priority: explicit <see cref="AnimationFrameSave.Name"/> (user-assigned) >
+    /// <see cref="Path.GetFileName"/> of <see cref="AnimationFrameSave.TextureName"/> >
+    /// position-based fallback "Frame N".
+    /// </summary>
     public static string BuildFrameHeader(AnimationFrameSave frame, int index = 0)
     {
-        if (!string.IsNullOrEmpty(frame.TextureName))
-            return Path.GetFileName(frame.TextureName);
         if (!string.IsNullOrEmpty(frame.Name))
             return frame.Name;
+        if (!string.IsNullOrEmpty(frame.TextureName))
+            return Path.GetFileName(frame.TextureName);
         return $"Frame {index + 1}";
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -119,52 +119,52 @@ public static class TreeBuilder
     /// </summary>
     public static void SyncShapesInto(TreeNodeVm frameNode, ShapesSave? shapesSave)
     {
-        var rects   = shapesSave?.AARectSaves  ?? new System.Collections.Generic.List<AARectSave>();
-        var circles = shapesSave?.CircleSaves  ?? new System.Collections.Generic.List<CircleSave>();
+            var rects   = shapesSave?.AARectSaves  ?? new System.Collections.Generic.List<AARectSave>();
+            var circles = shapesSave?.CircleSaves  ?? new System.Collections.Generic.List<CircleSave>();
 
-        // Remove shape VMs that no longer exist in the data lists.
-        for (int i = frameNode.Children.Count - 1; i >= 0; i--)
-        {
-            var child = frameNode.Children[i];
-            bool keep = (child.Data is AARectSave r && rects.Contains(r))
-                     || (child.Data is CircleSave  c && circles.Contains(c));
-            if (!keep) frameNode.Children.RemoveAt(i);
-        }
+            // Remove shape VMs that no longer exist in the data lists.
+            for (int i = frameNode.Children.Count - 1; i >= 0; i--)
+            {
+                var child = frameNode.Children[i];
+                bool keep = (child.Data is AARectSave r && rects.Contains(r))
+                         || (child.Data is CircleSave  c && circles.Contains(c));
+                if (!keep) frameNode.Children.RemoveAt(i);
+            }
 
-        // Ensure every desired shape has a VM at the correct index.
-        int pos = 0;
-        foreach (var r in rects)
-        {
-            var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, r));
-            if (vm is null)
+            // Ensure every desired shape has a VM at the correct index.
+            int pos = 0;
+            foreach (var r in rects)
             {
-                vm = new TreeNodeVm { Header = r.Name, Data = r, Kind = NodeKind.RectShape, IsRectNode = true };
-                frameNode.Children.Insert(pos, vm);
+                var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, r));
+                if (vm is null)
+                {
+                    vm = new TreeNodeVm { Header = r.Name, Data = r, Kind = NodeKind.RectShape, IsRectNode = true };
+                    frameNode.Children.Insert(pos, vm);
+                }
+                else
+                {
+                    vm.Header = r.Name;
+                    int cur = frameNode.Children.IndexOf(vm);
+                    if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+                }
+                pos++;
             }
-            else
+            foreach (var c in circles)
             {
-                vm.Header = r.Name;
-                int cur = frameNode.Children.IndexOf(vm);
-                if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+                var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, c));
+                if (vm is null)
+                {
+                    vm = new TreeNodeVm { Header = c.Name, Data = c, Kind = NodeKind.CircleShape, IsCircleNode = true };
+                    frameNode.Children.Insert(pos, vm);
+                }
+                else
+                {
+                    vm.Header = c.Name;
+                    int cur = frameNode.Children.IndexOf(vm);
+                    if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+                }
+                pos++;
             }
-            pos++;
-        }
-        foreach (var c in circles)
-        {
-            var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, c));
-            if (vm is null)
-            {
-                vm = new TreeNodeVm { Header = c.Name, Data = c, Kind = NodeKind.CircleShape, IsCircleNode = true };
-                frameNode.Children.Insert(pos, vm);
-            }
-            else
-            {
-                vm.Header = c.Name;
-                int cur = frameNode.Children.IndexOf(vm);
-                if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
-            }
-            pos++;
-        }
     }
 
     /// <summary>
@@ -198,7 +198,10 @@ public static class TreeBuilder
             }
             else
             {
-                vm.Header = BuildFrameHeader(frame, i);
+                // Only update header for named frames — unnamed "Frame N" labels stay
+                // stable across reorder so the user can visually track which frame moved.
+                if (!string.IsNullOrEmpty(frame.TextureName))
+                    vm.Header = BuildFrameHeader(frame, i);
                 vm.Meta   = $"{frame.FrameLength:0.00}s";
                 int cur   = chainNode.Children.IndexOf(vm);
                 if (cur != i) { chainNode.Children.RemoveAt(cur); chainNode.Children.Insert(i, vm); }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -59,9 +59,17 @@ public static class TreeBuilder
     /// <summary>
     /// Builds a single frame node with any shape children from
     /// <see cref="AnimationFrameSave.ShapesSave"/>.
+    /// Sets <see cref="AnimationFrameSave.Name"/> once for unnamed frames so the
+    /// label survives copy/paste and full tree rebuilds.
     /// </summary>
     public static TreeNodeVm BuildFrameNode(AnimationFrameSave frame, int index = 0)
     {
+        // Persist the display label into the data model on first creation so that
+        // copy/paste (which serializes the frame) and RefreshTreeView (full rebuild)
+        // reproduce the same label regardless of the frame's new position.
+        if (string.IsNullOrEmpty(frame.TextureName) && string.IsNullOrEmpty(frame.Name))
+            frame.Name = $"Frame {index + 1}";
+
         var node = new TreeNodeVm
         {
             Header = BuildFrameHeader(frame, index),
@@ -99,9 +107,11 @@ public static class TreeBuilder
     /// <summary>Returns the display label for a frame node.</summary>
     public static string BuildFrameHeader(AnimationFrameSave frame, int index = 0)
     {
-        if (string.IsNullOrEmpty(frame.TextureName))
-            return $"Frame {index + 1}";
-        return Path.GetFileName(frame.TextureName);
+        if (!string.IsNullOrEmpty(frame.TextureName))
+            return Path.GetFileName(frame.TextureName);
+        if (!string.IsNullOrEmpty(frame.Name))
+            return frame.Name;
+        return $"Frame {index + 1}";
     }
 
     // ── Diff-update helpers ───────────────────────────────────────────────────
@@ -169,44 +179,51 @@ public static class TreeBuilder
 
     /// <summary>
     /// Diff-updates the frame children of <paramref name="chainNode"/> to match
-    /// <paramref name="frames"/> without replacing existing VMs.
-    /// <para>
-    /// Frame VMs are matched by <see cref="TreeNodeVm.Data"/> reference.
-    /// Surviving VMs have their header and meta resynced and their shape children
-    /// recursively diff-updated via <see cref="SyncShapesInto"/>.
-    /// <see cref="TreeNodeVm.IsExpanded"/> is preserved on retained VMs.
-    /// </para>
+    /// <paramref name="frames"/> without replacing existing <see cref="TreeNodeVm"/>
+    /// instances.  Retained VMs keep their <see cref="TreeNodeVm.IsExpanded"/> state
+    /// (and Avalonia's TreeView keeps them in its <c>SelectedItems</c> because selection
+    /// uses object identity).  Headers and Meta are always refreshed; label stability
+    /// for unnamed frames is provided by <see cref="AnimationFrameSave.Name"/> which is
+    /// set once at creation time by <see cref="BuildFrameNode"/>.
     /// </summary>
-    public static void SyncFramesInto(TreeNodeVm chainNode, System.Collections.Generic.IList<AnimationFrameSave> frames)
+    public static void SyncFramesInto(TreeNodeVm chainNode, IList<AnimationFrameSave> frames)
     {
-        // Remove frame VMs whose data is no longer in the list.
-        for (int i = chainNode.Children.Count - 1; i >= 0; i--)
-        {
-            var child = chainNode.Children[i];
-            if (child.Data is AnimationFrameSave f && !frames.Contains(f))
-                chainNode.Children.RemoveAt(i);
-        }
+        var children = chainNode.Children;
 
-        // Ensure every desired frame has a VM at the correct index.
+        // Build a lookup of existing VMs keyed by frame reference.
+        var existingByFrame = new Dictionary<AnimationFrameSave, TreeNodeVm>(
+            ReferenceEqualityComparer.Instance);
+        foreach (var child in children)
+            if (child.Data is AnimationFrameSave f)
+                existingByFrame[f] = child;
+
+        // Step 1: Remove VMs whose frame is no longer in the list.
+        var frameSet = new HashSet<AnimationFrameSave>(frames, ReferenceEqualityComparer.Instance);
+        for (int i = children.Count - 1; i >= 0; i--)
+            if (children[i].Data is AnimationFrameSave f && !frameSet.Contains(f))
+                children.RemoveAt(i);
+
+        // Step 2: Append new VMs for frames not yet represented (step 3 reorders them).
+        for (int i = 0; i < frames.Count; i++)
+            if (!existingByFrame.ContainsKey(frames[i]))
+                children.Add(BuildFrameNode(frames[i], i));
+
+        // Step 3: Reorder children to match the target frame order, then refresh
+        //         Header and Meta.  Label stability comes from AnimationFrameSave.Name
+        //         (set once in BuildFrameNode) so BuildFrameHeader returns the same
+        //         value regardless of the frame's current position index.
         for (int i = 0; i < frames.Count; i++)
         {
-            var frame = frames[i];
-            var vm    = chainNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, frame));
-            if (vm is null)
+            var target = frames[i];
+            if (!ReferenceEquals(children[i].Data, target))
             {
-                chainNode.Children.Insert(i, BuildFrameNode(frame, i));
+                for (int j = i + 1; j < children.Count; j++)
+                    if (ReferenceEquals(children[j].Data, target))
+                    { children.Move(j, i); break; }
             }
-            else
-            {
-                // Only update header for named frames — unnamed "Frame N" labels stay
-                // stable across reorder so the user can visually track which frame moved.
-                if (!string.IsNullOrEmpty(frame.TextureName))
-                    vm.Header = BuildFrameHeader(frame, i);
-                vm.Meta   = $"{frame.FrameLength:0.00}s";
-                int cur   = chainNode.Children.IndexOf(vm);
-                if (cur != i) { chainNode.Children.RemoveAt(cur); chainNode.Children.Insert(i, vm); }
-                SyncShapesInto(vm, frame.ShapesSave);
-            }
+            children[i].Header = BuildFrameHeader(target, i);
+            children[i].Meta   = $"{target.FrameLength:0.00}s";
+            SyncShapesInto(children[i], target.ShapesSave);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -909,4 +909,65 @@ public class HeadlessTreeViewTests
         }
         finally { window.Close(); }
     }
+
+    [AvaloniaFact]
+    public void RenameChain_DoesNotCollapseChainNode()
+    {
+        // Regression: double-click rename was collapsing the chain node because
+        // OnAnimTreeDoubleTapped toggled IsExpanded even when the TextBlock's
+        // DoubleTapped handler had already handled the event.
+        // This test verifies that the rename flow (AppCommands.RenameChain →
+        // RefreshChainNode) leaves IsExpanded untouched.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var chainNode = GetRoots(GetTree(window))[0];
+            chainNode.IsExpanded = true;
+
+            ctx.AppCommands.RenameChain(chain, "Walk Renamed");
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(chainNode.IsExpanded, "Chain node must stay expanded after inline rename.");
+            Assert.Equal("Walk Renamed", chainNode.Header);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RenameFrameLabel_DoesNotCollapseParentChainNode()
+    {
+        // Regression: after committing a frame inline rename the parent chain was
+        // collapsing. This test verifies that setting frame.Name + RefreshTreeNode
+        // (the CommitInlineRename path for frames) leaves the parent IsExpanded intact.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "a.png" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var chainNode = GetRoots(GetTree(window))[0];
+            chainNode.IsExpanded = true;
+
+            // Simulate CommitInlineRename for a frame: set Name + RefreshTreeNode
+            frame.Name = "My Frame";
+            ctx.AppCommands.RefreshTreeNode(frame);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(chainNode.IsExpanded, "Parent chain node must stay expanded after frame label rename.");
+            Assert.Equal("My Frame", chainNode.Children[0].Header);
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -8,6 +8,7 @@ using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -969,5 +970,60 @@ public class HeadlessTreeViewTests
             Assert.Equal("My Frame", chainNode.Children[0].Header);
         }
         finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void PressEnterToConfirmRename_DoesNotCollapseChainNode()
+    {
+            // Regression: Avalonia 12.x TreeViewItem.OnKeyDown handles Key.Enter by toggling
+            // IsExpanded. With a Bubble-only subscription on AnimTree, the TreeViewItem processes
+            // Enter before our handler runs, collapsing the chain mid-rename.
+            // Fix: use RoutingStrategies.Tunnel so our handler intercepts Enter at the TreeView
+            // level (going DOWN) before the event ever reaches TreeViewItem.OnKeyDown.
+            var (window, ctx) = CreateWindow();
+            try
+            {
+                var chain = new AnimationChainSave { Name = "Walk" };
+                ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+                TriggerRefreshTreeView(window);
+                Dispatcher.UIThread.RunJobs();
+
+                var tree = GetTree(window);
+                var chainNode = GetRoots(tree)[0];
+                chainNode.IsExpanded = true;
+                Dispatcher.UIThread.RunJobs();
+
+                // Start inline rename
+                var beginMethod = typeof(MainWindow).GetMethod(
+                    "BeginInlineRenameSelected",
+                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    [typeof(AnimationChainSave)],
+                    null)
+                    ?? throw new InvalidOperationException("BeginInlineRenameSelected not found");
+                beginMethod.Invoke(window, [chain]);
+                Dispatcher.UIThread.RunJobs(); // flushes the Post(DispatcherPriority.Render) callback
+
+                // Locate the TextBox that BeginInlineRename activated
+                var tb = tree.GetVisualDescendants()
+                    .OfType<TextBox>()
+                    .FirstOrDefault(t => t.DataContext == chainNode);
+                Assert.NotNull(tb);
+
+                // Raise Key.Return — the Tunnel handler on AnimTree must intercept it
+                // before TreeViewItem.OnKeyDown toggles IsExpanded.
+                tb.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Source = tb,
+                    Key = Key.Return,
+                });
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(chainNode.IsExpanded,
+                    "Pressing Enter to confirm rename must not collapse the chain node.");
+            }
+            finally { window.Close(); }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -838,6 +838,45 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
+    public void MoveFrame_PreservesFrameVmIdentityAndSelection()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain  = new AnimationChainSave { Name = "Walk" };
+            var frameA = new AnimationFrameSave { TextureName = "a.png" };
+            var frameB = new AnimationFrameSave { TextureName = "b.png" };
+            chain.Frames.Add(frameA);
+            chain.Frames.Add(frameB);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree      = GetTree(window);
+            var chainNode = GetRoots(tree)[0];
+            var frameAVm  = chainNode.Children[0];
+            Assert.Same(frameA, frameAVm.Data);
+
+            // Select frameA in the tree and mark it expanded
+            tree.SelectedItems!.Add(frameAVm);
+            frameAVm.IsExpanded = true;
+
+            // Move frameA down one position
+            ctx.AppCommands.MoveFrame(frameA, chain, +1);
+            Dispatcher.UIThread.RunJobs();
+
+            // Same VM instance should now be at index 1
+            Assert.Same(frameAVm, chainNode.Children[1]);
+            // Avalonia selection must survive (relies on object identity)
+            Assert.Contains(frameAVm, tree.SelectedItems.Cast<TreeNodeVm>());
+            // Expanded state must be preserved
+            Assert.True(frameAVm.IsExpanded);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void PropFrameLen_ValueChanged_UpdatesFrameMetaImmediately()
     {
         var (window, ctx) = CreateWindow();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -352,23 +352,43 @@ public class TreeBuilderPureTests
     }
 
     [Fact]
-    public void SyncFramesInto_Reorder_UpdatesHeaderForUnnamedFrame()
+    public void SyncFramesInto_Reorder_KeepsUnnamedFrameHeaderStable()
     {
-        var frameA = new AnimationFrameSave { TextureName = "" };  // unnamed: "Frame 1"
-        var frameB = new AnimationFrameSave { TextureName = "" };  // unnamed: "Frame 2"
+        // Unnamed frames are labeled by creation order ("Frame 1", "Frame 2").
+        // After a reorder their labels must NOT change — the label staying put
+        // is how the user sees that the order actually changed.
+        var frameA = new AnimationFrameSave { TextureName = "" };
+        var frameB = new AnimationFrameSave { TextureName = "" };
         var chainNode = new TreeNodeVm();
-        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
-        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));  // "Frame 1"
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));  // "Frame 2"
 
-        Assert.Equal("Frame 1", chainNode.Children[0].Header);
-
-        // Move frameA to index 1
+        // Move frameA to index 1 (swap order)
         TreeBuilder.SyncFramesInto(chainNode, new[] { frameB, frameA });
 
-        // VM for frameA is now at index 1 → header should be "Frame 2"
-        var vmA = chainNode.Children[1];
-        Assert.Same(frameA, vmA.Data);
-        Assert.Equal("Frame 2", vmA.Header);
+        // Labels stay with their VMs — not renumbered by new position.
+        Assert.Equal("Frame 2", chainNode.Children[0].Header);  // frameB stays "Frame 2"
+        Assert.Equal("Frame 1", chainNode.Children[1].Header);  // frameA stays "Frame 1"
+    }
+
+    [Fact]
+    public void SyncFramesInto_MoveThirdToTop_ShowsFrame3AtTop()
+    {
+        // Regression: "Move to top" on the 3rd unnamed frame must produce
+        // "Frame 3 / Frame 1 / Frame 2" in the tree, not "Frame 1 / Frame 2 / Frame 3".
+        var frameA = new AnimationFrameSave { TextureName = "" };
+        var frameB = new AnimationFrameSave { TextureName = "" };
+        var frameC = new AnimationFrameSave { TextureName = "" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));  // "Frame 1"
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));  // "Frame 2"
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameC, 2));  // "Frame 3"
+
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameC, frameA, frameB });
+
+        Assert.Equal("Frame 3", chainNode.Children[0].Header);
+        Assert.Equal("Frame 1", chainNode.Children[1].Header);
+        Assert.Equal("Frame 2", chainNode.Children[2].Header);
     }
 }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -260,6 +260,116 @@ public class TreeBuilderPureTests
 
         Assert.Null(TreeBuilder.FindNodeForData(roots, unrelated));
     }
+
+    // ── SyncFramesInto ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SyncFramesInto_Reorder_ReusesExistingFrameVm()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+
+        var originalVmA = chainNode.Children[0];
+        var originalVmB = chainNode.Children[1];
+
+        // Reorder: put B first
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameB, frameA });
+
+        Assert.Same(originalVmA, chainNode.Children[1]);
+        Assert.Same(originalVmB, chainNode.Children[0]);
+    }
+
+    [Fact]
+    public void SyncFramesInto_Reorder_ChildOrderMatchesNewFrameOrder()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        var frameC = new AnimationFrameSave { TextureName = "c.png" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameC, 2));
+
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameC, frameA, frameB });
+
+        Assert.Same(frameC, chainNode.Children[0].Data);
+        Assert.Same(frameA, chainNode.Children[1].Data);
+        Assert.Same(frameB, chainNode.Children[2].Data);
+    }
+
+    [Fact]
+    public void SyncFramesInto_Reorder_PreservesIsExpanded()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+
+        chainNode.Children[0].IsExpanded = true;  // mark frameA VM expanded
+        var vmA = chainNode.Children[0];
+
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameB, frameA });
+
+        Assert.True(vmA.IsExpanded);
+    }
+
+    [Fact]
+    public void SyncFramesInto_AddedFrame_InsertsNewVm()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        var frameC = new AnimationFrameSave { TextureName = "c.png" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameA, frameC, frameB });
+
+        Assert.Equal(3, chainNode.Children.Count);
+        Assert.Same(frameC, chainNode.Children[1].Data);
+    }
+
+    [Fact]
+    public void SyncFramesInto_RemovedFrame_RemovesVm()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        var frameC = new AnimationFrameSave { TextureName = "c.png" };
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameC, 2));
+
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameA, frameC });
+
+        Assert.Equal(2, chainNode.Children.Count);
+        Assert.Same(frameA, chainNode.Children[0].Data);
+        Assert.Same(frameC, chainNode.Children[1].Data);
+    }
+
+    [Fact]
+    public void SyncFramesInto_Reorder_UpdatesHeaderForUnnamedFrame()
+    {
+        var frameA = new AnimationFrameSave { TextureName = "" };  // unnamed: "Frame 1"
+        var frameB = new AnimationFrameSave { TextureName = "" };  // unnamed: "Frame 2"
+        var chainNode = new TreeNodeVm();
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameA, 0));
+        chainNode.Children.Add(TreeBuilder.BuildFrameNode(frameB, 1));
+
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+
+        // Move frameA to index 1
+        TreeBuilder.SyncFramesInto(chainNode, new[] { frameB, frameA });
+
+        // VM for frameA is now at index 1 → header should be "Frame 2"
+        var vmA = chainNode.Children[1];
+        Assert.Same(frameA, vmA.Data);
+        Assert.Equal("Frame 2", vmA.Header);
+    }
 }
 
 // ── SyncShapesInto tests ──────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -707,9 +707,11 @@ public class TreeBuilderSyncFramesTests
 
         TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
 
-        // After swap, each frame's header must reflect its new index
-        Assert.Equal("Frame 1", chainNode.Children[0].Header);
-        Assert.Equal("Frame 2", chainNode.Children[1].Header);
+        // After swap, each frame's header must reflect its original name —
+        // labels are stable (stored in AnimationFrameSave.Name) so the user
+        // can visually identify which frame moved, not just its new position.
+        Assert.Equal("Frame 2", chainNode.Children[0].Header);
+        Assert.Equal("Frame 1", chainNode.Children[1].Header);
     }
 }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -152,6 +152,20 @@ public class TreeBuilderPureTests
     }
 
     [Fact]
+    public void BuildFrameHeader_NameOverridesTextureFilename()
+    {
+        // A user-assigned Name takes precedence over the texture filename so that
+        // double-click rename on a textured frame changes the display label without
+        // touching the texture reference.
+        var frame = new AnimationFrameSave
+        {
+            TextureName = "sprites/walk1.png",
+            Name = "Walk Start",
+        };
+        Assert.Equal("Walk Start", TreeBuilder.BuildFrameHeader(frame));
+    }
+
+    [Fact]
     public void BuildFrameNode_WithShapes_AddsShapeChildren()
     {
         var frame = new AnimationFrameSave

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -390,6 +390,54 @@ public class TreeBuilderPureTests
         Assert.Equal("Frame 1", chainNode.Children[1].Header);
         Assert.Equal("Frame 2", chainNode.Children[2].Header);
     }
+
+    [Fact]
+    public void BuildFrameNode_SetsNameForUnnamedFrame()
+    {
+        // BuildFrameNode must persist the display label into AnimationFrameSave.Name
+        // so copy/paste (which serializes the frame) and RefreshTreeView (full rebuild)
+        // reproduce the same label regardless of the frame's new position.
+        var frame = new AnimationFrameSave { TextureName = "" };
+
+        TreeBuilder.BuildFrameNode(frame, 2);  // position 2 → "Frame 3"
+
+        Assert.Equal("Frame 3", frame.Name);
+    }
+
+    [Fact]
+    public void BuildFrameNode_DoesNotOverwriteExistingName()
+    {
+        // When copying a chain the copied frames already have Name set.
+        // BuildFrameNode must not overwrite it with a position-based label.
+        var frame = new AnimationFrameSave { TextureName = "", Name = "Frame 3" };
+
+        TreeBuilder.BuildFrameNode(frame, 0);  // index 0, but Name already set
+
+        Assert.Equal("Frame 3", frame.Name);
+    }
+
+    [Fact]
+    public void BuildTree_ReorderedChainWithNamesSet_PreservesLabels()
+    {
+        // Simulates paste: deserialised frames carry their Name values from the original.
+        // BuildTree must use Name, not recompute from position.
+        var frameA = new AnimationFrameSave { TextureName = "", Name = "Frame 1" };
+        var frameB = new AnimationFrameSave { TextureName = "", Name = "Frame 2" };
+        var frameC = new AnimationFrameSave { TextureName = "", Name = "Frame 3" };
+
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameC);  // reordered: C first
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        acls.AnimationChains.Add(chain);
+
+        var nodes = TreeBuilder.BuildTree(acls);
+
+        Assert.Equal("Frame 3", nodes[0].Children[0].Header);
+        Assert.Equal("Frame 1", nodes[0].Children[1].Header);
+        Assert.Equal("Frame 2", nodes[0].Children[2].Header);
+    }
 }
 
 // ── SyncShapesInto tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the clear-and-rebuild in \RefreshChainNode\ with a diff-update that reuses existing frame VMs.

## Root cause

\RefreshChainNode\ called \
ode.Children.Clear()\ then rebuilt all frame \TreeNodeVm\s from scratch. Avalonia's \TreeView\ identifies selection by object identity — the old VMs were gone, so selection dropped. Same clear also reset \IsExpanded\ on every frame node.

## Fix

Added \TreeBuilder.SyncFramesInto(chainNode, frames)\:
1. Removes VMs whose frame was deleted
2. Appends VMs for new frames  
3. Reorders remaining VMs with \ObservableCollection.Move\ (never replace)
4. Refreshes \Header\/\Meta\ in place

Retained VMs keep their \IsExpanded\ state and stay in \TreeView.SelectedItems\. Affects all reorder commands: MoveFrame, MoveFrameToTop, MoveFrameToBottom, InvertFrameOrder, FlipChain, etc.

\RefreshChainNode\ now also computes \Header\/\Meta\ directly from the chain rather than building a throwaway replacement subtree.

## Tests

- 6 pure \TreeBuilderPureTests\ for \SyncFramesInto\ (VM reuse, order, IsExpanded preservation, add frame, remove frame, header update after index change)
- 1 headless \AvaloniaFact\ (\MoveFrame_PreservesFrameVmIdentityAndSelection\) that exercises the full end-to-end path and asserts the VM stays in \TreeView.SelectedItems\ after a reorder

Closes #185