### PR TITLE
fix(AE): double-clicking a frame centers on it instead of renaming

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1293,7 +1293,6 @@ public partial class MainWindow : Window
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddSeparator();
-            AddMenuItem("Rename (texture path)", () => BeginInlineRenameSelected(frame2));
             AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame2));
             AddSeparator();
             AddMenuItem("Delete Frame", () =>
@@ -2580,13 +2579,12 @@ public partial class MainWindow : Window
         await ShowMessageAsync($"Resized texture saved to:\n{newAbsPath}");
     }
 
-    // ── Rename Chain / Frame ──────────────────────────────────────────────────
-
     // ── Inline rename helpers ─────────────────────────────────────────────────
 
     /// <summary>
-    /// Double-tap on the text label of a tree node → inline rename.
-    /// Marks the event handled so it does not bubble to <see cref="OnAnimTreeDoubleTapped"/>.
+    /// Double-tap on the text label of a tree node. Marks the event handled so it does
+    /// not bubble to <see cref="OnAnimTreeDoubleTapped"/>, then routes the gesture
+    /// through <see cref="HandleHeaderTextDoubleTap"/>.
     /// </summary>
     private void OnHeaderTextDoubleTapped(object? sender, TappedEventArgs e)
     {
@@ -2594,12 +2592,19 @@ public partial class MainWindow : Window
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (tvi?.DataContext is not TreeNodeVm vm) return;
         e.Handled = true;
-
-        if (vm.Data is AnimationChainSave chain)
-            BeginInlineRename(vm, chain.Name);
-        else if (vm.Data is AnimationFrameSave)
-            BeginInlineRename(vm, vm.Header);
+        HandleHeaderTextDoubleTap(vm);
     }
+
+    /// <summary>
+    /// Routes a double-tap on a tree node's text <em>label</em>. A chain inline-renames
+    /// (its name is meaningful and used to look the chain up); every other node type —
+    /// frame, rect, circle — routes to <see cref="HandleAnimTreeNodeDoubleTap"/>, so a
+    /// frame centers the wireframe on itself. <see cref="AnimationFrameSave.Name"/> is
+    /// only a tree display label and is not referenced anywhere else, so the more useful
+    /// center-on-frame gesture wins the text-label real estate over an inline rename.
+    /// </summary>
+    internal void HandleHeaderTextDoubleTap(TreeNodeVm vm)
+        => HandleAnimTreeNodeDoubleTap(vm);
 
     /// <summary>
     /// Double-tap on blank space in a tree row (not the text label, not a Button) →
@@ -2694,68 +2699,18 @@ public partial class MainWindow : Window
         BeginInlineRename(vm, chain.Name);
     }
 
-    private void BeginInlineRenameSelected(AnimationFrameSave frame)
-    {
-        var vm = TreeBuilder.FindNodeForData(_treeRoots, frame);
-        if (vm is null) return;
-        BeginInlineRename(vm, vm.Header);
-    }
-
     private void CommitInlineRename(TreeNodeVm vm, string newName)
     {
         newName = newName.Trim();
         vm.IsEditing = false;
 
-        if (vm.Data is AnimationChainSave chain)
+        if (vm.Data is AnimationChainSave chain &&
+            !string.IsNullOrEmpty(newName) && newName != chain.Name)
         {
-            if (!string.IsNullOrEmpty(newName) && newName != chain.Name)
-                _appCommands.RenameChain(chain, newName);
-        }
-        else if (vm.Data is AnimationFrameSave frame)
-        {
-            // Rename updates frame.Name (the display label) — never frame.TextureName,
-            // which holds the actual texture path and must not be cleared.
-            if (newName != frame.Name)
-            {
-                frame.Name = newName;
-                _appCommands.RefreshTreeNode(frame);
-                _appCommands.SaveCurrentAnimationChainList();
-            }
+            _appCommands.RenameChain(chain, newName);
         }
 
         AnimTree.Focus();
-    }
-
-    private async Task AskRenameChainAsync(AnimationChainSave chain)
-    {
-        var name = await ShowStringInputDialogAsync("Rename Animation", "New name:", chain.Name);
-        if (name is null) return;
-        name = name.Trim();
-        if (string.IsNullOrEmpty(name))
-        {
-            await ShowMessageAsync("Animation name cannot be empty.");
-            return;
-        }
-        _appCommands.RenameChain(chain, name);
-        _appCommands.RefreshTreeNode(chain);
-        _events.RaiseAnimationChainsChanged();
-        _appCommands.SaveCurrentAnimationChainList();
-    }
-
-    private async Task AskRenameFrameAsync(AnimationFrameSave frame)
-    {
-        var name = await ShowStringInputDialogAsync(
-            "Change Texture Path",
-            "New texture path (relative to ACHX):",
-            frame.TextureName ?? "");
-        if (name is null) return;
-        _appCommands.RenameFrame(frame, name);
-        var chain = _objectFinder.GetAnimationChainContaining(frame);
-        if (chain is not null) _appCommands.RefreshTreeNode(chain);
-        _appCommands.RefreshWireframe();
-        RefreshTextureCombo();
-        _events.RaiseAnimationChainsChanged();
-        _appCommands.SaveCurrentAnimationChainList();
     }
 
     // ── View Texture in Explorer ──────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -433,20 +433,6 @@ namespace AnimationEditor.Core.CommandsAndState
             return true;
         }
 
-        /// <summary>
-        /// Set the texture name (file path) of a frame — the in-tree rename action (TV08).
-        /// Fires <see cref="ApplicationEvents.AnimationChainsChanged"/> and saves.
-        /// </summary>
-        public void RenameFrame(AnimationFrameSave frame, string newTextureName)
-        {
-            string? oldName = frame.TextureName;
-            frame.TextureName = newTextureName;
-            RefreshFrameNodeRequested?.Invoke(frame);
-            SaveCurrentAnimationChainList();
-            _events.RaiseAnimationChainsChanged();
-            _undoManager.Record(new SetFrameTextureNameCommand(frame, oldName, newTextureName, this, _events));
-        }
-
         public void AddFrame(AnimationChainSave chain, string? textureName = null)
         {
             var frame = new AnimationFrameSave

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -63,7 +63,6 @@ namespace AnimationEditor.Core.CommandsAndState
         Task AddAnimationChain();
         AnimationChainSave? AddAnimationChainWithName(string name);
         bool RenameChain(AnimationChainSave chain, string newName);
-        void RenameFrame(AnimationFrameSave frame, string newTextureName);
         void AddFrame(AnimationChainSave chain, string? textureName = null);
         void MoveChain(AnimationChainSave chain, int delta);
         void MoveChainToTop(AnimationChainSave chain);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeaderTextDoubleTapTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeaderTextDoubleTapTests.cs
@@ -1,0 +1,102 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for <see cref="MainWindow.HandleHeaderTextDoubleTap"/> — issue #234.
+/// Double-tapping a frame's text label must center the wireframe on the frame,
+/// never start an inline rename; a chain's text label still inline-renames.
+/// </summary>
+public class HeaderTextDoubleTapTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.UnitType                     = UnitType.Pixel;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, string name, int width, int height)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(width, height);
+        bm.Erase(SKColors.Blue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void HandleHeaderTextDoubleTap_ChainNode_BeginsInlineRename()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        var vm = new TreeNodeVm { Data = new AnimationChainSave { Name = "Walk" } };
+
+        window.HandleHeaderTextDoubleTap(vm);
+
+        Assert.True(vm.IsEditing,
+            "Double-tapping a chain's text label should start an inline rename — its name is meaningful.");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void HandleHeaderTextDoubleTap_FrameNode_CentersWireframeWithoutRenaming()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")
+                ?? throw new InvalidOperationException("WireframeCtrl not found");
+            wireframe.LoadTexture(WriteSolidPng(dir, "tex.png", 500, 500));
+            Dispatcher.UIThread.RunJobs();
+
+            // Frame UV 0.6–0.8 → a 100×100 region; centering zooms to fit it.
+            var frame = new AnimationFrameSave
+            {
+                LeftCoordinate  = 0.6f, TopCoordinate    = 0.6f,
+                RightCoordinate = 0.8f, BottomCoordinate = 0.8f,
+            };
+            var vm = new TreeNodeVm { Data = frame };
+
+            float? zoomChanged = null;
+            wireframe.ZoomChanged += v => zoomChanged = v;
+
+            window.HandleHeaderTextDoubleTap(vm);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(vm.IsEditing,
+                "Double-tapping a frame's text label must not start an inline rename.");
+            Assert.NotNull(zoomChanged); // wireframe re-zoomed to fit the frame → it centered
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -942,11 +942,11 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
-    public void RenameFrameLabel_DoesNotCollapseParentChainNode()
+    public void RefreshTreeNode_ForFrame_DoesNotCollapseParentChainNode()
     {
-        // Regression: after committing a frame inline rename the parent chain was
-        // collapsing. This test verifies that setting frame.Name + RefreshTreeNode
-        // (the CommitInlineRename path for frames) leaves the parent IsExpanded intact.
+        // Regression: refreshing a frame's tree node was collapsing its parent chain.
+        // RefreshTreeNode(frame) runs from many live paths (here driven via
+        // SetFrameTextureName) and must leave the parent's IsExpanded intact.
         var (window, ctx) = CreateWindow();
         try
         {
@@ -961,13 +961,12 @@ public class HeadlessTreeViewTests
             var chainNode = GetRoots(GetTree(window))[0];
             chainNode.IsExpanded = true;
 
-            // Simulate CommitInlineRename for a frame: set Name + RefreshTreeNode
-            frame.Name = "My Frame";
-            ctx.AppCommands.RefreshTreeNode(frame);
+            ctx.AppCommands.SetFrameTextureName(frame, "renamed.png");
             Dispatcher.UIThread.RunJobs();
 
-            Assert.True(chainNode.IsExpanded, "Parent chain node must stay expanded after frame label rename.");
-            Assert.Equal("My Frame", chainNode.Children[0].Header);
+            Assert.True(chainNode.IsExpanded,
+                "Parent chain node must stay expanded after a frame node refresh.");
+            Assert.Equal("renamed.png", chainNode.Children[0].Header);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -717,48 +717,4 @@ public class AppCommandsChainTests
         }
     }
 
-    // ── RenameFrame / SetFrameTextureName (TV08) ───────────────────────────────
-
-    [Fact]
-    public void RenameFrame_SetsTextureNameOnFrame()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new FlatRedBall2.Animation.Content.AnimationFrameSave
-            { TextureName = "old.png" };
-
-        ctx.AppCommands.RenameFrame(frame, "new.png");
-
-        Assert.Equal("new.png", frame.TextureName);
-    }
-
-    [Fact]
-    public void RenameFrame_RaisesAnimationChainsChanged()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new FlatRedBall2.Animation.Content.AnimationFrameSave();
-        bool fired = false;
-        void Handler() => fired = true;
-        ctx.ApplicationEvents.AnimationChainsChanged += Handler;
-        try
-        {
-            ctx.AppCommands.RenameFrame(frame, "hero.png");
-            Assert.True(fired);
-        }
-        finally
-        {
-            ctx.ApplicationEvents.AnimationChainsChanged -= Handler;
-        }
-    }
-
-    [Fact]
-    public void RenameFrame_EmptyString_SetsEmptyTextureName()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new FlatRedBall2.Animation.Content.AnimationFrameSave
-            { TextureName = "something.png" };
-
-        ctx.AppCommands.RenameFrame(frame, string.Empty);
-
-        Assert.Equal(string.Empty, frame.TextureName);
-    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SetFrameTextureNameUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SetFrameTextureNameUndoTests.cs
@@ -43,23 +43,4 @@ public class SetFrameTextureNameUndoTests
 
         Assert.Equal("updated.png", frame.TextureName);
     }
-
-    // ── RenameFrame + Undo ────────────────────────────────────────────────────
-
-    [Fact]
-    public void RenameFrame_Undo_RestoresOldTextureName()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var acls = ctx.Acls;
-        var chain = TestHelpers.MakeChain(acls, "Walk");
-        var frame = TestHelpers.MakeFrame("before.png");
-        chain.Frames.Add(frame);
-
-        ctx.AppCommands.RenameFrame(frame, "after.png");
-        Assert.Equal("after.png", frame.TextureName);
-
-        ctx.UndoManager.Undo();
-
-        Assert.Equal("before.png", frame.TextureName);
-    }
 }


### PR DESCRIPTION
## What

Double-tapping a frame node''s **text label** in the Animation Editor tree started an inline rename. `AnimationFrameSave.Name` is only a cosmetic display label (nothing — gameplay, animation lookup, file I/O — references it), and the label fills most of the row, so the natural "double-click the frame" gesture opened the rename editor instead of the more useful **center-the-wireframe-on-this-frame**.

`OnHeaderTextDoubleTapped` now routes through a new `HandleHeaderTextDoubleTap`, which delegates to the existing `HandleAnimTreeNodeDoubleTap`. Result: a frame centers, a chain still inline-renames (its name *is* meaningful), rects/circles center on their entity point — header-text and blank-space double-taps now behave identically.

## Dead-code cleanup (per discussion on the issue)

While fixing this I found the issue conflated two things, and the surface it pointed at was partly dead/mislabeled. Removed:

- `BeginInlineRenameSelected(AnimationFrameSave)` + the `CommitInlineRename` frame branch — the cosmetic `frame.Name` editing path.
- The context-menu item **"Rename (texture path)"** — it was *mislabeled*: it actually edited `frame.Name` (display label), not the texture path.
- `AskRenameChainAsync` and `AskRenameFrameAsync` — both entirely unreferenced.
- `AppCommands.RenameFrame` (+ `IAppCommands` decl) — a dead duplicate of `SetFrameTextureName`. **`SetFrameTextureName` is the live, wired-up texture-path command and is untouched** — so texture-path editing still works via the texture picker; only the dead duplicate is gone.

`frame.Name` is still a valid display-label source for `TreeBuilder.BuildFrameHeader`; it just is no longer user-editable from the tree.

## Tests

- New `HeaderTextDoubleTapTests`: frame label double-tap centers the wireframe and does **not** start a rename; chain label double-tap still inline-renames. (Written test-first — confirmed red against the old rename behavior, green after the fix.)
- Retargeted `HeadlessTreeViewTests.RenameFrameLabel_DoesNotCollapseParentChainNode` → `RefreshTreeNode_ForFrame_DoesNotCollapseParentChainNode`, now driven via the live `SetFrameTextureName` path (the old test simulated the deleted frame-rename commit).
- Removed the `RenameFrame_*` unit tests (3 in `AppCommandsChainTests`, 1 in `SetFrameTextureNameUndoTests`); `SetFrameTextureName` retains undo/redo coverage.
- Full AE suites green: 888 Core + 297 App.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)