### PR TITLE
AE: render shapes during preview playback

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -598,20 +598,27 @@ public class PreviewControl : Control
     };
 
     /// <summary>
-    /// Captures a thread-safe snapshot of collision shapes attached to the currently
-    /// selected frame. Shapes are sourced from <see cref="ISelectedState.SelectedFrame"/>
-    /// so they only appear when a specific frame is pinned (not during free playback).
+    /// Captures a thread-safe snapshot of collision shapes for the current display frame.
+    /// When a frame is pinned via tree selection, shapes come from that frame and selection
+    /// highlighting is applied. During free playback (no pinned frame), shapes come from the
+    /// currently-playing frame and are all rendered in the unselected style.
     /// </summary>
     private PreviewShapeInfo[] BuildShapeInfos()
     {
-        var frame = _selectedState!.SelectedFrame;
+        var pinnedFrame = _selectedState!.SelectedFrame;
+        var frame = pinnedFrame ?? GetCurrentPlaybackFrame();
         if (frame?.ShapesSave is null) return Array.Empty<PreviewShapeInfo>();
 
-        var selectedRects = _selectedState!.SelectedRectangles.ToHashSet();
-        if (_selectedState!.SelectedRectangle is { } sr) selectedRects.Add(sr);
+        var selectedRects   = new HashSet<AARectSave>();
+        var selectedCircles = new HashSet<CircleSave>();
 
-        var selectedCircles = _selectedState!.SelectedCircles.ToHashSet();
-        if (_selectedState!.SelectedCircle is { } sc) selectedCircles.Add(sc);
+        if (pinnedFrame is not null)
+        {
+            selectedRects = _selectedState!.SelectedRectangles.ToHashSet();
+            if (_selectedState!.SelectedRectangle is { } sr) selectedRects.Add(sr);
+            selectedCircles = _selectedState!.SelectedCircles.ToHashSet();
+            if (_selectedState!.SelectedCircle is { } sc) selectedCircles.Add(sc);
+        }
 
         var list = new List<PreviewShapeInfo>();
         foreach (var r in frame.ShapesSave!.AARectSaves)
@@ -622,6 +629,18 @@ public class PreviewControl : Control
                 selectedCircles.Contains(c)));
         return list.ToArray();
     }
+
+    /// <summary>Returns the frame in <see cref="ISelectedState.SelectedChain"/> at the current playback index.</summary>
+    private AnimationFrameSave? GetCurrentPlaybackFrame()
+    {
+        var chain = _selectedState!.SelectedChain;
+        if (chain is null || chain.Frames.Count == 0) return null;
+        int idx = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
+        return chain.Frames[idx];
+    }
+
+    /// <summary>Test-only: returns the shape infos that would be passed to the renderer for the current state.</summary>
+    internal PreviewShapeInfo[] GetShapeInfosForTest() => BuildShapeInfos();
 
     // -- Pointer events --------------------------------------------------------
 
@@ -1174,14 +1193,14 @@ public class PreviewControl : Control
 
     // -- Inner types -----------------------------------------------------------
 
-    private enum PreviewShapeKind { Rect, Circle }
+    internal enum PreviewShapeKind { Rect, Circle }
 
     /// <summary>
     /// Immutable snapshot of a single collision shape, safe to pass to the render thread.
     /// <para>For <see cref="PreviewShapeKind.Rect"/>: Param1=ScaleX, Param2=ScaleY.</para>
     /// <para>For <see cref="PreviewShapeKind.Circle"/>: Param1=Radius, Param2=0.</para>
     /// </summary>
-    private record PreviewShapeInfo(
+    internal record PreviewShapeInfo(
         PreviewShapeKind Kind,
         float X, float Y,
         float Param1, float Param2,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPlaybackShapesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPlaybackShapesTests.cs
@@ -1,0 +1,155 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies that collision-shape overlays follow the currently-playing frame during
+/// free playback (no frame pinned), so artists can see collision geometry in motion.
+/// Issue #190.
+/// </summary>
+public class PreviewPlaybackShapesTests
+{
+    private static (AnimationChainSave Chain, AnimationFrameSave Frame0, AnimationFrameSave Frame1)
+        MakeTwoFrameChain(float frame0Length = 0.1f, float frame1Length = 0.1f)
+    {
+        var rect0 = new AARectSave { X = 10f, Y = 0f, ScaleX = 5f, ScaleY = 5f };
+        var rect1 = new AARectSave { X = 20f, Y = 0f, ScaleX = 5f, ScaleY = 5f };
+
+        var frame0 = new AnimationFrameSave { FrameLength = frame0Length, ShapesSave = new ShapesSave() };
+        frame0.ShapesSave.AARectSaves.Add(rect0);
+
+        var frame1 = new AnimationFrameSave { FrameLength = frame1Length, ShapesSave = new ShapesSave() };
+        frame1.ShapesSave.AARectSaves.Add(rect1);
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frame0);
+        chain.Frames.Add(frame1);
+
+        return (chain, frame0, frame1);
+    }
+
+    // ── Shapes follow playback frame ──────────────────────────────────────────
+
+    /// <summary>
+    /// When no frame is pinned and playback advances to frame 1, BuildShapeInfos should
+    /// return the shapes attached to frame 1, not frame 0.
+    /// </summary>
+    [AvaloniaFact]
+    public void NoFramePinned_PlaybackOnFrame1_ReturnsFrame1Shapes()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var (chain, _, frame1) = MakeTwoFrameChain();
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = null;
+        Dispatcher.UIThread.RunJobs();
+
+        // Advance past frame 0 (0.1 s) so playback lands on frame 1.
+        ctrl.Playback.Play();
+        ctrl.Playback.Advance(0.15);
+
+        var shapes = ctrl.GetShapeInfosForTest();
+
+        Assert.Single(shapes);
+        Assert.Equal(PreviewControl.PreviewShapeKind.Rect, shapes[0].Kind);
+        Assert.Equal(frame1.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+    }
+
+    /// <summary>
+    /// When a frame is pinned via tree selection, shapes still come from that pinned
+    /// frame regardless of playback state — existing behaviour must not regress.
+    /// </summary>
+    [AvaloniaFact]
+    public void FramePinned_ReturnsPinnedFrameShapes_RegardlessOfPlaybackIndex()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var (chain, frame0, _) = MakeTwoFrameChain();
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame0;
+        Dispatcher.UIThread.RunJobs();
+
+        ctrl.Playback.Play();
+        ctrl.Playback.Advance(0.15); // would advance to frame 1 if frame were not pinned
+
+        var shapes = ctrl.GetShapeInfosForTest();
+
+        Assert.Single(shapes);
+        Assert.Equal(frame0.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+    }
+
+    /// <summary>
+    /// When playback is on frame 0 (no advancement), frame 0 shapes are returned.
+    /// </summary>
+    [AvaloniaFact]
+    public void NoFramePinned_PlaybackAtFrame0_ReturnsFrame0Shapes()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var (chain, frame0, _) = MakeTwoFrameChain();
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = null;
+        Dispatcher.UIThread.RunJobs();
+
+        // No advance — stays on frame 0.
+        var shapes = ctrl.GetShapeInfosForTest();
+
+        Assert.Single(shapes);
+        Assert.Equal(frame0.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+    }
+
+    /// <summary>
+    /// During free playback there is no shape selection; all shapes have IsSelected = false.
+    /// </summary>
+    [AvaloniaFact]
+    public void NoFramePinned_DuringPlayback_ShapesAreUnselected()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var (chain, _, _) = MakeTwoFrameChain();
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = null;
+        Dispatcher.UIThread.RunJobs();
+
+        ctrl.Playback.Play();
+        ctrl.Playback.Advance(0.15);
+
+        var shapes = ctrl.GetShapeInfosForTest();
+
+        Assert.All(shapes, s => Assert.False(s.IsSelected));
+    }
+
+    /// <summary>
+    /// When there is no chain, BuildShapeInfos returns empty — no crash.
+    /// </summary>
+    [AvaloniaFact]
+    public void NoChainNoFrame_ReturnsEmpty()
+    {
+        var ctx = TestHelpers.BuildServices();
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctx.SelectedState.SelectedChain = null;
+        ctx.SelectedState.SelectedFrame = null;
+
+        var shapes = ctrl.GetShapeInfosForTest();
+
+        Assert.Empty(shapes);
+    }
+}


### PR DESCRIPTION
Closes #190

## What changed

BuildShapeInfos in PreviewControl now falls back to the currently-playing frame when no frame is pinned (SelectedFrame is null). Shape overlays follow the animation frame-by-frame so artists can verify collision geometry in motion.

When rendering from the playback frame, all shapes are drawn in the unselected style — there is no interactive shape selection during free playback.

FrameIndexChanged already called InvalidateVisual in the constructor, so the repaint hook was already wired.

## Key changes
- BuildShapeInfos: use SelectedFrame ?? GetCurrentPlaybackFrame()
- GetCurrentPlaybackFrame(): new private helper indexing SelectedChain.Frames[clampedPlaybackIndex]
- PreviewShapeKind / PreviewShapeInfo promoted from private to internal for test access
- GetShapeInfosForTest(): new internal test accessor
- PreviewPlaybackShapesTests: 5 new tests covering the fix and regression-guarding the pinned-frame path