### PR TITLE
AE: multi-select chains render all frames + bulk edits in wireframe

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -388,6 +388,11 @@ public class WireframeControl : Control
     private bool _draggingChain;
     private readonly List<(FrameRect Rect, SKRect StartBounds)> _chainDragStarts = new();
 
+    // Bulk handle-drag state: populated at drag-start when multiple chains are selected.
+    // Holds the before-state and start bounds of ALL visible frames so ApplyHandleDrag
+    // can apply a uniform delta and OnPointerReleased can record a single undo entry.
+    private readonly List<(FrameRect Rect, SKRect StartBounds, float BL, float BT, float BR, float BB)> _bulkHandleDragStarts = new();
+
     // Before-UV snapshot captured at drag start for undo recording
     private float _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB;
 
@@ -883,6 +888,9 @@ public class WireframeControl : Control
     /// </summary>
     public void RefreshFrames() => RefreshFramesInternal();
 
+    /// <summary>Number of frame rects currently visible in the wireframe. For tests only.</summary>
+    public int FrameRectCount => _frameRects.Count;
+
     /// <summary>Re-detect the current texture from the selection, reload it, and refresh frames.</summary>
     public void RefreshAll()
     {
@@ -1047,6 +1055,7 @@ public class WireframeControl : Control
         _dragBeforeT = sel.Frame.TopCoordinate;
         _dragBeforeR = sel.Frame.RightCoordinate;
         _dragBeforeB = sel.Frame.BottomCoordinate;
+        _bulkHandleDragStarts.Clear();
 
         ApplyHandleDrag(new Point(endScreenX, endScreenY));
 
@@ -1057,6 +1066,54 @@ public class WireframeControl : Control
             sel.Frame.LeftCoordinate, sel.Frame.TopCoordinate,
             sel.Frame.RightCoordinate, sel.Frame.BottomCoordinate,
             _appCommands!, _events!));
+        _draggingRect   = null;
+        _draggingHandle = HandleKind.None;
+    }
+
+    /// <summary>
+    /// Test-only: simulates a bulk handle-drag gesture for multi-chain mode.
+    /// Applies the same handle delta to <paramref name="targetFrame"/> and every
+    /// other visible frame rect, then records a single <see cref="BulkFrameRegionChangedCommand"/>.
+    /// No-op when the target frame is not found in the visible rects, no bitmap is loaded,
+    /// or fewer than two frame rects are visible.
+    /// </summary>
+    public void SimulateBulkHandleDrag(AnimationFrameSave targetFrame,
+        HandleKind handle,
+        float startScreenX, float startScreenY,
+        float endScreenX,   float endScreenY)
+    {
+        var primary = _frameRects.FirstOrDefault(fr => fr.Frame == targetFrame);
+        if (primary is null || _bitmap is null) return;
+
+        _draggingRect    = primary;
+        _draggingHandle  = handle;
+        _dragStartWorld  = ScreenToTexture(startScreenX, startScreenY);
+        _dragStartBounds = primary.Bounds;
+        _dragBeforeL = primary.Frame.LeftCoordinate;
+        _dragBeforeT = primary.Frame.TopCoordinate;
+        _dragBeforeR = primary.Frame.RightCoordinate;
+        _dragBeforeB = primary.Frame.BottomCoordinate;
+
+        _bulkHandleDragStarts.Clear();
+        foreach (var fr in _frameRects)
+            _bulkHandleDragStarts.Add((fr, fr.Bounds,
+                fr.Frame.LeftCoordinate, fr.Frame.TopCoordinate,
+                fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
+
+        ApplyHandleDrag(new Point(endScreenX, endScreenY));
+
+        var snapshots = _bulkHandleDragStarts
+            .Select(s => new BulkFrameRegionChangedCommand.FrameSnapshot(
+                s.Rect.Frame,
+                s.BL, s.BT, s.BR, s.BB,
+                s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
+                s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
+            .ToList();
+        _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+        foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
+            FrameRegionChanged?.Invoke(fr.Frame);
+
+        _bulkHandleDragStarts.Clear();
         _draggingRect   = null;
         _draggingHandle = HandleKind.None;
     }
@@ -1364,7 +1421,7 @@ public class WireframeControl : Control
             {
                 if (hitFrame != null)
                 {
-                    // Single-frame drag
+                    // Single-frame drag (or bulk handle drag when multi-chain selected)
                     _draggingRect = hitFrame;
                     _draggingHandle = hitHandle;
                     _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
@@ -1373,6 +1430,17 @@ public class WireframeControl : Control
                     _dragBeforeT = hitFrame.Frame.TopCoordinate;
                     _dragBeforeR = hitFrame.Frame.RightCoordinate;
                     _dragBeforeB = hitFrame.Frame.BottomCoordinate;
+
+                    // In multi-chain mode, capture before-state of ALL visible frames for
+                    // bulk apply and a single atomic undo command.
+                    _bulkHandleDragStarts.Clear();
+                    if ((_selectedState?.SelectedChains?.Count ?? 0) > 1)
+                    {
+                        foreach (var fr in _frameRects)
+                            _bulkHandleDragStarts.Add((fr, fr.Bounds,
+                                fr.Frame.LeftCoordinate, fr.Frame.TopCoordinate,
+                                fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
+                    }
                 }
                 else
                 {
@@ -1561,13 +1629,32 @@ public class WireframeControl : Control
 
         if (_draggingRect != null)
         {
-            FrameRegionChanged?.Invoke(_draggingRect.Frame);
-            _undoManager!.Record(new FrameRegionChangedCommand(
-                _draggingRect.Frame,
-                _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
-                _draggingRect.Frame.LeftCoordinate, _draggingRect.Frame.TopCoordinate,
-                _draggingRect.Frame.RightCoordinate, _draggingRect.Frame.BottomCoordinate,
-                _appCommands!, _events!));
+            if (_bulkHandleDragStarts.Count > 0)
+            {
+                // Bulk drag: record one atomic undo command covering all affected frames,
+                // then notify listeners for each changed frame.
+                var snapshots = _bulkHandleDragStarts
+                    .Select(s => new BulkFrameRegionChangedCommand.FrameSnapshot(
+                        s.Rect.Frame,
+                        s.BL, s.BT, s.BR, s.BB,
+                        s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
+                        s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
+                    .ToList();
+                _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+                foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
+                    FrameRegionChanged?.Invoke(fr.Frame);
+                _bulkHandleDragStarts.Clear();
+            }
+            else
+            {
+                FrameRegionChanged?.Invoke(_draggingRect.Frame);
+                _undoManager!.Record(new FrameRegionChangedCommand(
+                    _draggingRect.Frame,
+                    _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
+                    _draggingRect.Frame.LeftCoordinate, _draggingRect.Frame.TopCoordinate,
+                    _draggingRect.Frame.RightCoordinate, _draggingRect.Frame.BottomCoordinate,
+                    _appCommands!, _events!));
+            }
             _draggingRect = null;
             _draggingHandle = HandleKind.None;
             e.Pointer.Capture(null);
@@ -1730,13 +1817,32 @@ public class WireframeControl : Control
 
         _draggingRect.Bounds = new SKRect(nb.Left, nb.Top, nb.Right, nb.Bottom);
 
-        // Write UV coords back to the frame
+        // Write UV coords back to the primary frame
         var (l, t, r, b) = DragHandleApplier.ToUvCoords(nb, _bitmap.Width, _bitmap.Height);
         var f = _draggingRect.Frame;
         f.LeftCoordinate   = l;
         f.RightCoordinate  = r;
         f.TopCoordinate    = t;
         f.BottomCoordinate = b;
+
+        // Apply the same delta to all other frames in bulk mode
+        if (_bulkHandleDragStarts.Count > 0)
+        {
+            float texW = _bitmap.Width, texH = _bitmap.Height;
+            foreach (var (fr, startB, _, _, _, _) in _bulkHandleDragStarts)
+            {
+                if (fr == _draggingRect) continue;
+                var sb = new BoundsRect(startB.Left, startB.Top, startB.Right, startB.Bottom);
+                var nb2 = DragHandleApplier.Apply(_draggingHandle, dx, dy, sb);
+                nb2 = DragHandleApplier.SnapEdges(nb2, _draggingHandle, snapSize);
+                fr.Bounds = new SKRect(nb2.Left, nb2.Top, nb2.Right, nb2.Bottom);
+                var (l2, t2, r2, b2) = DragHandleApplier.ToUvCoords(nb2, texW, texH);
+                fr.Frame.LeftCoordinate   = l2;
+                fr.Frame.RightCoordinate  = r2;
+                fr.Frame.TopCoordinate    = t2;
+                fr.Frame.BottomCoordinate = b2;
+            }
+        }
 
         // Live update for the property panel (no save / tree refresh yet)
         FrameLiveUpdated?.Invoke(_draggingRect.Frame);
@@ -1833,8 +1939,25 @@ public class WireframeControl : Control
             return kind == HandleKind.None ? (null, HandleKind.None) : (sel, kind);
         }
 
-        // Chain selected (no individual frame): test against the composite bounding rect.
-        // All hits are treated as Move since resizing the group is not supported.
+        // Multi-chain mode: test handles on every individual frame rect so bulk resize
+        // (uniform delta) is accessible even when no single frame is selected.
+        if ((_selectedState?.SelectedChains?.Count ?? 0) > 1 && _frameRects.Count > 0)
+        {
+            foreach (var fr in _frameRects)
+            {
+                var sr = ToScreen(fr.Bounds);
+                var kind = DragHandleHitTester.GetHandleAt(
+                    (float)pos.X, (float)pos.Y,
+                    sr.Left, sr.Top, sr.Right, sr.Bottom,
+                    handleOffset: 5f);
+                if (kind != HandleKind.None)
+                    return (fr, kind);
+            }
+            // No per-frame handle hit — fall through to composite Move.
+        }
+
+        // Single chain or multi-chain composite Move handle.
+        // All hits are treated as Move since resizing the group via the bounding rect is not supported.
         if (_selectedState?.SelectedChain != null && _frameRects.Count > 0)
         {
             var chainRect = ComputeChainBoundingRect();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -346,8 +346,9 @@ public partial class MainWindow : Window
 
     private void OnFrameCreatedFromRegion(int minX, int minY, int maxX, int maxY)
     {
-        var chain = _selectedState.SelectedChain;
-        if (chain is null) return;
+        var selectedChains = _selectedState.SelectedChains;
+        var primaryChain = selectedChains.Count > 0 ? selectedChains[0] : _selectedState.SelectedChain;
+        if (primaryChain is null) return;
 
         var texPath = WireframeCtrl.LoadedTexturePath;
         if (string.IsNullOrEmpty(texPath)) return;
@@ -364,20 +365,34 @@ public partial class MainWindow : Window
                 texPath).Replace('\\', '/')
             : texPath;
 
-        var frame = new AnimationFrameSave
-        {
-            TextureName        = relPath,
-            LeftCoordinate     = minX / (float)bitmapW,
-            RightCoordinate    = maxX / (float)bitmapW,
-            TopCoordinate      = minY / (float)bitmapH,
-            BottomCoordinate   = maxY / (float)bitmapH,
-            FrameLength        = 0.1f,
-            ShapesSave = new ShapesSave()
-        };
+        // When multiple chains are selected, add a distinct frame to each one.
+        // When only one chain is in scope, behave as before and select the new frame.
+        var chainsToAddTo = selectedChains.Count > 1 ? selectedChains : new List<AnimationChainSave> { primaryChain };
 
-        chain.Frames.Add(frame);
-        _appCommands.RefreshTreeNode(chain);
-        _selectedState.SelectedFrame = frame;
+        AnimationFrameSave? primaryFrame = null;
+        foreach (var chain in chainsToAddTo)
+        {
+            var frame = new AnimationFrameSave
+            {
+                TextureName        = relPath,
+                LeftCoordinate     = minX / (float)bitmapW,
+                RightCoordinate    = maxX / (float)bitmapW,
+                TopCoordinate      = minY / (float)bitmapH,
+                BottomCoordinate   = maxY / (float)bitmapH,
+                FrameLength        = 0.1f,
+                ShapesSave = new ShapesSave()
+            };
+            chain.Frames.Add(frame);
+            _appCommands.RefreshTreeNode(chain);
+            if (chain == primaryChain)
+                primaryFrame = frame;
+        }
+
+        // In single-chain mode select the new frame (preserves existing UX).
+        // In multi-chain mode leave selection unchanged so the multi-chain view is preserved.
+        if (chainsToAddTo.Count == 1 && primaryFrame != null)
+            _selectedState.SelectedFrame = primaryFrame;
+
         _events.RaiseAnimationChainsChanged();
     }
 
@@ -455,7 +470,11 @@ public partial class MainWindow : Window
     {
         string? texPath = null;
 
-        var frame = _selectedState.SelectedFrame;
+        // Prefer selected frame, then fall back to selected chains/chain for texture lookup.
+        var frame = _selectedState.SelectedFrame
+            ?? _selectedState.SelectedChains.SelectMany(c => c.Frames).FirstOrDefault()
+            ?? _selectedState.SelectedChain?.Frames?.FirstOrDefault();
+
         if (frame != null && !string.IsNullOrEmpty(frame.TextureName) &&
             !string.IsNullOrEmpty(_projectManager.FileName))
         {
@@ -2145,7 +2164,11 @@ public partial class MainWindow : Window
         if (selectedVm is null) return;
 
         if (selectedVm.Data is AnimationChainSave chainToDel)
-            _ = _appCommands.AskToDeleteAnimationChains(new() { chainToDel });
+        {
+            var chains = _selectedState.SelectedChains;
+            _ = _appCommands.AskToDeleteAnimationChains(
+                chains.Count > 0 ? chains : new() { chainToDel });
+        }
         else if (selectedVm.Data is AnimationFrameSave frameToDel)
             _ = _appCommands.AskToDeleteFrames(new() { frameToDel });
         else if (selectedVm.Data is AARectSave rectToDel)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
@@ -1,0 +1,61 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Undo/redo record for a simultaneous region change across multiple frames
+    /// (e.g. a bulk handle-drag applied to all frames across selected chains).
+    /// </summary>
+    public sealed class BulkFrameRegionChangedCommand : IUndoableCommand
+    {
+        public readonly record struct FrameSnapshot(
+            AnimationFrameSave Frame,
+            float BL, float BT, float BR, float BB,
+            float AL, float AT, float AR, float AB);
+
+        private readonly IReadOnlyList<FrameSnapshot> _snapshots;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public BulkFrameRegionChangedCommand(
+            IReadOnlyList<FrameSnapshot> snapshots,
+            IAppCommands commands,
+            IApplicationEvents events)
+        {
+            _snapshots = snapshots;
+            _commands  = commands;
+            _events    = events;
+        }
+
+        public void Undo()
+        {
+            foreach (var s in _snapshots)
+            {
+                s.Frame.LeftCoordinate   = s.BL;
+                s.Frame.TopCoordinate    = s.BT;
+                s.Frame.RightCoordinate  = s.BR;
+                s.Frame.BottomCoordinate = s.BB;
+                _commands.RefreshTreeNode(s.Frame);
+            }
+            _events.RaiseAnimationChainsChanged();
+            _commands.RefreshWireframe();
+            _commands.SaveCurrentAnimationChainList();
+        }
+
+        public void Redo()
+        {
+            foreach (var s in _snapshots)
+            {
+                s.Frame.LeftCoordinate   = s.AL;
+                s.Frame.TopCoordinate    = s.AT;
+                s.Frame.RightCoordinate  = s.AR;
+                s.Frame.BottomCoordinate = s.AB;
+                _commands.RefreshTreeNode(s.Frame);
+            }
+            _events.RaiseAnimationChainsChanged();
+            _commands.RefreshWireframe();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ISelectedState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ISelectedState.cs
@@ -15,7 +15,7 @@ namespace AnimationEditor.Core
         AARectSave? SelectedRectangle { get; set; }
         CircleSave? SelectedCircle { get; set; }
         object? SelectedShape { get; }
-        List<AnimationChainSave> SelectedChains { get; set; }
+        List<AnimationChainSave> SelectedChains { get; }
         List<AnimationFrameSave> SelectedFrames { get; }
         List<AARectSave> SelectedRectangles { get; }
         List<CircleSave> SelectedCircles { get; }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
@@ -87,7 +87,8 @@ namespace AnimationEditor.Core
 
         public object? SelectedShape => (object?)_selectedRectangle ?? _selectedCircle;
 
-        public List<AnimationChainSave> SelectedChains { get; set; } = new List<AnimationChainSave>();
+        public List<AnimationChainSave> SelectedChains =>
+            _selectedNodes.OfType<AnimationChainSave>().ToList();
 
         public List<AnimationFrameSave> SelectedFrames
         {
@@ -171,7 +172,6 @@ namespace AnimationEditor.Core
             _selectedRectangle = null;
             _selectedCircle = null;
             _selectedNodes = new List<object>();
-            SelectedChains = new List<AnimationChainSave>();
             SelectionChanged?.Invoke();
         }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMultiChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMultiChainTests.cs
@@ -1,0 +1,266 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for multi-chain selection in the wireframe:
+///   1. All selected chains' frames render when SelectedNodes contains multiple chains.
+///   2. Bulk handle-drag applies the same delta to every visible frame.
+///   3. Chain drag moves all chains' frames together.
+///
+/// Camera fixed at pan=(0,0) zoom=1 so texture pixels == screen pixels.
+/// Texture size: 64 × 64.
+/// </summary>
+public class WireframeMultiChainTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier             = 1f;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, SKColor color, int size = 64,
+                                         string name = "sprite.png")
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// Builds two chains on the same 64×64 texture.
+    /// chain1.Frames[0]: left half  (0→0.5, full height)
+    /// chain2.Frames[0]: right half (0.5→1, full height)
+    /// SelectedNodes = [chain1, chain2], SelectedChain = chain1, SelectedFrame = null.
+    /// </summary>
+    private static (WireframeControl ctrl, AnimationChainSave c1, AnimationChainSave c2,
+                    AnimationFrameSave f1, AnimationFrameSave f2, string dir)
+        BuildMultiChainCtrl(TestServices ctx)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.DarkGray, name: "sprite.png");
+
+        var f1 = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            LeftCoordinate   = 0f,  TopCoordinate    = 0f,
+            RightCoordinate  = 0.5f, BottomCoordinate = 1f,
+            FrameLength      = 0.1f, ShapesSave = new ShapesSave()
+        };
+        var f2 = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            LeftCoordinate   = 0.5f, TopCoordinate    = 0f,
+            RightCoordinate  = 1f,   BottomCoordinate = 1f,
+            FrameLength      = 0.1f, ShapesSave = new ShapesSave()
+        };
+
+        var c1 = new AnimationChainSave { Name = "Run" };
+        c1.Frames.Add(f1);
+        var c2 = new AnimationChainSave { Name = "Idle" };
+        c2.Frames.Add(f2);
+
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(c1);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(c2);
+        ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedNodes = new List<object> { c1, c2 };
+        ctx.SelectedState.SelectedChain = c1;
+        // SelectedFrame remains null → multi-chain mode
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.RefreshFrames();
+
+        return (ctrl, c1, c2, f1, f2, dir);
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When SelectedNodes contains two chains, both chains' frames must appear
+    /// in the wireframe (FrameRectCount == 2).
+    /// </summary>
+    [AvaloniaFact]
+    public void MultiChain_SelectedNodes_RendersFramesFromAllChains()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, _, _, dir) = BuildMultiChainCtrl(ctx);
+        try
+        {
+            Assert.Equal(2, ctrl.FrameRectCount);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// When only a single chain is in SelectedNodes, only that chain's frames render.
+    /// </summary>
+    [AvaloniaFact]
+    public void SingleChain_SelectedNodes_RendersOnlyThatChainsFrames()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var png = WriteSolidPng(dir, SKColors.DarkGray, name: "sprite.png");
+            var f = new AnimationFrameSave
+            {
+                TextureName = "sprite.png",
+                LeftCoordinate = 0f, TopCoordinate = 0f,
+                RightCoordinate = 1f, BottomCoordinate = 1f,
+                FrameLength = 0.1f, ShapesSave = new ShapesSave()
+            };
+            var chain = new AnimationChainSave { Name = "Run" };
+            chain.Frames.Add(f);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            ctx.SelectedState.SelectedNodes = new List<object> { chain };
+            ctx.SelectedState.SelectedChain = chain;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.SetCamera(0f, 0f, 1f);
+            ctrl.RefreshFrames();
+
+            Assert.Equal(1, ctrl.FrameRectCount);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Bulk handle drag ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Bulk Right-handle drag: drag the right edge of f1 inward by 8px.
+    /// At zoom=1, 8px = 8/64 = 0.125 UV units.
+    /// Both f1 and f2 must have their right coordinate decreased by 0.125.
+    /// </summary>
+    [AvaloniaFact]
+    public void BulkHandleDrag_Right_AppliesSameDeltaToBothFrames()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, f1, f2, dir) = BuildMultiChainCtrl(ctx);
+        try
+        {
+            // f1 right edge in screen space at zoom=1: 0.5 * 64 = 32
+            // Drag from screen x=32 to x=24 → dx = -8 → right UV decreases by 8/64 = 0.125
+            ctrl.SimulateBulkHandleDrag(f1, HandleKind.MidRight,
+                startScreenX: 32f, startScreenY: 32f,
+                endScreenX:   24f, endScreenY:   32f);
+
+            Assert.Equal(0.5f  - 0.125f, f1.RightCoordinate, precision: 4);
+            Assert.Equal(1f    - 0.125f, f2.RightCoordinate, precision: 4);
+            // Left edges must be unchanged
+            Assert.Equal(0f,   f1.LeftCoordinate, precision: 4);
+            Assert.Equal(0.5f, f2.LeftCoordinate, precision: 4);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Bulk TopLeft handle drag: both frames shrink by the same amount.
+    /// </summary>
+    [AvaloniaFact]
+    public void BulkHandleDrag_TopLeft_AppliesSameDeltaToBothFrames()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, f1, f2, dir) = BuildMultiChainCtrl(ctx);
+        try
+        {
+            // f1 top-left corner in screen space: (0,0). Drag to (8,8) → left+8, top+8.
+            ctrl.SimulateBulkHandleDrag(f1, HandleKind.TopLeft,
+                startScreenX: 0f, startScreenY: 0f,
+                endScreenX:   8f, endScreenY:   8f);
+
+            float delta = 8f / 64f; // 0.125
+
+            Assert.Equal(0f   + delta, f1.LeftCoordinate,   precision: 4);
+            Assert.Equal(0.5f + delta, f2.LeftCoordinate,   precision: 4);
+            Assert.Equal(0f   + delta, f1.TopCoordinate,    precision: 4);
+            Assert.Equal(0f   + delta, f2.TopCoordinate,    precision: 4);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Bulk undo ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// After a bulk drag, a single undo should revert BOTH frames to their
+    /// pre-drag UV coordinates.
+    /// </summary>
+    [AvaloniaFact]
+    public void BulkHandleDrag_Undo_RevertsAllFrames()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, f1, f2, dir) = BuildMultiChainCtrl(ctx);
+        try
+        {
+            float f1RightBefore = f1.RightCoordinate;
+            float f2RightBefore = f2.RightCoordinate;
+
+            ctrl.SimulateBulkHandleDrag(f1, HandleKind.MidRight,
+                startScreenX: 32f, startScreenY: 32f,
+                endScreenX:   24f, endScreenY:   32f);
+
+            ctx.UndoManager.Undo();
+
+            Assert.Equal(f1RightBefore, f1.RightCoordinate, precision: 4);
+            Assert.Equal(f2RightBefore, f2.RightCoordinate, precision: 4);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Chain drag across multiple chains ─────────────────────────────────────
+
+    /// <summary>
+    /// Chain drag must translate frames from ALL selected chains.
+    /// Both f1 and f2 should move by the same (dx, dy).
+    /// </summary>
+    [AvaloniaFact]
+    public void ChainDrag_MultiChain_MovesAllChainFrames()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, f1, f2, dir) = BuildMultiChainCtrl(ctx);
+        try
+        {
+            float f1L = f1.LeftCoordinate, f1R = f1.RightCoordinate;
+            float f2L = f2.LeftCoordinate, f2R = f2.RightCoordinate;
+
+            // Drag 8px to the right → all UV left/right coords shift by 8/64 = 0.125
+            ctrl.SimulateChainDrag(
+                startScreenX: 0f, startScreenY: 0f,
+                endScreenX:   8f, endScreenY:   0f);
+
+            float delta = 8f / 64f;
+            Assert.Equal(f1L + delta, f1.LeftCoordinate,  precision: 4);
+            Assert.Equal(f1R + delta, f1.RightCoordinate, precision: 4);
+            Assert.Equal(f2L + delta, f2.LeftCoordinate,  precision: 4);
+            Assert.Equal(f2R + delta, f2.RightCoordinate, precision: 4);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
@@ -282,6 +282,43 @@ public class SelectedStateTests
         Assert.Null(ctx.SelectedState.SelectedTextureName);
     }
 
+    // ── SelectedChains computed ───────────────────────────────────────────────
+
+    [Fact]
+    public void SelectedChains_ReturnsChainNodesFromSelectedNodes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var c1 = TestHelpers.MakeChain(acls, "Run");
+        var c2 = TestHelpers.MakeChain(acls, "Idle");
+        ctx.SelectedState.SelectedNodes = new List<object> { c1, c2 };
+
+        var chains = ctx.SelectedState.SelectedChains;
+
+        Assert.Contains(c1, chains);
+        Assert.Contains(c2, chains);
+    }
+
+    [Fact]
+    public void SelectedChains_EmptyWhenNoChainNodes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.SelectedState.SelectedNodes = new List<object>();
+
+        Assert.Empty(ctx.SelectedState.SelectedChains);
+    }
+
+    [Fact]
+    public void SelectedChains_IgnoresNonChainNodes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Run", 1);
+        ctx.SelectedState.SelectedNodes = new List<object> { chain.Frames[0] };
+
+        Assert.Empty(ctx.SelectedState.SelectedChains);
+    }
+
     // ── SelectedFrames / multi-select ─────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements multi-chain selection features in the Animation Editor wireframe panel.

### Root Cause Fixed
\SelectedChains\ was a stored property that was never assigned anywhere. \OnTreeSelectionChanged\ only set \SelectedNodes\ (raw objects), making the multi-chain rendering path in \RefreshFramesInternal\ dead code. The fix makes \SelectedChains\ a computed property derived from \SelectedNodes\.

### Changes

**Core:**
- \SelectedChains\ is now \=> _selectedNodes.OfType<AnimationChainSave>().ToList()\
- New \BulkFrameRegionChangedCommand\: atomic undo/redo for bulk frame region edits

**WireframeControl:**
- \HitTestHandle\: tests individual frame handles in multi-chain mode
- \ApplyHandleDrag\: applies uniform delta to all frames when in bulk mode
- \OnPointerReleased\: uses \BulkFrameRegionChangedCommand\ for bulk operations
- Added \SimulateBulkHandleDrag\ test-only method

**MainWindow:**
- \SyncTextureCombo\: falls back to \SelectedChains\ frames when no single frame selected
- \OnFrameCreatedFromRegion\: adds distinct \AnimationFrameSave\ instances to all selected chains
- \HandleDelete\: passes all \SelectedChains\ when multiple chains are selected

### Tests
- 3 Core tests: computed \SelectedChains\ property
- 6 App integration tests (\WireframeMultiChainTests\): rendering, bulk handle drag, undo, chain drag

Closes #184