### PR TITLE
WIP: animation chain loading + tree population (#141)

### DIFF
--- a/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -39,18 +39,21 @@ namespace AnimationEditor.Core
         {
             if (fileName.Exists())
             {
-                var acls = AnimationChainListSave.FromFile(fileName.FullPath);
 
-                AddShapeCollectionsToFrames(acls);
+                    var acls = AnimationChainListSave.FromFile(fileName.FullPath);
 
-                OnDiskCoordinateType = acls.CoordinateType;
-                NormalizeCoordinatesToUv(acls, fileName.GetDirectoryContainingThis().FullPath);
+                    AddShapeCollectionsToFrames(acls);
 
-                AnimationChainListSave = acls;
-                FileName = fileName.FullPath;
+                    OnDiskCoordinateType = acls.CoordinateType;
+                    NormalizeCoordinatesToUv(acls, fileName.GetDirectoryContainingThis().FullPath);
 
-                if (!string.IsNullOrEmpty(acls.ProjectFile))
-                    TryLoadProjectFile(new FilePath(fileName.GetDirectoryContainingThis().FullPath + acls.ProjectFile));
+                    AnimationChainListSave = acls;
+                    FileName = fileName.FullPath;
+
+                    if (!string.IsNullOrEmpty(acls.ProjectFile))
+                        TryLoadProjectFile(new FilePath(fileName.GetDirectoryContainingThis().FullPath + acls.ProjectFile));
+
+
             }
         }
 

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/LoadAnimationChainTreePopulationTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/LoadAnimationChainTreePopulationTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+// Regression guard for the user-visible flow "File -> Load -> tree populates".
+// AnimationEditor.Core.Tests cover the load chain up to RefreshTreeViewRequested firing,
+// but they cannot observe the actual MainWindow._treeRoots ObservableCollection that the
+// TreeView is bound to. This test does — load a real .achx, drive UI jobs, assert the tree
+// reflects the chains.
+public class LoadAnimationChainTreePopulationTests
+{
+    private const string TwoChainAchx =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AnimationChainArraySave>
+          <CoordinateType>Pixel</CoordinateType>
+          <AnimationChain>
+            <Name>Idle</Name>
+            <Frame>
+              <TextureName>Sheet.png</TextureName><FrameLength>0.1</FrameLength>
+              <LeftCoordinate>0</LeftCoordinate><RightCoordinate>32</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate><BottomCoordinate>32</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+          <AnimationChain>
+            <Name>Walk</Name>
+            <Frame>
+              <TextureName>Sheet.png</TextureName><FrameLength>0.1</FrameLength>
+              <LeftCoordinate>32</LeftCoordinate><RightCoordinate>64</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate><BottomCoordinate>32</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    [AvaloniaFact]
+    public void LoadAnimationChain_ViaAppCommands_PopulatesTreeRoots()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = AnimationEditor.Core.IO.NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achxPath = Path.Combine(dir, "test.achx");
+        File.WriteAllText(achxPath, TwoChainAchx, Encoding.UTF8);
+        try
+        {
+            ctx.AppCommands.LoadAnimationChain(achxPath);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(2, roots.Count);
+            Assert.Equal("Idle", roots[0].Header);
+            Assert.Equal("Walk", roots[1].Header);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
@@ -9,11 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- FRB2 marks MonoGame.Framework.DesktopGL PrivateAssets=All to keep it out
-         of the engine NuGet's transitive set. The Animation Editor links FRB2 by
-         project ref and ends up calling APIs whose JIT-resolution pulls in
-         MonoGame.Framework, so we restore the reference here. -->
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
+    <!-- No MonoGame.Framework.DesktopGL PackageReference. AnimationEditor.Core (and the
+         live AE app) does not link MonoGame, so this test project must not either —
+         otherwise FRB2 APIs that accidentally introduce a JIT-time MonoGame dependency
+         pass tests here but blow up in the live app with a TypeLoadException. -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadAnimationChainTests.cs
+++ b/FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadAnimationChainTests.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Text;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// End-to-end load path: AppCommands.LoadAnimationChain points at a real .achx, and the
+// ProjectManager.AnimationChainListSave that the tree-view builds from should hold the
+// parsed chains. Mirrors the user flow "File -> Load .achx -> tree populates".
+public class AppCommandsLoadAnimationChainTests
+{
+    private const string TwoChainAchx =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AnimationChainArraySave>
+          <FileRelativeTextures>true</FileRelativeTextures>
+          <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+          <CoordinateType>Pixel</CoordinateType>
+          <AnimationChain>
+            <Name>Idle</Name>
+            <Frame>
+              <TextureName>Sheet.png</TextureName>
+              <FrameLength>0.1</FrameLength>
+              <LeftCoordinate>0</LeftCoordinate><RightCoordinate>32</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate><BottomCoordinate>32</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+          <AnimationChain>
+            <Name>Walk</Name>
+            <Frame>
+              <TextureName>Sheet.png</TextureName>
+              <FrameLength>0.1</FrameLength>
+              <LeftCoordinate>32</LeftCoordinate><RightCoordinate>64</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate><BottomCoordinate>32</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    [Fact]
+    public void LoadAnimationChain_RealAchxOnDisk_PopulatesAnimationChainListSaveWithChains()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        using var temp = new TestHelpers.TempDir();
+        var achxPath = Path.Combine(temp.Path, "test.achx");
+        File.WriteAllText(achxPath, TwoChainAchx, Encoding.UTF8);
+
+        ctx.AppCommands.LoadAnimationChain(achxPath);
+
+        Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
+        Assert.Equal(2, ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Count);
+        Assert.Equal("Idle", ctx.ProjectManager.AnimationChainListSave.AnimationChains[0].Name);
+        Assert.Equal("Walk", ctx.ProjectManager.AnimationChainListSave.AnimationChains[1].Name);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_RealAchxOnDisk_FiresRefreshTreeViewRequested()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        using var temp = new TestHelpers.TempDir();
+        var achxPath = Path.Combine(temp.Path, "test.achx");
+        File.WriteAllText(achxPath, TwoChainAchx, Encoding.UTF8);
+
+        int refreshCount = 0;
+        ctx.AppCommands.RefreshTreeViewRequested += () => refreshCount++;
+
+        ctx.AppCommands.LoadAnimationChain(achxPath);
+
+        Assert.True(refreshCount > 0, "RefreshTreeViewRequested must fire so the UI rebuilds the tree.");
+    }
+}

--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Xml.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using XnaTitleContainer = Microsoft.Xna.Framework.TitleContainer;
 
 namespace FlatRedBall2.Animation.Content;
 
@@ -81,10 +80,11 @@ public class AnimationChainListSave
     /// overload exists for tooling and tests that work without a <see cref="ContentLoader"/>.
     /// </summary>
     /// <param name="filePath">Path to the .achx file, relative to the title container.</param>
-    /// <param name="streamProvider">Optional byte source. Defaults to <c>TitleContainer.OpenStream</c>.</param>
-    public static AnimationChainListSave FromFile(string filePath, Func<string, Stream>? streamProvider)
+    /// <param name="streamProvider">Byte source. Required — there is no default, so consumers
+    /// that don't link MonoGame (the Animation Editor) don't pay a JIT-time assembly load on
+    /// <c>TitleContainer</c>.</param>
+    public static AnimationChainListSave FromFile(string filePath, Func<string, Stream> streamProvider)
     {
-        streamProvider ??= XnaTitleContainer.OpenStream;
         using var stream = streamProvider(filePath);
         var doc = XDocument.Load(stream);
         var root = doc.Root!;


### PR DESCRIPTION
> **Draft / WIP — not ready to merge.** This was uncommitted work-in-progress sitting in the `141-animation-editor-frb2-migration` worktree. The worktree was being cleaned up, so the changes were snapshotted into commit `7d53e86` and pushed here so nothing is lost and you can review/decide what to do with it.

## What''s in the WIP commit

Part of the Animation Editor FRB2 migration (#141). 5 files, +169 / −17:

- `FRBDK/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs` — modified
- `FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj` — modified
- `src/Animation/Content/AnimationChainListSave.cs` — modified
- `FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/LoadAnimationChainTreePopulationTests.cs` — **new**
- `FRBDK/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadAnimationChainTests.cs` — **new**

## Status

Unknown — this is a raw snapshot of in-progress work. It has **not** been built or tested in this state, and the commit may not be at a coherent stopping point. Intentionally **not** marked `Closes #141`, since the migration isn''t complete.

Relates to #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)