### PR TITLE
fix(AE): preserve tree collapse state across copy/paste and reorder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1051,21 +1051,11 @@ public partial class MainWindow : Window
         try
         {
             var acls = _projectManager.AnimationChainListSave;
+            if (acls is null) { _treeRoots.Clear(); return; }
 
-            // Preserve expanded chain names before clearing
-            var expanded = TreeBuilder.GetExpandedChainNames(_treeRoots).ToHashSet();
-
-            _treeRoots.Clear();
-
-            if (acls is null) return;
-
-            foreach (var chain in acls.AnimationChains)
-            {
-                var node = TreeBuilder.BuildChainNode(chain);
-                // Restore expand state — keep true if no prior state recorded yet
-                node.IsExpanded = expanded.Count == 0 || expanded.Contains(chain.Name);
-                _treeRoots.Add(node);
-            }
+            // Diff-update the root nodes instead of clearing and rebuilding, so each
+            // chain's collapse state (and selection) survives copy/paste and reorder.
+            TreeBuilder.SyncChainsInto(_treeRoots, acls.AnimationChains);
 
             // Re-select to keep visual state
             SyncTreeSelection();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using FlatRedBall2.Animation.Content;
@@ -229,6 +230,60 @@ public static class TreeBuilder
             children[i].Header = BuildFrameHeader(target, i);
             children[i].Meta   = $"{target.FrameLength:0.00}s";
             SyncShapesInto(children[i], target.ShapesSave);
+        }
+    }
+
+    /// <summary>
+    /// Diff-updates the root chain nodes in <paramref name="roots"/> to match
+    /// <paramref name="chains"/> without replacing existing <see cref="TreeNodeVm"/>
+    /// instances.  Retained chain VMs keep their <see cref="TreeNodeVm.IsExpanded"/>
+    /// state (and Avalonia's TreeView keeps them selected, since selection uses object
+    /// identity); their <see cref="TreeNodeVm.Header"/> and <see cref="TreeNodeVm.Meta"/>
+    /// are resynced and their frame children are diff-updated via
+    /// <see cref="SyncFramesInto"/>.  New chains get a freshly-built node (expanded by
+    /// default, per <see cref="BuildChainNode"/>); VMs for removed chains are deleted.
+    /// <para>
+    /// This is the chain-level counterpart of <see cref="SyncFramesInto"/>: it lets
+    /// copy/paste and reorder preserve each chain's collapse state instead of
+    /// rebuilding the whole tree and re-expanding everything.
+    /// </para>
+    /// </summary>
+    public static void SyncChainsInto(
+        ObservableCollection<TreeNodeVm> roots,
+        IList<AnimationChainSave> chains)
+    {
+        // Step 1: Remove root VMs whose chain is no longer in the list.
+        var chainSet = new HashSet<AnimationChainSave>(chains, ReferenceEqualityComparer.Instance);
+        for (int i = roots.Count - 1; i >= 0; i--)
+            if (roots[i].Data is AnimationChainSave c && !chainSet.Contains(c))
+                roots.RemoveAt(i);
+
+        // Build a lookup of surviving VMs keyed by chain reference.
+        var existingByChain = new Dictionary<AnimationChainSave, TreeNodeVm>(
+            ReferenceEqualityComparer.Instance);
+        foreach (var root in roots)
+            if (root.Data is AnimationChainSave c)
+                existingByChain[c] = root;
+
+        // Step 2: Append new VMs for chains not yet represented (step 3 reorders them).
+        foreach (var chain in chains)
+            if (!existingByChain.ContainsKey(chain))
+                roots.Add(BuildChainNode(chain));
+
+        // Step 3: Reorder to match the target chain order, then resync each retained
+        //         node's Header/Meta and diff-update its frame children.
+        for (int i = 0; i < chains.Count; i++)
+        {
+            var target = chains[i];
+            if (!ReferenceEquals(roots[i].Data, target))
+            {
+                for (int j = i + 1; j < roots.Count; j++)
+                    if (ReferenceEquals(roots[j].Data, target))
+                    { roots.Move(j, i); break; }
+            }
+            roots[i].Header = target.Name;
+            roots[i].Meta   = $"{target.Frames.Count} fr";
+            SyncFramesInto(roots[i], target.Frames);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -839,6 +839,38 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
+    public void MoveChain_PreservesChainCollapseState()
+    {
+        // Regression (#237): reordering chains rebuilt the whole tree and re-expanded
+        // every chain. MoveChain must leave each chain's collapse state untouched.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chainA = new AnimationChainSave { Name = "Walk" };
+            var chainB = new AnimationChainSave { Name = "Run" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainA);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainB);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var roots = GetRoots(GetTree(window));
+            var chainAVm = roots[0];
+            chainAVm.IsExpanded = false;  // user collapses "Walk"
+
+            ctx.AppCommands.MoveChain(chainA, +1);
+            Dispatcher.UIThread.RunJobs();
+
+            // Same VM instance moved to index 1, still collapsed.
+            Assert.Same(chainAVm, roots[1]);
+            Assert.False(chainAVm.IsExpanded);
+            // The other chain keeps its (default expanded) state.
+            Assert.True(roots[0].IsExpanded);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void MoveFrame_PreservesFrameVmIdentityAndSelection()
     {
         var (window, ctx) = CreateWindow();
@@ -907,6 +939,37 @@ public class HeadlessTreeViewTests
 
             var roots = GetRoots(GetTree(window));
             Assert.Equal("0.55s", roots[0].Children[0].Meta);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTreeView_AfterChainAdded_PreservesExistingCollapseState()
+    {
+        // Regression (#237): copy/paste appends a chain then calls RefreshTreeView.
+        // The full rebuild re-expanded every pre-existing chain. RefreshTreeView
+        // must preserve the collapse state of chains that already had a tree node.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var existing = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(existing);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var roots = GetRoots(GetTree(window));
+            roots[0].IsExpanded = false;  // user collapses "Walk"
+
+            // Simulate the paste path: a new chain is appended, then the tree refreshes.
+            var pasted = new AnimationChainSave { Name = "Walk2" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(pasted);
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(roots[0].IsExpanded);   // pre-existing chain stays collapsed
+            Assert.Same(pasted, roots[1].Data);
+            Assert.True(roots[1].IsExpanded);    // pasted chain defaults to expanded
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core.ViewModels;
 using FlatRedBall2.Animation.Content;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Xunit;
 
@@ -273,6 +274,99 @@ public class TreeBuilderPureTests
         var unrelated = new AnimationChainSave { Name = "Y" };
 
         Assert.Null(TreeBuilder.FindNodeForData(roots, unrelated));
+    }
+
+    // ── SyncChainsInto ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SyncChainsInto_AddedChain_InsertsExpandedVm()
+    {
+        // Regression (#237): a pasted chain is new — it gets the default expanded
+        // state, while the pre-existing collapsed chain keeps its state.
+        var existing = new AnimationChainSave { Name = "Walk" };
+        var roots = new ObservableCollection<TreeNodeVm> { TreeBuilder.BuildChainNode(existing) };
+        roots[0].IsExpanded = false;  // user collapsed the existing chain
+        var pasted = new AnimationChainSave { Name = "Walk2" };
+
+        TreeBuilder.SyncChainsInto(roots, new[] { existing, pasted });
+
+        Assert.Equal(2, roots.Count);
+        Assert.False(roots[0].IsExpanded);   // pre-existing chain stays collapsed
+        Assert.Same(pasted, roots[1].Data);
+        Assert.True(roots[1].IsExpanded);    // new chain defaults to expanded
+    }
+
+    [Fact]
+    public void SyncChainsInto_RemovedChain_DropsVm()
+    {
+        var chainA = new AnimationChainSave { Name = "Walk" };
+        var chainB = new AnimationChainSave { Name = "Run" };
+        var roots = new ObservableCollection<TreeNodeVm>
+        {
+            TreeBuilder.BuildChainNode(chainA),
+            TreeBuilder.BuildChainNode(chainB),
+        };
+
+        TreeBuilder.SyncChainsInto(roots, new[] { chainB });
+
+        Assert.Single(roots);
+        Assert.Same(chainB, roots[0].Data);
+    }
+
+    [Fact]
+    public void SyncChainsInto_Reorder_PreservesIsExpanded()
+    {
+        // Regression (#237): reordering chains must not re-expand a collapsed chain.
+        var chainA = new AnimationChainSave { Name = "Walk" };
+        var chainB = new AnimationChainSave { Name = "Run" };
+        var roots = new ObservableCollection<TreeNodeVm>
+        {
+            TreeBuilder.BuildChainNode(chainA),
+            TreeBuilder.BuildChainNode(chainB),
+        };
+        roots[0].IsExpanded = false;  // user collapsed "Walk"
+        var vmA = roots[0];
+
+        TreeBuilder.SyncChainsInto(roots, new[] { chainB, chainA });
+
+        Assert.False(vmA.IsExpanded);
+    }
+
+    [Fact]
+    public void SyncChainsInto_Reorder_ReusesExistingChainVm()
+    {
+        var chainA = new AnimationChainSave { Name = "Walk" };
+        var chainB = new AnimationChainSave { Name = "Run" };
+        var roots = new ObservableCollection<TreeNodeVm>
+        {
+            TreeBuilder.BuildChainNode(chainA),
+            TreeBuilder.BuildChainNode(chainB),
+        };
+        var originalVmA = roots[0];
+        var originalVmB = roots[1];
+
+        TreeBuilder.SyncChainsInto(roots, new[] { chainB, chainA });
+
+        Assert.Same(originalVmA, roots[1]);
+        Assert.Same(originalVmB, roots[0]);
+    }
+
+    [Fact]
+    public void SyncChainsInto_RetainedChain_RefreshesHeaderMetaAndSyncsFrames()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var roots = new ObservableCollection<TreeNodeVm> { TreeBuilder.BuildChainNode(chain) };
+
+        // Mutate the data model the way a rename + add-frame would.
+        chain.Name = "Walk Renamed";
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+
+        TreeBuilder.SyncChainsInto(roots, new[] { chain });
+
+        Assert.Equal("Walk Renamed", roots[0].Header);
+        Assert.Equal("1 fr", roots[0].Meta);
+        Assert.Single(roots[0].Children);
+        Assert.Equal("a.png", roots[0].Children[0].Header);
     }
 
     // ── SyncFramesInto ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In the Animation Editor tree view, the expand/collapse state of each `AnimationChainSave` node was lost after copy/pasting a chain or reordering chains — **all** chains ended up expanded regardless of their prior state (#237).

## Root cause

`MainWindow.RefreshTreeView()` cleared `_treeRoots` and rebuilt every chain node from scratch via `TreeBuilder.BuildChainNode`, which hard-codes `IsExpanded = true`. Its attempt to snapshot/restore expanded names was unreliable (the `IsExpanded` two-way binding lives in a low-priority `Style` setter, and an empty snapshot re-expanded everything). Copy/paste and all `MoveChain*` reorder commands route through `RefreshTreeView`, so both lost collapse state.

## Fix

Adds `TreeBuilder.SyncChainsInto` — the chain-level counterpart of the existing `SyncFramesInto` (commit `a10d401`, "diff-update frame children to preserve tree selection and expand state"). It diff-updates the root nodes **in place**:

- Existing chain VMs are retained — keeping their `IsExpanded` state and Avalonia's identity-based selection — and reordered with `Move`.
- VMs for removed chains are dropped.
- New chains (e.g. the pasted copy) get a freshly built node, expanded by default.
- Retained nodes have their `Header`/`Meta` resynced and frame children diff-updated via `SyncFramesInto`.

`RefreshTreeView` now calls `SyncChainsInto` instead of clear-and-rebuild, which fixes the bug for every chain-level mutation that routes through it (copy/paste, reorder, add/delete chain).

`TreeBuilder.GetExpandedChainNames` is left in place — it is still covered by tests and is intended for future `AESettingsSave.ExpandedNodes` session persistence (out of scope here).

## Tests

Test-first (red→green confirmed):
- **Core** — 5 `SyncChainsInto` tests in `TreeBuilderTests.cs` (reorder reuses VMs / preserves `IsExpanded` / matches order, added chain inserts an expanded VM, removed chain drops its VM, retained chain resyncs header/meta/frames).
- **App (headless)** — `MoveChain_PreservesChainCollapseState` and `RefreshTreeView_AfterChainAdded_PreservesExistingCollapseState` in `HeadlessTreeViewTests.cs`, exercising the reorder and paste-shaped flows end-to-end. Both confirmed failing against the old `RefreshTreeView`.

Full suite green: 897 Core + 297 App tests pass.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
