### PR TITLE
AE: hide Move commands in frame right-click menu when chain has one frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1181,12 +1181,15 @@ public partial class MainWindow : Window
         else if (vm?.Data is AnimationFrameSave frame2)
         {
             var chain2 = _objectFinder.GetAnimationChainContaining(frame2);
-            if (chain2 is not null)
+            if (chain2 is not null && chain2.Frames.Count > 1)
             {
-                AddMenuItem("^^ Move To Top",    () => _appCommands.MoveFrameToTop(frame2, chain2));
-                AddMenuItem("^  Move Up",         () => _appCommands.MoveFrame(frame2, chain2, -1));
-                AddMenuItem("v  Move Down",        () => _appCommands.MoveFrame(frame2, chain2, +1));
-                AddMenuItem("vv Move To Bottom",  () => _appCommands.MoveFrameToBottom(frame2, chain2));
+                var frameIndex = chain2.Frames.IndexOf(frame2);
+                var isFirst    = frameIndex == 0;
+                var isLast     = frameIndex == chain2.Frames.Count - 1;
+                if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveFrameToTop(frame2, chain2));
+                if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveFrame(frame2, chain2, -1));
+                if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveFrame(frame2, chain2, +1));
+                if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveFrameToBottom(frame2, chain2));
                 AddSeparator();
             }
             AddMenuItem("Add AxisAlignedRectangle", () => _appCommands.AddAxisAlignedRectangle(frame2));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1206,11 +1206,18 @@ public partial class MainWindow : Window
         }
         else if (vm?.Data is AnimationChainSave chain)
         {
-            AddMenuItem("^^ Move To Top",    () => _appCommands.MoveChainToTop(chain));
-            AddMenuItem("^  Move Up",         () => _appCommands.MoveChain(chain, -1));
-            AddMenuItem("v  Move Down",        () => _appCommands.MoveChain(chain, +1));
-            AddMenuItem("vv Move To Bottom",  () => _appCommands.MoveChainToBottom(chain));
-            AddSeparator();
+            var chains = _projectManager.AnimationChainListSave?.AnimationChains;
+            if (chains is not null && chains.Count > 1)
+            {
+                var chainIndex = chains.IndexOf(chain);
+                var isFirst    = chainIndex == 0;
+                var isLast     = chainIndex == chains.Count - 1;
+                if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveChainToTop(chain));
+                if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveChain(chain, -1));
+                if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveChain(chain, +1));
+                if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveChainToBottom(chain));
+                AddSeparator();
+            }
             AddMenuItem("Adjust Frame Time…", () => AskAdjustFrameTime(chain));
             AddMenuItem("Flip Horizontally",  () => _appCommands.FlipChainHorizontally(chain));
             AddMenuItem("Flip Vertically",    () => _appCommands.FlipChainVertically(chain));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -266,8 +266,13 @@ public class HeadlessTreeViewTests
             var tree  = GetTree(window);
             var roots = GetRoots(tree);
 
-            var chain = new AnimationChainSave { Name = "Idle" };
-            var vm    = new TreeNodeVm { Header = "Idle", Data = chain };
+            // Three chains so the middle one has all four move items available.
+            var chain0 = new AnimationChainSave { Name = "Idle" };
+            var chain1 = new AnimationChainSave { Name = "Walk" };
+            var chain2 = new AnimationChainSave { Name = "Run"  };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.AddRange([chain0, chain1, chain2]);
+
+            var vm = new TreeNodeVm { Header = "Walk", Data = chain1 };
             roots.Add(vm);
             tree.SelectedItem = vm;
 
@@ -278,6 +283,91 @@ public class HeadlessTreeViewTests
             Assert.Contains("Flip Vertically",   headers);
             Assert.Contains("^  Move Up",         headers);
             Assert.Contains("v  Move Down",        headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Chain_SingleChainList_HidesAllMoveItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain = new AnimationChainSave { Name = "Idle" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var vm = new TreeNodeVm { Header = "Idle", Data = chain };
+            roots.Add(vm);
+            tree.SelectedItem = vm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.DoesNotContain("^^ Move To Top",   headers);
+            Assert.DoesNotContain("^  Move Up",        headers);
+            Assert.DoesNotContain("v  Move Down",      headers);
+            Assert.DoesNotContain("vv Move To Bottom", headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Chain_FirstChainInList_HidesUpAndTopItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain0 = new AnimationChainSave { Name = "Idle" };
+            var chain1 = new AnimationChainSave { Name = "Walk" };
+            var chain2 = new AnimationChainSave { Name = "Run"  };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.AddRange([chain0, chain1, chain2]);
+
+            var vm = new TreeNodeVm { Header = "Idle", Data = chain0 };
+            roots.Add(vm);
+            tree.SelectedItem = vm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.DoesNotContain("^^ Move To Top",   headers);
+            Assert.DoesNotContain("^  Move Up",        headers);
+            Assert.Contains("v  Move Down",            headers);
+            Assert.Contains("vv Move To Bottom",       headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Chain_LastChainInList_HidesDownAndBottomItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain0 = new AnimationChainSave { Name = "Idle" };
+            var chain1 = new AnimationChainSave { Name = "Walk" };
+            var chain2 = new AnimationChainSave { Name = "Run"  };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.AddRange([chain0, chain1, chain2]);
+
+            var vm = new TreeNodeVm { Header = "Run", Data = chain2 };
+            roots.Add(vm);
+            tree.SelectedItem = vm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.Contains("^^ Move To Top",          headers);
+            Assert.Contains("^  Move Up",              headers);
+            Assert.DoesNotContain("v  Move Down",      headers);
+            Assert.DoesNotContain("vv Move To Bottom", headers);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -304,6 +304,134 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
+    public void ContextMenu_Frame_SingleFrameChain_HidesAllMoveItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain = new AnimationChainSave { Name = "OnlyOne" };
+            var frame = new AnimationFrameSave { TextureName = "A.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var frameVm = new TreeNodeVm { Header = "Frame 0", Data = frame };
+            roots.Add(frameVm);
+            tree.SelectedItem = frameVm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.DoesNotContain("^^ Move To Top",   headers);
+            Assert.DoesNotContain("^  Move Up",        headers);
+            Assert.DoesNotContain("v  Move Down",      headers);
+            Assert.DoesNotContain("vv Move To Bottom", headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Frame_FirstFrameOfMultiFrameChain_HidesUpAndTopItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain  = new AnimationChainSave { Name = "Walk" };
+            var frame0 = new AnimationFrameSave { TextureName = "A.png", ShapesSave = new ShapesSave() };
+            var frame1 = new AnimationFrameSave { TextureName = "B.png", ShapesSave = new ShapesSave() };
+            var frame2 = new AnimationFrameSave { TextureName = "C.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame0);
+            chain.Frames.Add(frame1);
+            chain.Frames.Add(frame2);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var frameVm = new TreeNodeVm { Header = "Frame 0", Data = frame0 };
+            roots.Add(frameVm);
+            tree.SelectedItem = frameVm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.DoesNotContain("^^ Move To Top",   headers);
+            Assert.DoesNotContain("^  Move Up",        headers);
+            Assert.Contains("v  Move Down",            headers);
+            Assert.Contains("vv Move To Bottom",       headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Frame_LastFrameOfMultiFrameChain_HidesDownAndBottomItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain  = new AnimationChainSave { Name = "Walk" };
+            var frame0 = new AnimationFrameSave { TextureName = "A.png", ShapesSave = new ShapesSave() };
+            var frame1 = new AnimationFrameSave { TextureName = "B.png", ShapesSave = new ShapesSave() };
+            var frame2 = new AnimationFrameSave { TextureName = "C.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame0);
+            chain.Frames.Add(frame1);
+            chain.Frames.Add(frame2);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var frameVm = new TreeNodeVm { Header = "Frame 2", Data = frame2 };
+            roots.Add(frameVm);
+            tree.SelectedItem = frameVm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.Contains("^^ Move To Top",          headers);
+            Assert.Contains("^  Move Up",              headers);
+            Assert.DoesNotContain("v  Move Down",      headers);
+            Assert.DoesNotContain("vv Move To Bottom", headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_Frame_MiddleFrameOfChain_ShowsAllMoveItems()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tree  = GetTree(window);
+            var roots = GetRoots(tree);
+
+            var chain  = new AnimationChainSave { Name = "Walk" };
+            var frame0 = new AnimationFrameSave { TextureName = "A.png", ShapesSave = new ShapesSave() };
+            var frame1 = new AnimationFrameSave { TextureName = "B.png", ShapesSave = new ShapesSave() };
+            var frame2 = new AnimationFrameSave { TextureName = "C.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame0);
+            chain.Frames.Add(frame1);
+            chain.Frames.Add(frame2);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var frameVm = new TreeNodeVm { Header = "Frame 1", Data = frame1 };
+            roots.Add(frameVm);
+            tree.SelectedItem = frameVm;
+
+            TriggerContextMenuOpening(window);
+
+            var headers = ContextMenuHeaders(window);
+            Assert.Contains("^^ Move To Top",   headers);
+            Assert.Contains("^  Move Up",        headers);
+            Assert.Contains("v  Move Down",      headers);
+            Assert.Contains("vv Move To Bottom", headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void ContextMenu_FrameSelected_ContainsShapeItems()
     {
         var (window, ctx) = CreateWindow();


### PR DESCRIPTION
## Summary

Gates the four frame-reorder context-menu items (Move To Top, Move Up, Move Down, Move To Bottom) on the frame's position within its parent chain:

- **All four hidden** when chain.Frames.Count == 1 (the only-frame case from the issue).
- **Move To Top / Move Up hidden** when the frame is already at index 0 (first frame).
- **Move Down / Move To Bottom hidden** when the frame is already at the last index (last frame).

## Tests

Four new [AvaloniaFact] tests in HeadlessTreeViewTests:

| Test | Scenario |
|---|---|
| ContextMenu_Frame_SingleFrameChain_HidesAllMoveItems | Chain with 1 frame → no move items |
| ContextMenu_Frame_FirstFrameOfMultiFrameChain_HidesUpAndTopItems | Frame at index 0 → Down/Bottom only |
| ContextMenu_Frame_LastFrameOfMultiFrameChain_HidesDownAndBottomItems | Frame at last index → Up/Top only |
| ContextMenu_Frame_MiddleFrameOfChain_ShowsAllMoveItems | Frame in middle → all four items |

All 257 tests pass.

Closes #186