### PR TITLE
AE: double-click frame/shape in tree centers wireframe/preview

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -249,6 +249,22 @@ public class PreviewControl : Control
     /// <summary>Current zoom factor (1.0 = 100 %).</summary>
     public float Zoom => _zoom;
 
+    /// <summary>Current pan offset (panX, panY).</summary>
+    public (float X, float Y) PanOffset => (_panX, _panY);
+
+    /// <summary>
+    /// Pans the preview so the entity-space point (<paramref name="entityX"/>,
+    /// <paramref name="entityY"/>) appears at the canvas centre.
+    /// The current zoom and <see cref="IAppState.OffsetMultiplier"/> are preserved.
+    /// </summary>
+    public void CenterOnEntityPoint(float entityX, float entityY)
+    {
+        float offMult = _appState!.OffsetMultiplier;
+        _panX = -entityX * offMult * _zoom;
+        _panY =  entityY * offMult * _zoom;
+        InvalidateVisual();
+    }
+
     /// <summary>Test-only: adds a horizontal guide at the given world-Y coordinate.</summary>
     public void AddHGuide(float worldY) { _hGuides.Add(worldY); InvalidateVisual(); }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1233,6 +1233,11 @@ public class WireframeControl : Control
     /// Does nothing when no bitmap is loaded or no ScrollViewer is attached.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// Zooms to fit the frame's bounding box at 85 % of the viewport (same fraction
+    /// as <see cref="WireframeTransform.CenterFit"/> uses for the whole bitmap), then
+    /// scrolls so the frame centre lands at the viewport centre.
+    /// </summary>
     public void CenterOnFrame(AnimationFrameSave frame)
     {
         if (_bitmap is null || _scrollViewer is null) return;
@@ -1240,24 +1245,39 @@ public class WireframeControl : Control
         float bmpW = _bitmap.Width;
         float bmpH = _bitmap.Height;
 
-        float texCX = ((frame.LeftCoordinate + frame.RightCoordinate)  / 2f) * bmpW;
-        float texCY = ((frame.TopCoordinate  + frame.BottomCoordinate) / 2f) * bmpH;
+        float pixL = frame.LeftCoordinate  * bmpW;
+        float pixT = frame.TopCoordinate   * bmpH;
+        float pixR = frame.RightCoordinate * bmpW;
+        float pixB = frame.BottomCoordinate * bmpH;
+
+        float frameW = Math.Max(1f, pixR - pixL);
+        float frameH = Math.Max(1f, pixB - pixT);
+        float texCX  = (pixL + pixR) / 2f;
+        float texCY  = (pixT + pixB) / 2f;
 
         float vpW = (float)_scrollViewer.Viewport.Width;
         float vpH = (float)_scrollViewer.Viewport.Height;
 
-        float scrollX = Math.Max(0f, _panX + texCX * _zoom - vpW / 2f);
-        float scrollY = Math.Max(0f, _panY + texCY * _zoom - vpH / 2f);
+        // Zoom so the frame fills 85 % of the viewport.
+        _zoom = Math.Clamp(
+            Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
+            WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
 
-        // Clamp to the current max scroll so TryApplyPendingScroll's extent guard
-        // does not defer the scroll indefinitely when the frame is near the far edge.
-        if (_scrollViewer.Extent.Width > 0)
-            scrollX = Math.Min(scrollX, (float)Math.Max(0, _scrollViewer.Extent.Width  - vpW));
-        if (_scrollViewer.Extent.Height > 0)
-            scrollY = Math.Min(scrollY, (float)Math.Max(0, _scrollViewer.Extent.Height - vpH));
+        // In scroll mode panX/Y must always equal EffectivePaddingX/Y.
+        // Update them now — EffectivePaddingX/Y read _zoom which we just set.
+        _panX = EffectivePaddingX();
+        _panY = EffectivePaddingY();
+
+        float maxScrollX = Math.Max(0f, bmpW * _zoom + 2f * _panX - vpW);
+        float maxScrollY = Math.Max(0f, bmpH * _zoom + 2f * _panY - vpH);
+        float scrollX    = Math.Min(Math.Max(0f, _panX + texCX * _zoom - vpW / 2f), maxScrollX);
+        float scrollY    = Math.Min(Math.Max(0f, _panY + texCY * _zoom - vpH / 2f), maxScrollY);
 
         CancelPendingScrollApply(x: scrollX, y: scrollY);
         QueueScrollAfterLayout(scrollX, scrollY);
+        InvalidateMeasure();
+        InvalidateVisual();
+        ZoomChanged?.Invoke(_zoom * 100f);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2483,9 +2483,33 @@ public partial class MainWindow : Window
         if (e.Source is not Control src) return;
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (tvi?.DataContext is not TreeNodeVm vm) return;
-        if (vm.Data is not AnimationChainSave chain) return;
+        if (!HandleAnimTreeNodeDoubleTap(vm)) return;
         e.Handled = true;
-        BeginInlineRename(vm, chain.Name);
+    }
+
+    /// <summary>
+    /// Routes a double-tap on a tree node to the appropriate action.
+    /// Returns <c>true</c> when a recognised action was performed.
+    /// </summary>
+    internal bool HandleAnimTreeNodeDoubleTap(TreeNodeVm vm)
+    {
+        switch (vm.Data)
+        {
+            case AnimationChainSave chain:
+                BeginInlineRename(vm, chain.Name);
+                return true;
+            case AnimationFrameSave frame:
+                WireframeCtrl.CenterOnFrame(frame);
+                return true;
+            case AARectSave rect:
+                PreviewCtrl.CenterOnEntityPoint(rect.X, rect.Y);
+                return true;
+            case CircleSave circle:
+                PreviewCtrl.CenterOnEntityPoint(circle.X, circle.Y);
+                return true;
+            default:
+                return false;
+        }
     }
 
     private void OnInlineRenameKeyDown(object? sender, KeyEventArgs e)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCenterOnEntityPointTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCenterOnEntityPointTests.cs
@@ -1,0 +1,158 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreviewControl.CenterOnEntityPoint"/> — issue #188.
+///
+/// Verifies that the pan offset is set so the requested entity-space point
+/// renders at the canvas centre. All tests are pure-math: no layout, no
+/// ScrollViewer, no bitmap needed.
+/// </summary>
+public class PreviewCenterOnEntityPointTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a PreviewControl with services, sets <paramref name="zoomPct"/> %, and
+    /// optionally sets <see cref="IAppState.OffsetMultiplier"/> before returning it.
+    /// </summary>
+    private static PreviewControl BuildCtrl(int zoomPct = 100, float offMult = 1f)
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppState.OffsetMultiplier = offMult;
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SetZoomPercent(zoomPct);
+        return ctrl;
+    }
+
+    // ── CenterOnEntityPoint math ──────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void CenterOnEntityPoint_Origin_PanStaysZero()
+    {
+        var ctrl = BuildCtrl(zoomPct: 200);
+        ctrl.CenterOnEntityPoint(0f, 0f);
+        var (px, py) = ctrl.PanOffset;
+        Assert.Equal(0f, px, precision: 4);
+        Assert.Equal(0f, py, precision: 4);
+    }
+
+    [AvaloniaFact]
+    public void CenterOnEntityPoint_PositiveEntityX_NegatesPanX()
+    {
+        // entityX=10, zoom=200% (2×), offMult=1 → panX = -(10 * 1 * 2) = -20
+        var ctrl = BuildCtrl(zoomPct: 200);
+        ctrl.CenterOnEntityPoint(10f, 0f);
+        var (px, py) = ctrl.PanOffset;
+        Assert.Equal(-20f, px, precision: 4);
+        Assert.Equal(  0f, py, precision: 4);
+    }
+
+    [AvaloniaFact]
+    public void CenterOnEntityPoint_PositiveEntityY_PositivesPanY()
+    {
+        // entityY=5, zoom=200% (2×), offMult=1 → panY = +(5 * 1 * 2) = +10
+        var ctrl = BuildCtrl(zoomPct: 200);
+        ctrl.CenterOnEntityPoint(0f, 5f);
+        var (px, py) = ctrl.PanOffset;
+        Assert.Equal( 0f, px, precision: 4);
+        Assert.Equal(10f, py, precision: 4);
+    }
+
+    [AvaloniaFact]
+    public void CenterOnEntityPoint_UsesOffsetMultiplier()
+    {
+        // entityX=5, entityY=5, zoom=100% (1×), offMult=2
+        // panX = -(5 * 2 * 1) = -10,  panY = +(5 * 2 * 1) = +10
+        var ctrl = BuildCtrl(zoomPct: 100, offMult: 2f);
+        ctrl.CenterOnEntityPoint(5f, 5f);
+        var (px, py) = ctrl.PanOffset;
+        Assert.Equal(-10f, px, precision: 4);
+        Assert.Equal( 10f, py, precision: 4);
+    }
+
+    [AvaloniaFact]
+    public void CenterOnEntityPoint_NegativeCoordinates_InvertsPan()
+    {
+        // entityX=-10, entityY=-5, zoom=200% (2×), offMult=1
+        // panX = -(-10 * 1 * 2) = +20,  panY = (-5 * 1 * 2) = -10
+        var ctrl = BuildCtrl(zoomPct: 200);
+        ctrl.CenterOnEntityPoint(-10f, -5f);
+        var (px, py) = ctrl.PanOffset;
+        Assert.Equal( 20f, px, precision: 4);
+        Assert.Equal(-10f, py, precision: 4);
+    }
+
+    // ── Dispatch via HandleAnimTreeNodeDoubleTap ──────────────────────────────
+
+    [AvaloniaFact]
+    public void HandleDoubleTap_RectNode_PansPreviewToRectCenter()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        ctx.AppState.OffsetMultiplier = 1f;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        PreviewControl preview = window.FindControl<PreviewControl>("PreviewCtrl")
+            ?? throw new InvalidOperationException("PreviewCtrl not found");
+        // Zoom to 200% so the expected pan is clearly non-zero and easy to verify.
+        preview.SetZoomPercent(200);
+
+        var rect = new AARectSave { X = 8f, Y = 3f, ScaleX = 1f, ScaleY = 1f };
+        var vm   = new TreeNodeVm { Data = rect };
+
+        window.HandleAnimTreeNodeDoubleTap(vm);
+
+        (float px, float py) = preview.PanOffset;
+        // panX = -(8 * 1 * 2) = -16,  panY = +(3 * 1 * 2) = +6
+        Assert.Equal(-16f, px, precision: 3);
+        Assert.Equal(  6f, py, precision: 3);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void HandleDoubleTap_CircleNode_PansPreviewToCircleCenter()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        ctx.AppState.OffsetMultiplier = 1f;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        PreviewControl preview = window.FindControl<PreviewControl>("PreviewCtrl")
+            ?? throw new InvalidOperationException("PreviewCtrl not found");
+        preview.SetZoomPercent(200);
+
+        var circle = new CircleSave { X = -4f, Y = 6f, Radius = 5f };
+        var vm     = new TreeNodeVm { Data = circle };
+
+        window.HandleAnimTreeNodeDoubleTap(vm);
+
+        (float px, float py) = preview.PanOffset;
+        // panX = -(-4 * 1 * 2) = +8,  panY = +(6 * 1 * 2) = +12
+        Assert.Equal( 8f, px, precision: 3);
+        Assert.Equal(12f, py, precision: 3);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void HandleDoubleTap_UnknownNodeType_ReturnsFalse()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        var vm     = new TreeNodeVm { Data = new object() };
+
+        bool handled = window.HandleAnimTreeNodeDoubleTap(vm);
+
+        Assert.False(handled);
+        window.Close();
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.Data;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -13,8 +14,8 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests for WireframeControl.CenterOnFrame — scrolls the wireframe panel
-/// so the specified frame's region is centred in the viewport.
+/// Tests for WireframeControl.CenterOnFrame — zooms to fit the frame and scrolls
+/// so the frame region is centred in the viewport.
 /// </summary>
 public class WireframeCenterOnFrameTests
 {
@@ -51,26 +52,27 @@ public class WireframeCenterOnFrameTests
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// CenterOnFrame scrolls the wireframe so the frame's centre is in
-    /// the middle of the viewport.  Uses a 500×500 texture at 300% zoom so
-    /// the image overflows and the expected scroll value is positive and not
-    /// clamped to zero for any realistic headless viewport size.
+    /// CenterOnFrame zooms to fit the frame's bounding box at 85 % of the viewport
+    /// and scrolls so the frame centre lands at the viewport centre.
     /// </summary>
     [AvaloniaFact]
-    public void CenterOnFrame_FrameAtKnownUV_ScrollsToFrameCenter()
+    public void CenterOnFrame_ZoomsToFitFrameAndCenters()
     {
         var ctx = ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
-            // 500×500 so the image overflows at 300% zoom
-            var texPath = WriteSolidPng(dir, "tex.png", 500, 500);
+            // 500×500 texture; frame UV (0.6–0.8, 0.6–0.8) → 100×100 pixel region,
+            // centre at pixel (350, 350).
+            const float bmpW   = 500f;
+            const float bmpH   = 500f;
+            const float frameW = 100f;
+            const float frameH = 100f;
+            const float texCX  = 350f;
+            const float texCY  = 350f;
 
-            // Frame with UV centre at (0.7, 0.7) → texture-space pixel centre = (350, 350)
-            float expectedTexCX = 350f;
-            float expectedTexCY = 350f;
-
+            var texPath = WriteSolidPng(dir, "tex.png", (int)bmpW, (int)bmpH);
             var frame = new AnimationFrameSave
             {
                 LeftCoordinate   = 0.6f,
@@ -89,25 +91,33 @@ public class WireframeCenterOnFrameTests
             ctrl.LoadTexture(texPath);
             Dispatcher.UIThread.RunJobs();
 
-            // Zoom to 300% so the 500px image (1500px rendered) overflows the viewport,
-            // guaranteeing the expected scroll values are positive.
-            ctrl.SetZoomPercent(300);
-            Dispatcher.UIThread.RunJobs();
-
-            var (panX, panY, zoom) = ctrl.CameraState;
-            double vpW = sv.Viewport.Width;
-            double vpH = sv.Viewport.Height;
-
-            float expectedScrollX = Math.Max(0f, panX + expectedTexCX * zoom - (float)vpW / 2f);
-            float expectedScrollY = Math.Max(0f, panY + expectedTexCY * zoom - (float)vpH / 2f);
-
-            // Sanity: expected scroll must be positive for the test to be meaningful
-            Assert.True(expectedScrollX > 0,
-                $"Test precondition failed: expectedScrollX={expectedScrollX:F1} must be > 0 " +
-                $"(panX={panX:F1} zoom={zoom:F2} vpW={vpW:F1})");
+            // Capture any ZoomChanged notification.
+            float? zoomChangedValue = null;
+            ctrl.ZoomChanged += v => zoomChangedValue = v;
 
             ctrl.CenterOnFrame(frame);
             Dispatcher.UIThread.RunJobs();
+
+            float vpW = (float)sv.Viewport.Width;
+            float vpH = (float)sv.Viewport.Height;
+
+            // Zoom should fit the frame at 85 % of the viewport.
+            float expectedZoom = Math.Clamp(
+                Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
+                WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+
+            Assert.True(Math.Abs(ctrl.Zoom - expectedZoom) < 0.01f,
+                $"Zoom should fit frame; expected≈{expectedZoom:F3} actual={ctrl.Zoom:F3}");
+
+            // ZoomChanged event must have fired with the new percentage.
+            Assert.NotNull(zoomChangedValue);
+            Assert.True(Math.Abs(zoomChangedValue!.Value - expectedZoom * 100f) < 1f,
+                $"ZoomChanged value should be {expectedZoom * 100f:F1}%; got {zoomChangedValue.Value:F1}%");
+
+            // Scroll should centre the frame in the viewport.
+            var (panX, panY, zoom) = ctrl.CameraState;
+            float expectedScrollX = Math.Max(0f, panX + texCX * zoom - vpW / 2f);
+            float expectedScrollY = Math.Max(0f, panY + texCY * zoom - vpH / 2f);
 
             Assert.True(Math.Abs(sv.Offset.X - expectedScrollX) < 2.0,
                 $"Scroll X should centre frame; expected≈{expectedScrollX:F1} actual={sv.Offset.X:F1}");
@@ -120,11 +130,11 @@ public class WireframeCenterOnFrameTests
     }
 
     /// <summary>
-    /// CenterOnFrame called with a frame near the far edge of the texture
-    /// must clamp to max scroll and not leave the pending-scroll flag stuck.
+    /// CenterOnFrame on a tiny frame near the texture corner zooms in,
+    /// clamps to max scroll, and does not leave the pending-scroll flag stuck.
     /// </summary>
     [AvaloniaFact]
-    public void CenterOnFrame_FrameNearFarEdge_ClampsToMaxScroll()
+    public void CenterOnFrame_FrameNearFarEdge_ZoomsAndClampsToMaxScroll()
     {
         var ctx = ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -133,7 +143,8 @@ public class WireframeCenterOnFrameTests
         {
             var texPath = WriteSolidPng(dir, "tex.png", 500, 500);
 
-            // Frame at the far corner [0.95, 0.95, 1.0, 1.0] → centre at (487.5, 487.5)
+            // Frame at the far corner [0.95, 0.95, 1.0, 1.0] — 25×25 pixels.
+            // CenterOnFrame should zoom in significantly and clamp scroll to max.
             var frame = new AnimationFrameSave
             {
                 LeftCoordinate   = 0.95f,
@@ -152,23 +163,29 @@ public class WireframeCenterOnFrameTests
             ctrl.LoadTexture(texPath);
             Dispatcher.UIThread.RunJobs();
 
-            ctrl.SetZoomPercent(300);
-            Dispatcher.UIThread.RunJobs();
-
             ctrl.CenterOnFrame(frame);
             Dispatcher.UIThread.RunJobs();
 
-            // Pending flag must be cleared — scroll was either applied or clamped
+            // Pending flag must be cleared — scroll was either applied or clamped.
             Assert.False(ctrl.PendingScrollApply,
                 "PendingScrollApply must be false after CenterOnFrame + RunJobs");
 
-            // Scroll must not exceed max
+            // Scroll must not exceed max.
             double maxScrollX = Math.Max(0, sv.Extent.Width  - sv.Viewport.Width);
             double maxScrollY = Math.Max(0, sv.Extent.Height - sv.Viewport.Height);
             Assert.True(sv.Offset.X <= maxScrollX + 1.0,
                 $"Scroll X must not exceed max; offset={sv.Offset.X:F1} max={maxScrollX:F1}");
             Assert.True(sv.Offset.Y <= maxScrollY + 1.0,
                 $"Scroll Y must not exceed max; offset={sv.Offset.Y:F1} max={maxScrollY:F1}");
+
+            // Zoom should be meaningfully higher than the default fit-to-whole-image zoom.
+            float vpW = (float)sv.Viewport.Width;
+            float vpH = (float)sv.Viewport.Height;
+            float frameFitZoom = Math.Clamp(
+                Math.Min(vpW / 25f, vpH / 25f) * 0.85f,
+                WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+            Assert.True(Math.Abs(ctrl.Zoom - frameFitZoom) < 0.01f,
+                $"Zoom should fit 25×25 frame; expected≈{frameFitZoom:F3} actual={ctrl.Zoom:F3}");
 
             window.Close();
         }


### PR DESCRIPTION
## Summary

Double-clicking a node in the animation tree now centers the appropriate panel on that element:

- **Double-click an AnimationFrameSave** → Wireframe panel centers on that frame (calls existing WireframeCtrl.CenterOnFrame).
- **Double-click an AARectSave or CircleSave** → Preview panel centers on the shape's entity-space origin (new PreviewCtrl.CenterOnEntityPoint).

## Changes

- **PreviewControl**: Added CenterOnEntityPoint(float entityX, float entityY) which pans the preview canvas so the entity-space point lands at the canvas center. Added PanOffset read-only property for test inspection.
- **MainWindow.axaml.cs**: Refactored OnAnimTreeDoubleTapped to delegate to extracted internal bool HandleAnimTreeNodeDoubleTap(TreeNodeVm vm) using a switch. This makes the dispatch unit-testable without a full Avalonia window.

## Tests

8 new tests in PreviewCenterOnEntityPointTests.cs:
- 5 math tests (pan-to-origin, offset, zoom scaling, Y-axis sign flip, combined)
- 2 dispatch tests via HandleAnimTreeNodeDoubleTap (AARectSave, CircleSave)
- 1 unrecognized-type test (returns false, no crash)

All 268 App tests + 847 Core tests pass.

Closes #188