### PR TITLE
Fix ruler labels at high zoom: dynamic sub-pixel step and decimal formatting

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1403,9 +1403,8 @@ public class PreviewControl : Control
         {
             float sx = cx + wx * s.Zoom;
             if (sx < RulerSize || sx > s.Width) continue;
-            bool isMajor = MathF.Abs(wx % majorStep) < minorStep * 0.4f;
+            bool isMajor = IsMajorTick(wx, majorStep, minorStep);
             float tickH = isMajor ? RulerSize * 0.55f : RulerSize * 0.30f;
-            canvas.DrawLine(sx, RulerSize - tickH, sx, RulerSize, tickPaint);
             if (isMajor)
                 canvas.DrawText(FormatRulerLabel(majorStep, wx), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
         }
@@ -1417,7 +1416,7 @@ public class PreviewControl : Control
         {
             float sy = cy + wy * s.Zoom;
             if (sy < RulerSize || sy > s.Height) continue;
-            bool isMajor = MathF.Abs(wy % majorStep) < minorStep * 0.4f;
+            bool isMajor = IsMajorTick(wy, majorStep, minorStep);
             float tickW = isMajor ? RulerSize * 0.55f : RulerSize * 0.30f;
             canvas.DrawLine(RulerSize - tickW, sy, RulerSize, sy, tickPaint);
             if (isMajor)
@@ -1454,6 +1453,14 @@ public class PreviewControl : Control
         using var borderPaint = new SKPaint { Color = new SKColor(80, 80, 85), StrokeWidth = 1f };
         canvas.DrawLine(RulerSize, 0, RulerSize, s.Height, borderPaint);
         canvas.DrawLine(0, RulerSize, s.Width, RulerSize, borderPaint);
+    }
+
+    internal static bool IsMajorTick(float value, float majorStep, float minorStep)
+    {
+        // Use nearest-multiple distance instead of % to correctly handle negative values.
+        // C# % truncates toward zero, so e.g. -3.9999998 % 2 ≈ -2 (not ≈ 0).
+        float distToNearest = value - MathF.Round(value / majorStep) * majorStep;
+        return MathF.Abs(distToNearest) < minorStep * 0.4f;
     }
 
     internal static float GetRulerStep(float zoom)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1405,6 +1405,7 @@ public class PreviewControl : Control
             if (sx < RulerSize || sx > s.Width) continue;
             bool isMajor = IsMajorTick(wx, majorStep, minorStep);
             float tickH = isMajor ? RulerSize * 0.55f : RulerSize * 0.30f;
+            canvas.DrawLine(sx, RulerSize - tickH, sx, RulerSize, tickPaint);
             if (isMajor)
                 canvas.DrawText(FormatRulerLabel(majorStep, wx), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1407,7 +1407,7 @@ public class PreviewControl : Control
             float tickH = isMajor ? RulerSize * 0.55f : RulerSize * 0.30f;
             canvas.DrawLine(sx, RulerSize - tickH, sx, RulerSize, tickPaint);
             if (isMajor)
-                canvas.DrawText(((int)MathF.Round(wx)).ToString(), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
+                canvas.DrawText(FormatRulerLabel(majorStep, wx), sx + 1f, RulerSize - tickH - 1f, labelFont, labelPaint);
         }
 
         // Left (vertical) ruler - ticks at world-Y positions.
@@ -1425,7 +1425,7 @@ public class PreviewControl : Control
                 canvas.Save();
                 canvas.Translate(RulerSize - tickW - 1f, sy);
                 canvas.RotateDegrees(-90f);
-                canvas.DrawText(((int)MathF.Round(wy)).ToString(), 0f, 0f, labelFont, labelPaint);
+                canvas.DrawText(FormatRulerLabel(majorStep, wy), 0f, 0f, labelFont, labelPaint);
                 canvas.Restore();
             }
         }
@@ -1456,14 +1456,19 @@ public class PreviewControl : Control
         canvas.DrawLine(0, RulerSize, s.Width, RulerSize, borderPaint);
     }
 
-    private static float GetRulerStep(float zoom)
+    internal static float GetRulerStep(float zoom)
     {
         float targetWorld = 50f / zoom; // target ~50 screen px per major tick
-        float[] candidates = { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
+        float[] candidates = { 0.125f, 0.25f, 0.5f, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000 };
         foreach (float c in candidates)
             if (c >= targetWorld) return c;
         return 1000f;
     }
+
+    internal static string FormatRulerLabel(float majorStep, float worldValue) =>
+        majorStep >= 1f
+            ? ((int)MathF.Round(worldValue)).ToString()
+            : worldValue.ToString("0.###");
 
     private static void DrawFrameCore(
         SKCanvas canvas, AnimationFrameSave frame, SKBitmap bm,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RulerStepTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RulerStepTests.cs
@@ -4,11 +4,44 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests for ruler step selection and label formatting at all zoom levels,
-/// including high zoom (2000%+) where sub-pixel steps are needed.
+/// Tests for ruler step selection, major-tick detection, and label formatting at all zoom
+/// levels, including high zoom (2000%+) and negative world coordinates.
 /// </summary>
 public class RulerStepTests
 {
+    // ── IsMajorTick ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsMajorTick_PositiveExactMultiple_IsTrue()
+    {
+        // majorStep=2, minorStep=0.4 — positive multiples of 2 must be major
+        Assert.True(PreviewControl.IsMajorTick(4f, majorStep: 2f, minorStep: 0.4f));
+    }
+
+    [Fact]
+    public void IsMajorTick_NegativeExactMultiple_IsTrue()
+    {
+        // -4 is on the 2-unit grid — must be major (fails with wx % step)
+        Assert.True(PreviewControl.IsMajorTick(-4f, majorStep: 2f, minorStep: 0.4f));
+    }
+
+    [Fact]
+    public void IsMajorTick_NegativeNearMiss_IsFalse()
+    {
+        // -3.6 is NOT on the 2-unit grid
+        Assert.False(PreviewControl.IsMajorTick(-3.6f, majorStep: 2f, minorStep: 0.4f));
+    }
+
+    [Fact]
+    public void IsMajorTick_NegativeWithFloatDrift_IsTrue()
+    {
+        // Simulate the float-accumulation scenario: wx slightly below -4
+        // (the bug scenario — wx % 2 gives ≈ -2, not ≈ 0)
+        Assert.True(PreviewControl.IsMajorTick(-4f + 1e-5f, majorStep: 2f, minorStep: 0.4f));
+        Assert.True(PreviewControl.IsMajorTick(-4f - 1e-5f, majorStep: 2f, minorStep: 0.4f));
+    }
+
+
     // ── GetRulerStep – normal zoom ────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RulerStepTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RulerStepTests.cs
@@ -1,0 +1,108 @@
+using AnimationEditor.App.Controls;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for ruler step selection and label formatting at all zoom levels,
+/// including high zoom (2000%+) where sub-pixel steps are needed.
+/// </summary>
+public class RulerStepTests
+{
+    // ── GetRulerStep – normal zoom ────────────────────────────────────────────
+
+    [Fact]
+    public void GetRulerStep_At1xZoom_Returns50()
+    {
+        Assert.Equal(50f, PreviewControl.GetRulerStep(1f));
+    }
+
+    [Fact]
+    public void GetRulerStep_At5xZoom_Returns10()
+    {
+        Assert.Equal(10f, PreviewControl.GetRulerStep(5f));
+    }
+
+    [Fact]
+    public void GetRulerStep_At20xZoom_Returns5()
+    {
+        // targetWorld = 50/20 = 2.5 → smallest candidate ≥ 2.5 is 5
+        Assert.Equal(5f, PreviewControl.GetRulerStep(20f));
+    }
+
+    [Fact]
+    public void GetRulerStep_At50xZoom_Returns1()
+    {
+        // targetWorld = 50/50 = 1.0 → smallest candidate ≥ 1.0 is 1
+        Assert.Equal(1f, PreviewControl.GetRulerStep(50f));
+    }
+
+    // ── GetRulerStep – high zoom (sub-pixel steps required) ──────────────────
+
+    [Fact]
+    public void GetRulerStep_At100xZoom_Returns0Point5()
+    {
+        // targetWorld = 50/100 = 0.5 → should pick 0.5 not 1
+        Assert.Equal(0.5f, PreviewControl.GetRulerStep(100f));
+    }
+
+    [Fact]
+    public void GetRulerStep_At200xZoom_Returns0Point25()
+    {
+        // targetWorld = 50/200 = 0.25 → should pick 0.25
+        Assert.Equal(0.25f, PreviewControl.GetRulerStep(200f));
+    }
+
+    [Fact]
+    public void GetRulerStep_At400xZoom_Returns0Point125()
+    {
+        // targetWorld = 50/400 = 0.125 → should pick 0.125
+        Assert.Equal(0.125f, PreviewControl.GetRulerStep(400f));
+    }
+
+    [Fact]
+    public void GetRulerStep_BeyondAllCandidates_ReturnsSmallestCandidate()
+    {
+        // targetWorld = 50/10000 = 0.005, below all candidates → return 0.125
+        Assert.Equal(0.125f, PreviewControl.GetRulerStep(10000f));
+    }
+
+    // ── FormatRulerLabel ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void FormatRulerLabel_WholeStep_IntegerValue_ReturnsInteger()
+    {
+        Assert.Equal("10", PreviewControl.FormatRulerLabel(majorStep: 5f, worldValue: 10f));
+    }
+
+    [Fact]
+    public void FormatRulerLabel_WholeStep_NegativeValue_ReturnsInteger()
+    {
+        Assert.Equal("-25", PreviewControl.FormatRulerLabel(majorStep: 25f, worldValue: -25f));
+    }
+
+    [Fact]
+    public void FormatRulerLabel_FractionalStep_HalfValue_ShowsDecimal()
+    {
+        Assert.Equal("0.5", PreviewControl.FormatRulerLabel(majorStep: 0.5f, worldValue: 0.5f));
+    }
+
+    [Fact]
+    public void FormatRulerLabel_FractionalStep_QuarterValue_ShowsDecimal()
+    {
+        Assert.Equal("0.25", PreviewControl.FormatRulerLabel(majorStep: 0.25f, worldValue: 0.25f));
+    }
+
+    [Fact]
+    public void FormatRulerLabel_FractionalStep_WholeValue_ShowsIntegerDigits()
+    {
+        // worldValue = 1.0, step = 0.5 → "1" (0.### trims trailing zeros)
+        Assert.Equal("1", PreviewControl.FormatRulerLabel(majorStep: 0.5f, worldValue: 1f));
+    }
+
+    [Fact]
+    public void FormatRulerLabel_FractionalStep_EighthValue_ShowsDecimal()
+    {
+        Assert.Equal("0.125", PreviewControl.FormatRulerLabel(majorStep: 0.125f, worldValue: 0.125f));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes ruler labels becoming too sparse at high zoom levels (2000%+).

## Changes

**PreviewControl.cs**
- GetRulerStep: extended candidates to include 