### PR TITLE
fix(AE): About dialog centered on owner, version + repo link

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -620,20 +620,57 @@ public partial class MainWindow : Window
     private void OnSaveAsClick(object? sender, RoutedEventArgs e) =>
         _ = _appCommands.SaveCurrentAnimationChainListAsync();
 
+    internal const string GitHubUrl = "https://github.com/vchelaru/FlatRedBall2";
+
     private void OnAboutClick(object? sender, RoutedEventArgs e)
-    {
-        _ = new Window
+        => _ = BuildAboutWindow().ShowDialog(this);
+
+    /// <summary>
+    /// Returns a fully-configured About window centered on its owner.
+    /// Extracted for testability.
+    /// </summary>
+    internal static Window BuildAboutWindow() =>
+        new Window
         {
             Title = "About AnimationEditor",
-            Width = 320,
-            Height = 130,
-            Content = new TextBlock
+            Width = 420,
+            Height = 220,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Content = BuildAboutContent(),
+        };
+
+    /// <summary>
+    /// Builds the content panel for the About dialog.
+    /// Extracted for testability.
+    /// </summary>
+    internal static Control BuildAboutContent()
+    {
+        var ver = typeof(MainWindow).Assembly.GetName().Version;
+        var versionText = ver is null ? "unknown" : $"{ver.Major}.{ver.Minor}.{ver.Build}";
+
+        var linkButton = new Button { Content = GitHubUrl };
+        linkButton.Click += (_, _) =>
+        {
+            try
             {
-                Text = "AnimationEditor: Avalonia Port\n© FlatRedBall Contributors",
-                Margin = new Avalonia.Thickness(16),
-                TextWrapping = Avalonia.Media.TextWrapping.Wrap
+                Process.Start(new ProcessStartInfo(GitHubUrl) { UseShellExecute = true });
             }
-        }.ShowDialog(this);
+            catch { }
+        };
+
+        return new StackPanel
+        {
+            Margin = new Avalonia.Thickness(20),
+            Spacing = 8,
+            Children =
+            {
+                new TextBlock { Text = "AnimationEditor", FontSize = 16 },
+                new TextBlock { Text = $"Version {versionText}" },
+                new TextBlock { Text = "© FlatRedBall Contributors" },
+                linkButton,
+            }
+        };
     }
 
     // ── Preview controls wiring ───────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AboutDialogTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AboutDialogTests.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for the About dialog (issue #194): centered on owner,
+/// non-resizable, correct title, version number from assembly, and GitHub link.
+/// </summary>
+public class AboutDialogTests
+{
+    [AvaloniaFact]
+    public void BuildAboutContent_ContainsVersionTextBlock()
+    {
+        var panel = (StackPanel)MainWindow.BuildAboutContent();
+
+        var versionBlock = panel.Children
+            .OfType<TextBlock>()
+            .FirstOrDefault(tb => tb.Text?.StartsWith("Version") == true);
+
+        Assert.NotNull(versionBlock);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutContent_VersionText_MatchesThreePartFormat()
+    {
+        var panel = (StackPanel)MainWindow.BuildAboutContent();
+
+        var text = panel.Children
+            .OfType<TextBlock>()
+            .Select(tb => tb.Text)
+            .FirstOrDefault(t => t?.StartsWith("Version") == true);
+
+        Assert.Matches(new Regex(@"^Version \d+\.\d+\.\d+$"), text!);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutContent_ContainsGitHubLinkButton()
+    {
+        var panel = (StackPanel)MainWindow.BuildAboutContent();
+
+        var linkBtn = panel.Children
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Content?.ToString()?.Contains("github.com/vchelaru/FlatRedBall2") == true);
+
+        Assert.NotNull(linkBtn);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutWindow_HasCenterOwnerStartupLocation()
+    {
+        var window = MainWindow.BuildAboutWindow();
+
+        Assert.Equal(WindowStartupLocation.CenterOwner, window.WindowStartupLocation);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutWindow_IsNotResizable()
+    {
+        var window = MainWindow.BuildAboutWindow();
+
+        Assert.False(window.CanResize);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutWindow_HasCorrectTitle()
+    {
+        var window = MainWindow.BuildAboutWindow();
+
+        Assert.Equal("About AnimationEditor", window.Title);
+    }
+}


### PR DESCRIPTION
Fixes the three gaps in Help -> About:

1. **Floats off-screen** - added WindowStartupLocation.CenterOwner so the dialog always opens centered on the main window.
2. **Missing version** - reads typeof(MainWindow).Assembly.GetName().Version (Major.Minor.Build) and shows it as Version X.Y.Z.
3. **Missing repo link** - a Button labeled with the GitHub URL opens the default browser via Process.Start(UseShellExecute=true), wrapped in try/catch so a shell failure cannot crash the dialog.

Also sets CanResize = false and enlarges the window slightly (420x220) to give the new content room.

### Tests

6 new [AvaloniaFact] tests in AboutDialogTests.cs covering:
- Version TextBlock present
- Version text matches Version d+.d+.d+
- GitHub link button present
- WindowStartupLocation.CenterOwner
- CanResize == false
- Title == About AnimationEditor

All 1172 tests pass.

Closes #194