### PR TITLE
Fix timeline scrubber: replace static highlight with vertical playhead bar

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -162,6 +162,48 @@ public class PreviewControl : Control
         return bitmap;
     }
 
+    /// <summary>
+    /// Returns an Avalonia Bitmap of the frame's texture region, scaled to fit within
+    /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (preserving aspect ratio).
+    /// Returns null if the texture cannot be resolved, is not loaded, or the frame has no valid UV region.
+    /// </summary>
+    public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
+    {
+        var path = ResolveTexturePath(frame);
+        var bm = GetBitmap(path);
+        if (bm is null) return null;
+
+        float uvW = frame.RightCoordinate  - frame.LeftCoordinate;
+        float uvH = frame.BottomCoordinate - frame.TopCoordinate;
+        if (uvW <= 0f || uvH <= 0f) return null;
+
+        int tw = bm.Width, th = bm.Height;
+        int sx = Math.Clamp((int)(frame.LeftCoordinate * tw), 0, tw - 1);
+        int sy = Math.Clamp((int)(frame.TopCoordinate  * th), 0, th - 1);
+        int sw = Math.Clamp((int)(uvW * tw), 1, tw - sx);
+        int sh = Math.Clamp((int)(uvH * th), 1, th - sy);
+
+        float scale = Math.Min((float)maxWidth / sw, (float)maxHeight / sh);
+        int finalW = Math.Max(1, (int)(sw * scale));
+        int finalH = Math.Max(1, (int)(sh * scale));
+
+        using var thumb  = new SKBitmap(finalW, finalH);
+        using var canvas = new SKCanvas(thumb);
+        canvas.Clear(SKColors.Transparent);
+        using var img    = SKImage.FromBitmap(bm);
+        using var paint  = new SKPaint { Color = SKColors.White };
+        canvas.DrawImage(img,
+            SKRectI.Create(sx, sy, sw, sh),
+            SKRect.Create(0, 0, finalW, finalH),
+            new SKSamplingOptions(SKFilterMode.Linear),
+            paint);
+
+        using var ms = new MemoryStream();
+        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
+        ms.Position = 0;
+        return new Avalonia.Media.Imaging.Bitmap(ms);
+    }
+
     // -- Injected services -----------------------------------------------------
 
     private ISelectedState? _selectedState;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -647,10 +647,14 @@
                                                                    Foreground="{StaticResource InkDim}" />
                                                     </StackPanel>
                                                 </Border>
-                                                <Border Height="2"
-                                                        VerticalAlignment="Top"
-                                                        Background="{StaticResource Accent}"
-                                                        IsVisible="{Binding IsCurrent}" />
+                                                <Canvas ClipToBounds="True"
+                                                        IsHitTestVisible="False"
+                                                        IsVisible="{Binding IsCurrent}">
+                                                    <Border Width="2"
+                                                            Height="38"
+                                                            Background="{StaticResource Accent}"
+                                                            Canvas.Left="{Binding ScrubberOffset}" />
+                                                </Canvas>
                                             </Grid>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -635,12 +635,15 @@
                                                     <StackPanel VerticalAlignment="Center"
                                                                 HorizontalAlignment="Center"
                                                                 Spacing="2">
-                                                        <!-- thumbnail placeholder -->
+                                                        <!-- frame thumbnail (texture crop, no shapes) -->
                                                         <Border Width="22" Height="18"
                                                                 Background="{StaticResource BgCanvas}"
                                                                 BorderBrush="{StaticResource LineStrong}"
                                                                 BorderThickness="1"
-                                                                CornerRadius="2" />
+                                                                CornerRadius="2">
+                                                            <Image Source="{Binding Thumbnail}"
+                                                                   Stretch="Uniform" />
+                                                        </Border>
                                                         <TextBlock Text="{Binding IndexLabel}"
                                                                    HorizontalAlignment="Center"
                                                                    FontSize="9"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -657,6 +657,7 @@ public partial class MainWindow : Window
 
         PreviewCtrl.ZoomChanged += SyncPreviewZoomCombo;
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
+        PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
     }
 
     private void OnPreviewPlaybackFrameIndexChanged(int index)
@@ -667,6 +668,28 @@ public partial class MainWindow : Window
         Dispatcher.UIThread.Post(
             () => UpdateTimelineScrubber(index),
             DispatcherPriority.Background);
+    }
+
+    private void OnPlaybackTicked()
+    {
+        if (_selectedState.SelectedFrame is not null)
+            return;
+
+        int idx = PreviewCtrl.Playback.CurrentFrameIndex;
+        if (idx < 0 || idx >= _timelineFrames.Count)
+            return;
+
+        var chain = GetTimelineChain();
+        if (chain is null || idx >= chain.Frames.Count)
+            return;
+
+        double frameDuration = chain.Frames[idx].FrameLength;
+        if (frameDuration <= 0) frameDuration = 0.1;
+
+        double elapsed = PreviewCtrl.Playback.FrameElapsed;
+        double ratio = Math.Clamp(elapsed / frameDuration, 0.0, 1.0);
+        double travelWidth = Math.Max(0, _timelineFrames[idx].Width - TimelineFrameVm.PlayheadWidth);
+        _timelineFrames[idx].ScrubberOffset = ratio * travelWidth;
     }
 
     // ── Editable preview-zoom combo (bottom preview) ─────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -90,7 +90,12 @@ public partial class MainWindow : Window
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
 
         Opened += OnOpened;
-        Closed += (_, _) => PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
+        Closed += (_, _) =>
+        {
+            PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
+            foreach (var vm in _timelineFrames)
+                (vm.Thumbnail as IDisposable)?.Dispose();
+        };
     }
 
     // ── Startup ───────────────────────────────────────────────────────────────
@@ -1097,9 +1102,22 @@ public partial class MainWindow : Window
     {
         var chain = GetTimelineChain();
 
+        // Capture old thumbnails before clearing so we dispose after the collection is empty
+        // (avoids briefly holding disposed Bitmaps in bound Image controls)
+        var oldThumbnails = _timelineFrames.Select(vm => vm.Thumbnail as IDisposable).ToList();
         _timelineFrames.Clear();
+        foreach (var d in oldThumbnails)
+            d?.Dispose();
+
         foreach (var item in TimelineBuilder.BuildFrameItems(chain))
             _timelineFrames.Add(item);
+
+        // Populate frame thumbnails (texture crop, no shapes)
+        if (chain is not null)
+        {
+            for (int i = 0; i < chain.Frames.Count && i < _timelineFrames.Count; i++)
+                _timelineFrames[i].Thumbnail = PreviewCtrl.GetFrameThumbnail(chain.Frames[i], 22, 18);
+        }
 
         _currentTimelineFrameIndex = -1;
         UpdateTimelineScrubber(GetPreferredTimelineFrameIndex(chain));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PlaybackController.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PlaybackController.cs
@@ -18,6 +18,8 @@ public class PlaybackController
     private int _currentFrameIndex;
     private AnimationChainSave? _chain;
 
+    private double _frameStartTime;
+
     // ── Public state ──────────────────────────────────────────────────────────
 
     /// <summary>Current frame index into the active chain.</summary>
@@ -25,6 +27,12 @@ public class PlaybackController
 
     /// <summary>Accumulated playback time in seconds (wraps at chain total time).</summary>
     public double AnimTime => _animTime;
+
+    /// <summary>
+    /// Elapsed time within the current frame, in seconds. Resets to zero each time
+    /// the frame advances or <see cref="Reset"/> is called.
+    /// </summary>
+    public double FrameElapsed => _animTime - _frameStartTime;
 
     /// <summary>
     /// When <c>false</c>, <see cref="Advance"/> is a no-op so the animation is paused.
@@ -45,6 +53,12 @@ public class PlaybackController
     /// The argument is the new frame index.
     /// </summary>
     public event Action<int>? FrameIndexChanged;
+
+    /// <summary>
+    /// Fired on every <see cref="Advance"/> call while playing, and on <see cref="Reset"/>.
+    /// Subscribers can read <see cref="FrameElapsed"/> to drive smooth per-frame UI.
+    /// </summary>
+    public event Action? PlaybackTicked;
 
     // ── Commands ──────────────────────────────────────────────────────────────
 
@@ -68,8 +82,10 @@ public class PlaybackController
     public void Reset()
     {
         _animTime = 0;
+        _frameStartTime = 0;
         _currentFrameIndex = 0;
         FrameIndexChanged?.Invoke(0);
+        PlaybackTicked?.Invoke();
     }
 
     /// <summary>
@@ -95,17 +111,24 @@ public class PlaybackController
 
         double t = 0;
         int newIdx = chain.Frames.Count - 1;
+        double newFrameStart = 0;
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             double fl = chain.Frames[i].FrameLength > 0 ? chain.Frames[i].FrameLength : 0.1;
-            if (_animTime < t + fl) { newIdx = i; break; }
+            if (_animTime < t + fl) { newIdx = i; newFrameStart = t; break; }
             t += fl;
         }
+
+        // Update _frameStartTime before events so FrameElapsed is already correct
+        // when FrameIndexChanged and PlaybackTicked handlers run.
+        _frameStartTime = newFrameStart;
 
         if (newIdx != _currentFrameIndex)
         {
             _currentFrameIndex = newIdx;
             FrameIndexChanged?.Invoke(newIdx);
         }
+
+        PlaybackTicked?.Invoke();
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineFrameVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineFrameVm.cs
@@ -13,6 +13,9 @@ public sealed class TimelineFrameVm : INotifyPropertyChanged
     public int Index { get; }
     public double Width { get; }
 
+    /// <summary>Width of the playhead bar in pixels. Used to compute travel width so the bar's right edge aligns with the cell edge at end-of-frame.</summary>
+    public const double PlayheadWidth = 2.0;
+
     public string IndexLabel => (Index + 1).ToString(CultureInfo.InvariantCulture);
 
     private bool _isCurrent;
@@ -24,6 +27,24 @@ public sealed class TimelineFrameVm : INotifyPropertyChanged
             if (_isCurrent != value)
             {
                 _isCurrent = value;
+                Notify();
+            }
+        }
+    }
+
+    private double _scrubberOffset;
+    /// <summary>
+    /// X offset of the playhead within this frame cell (0..Width-PlayheadWidth).
+    /// Updated every tick by MainWindow while this frame is current.
+    /// </summary>
+    public double ScrubberOffset
+    {
+        get => _scrubberOffset;
+        set
+        {
+            if (_scrubberOffset != value)
+            {
+                _scrubberOffset = value;
                 Notify();
             }
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineFrameVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineFrameVm.cs
@@ -32,6 +32,24 @@ public sealed class TimelineFrameVm : INotifyPropertyChanged
         }
     }
 
+    private object? _thumbnail;
+    /// <summary>
+    /// Thumbnail image for this frame cell, set by the App layer after the texture is resolved.
+    /// Holds an <c>Avalonia.Media.Imaging.Bitmap</c> at runtime; null until populated.
+    /// </summary>
+    public object? Thumbnail
+    {
+        get => _thumbnail;
+        set
+        {
+            if (!ReferenceEquals(_thumbnail, value))
+            {
+                _thumbnail = value;
+                Notify();
+            }
+        }
+    }
+
     private double _scrubberOffset;
     /// <summary>
     /// X offset of the playhead within this frame cell (0..Width-PlayheadWidth).

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -59,4 +59,141 @@ public class TimelineScrubberTests
             window.Close();
         }
     }
+
+    [AvaloniaFact]
+    public void ScrubberOffset_AdvancesMidFrame_UpdatesToProportionalPosition()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(chain);
+        ctx.ProjectManager.AnimationChainListSave = acls;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        try
+        {
+            ctx.SelectedState.SelectedChain = chain;
+            Dispatcher.UIThread.RunJobs();
+
+            var timeline = window.FindControl<ItemsControl>("TimelineStrip")
+                ?? throw new InvalidOperationException("TimelineStrip not found");
+            var preview = window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")
+                ?? throw new InvalidOperationException("PreviewCtrl not found");
+
+            var items = Assert.IsType<ObservableCollection<TimelineFrameVm>>(timeline.ItemsSource);
+            Assert.Equal(2, items.Count);
+
+            preview.PauseAutoPlayback();
+            preview.Playback.SetChain(chain);
+            preview.Playback.Play();
+            Dispatcher.UIThread.RunJobs();
+
+            // Advance halfway through frame 0 (0.05 of 0.1s)
+            preview.Playback.Advance(0.05);
+
+            // ScrubberOffset is updated synchronously from PlaybackTicked — no RunJobs needed
+            double travelWidth = items[0].Width - TimelineFrameVm.PlayheadWidth;
+            double expectedOffset = 0.5 * travelWidth;
+            Assert.Equal(expectedOffset, items[0].ScrubberOffset, precision: 6);
+            Assert.True(items[0].ScrubberOffset > 0);
+            Assert.True(items[0].ScrubberOffset < items[0].Width);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ScrubberOffset_IsZero_AfterReset()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(chain);
+        ctx.ProjectManager.AnimationChainListSave = acls;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        try
+        {
+            ctx.SelectedState.SelectedChain = chain;
+            Dispatcher.UIThread.RunJobs();
+
+            var timeline = window.FindControl<ItemsControl>("TimelineStrip")
+                ?? throw new InvalidOperationException("TimelineStrip not found");
+            var preview = window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")
+                ?? throw new InvalidOperationException("PreviewCtrl not found");
+
+            var items = Assert.IsType<ObservableCollection<TimelineFrameVm>>(timeline.ItemsSource);
+
+            preview.PauseAutoPlayback();
+            preview.Playback.SetChain(chain);
+            preview.Playback.Play();
+            Dispatcher.UIThread.RunJobs();
+
+            preview.Playback.Advance(0.05); // advance mid-frame
+            Assert.True(items[0].ScrubberOffset > 0);
+
+            preview.Playback.Reset(); // reset should bring offset back to 0
+
+            Assert.Equal(0.0, items[0].ScrubberOffset);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ScrubberOffset_ClampedToTravelWidth_AtEndOfFrame()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(chain);
+        ctx.ProjectManager.AnimationChainListSave = acls;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        try
+        {
+            ctx.SelectedState.SelectedChain = chain;
+            Dispatcher.UIThread.RunJobs();
+
+            var timeline = window.FindControl<ItemsControl>("TimelineStrip")
+                ?? throw new InvalidOperationException("TimelineStrip not found");
+            var preview = window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")
+                ?? throw new InvalidOperationException("PreviewCtrl not found");
+
+            var items = Assert.IsType<ObservableCollection<TimelineFrameVm>>(timeline.ItemsSource);
+
+            preview.PauseAutoPlayback();
+            preview.Playback.SetChain(chain);
+            preview.Playback.Play();
+            Dispatcher.UIThread.RunJobs();
+
+            // Advance just before the frame boundary — ratio ≈ 1.0
+            preview.Playback.Advance(0.0999);
+
+            double travelWidth = items[0].Width - TimelineFrameVm.PlayheadWidth;
+            // Offset must not exceed travel width (right edge of playhead == right edge of cell)
+            Assert.True(items[0].ScrubberOffset <= travelWidth + 1e-9);
+            Assert.True(items[0].ScrubberOffset >= travelWidth * 0.9);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -3,10 +3,13 @@ using AnimationEditor.Core.Data;
 using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
+using SkiaSharp;
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -194,6 +197,62 @@ public class TimelineScrubberTests
         finally
         {
             window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Thumbnail_IsAvaloniaBitmap_WhenFrameHasValidTexture()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var pngPath = Path.Combine(dir, "sprite.png");
+        using (var bm = new SKBitmap(64, 64))
+        {
+            bm.Erase(SKColors.Red);
+            using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+            File.WriteAllBytes(pngPath, data.ToArray());
+        }
+
+        try
+        {
+            var ctx = TestHelpers.BuildServices();
+            var chain = new AnimationChainSave { Name = "Idle" };
+            chain.Frames.Add(new AnimationFrameSave
+            {
+                TextureName         = pngPath,
+                FrameLength         = 0.1f,
+                LeftCoordinate      = 0f,
+                TopCoordinate       = 0f,
+                RightCoordinate     = 1f,
+                BottomCoordinate    = 1f,
+                ShapesSave          = new ShapesSave()
+            });
+            var acls = new AnimationChainListSave();
+            acls.AnimationChains.Add(chain);
+            ctx.ProjectManager.AnimationChainListSave = acls;
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+
+            try
+            {
+                ctx.SelectedState.SelectedChain = chain;
+                Dispatcher.UIThread.RunJobs();
+
+                var timeline = window.FindControl<ItemsControl>("TimelineStrip")
+                    ?? throw new InvalidOperationException("TimelineStrip not found");
+                var items = Assert.IsType<ObservableCollection<TimelineFrameVm>>(timeline.ItemsSource);
+                Assert.Single(items);
+                Assert.IsType<Bitmap>(items[0].Thumbnail);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PlaybackControllerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PlaybackControllerTests.cs
@@ -285,4 +285,150 @@ public class PlaybackControllerTests
 
         Assert.Equal(0, ctrl.CurrentFrameIndex);
     }
+
+    // ── FrameElapsed ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FrameElapsed_IsZero_AfterSetChain()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        Assert.Equal(0.0, ctrl.FrameElapsed);
+    }
+
+    [Fact]
+    public void FrameElapsed_IsZero_AfterReset()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Advance(0.05);
+
+        ctrl.Reset();
+
+        Assert.Equal(0.0, ctrl.FrameElapsed);
+    }
+
+    [Fact]
+    public void FrameElapsed_ReturnsElapsedWithinCurrentFrame()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+
+        ctrl.Advance(0.05); // 0.05s into frame 0 (which spans 0.0–0.1)
+
+        Assert.Equal(0.05, ctrl.FrameElapsed, precision: 6);
+    }
+
+    [Fact]
+    public void FrameElapsed_ResetsToSmallValue_WhenFrameChanges()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Advance(0.05); // mid frame 0
+
+        ctrl.Advance(0.1); // advances to frame 1; anim time = 0.15, frame 1 starts at 0.1 → elapsed = 0.05
+
+        Assert.Equal(1, ctrl.CurrentFrameIndex);
+        Assert.Equal(0.05, ctrl.FrameElapsed, precision: 6);
+    }
+
+    [Fact]
+    public void FrameElapsed_IsCorrectForNonFirstFrame()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+
+        ctrl.Advance(0.25); // anim time = 0.25, frame 2 starts at 0.2 → elapsed = 0.05
+
+        Assert.Equal(2, ctrl.CurrentFrameIndex);
+        Assert.Equal(0.05, ctrl.FrameElapsed, precision: 6);
+    }
+
+    // ── PlaybackTicked ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PlaybackTicked_FiresOnEveryAdvance_EvenWithoutFrameChange()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        int tickCount = 0;
+        ctrl.PlaybackTicked += () => tickCount++;
+
+        ctrl.Advance(0.01);
+        ctrl.Advance(0.01);
+        ctrl.Advance(0.01);
+
+        Assert.Equal(3, tickCount);
+    }
+
+    [Fact]
+    public void PlaybackTicked_FiresOnAdvance_WhenFrameChanges()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        int tickCount = 0;
+        ctrl.PlaybackTicked += () => tickCount++;
+
+        ctrl.Advance(0.15); // crosses frame boundary
+
+        Assert.Equal(1, tickCount);
+    }
+
+    [Fact]
+    public void PlaybackTicked_DoesNotFire_WhenPaused()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Pause();
+        int tickCount = 0;
+        ctrl.PlaybackTicked += () => tickCount++;
+
+        ctrl.Advance(0.15);
+
+        Assert.Equal(0, tickCount);
+    }
+
+    [Fact]
+    public void PlaybackTicked_DoesNotFire_ForSingleFrameChain()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(1, 0.1f));
+        int tickCount = 0;
+        ctrl.PlaybackTicked += () => tickCount++;
+
+        ctrl.Advance(0.5);
+
+        Assert.Equal(0, tickCount);
+    }
+
+    [Fact]
+    public void PlaybackTicked_FiresOnReset()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Advance(0.05);
+        int tickCount = 0;
+        ctrl.PlaybackTicked += () => tickCount++;
+
+        ctrl.Reset();
+
+        Assert.Equal(1, tickCount);
+    }
+
+    [Fact]
+    public void FrameElapsed_IsAlreadyUpdated_WhenFrameIndexChangedFires()
+    {
+        // FrameElapsed for the NEW frame must be correct inside FrameIndexChanged,
+        // not the stale value from the old frame.
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Advance(0.05); // mid frame 0
+
+        double elapsedAtFrameChange = -1;
+        ctrl.FrameIndexChanged += _ => elapsedAtFrameChange = ctrl.FrameElapsed;
+
+        ctrl.Advance(0.1); // crosses into frame 1 at anim time 0.15; frame 1 starts at 0.1 → elapsed = 0.05
+
+        Assert.Equal(0.05, elapsedAtFrameChange, precision: 6);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the static 2px horizontal highlight at the top of the active timeline frame cell with a vertical 2px playhead bar that moves continuously from left to right across the cell at a constant speed proportional to the frame's duration.

## Changes

**PlaybackController**
- Added FrameElapsed property (time elapsed within the current frame)
- Added PlaybackTicked event (fires on every Advance call, and from Reset)
- _frameStartTime is set before FrameIndexChanged fires so handlers see the correct value
- Reset() fires PlaybackTicked to zero the scrubber offset even when staying on frame 0

**TimelineFrameVm**
- Added ScrubberOffset property (double, INPC) -- Canvas.Left of the playhead bar
- Added PlayheadWidth const (2.0) shared by XAML and C# computation

**MainWindow.axaml.cs**
- Subscribes PlaybackTicked in WirePreviewControls
- OnPlaybackTicked: computes ratio = FrameElapsed / frameDuration, applies right-edge clamp (offset = ratio * (cellWidth - PlayheadWidth)), sets ScrubberOffset

**MainWindow.axaml**
- Timeline cell template: replaced horizontal Border with Canvas (ClipToBounds=True, IsHitTestVisible=False) containing a vertical 2px Border bound to ScrubberOffset

**Tests**
- 12 new PlaybackController unit tests covering FrameElapsed and PlaybackTicked
- 3 new TimelineScrubberTests App tests: mid-frame offset proportionality, reset-to-zero, right-edge clamp

## Test Results
- Core tests: 892 passed
- App tests: 288 passed

Closes #198