### PR TITLE
AE: rename user-facing 'Chain' to 'Animation' for clarity

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -323,14 +323,14 @@
                     </TreeView.ItemTemplate>
                 </TreeView>
 
-                <!-- ── Add Chain button ── -->
+                <!-- ── Add Animation button ── -->
                 <Border Grid.Row="2"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,1,0,0"
                         Background="{StaticResource BgApp}"
                         Padding="8,6">
                     <Button x:Name="AddChainBtn"
-                            Content="+ Add Chain"
+                            Content="+ Add Animation"
                             HorizontalAlignment="Stretch"
                             Height="30"
                             Foreground="{StaticResource Ink}" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -744,7 +744,7 @@ public partial class MainWindow : Window
             OnTreePointerPressed,
             RoutingStrategies.Tunnel);
 
-        // "Add Chain" button under the tree
+        // "Add Animation" button under the tree
         AddChainBtn.Click += (_, _) =>
         {
             if (_projectManager.AnimationChainListSave is null)
@@ -1213,7 +1213,7 @@ public partial class MainWindow : Window
             AddMenuItem("Flip Vertically",    () => _appCommands.FlipChainVertically(chain));
             AddMenuItem("Invert Frame Order", () => _appCommands.InvertFrameOrder(chain));
             AddSeparator();
-            AddMenuItem("Add AnimationChain", AddAnimationChainAndBeginInlineRename);
+            AddMenuItem("Add Animation", AddAnimationChainAndBeginInlineRename);
             AddMenuItem("Add Frame",          () => _appCommands.AddFrame(chain));
             AddMenuItem("Add Multiple Frames…", () => _ = AskAddMultipleFramesAsync(chain));
             AddSeparator();
@@ -1227,12 +1227,12 @@ public partial class MainWindow : Window
             AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
             AddMenuItem("Rename…",          () => BeginInlineRenameSelected(chain));
             AddSeparator();
-            AddMenuItem("Delete AnimationChain",
+            AddMenuItem("Delete Animation",
                 () => _ = _appCommands.AskToDeleteAnimationChains(new() { chain }));
         }
         else
         {
-            AddMenuItem("Add AnimationChain", () =>
+            AddMenuItem("Add Animation", () =>
             {
                 if (_projectManager.AnimationChainListSave is null)
                     _projectManager.AnimationChainListSave = new AnimationChainListSave();
@@ -1461,18 +1461,18 @@ public partial class MainWindow : Window
         var panel = new StackPanel { Margin = new Avalonia.Thickness(16), Spacing = 10 };
         panel.Children.Add(new TextBlock
         {
-            Text = $"The selected file:\n\n{absoluteTexturePath}\n\nis not relative to the Animation Chain file.  What would you like to do?",
+            Text = $"The selected file:\n\n{absoluteTexturePath}\n\nis not relative to the Animation file.  What would you like to do?",
             TextWrapping = Avalonia.Media.TextWrapping.Wrap
         });
 
         var copyBtn = new Button
         {
-            Content = "Copy the file to the same folder as the Animation Chain",
+            Content = "Copy the file to the same folder as the Animation",
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch
         };
         var keepBtn = new Button
         {
-            Content = "Keep the file where it is (this may limit the portability of the Animation Chain file)",
+            Content = "Keep the file where it is (this may limit the portability of the Animation file)",
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch
         };
 
@@ -2562,12 +2562,12 @@ public partial class MainWindow : Window
 
     private async Task AskRenameChainAsync(AnimationChainSave chain)
     {
-        var name = await ShowStringInputDialogAsync("Rename Animation Chain", "New name:", chain.Name);
+        var name = await ShowStringInputDialogAsync("Rename Animation", "New name:", chain.Name);
         if (name is null) return;
         name = name.Trim();
         if (string.IsNullOrEmpty(name))
         {
-            await ShowMessageAsync("Chain name cannot be empty.");
+            await ShowMessageAsync("Animation name cannot be empty.");
             return;
         }
         _appCommands.RenameChain(chain, name);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -188,7 +188,7 @@ public class HeadlessTreeViewTests
 
             TriggerContextMenuOpening(window);
 
-            Assert.Contains("Add AnimationChain", ContextMenuHeaders(window));
+            Assert.Contains("Add Animation", ContextMenuHeaders(window));
         }
         finally { window.Close(); }
     }
@@ -231,7 +231,7 @@ public class HeadlessTreeViewTests
 
             TriggerContextMenuOpening(window);
 
-            Assert.Contains("Delete AnimationChain", ContextMenuHeaders(window));
+            Assert.Contains("Delete Animation", ContextMenuHeaders(window));
         }
         finally { window.Close(); }
     }
@@ -414,7 +414,7 @@ public class HeadlessTreeViewTests
             TriggerContextMenuOpening(window);
 
             var headers = ContextMenuHeaders(window);
-            Assert.Contains("Delete AnimationChain", headers);
+            Assert.Contains("Delete Animation", headers);
             Assert.DoesNotContain("Delete Frame", headers);
         }
         finally { window.Close(); }


### PR DESCRIPTION
Renames all user-facing 'Chain'/'AnimationChain' UI strings to 'Animation', while keeping file-format-identifying labels ('Animation Chain' in the file picker and filter) unchanged.

## Changes

| Location | Before | After |
|---|---|---|
| \+ Add Chain\ button | \+ Add Chain\ | \+ Add Animation\ |
| Context menu (no selection) | \Add AnimationChain\ | \Add Animation\ |
| Context menu (chain selected) | \Add AnimationChain\ / \Delete AnimationChain\ | \Add Animation\ / \Delete Animation\ |
| Rename dialog title | \Rename Animation Chain\ | \Rename Animation\ |
| Rename error | \Chain name cannot be empty.\ | \Animation name cannot be empty.\ |
| Texture path dialog | \...Animation Chain file...\ | \...Animation file...\ |
| File picker title/filter | \Open Animation Chain\ / \Animation Chain\ | **kept** (identifies .achx format) |

Test assertions in \HeadlessTreeViewTests\ updated to match new labels. All 253 tests pass.

Closes #187