### PR TITLE
AE: Expand All / Collapse All now recurses into frame/shape children

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -797,7 +797,7 @@ public partial class MainWindow : Window
     private void SetAllExpanded(bool expanded)
     {
         foreach (var node in _treeRoots)
-            node.IsExpanded = expanded;
+            TreeNodeVm.SetExpandedRecursive(node, expanded);
     }
 
     private void AddAnimationChainAndBeginInlineRename()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -90,6 +90,16 @@ public class TreeNodeVm : INotifyPropertyChanged
     public bool IsCircleNode { get; set; }
 
     public ObservableCollection<TreeNodeVm> Children { get; } = new();
+
+    /// <summary>
+    /// Sets <see cref="IsExpanded"/> on <paramref name="node"/> and every descendant.
+    /// </summary>
+    public static void SetExpandedRecursive(TreeNodeVm node, bool expanded)
+    {
+        node.IsExpanded = expanded;
+        foreach (var child in node.Children)
+            SetExpandedRecursive(child, expanded);
+    }
 }
 
 /// <summary>Identifies the type of data a <see cref="TreeNodeVm"/> represents, for icon selection.</summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
@@ -128,4 +128,75 @@ public class TreeNodeVmTests
         vm.CancelEdit();
         Assert.Equal("Run", vm.Header);
     }
+
+    // ── SetExpandedRecursive ──────────────────────────────────────────────────
+
+    [Fact]
+    public void SetExpandedRecursive_SetsRootNode()
+    {
+        var root = new TreeNodeVm { IsExpanded = false };
+
+        TreeNodeVm.SetExpandedRecursive(root, true);
+
+        Assert.True(root.IsExpanded);
+    }
+
+    [Fact]
+    public void SetExpandedRecursive_SetsDirectChildren()
+    {
+        var root = new TreeNodeVm();
+        var child1 = new TreeNodeVm { IsExpanded = false };
+        var child2 = new TreeNodeVm { IsExpanded = false };
+        root.Children.Add(child1);
+        root.Children.Add(child2);
+
+        TreeNodeVm.SetExpandedRecursive(root, true);
+
+        Assert.True(child1.IsExpanded);
+        Assert.True(child2.IsExpanded);
+    }
+
+    [Fact]
+    public void SetExpandedRecursive_SetsGrandchildren()
+    {
+        // chain → frame → rect  (3-level tree)
+        var chain = new TreeNodeVm { IsChainNode = true };
+        var frame = new TreeNodeVm { IsFrameNode = true };
+        var rect  = new TreeNodeVm { IsRectNode  = true };
+        frame.Children.Add(rect);
+        chain.Children.Add(frame);
+
+        TreeNodeVm.SetExpandedRecursive(chain, true);
+
+        Assert.True(chain.IsExpanded);
+        Assert.True(frame.IsExpanded);
+        Assert.True(rect.IsExpanded);
+    }
+
+    [Fact]
+    public void SetExpandedRecursive_CollapseAll_SetsAllFalse()
+    {
+        var chain = new TreeNodeVm { IsExpanded = true };
+        var frame = new TreeNodeVm { IsExpanded = true };
+        var rect  = new TreeNodeVm { IsExpanded = true };
+        frame.Children.Add(rect);
+        chain.Children.Add(frame);
+
+        TreeNodeVm.SetExpandedRecursive(chain, false);
+
+        Assert.False(chain.IsExpanded);
+        Assert.False(frame.IsExpanded);
+        Assert.False(rect.IsExpanded);
+    }
+
+    [Fact]
+    public void SetExpandedRecursive_LeafNode_IsHarmlessNoop()
+    {
+        var leaf = new TreeNodeVm { IsRectNode = true };  // no children
+
+        var ex = Record.Exception(() => TreeNodeVm.SetExpandedRecursive(leaf, true));
+
+        Assert.Null(ex);
+        Assert.True(leaf.IsExpanded);
+    }
 }


### PR DESCRIPTION
## Summary

SetAllExpanded only iterated the root (chain) nodes, so frames with shape children were never expanded or collapsed.

## Changes

- **TreeNodeVm.cs** — Added public static SetExpandedRecursive(node, expanded) that recurses into Children
- **MainWindow.axaml.cs** — SetAllExpanded now calls TreeNodeVm.SetExpandedRecursive for each root instead of setting IsExpanded directly
- **TreeNodeVmTests.cs** — 5 new tests: root node, direct children, grandchildren (chain→frame→rect), collapse direction, leaf no-op

Closes #192