### PR TITLE
AE: diff-update shape/frame nodes to fix selection drop on property-grid edits and reorder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1000,10 +1000,8 @@ public partial class MainWindow : Window
         else
         {
             node.Header = rebuiltChainNode.Header;
-            node.Meta = rebuiltChainNode.Meta;
-            node.Children.Clear();
-            for (int i = 0; i < chain.Frames.Count; i++)
-                node.Children.Add(TreeBuilder.BuildFrameNode(chain.Frames[i], i));
+            node.Meta   = rebuiltChainNode.Meta;
+            TreeBuilder.SyncFramesInto(node, chain.Frames);
         }
     }
 
@@ -1025,13 +1023,11 @@ public partial class MainWindow : Window
         }
         else
         {
-            frameNode.Header = rebuiltFrameNode.Header;
-            frameNode.Kind = rebuiltFrameNode.Kind;
+            frameNode.Header     = rebuiltFrameNode.Header;
+            frameNode.Kind       = rebuiltFrameNode.Kind;
             frameNode.IsFrameNode = rebuiltFrameNode.IsFrameNode;
-            frameNode.Meta = rebuiltFrameNode.Meta;
-            frameNode.Children.Clear();
-            foreach (var child in rebuiltFrameNode.Children)
-                frameNode.Children.Add(child);
+            frameNode.Meta       = rebuiltFrameNode.Meta;
+            TreeBuilder.SyncShapesInto(frameNode, frame.ShapesSave);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -104,6 +104,109 @@ public static class TreeBuilder
         return Path.GetFileName(frame.TextureName);
     }
 
+    // ── Diff-update helpers ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Diff-updates the shape children of <paramref name="frameNode"/> to match
+    /// <paramref name="shapesSave"/> without replacing existing VMs.
+    /// <para>
+    /// VMs whose <see cref="TreeNodeVm.Data"/> still appears in
+    /// <paramref name="shapesSave"/> are reused and their
+    /// <see cref="TreeNodeVm.Header"/> is resynced (so a renamed shape is reflected).
+    /// VMs for removed shapes are deleted; new VMs are created for added shapes.
+    /// Order is: rects first, then circles.
+    /// </para>
+    /// </summary>
+    public static void SyncShapesInto(TreeNodeVm frameNode, ShapesSave? shapesSave)
+    {
+        var rects   = shapesSave?.AARectSaves  ?? new System.Collections.Generic.List<AARectSave>();
+        var circles = shapesSave?.CircleSaves  ?? new System.Collections.Generic.List<CircleSave>();
+
+        // Remove shape VMs that no longer exist in the data lists.
+        for (int i = frameNode.Children.Count - 1; i >= 0; i--)
+        {
+            var child = frameNode.Children[i];
+            bool keep = (child.Data is AARectSave r && rects.Contains(r))
+                     || (child.Data is CircleSave  c && circles.Contains(c));
+            if (!keep) frameNode.Children.RemoveAt(i);
+        }
+
+        // Ensure every desired shape has a VM at the correct index.
+        int pos = 0;
+        foreach (var r in rects)
+        {
+            var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, r));
+            if (vm is null)
+            {
+                vm = new TreeNodeVm { Header = r.Name, Data = r, Kind = NodeKind.RectShape, IsRectNode = true };
+                frameNode.Children.Insert(pos, vm);
+            }
+            else
+            {
+                vm.Header = r.Name;
+                int cur = frameNode.Children.IndexOf(vm);
+                if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+            }
+            pos++;
+        }
+        foreach (var c in circles)
+        {
+            var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, c));
+            if (vm is null)
+            {
+                vm = new TreeNodeVm { Header = c.Name, Data = c, Kind = NodeKind.CircleShape, IsCircleNode = true };
+                frameNode.Children.Insert(pos, vm);
+            }
+            else
+            {
+                vm.Header = c.Name;
+                int cur = frameNode.Children.IndexOf(vm);
+                if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+            }
+            pos++;
+        }
+    }
+
+    /// <summary>
+    /// Diff-updates the frame children of <paramref name="chainNode"/> to match
+    /// <paramref name="frames"/> without replacing existing VMs.
+    /// <para>
+    /// Frame VMs are matched by <see cref="TreeNodeVm.Data"/> reference.
+    /// Surviving VMs have their header and meta resynced and their shape children
+    /// recursively diff-updated via <see cref="SyncShapesInto"/>.
+    /// <see cref="TreeNodeVm.IsExpanded"/> is preserved on retained VMs.
+    /// </para>
+    /// </summary>
+    public static void SyncFramesInto(TreeNodeVm chainNode, System.Collections.Generic.IList<AnimationFrameSave> frames)
+    {
+        // Remove frame VMs whose data is no longer in the list.
+        for (int i = chainNode.Children.Count - 1; i >= 0; i--)
+        {
+            var child = chainNode.Children[i];
+            if (child.Data is AnimationFrameSave f && !frames.Contains(f))
+                chainNode.Children.RemoveAt(i);
+        }
+
+        // Ensure every desired frame has a VM at the correct index.
+        for (int i = 0; i < frames.Count; i++)
+        {
+            var frame = frames[i];
+            var vm    = chainNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, frame));
+            if (vm is null)
+            {
+                chainNode.Children.Insert(i, BuildFrameNode(frame, i));
+            }
+            else
+            {
+                vm.Header = BuildFrameHeader(frame, i);
+                vm.Meta   = $"{frame.FrameLength:0.00}s";
+                int cur   = chainNode.Children.IndexOf(vm);
+                if (cur != i) { chainNode.Children.RemoveAt(cur); chainNode.Children.Insert(i, vm); }
+                SyncShapesInto(vm, frame.ShapesSave);
+            }
+        }
+    }
+
     // ── Expand-state persistence ──────────────────────────────────────────────
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -262,6 +262,265 @@ public class TreeBuilderPureTests
     }
 }
 
+// ── SyncShapesInto tests ──────────────────────────────────────────────────────
+
+public class TreeBuilderSyncShapesTests
+{
+    private static TreeNodeVm FrameNodeWithRect(out AARectSave rect)
+    {
+        rect = new AARectSave { Name = "HitBox" };
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.AARectSaves.Add(rect);
+        return TreeBuilder.BuildFrameNode(frame);
+    }
+
+    private static TreeNodeVm FrameNodeWithCircle(out CircleSave circle)
+    {
+        circle = new CircleSave { Name = "Hurt" };
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.CircleSaves.Add(circle);
+        return TreeBuilder.BuildFrameNode(frame);
+    }
+
+    [Fact]
+    public void SyncShapesInto_ExistingRectVm_IsPreservedByReference()
+    {
+        var frameNode = FrameNodeWithRect(out var rect);
+        var originalVm = frameNode.Children[0];
+        var ss = new ShapesSave();
+        ss.AARectSaves.Add(rect);
+
+        TreeBuilder.SyncShapesInto(frameNode, ss);
+
+        Assert.Same(originalVm, frameNode.Children[0]);
+    }
+
+    [Fact]
+    public void SyncShapesInto_ExistingCircleVm_IsPreservedByReference()
+    {
+        var frameNode = FrameNodeWithCircle(out var circle);
+        var originalVm = frameNode.Children[0];
+        var ss = new ShapesSave();
+        ss.CircleSaves.Add(circle);
+
+        TreeBuilder.SyncShapesInto(frameNode, ss);
+
+        Assert.Same(originalVm, frameNode.Children[0]);
+    }
+
+    [Fact]
+    public void SyncShapesInto_RectNameChange_UpdatesHeader()
+    {
+        var frameNode = FrameNodeWithRect(out var rect);
+        rect.Name = "NewName";
+        var ss = new ShapesSave();
+        ss.AARectSaves.Add(rect);
+
+        TreeBuilder.SyncShapesInto(frameNode, ss);
+
+        Assert.Equal("NewName", frameNode.Children[0].Header);
+    }
+
+    [Fact]
+    public void SyncShapesInto_CircleNameChange_UpdatesHeader()
+    {
+        var frameNode = FrameNodeWithCircle(out var circle);
+        circle.Name = "NewCircle";
+        var ss = new ShapesSave();
+        ss.CircleSaves.Add(circle);
+
+        TreeBuilder.SyncShapesInto(frameNode, ss);
+
+        Assert.Equal("NewCircle", frameNode.Children[0].Header);
+    }
+
+    [Fact]
+    public void SyncShapesInto_AddedRect_IsInserted()
+    {
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        var frameNode = TreeBuilder.BuildFrameNode(frame);
+        var newRect = new AARectSave { Name = "New" };
+        frame.ShapesSave.AARectSaves.Add(newRect);
+
+        TreeBuilder.SyncShapesInto(frameNode, frame.ShapesSave);
+
+        Assert.Single(frameNode.Children);
+        Assert.Same(newRect, frameNode.Children[0].Data);
+    }
+
+    [Fact]
+    public void SyncShapesInto_RemovedRect_IsRemoved()
+    {
+        var frameNode = FrameNodeWithRect(out _);
+        Assert.Single(frameNode.Children);
+
+        TreeBuilder.SyncShapesInto(frameNode, new ShapesSave());
+
+        Assert.Empty(frameNode.Children);
+    }
+
+    [Fact]
+    public void SyncShapesInto_NullShapesSave_ClearsAllShapeChildren()
+    {
+        var frameNode = FrameNodeWithRect(out _);
+        Assert.Single(frameNode.Children);
+
+        TreeBuilder.SyncShapesInto(frameNode, null);
+
+        Assert.Empty(frameNode.Children);
+    }
+
+    [Fact]
+    public void SyncShapesInto_PreservesRectsBeforeCirclesOrder()
+    {
+        var rect   = new AARectSave  { Name = "R" };
+        var circle = new CircleSave  { Name = "C" };
+        var frame  = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.AARectSaves.Add(rect);
+        frame.ShapesSave.CircleSaves.Add(circle);
+        var frameNode  = TreeBuilder.BuildFrameNode(frame);
+        var originalRectVm   = frameNode.Children[0];
+        var originalCircleVm = frameNode.Children[1];
+
+        TreeBuilder.SyncShapesInto(frameNode, frame.ShapesSave);
+
+        Assert.Same(originalRectVm,   frameNode.Children[0]);
+        Assert.Same(originalCircleVm, frameNode.Children[1]);
+    }
+}
+
+// ── SyncFramesInto tests ──────────────────────────────────────────────────────
+
+public class TreeBuilderSyncFramesTests
+{
+    [Fact]
+    public void SyncFramesInto_ExistingFrameVm_IsPreservedByReference()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "walk1.png" };
+        chain.Frames.Add(frame);
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        var originalVm = chainNode.Children[0];
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        Assert.Same(originalVm, chainNode.Children[0]);
+    }
+
+    [Fact]
+    public void SyncFramesInto_ReorderedFrames_VmsAreReordered()
+    {
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        var vmA = chainNode.Children[0];
+        var vmB = chainNode.Children[1];
+
+        chain.Frames.Clear();
+        chain.Frames.Add(frameB);
+        chain.Frames.Add(frameA);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        Assert.Same(vmB, chainNode.Children[0]);
+        Assert.Same(vmA, chainNode.Children[1]);
+    }
+
+    [Fact]
+    public void SyncFramesInto_IsExpanded_PreservedAfterReorder()
+    {
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        var frameA = new AnimationFrameSave { TextureName = "a.png" };
+        var frameB = new AnimationFrameSave { TextureName = "b.png" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        chainNode.Children[0].IsExpanded = true;
+
+        chain.Frames.Clear();
+        chain.Frames.Add(frameB);
+        chain.Frames.Add(frameA);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        // frameA moved to index 1 and must still be expanded
+        Assert.False(chainNode.Children[0].IsExpanded);
+        Assert.True(chainNode.Children[1].IsExpanded);
+    }
+
+    [Fact]
+    public void SyncFramesInto_NewFrame_IsAdded()
+    {
+        var chain     = new AnimationChainSave { Name = "Walk" };
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        var newFrame  = new AnimationFrameSave { TextureName = "new.png" };
+        chain.Frames.Add(newFrame);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        Assert.Single(chainNode.Children);
+        Assert.Same(newFrame, chainNode.Children[0].Data);
+    }
+
+    [Fact]
+    public void SyncFramesInto_RemovedFrame_IsRemoved()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "walk1.png" };
+        chain.Frames.Add(frame);
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        chain.Frames.Clear();
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        Assert.Empty(chainNode.Children);
+    }
+
+    [Fact]
+    public void SyncFramesInto_RecursesSyncShapesInto_ExistingFrameNode()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var rect  = new AARectSave { Name = "Hit" };
+        var frame = new AnimationFrameSave { TextureName = "w1.png", ShapesSave = new ShapesSave() };
+        frame.ShapesSave.AARectSaves.Add(rect);
+        chain.Frames.Add(frame);
+        var chainNode     = TreeBuilder.BuildChainNode(chain);
+        var frameVm       = chainNode.Children[0];
+        var originalRectVm = frameVm.Children[0];
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        Assert.Same(frameVm,        chainNode.Children[0]);
+        Assert.Same(originalRectVm, chainNode.Children[0].Children[0]);
+    }
+
+    [Fact]
+    public void SyncFramesInto_FrameHeader_UpdatesAfterIndexChange()
+    {
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        var frameA = new AnimationFrameSave { TextureName = "" };
+        var frameB = new AnimationFrameSave { TextureName = "" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);
+
+        chain.Frames.Clear();
+        chain.Frames.Add(frameB);
+        chain.Frames.Add(frameA);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        // After swap, each frame's header must reflect its new index
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);
+    }
+}
+
 // ── Singleton-touching tests (RouteNodeSelection) ─────────────────────────────
 
 [Collection("SequentialSingletons")]


### PR DESCRIPTION
## Summary

Fixes the root cause shared by #189 and #185: clear-and-rebuild of child VMs in \RefreshFrameNode\ / \RefreshChainNode\ invalidates any \TreeView.SelectedItem\ pointing at the old VMs.

## Changes

### \TreeBuilder\ — two new diff-update helpers

- **\SyncShapesInto(frameNode, shapesSave)\** — walks the existing shape children of a frame node, reuses VMs matched by \Data\ reference (resyncing the \Header\ for renames), inserts VMs for new shapes, and removes VMs for deleted shapes. Order preserved: rects first, then circles.
- **\SyncFramesInto(chainNode, frames)\** — same pattern for frame children of a chain node. Preserves \IsExpanded\ on retained VMs; recursively calls \SyncShapesInto\ so shape children are also kept alive.

### \MainWindow.axaml.cs\

- \RefreshFrameNode\: replaced \Children.Clear()\ + rebuild with \TreeBuilder.SyncShapesInto\.
- \RefreshChainNode\: replaced \Children.Clear()\ + rebuild with \TreeBuilder.SyncFramesInto\.

## Tests

15 new pure unit tests in \TreeBuilderSyncShapesTests\ / \TreeBuilderSyncFramesTests\. All 862 tests pass.

Closes #189
Closes #185