### PR TITLE
AE: show context hint in property panel when animation is selected

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1533,7 +1533,14 @@ public partial class MainWindow : Window
             var circ  = _selectedState.SelectedCircle;
             var hasShapeSelection = rect is not null || circ is not null;
 
-            PropNoneLabel.IsVisible   = frame is null && rect is null && circ is null;
+            bool noneVisible = frame is null && rect is null && circ is null;
+            PropNoneLabel.IsVisible = noneVisible;
+            if (noneVisible)
+            {
+                PropNoneLabel.Text = _selectedState.SelectedChain is not null
+                    ? "Select a frame or shape to edit its properties."
+                    : "No selection";
+            }
             PropFramePanel.IsVisible  = frame is not null && !hasShapeSelection;
             PropRectPanel.IsVisible   = rect  is not null;
             PropCirclePanel.IsVisible = circ  is not null;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UnitTypePropPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UnitTypePropPanelTests.cs
@@ -123,6 +123,40 @@ public class UnitTypePropPanelTests
         finally { window.Close(); }
     }
 
+    [AvaloniaFact]
+    public void PropNoneLabel_WhenChainSelected_ShowsContextHint()
+    {
+        var window = CreateWindowWithFrame(out _);
+        try
+        {
+            // Directly set a chain with no frame — SelectedChain setter clears frame/rect/circ
+            ctx.SelectedState.SelectedChain = new AnimationChainSave { Name = "Walk" };
+            Dispatcher.UIThread.RunJobs();
+
+            var label = FindCtrl<TextBlock>(window, "PropNoneLabel");
+            Assert.True(label.IsVisible);
+            Assert.Equal("Select a frame or shape to edit its properties.", label.Text);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void PropNoneLabel_WhenNothingSelected_ShowsNoSelection()
+    {
+        var window = CreateWindowWithFrame(out _);
+        try
+        {
+            // Reset clears chain + frame + shapes and fires SelectionChanged
+            ctx.SelectedState.Reset();
+            Dispatcher.UIThread.RunJobs();
+
+            var label = FindCtrl<TextBlock>(window, "PropNoneLabel");
+            Assert.True(label.IsVisible);
+            Assert.Equal("No selection", label.Text);
+        }
+        finally { window.Close(); }
+    }
+
     // ── Pixel mode ────────────────────────────────────────────────────────────
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

When an animation chain is selected but no frame or shape is active, the property panel now shows **'Select a frame or shape to edit its properties.'** instead of the misleading **'No selection'**.

**'No selection'** is still shown when nothing at all is selected (full reset state).

## Implementation

- RefreshPropertyPanel() in MainWindow.axaml.cs: checks _selectedState.SelectedChain when the none-label is visible and updates the text accordingly.
- Two new headless tests in UnitTypePropPanelTests.cs covering both states.

Closes #191