### PR TITLE
fix(AE): paste animation chains directly below the copied source

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2169,13 +2169,7 @@ public partial class MainWindow : Window
 
         if (chains is { Count: > 0 })
         {
-            var existingNames = acls.AnimationChains.Select(c => c.Name).ToList();
-            foreach (var chain in chains)
-            {
-                chain.Name = StringFunctions.MakeStringUnique(chain.Name, existingNames, 2);
-                existingNames.Add(chain.Name);
-                acls.AnimationChains.Add(chain);
-            }
+            ChainPasteLogic.InsertPastedChains(acls, chains);
             _selectedState.SelectedChain = chains[^1];
             RefreshTreeView();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ChainPasteLogic.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ChainPasteLogic.cs
@@ -1,0 +1,46 @@
+using AnimationEditor.Core.Utilities;
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Places pasted animation chains into an <see cref="AnimationChainListSave"/>.
+/// Kept separate from clipboard (de)serialization so the placement rule is
+/// unit-testable without touching the app layer or the system clipboard.
+/// </summary>
+public static class ChainPasteLogic
+{
+    /// <summary>
+    /// Renames each pasted chain to be unique within <paramref name="acls"/>, then inserts
+    /// the block directly below the lowest (last) source chain the copy was made from —
+    /// matched by the names the pasted chains still carry from the clipboard. When no
+    /// source chain is present (e.g. pasting into a different project, or the source was
+    /// deleted), the block is appended at the end. The pasted block's relative order is
+    /// preserved.
+    /// </summary>
+    public static void InsertPastedChains(
+        AnimationChainListSave acls,
+        IReadOnlyList<AnimationChainSave> pastedChains)
+    {
+        if (pastedChains.Count == 0) return;
+
+        // The pasted chains still carry their source names at this point (renaming
+        // happens below), so they double as the lookup key for the source rows.
+        var sourceNames = pastedChains.Select(c => c.Name).ToHashSet();
+        int insertIndex = acls.AnimationChains.Count;
+        for (int i = 0; i < acls.AnimationChains.Count; i++)
+        {
+            if (sourceNames.Contains(acls.AnimationChains[i].Name))
+                insertIndex = i + 1;
+        }
+
+        var existingNames = acls.AnimationChains.Select(c => c.Name).ToList();
+        foreach (var chain in pastedChains)
+        {
+            chain.Name = StringFunctions.MakeStringUnique(chain.Name, existingNames, 2);
+            existingNames.Add(chain.Name);
+            acls.AnimationChains.Insert(insertIndex, chain);
+            insertIndex++;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainPasteLogicTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainPasteLogicTests.cs
@@ -1,0 +1,75 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ChainPasteLogicTests
+{
+    static AnimationChainListSave Acls(params string[] names)
+    {
+        var acls = new AnimationChainListSave();
+        foreach (var name in names)
+            acls.AnimationChains.Add(new AnimationChainSave { Name = name });
+        return acls;
+    }
+
+    static AnimationChainSave Chain(string name) => new AnimationChainSave { Name = name };
+
+    [Fact]
+    public void InsertPastedChains_InsertsDirectlyBelowSource()
+    {
+        var acls = Acls("Walk", "Run", "Jump");
+
+        ChainPasteLogic.InsertPastedChains(acls, new[] { Chain("Walk") });
+
+        Assert.Equal(new[] { "Walk", "Walk2", "Run", "Jump" },
+            acls.AnimationChains.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void InsertPastedChains_MultipleSources_InsertsBelowLowestSource()
+    {
+        var acls = Acls("Walk", "Run", "Jump");
+
+        // Copied "Walk" and "Run" together; the block lands below "Run" (the lowest source).
+        ChainPasteLogic.InsertPastedChains(acls, new[] { Chain("Walk"), Chain("Run") });
+
+        Assert.Equal(new[] { "Walk", "Run", "Walk2", "Run2", "Jump" },
+            acls.AnimationChains.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void InsertPastedChains_NonAdjacentSources_InsertsBelowLastSource()
+    {
+        var acls = Acls("Walk", "Run", "Jump");
+
+        ChainPasteLogic.InsertPastedChains(acls, new[] { Chain("Walk"), Chain("Jump") });
+
+        Assert.Equal(new[] { "Walk", "Run", "Jump", "Walk2", "Jump2" },
+            acls.AnimationChains.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void InsertPastedChains_NoMatchingSource_AppendsAtEnd()
+    {
+        var acls = Acls("Walk", "Run");
+
+        // Pasting into a project that never had the source chain.
+        ChainPasteLogic.InsertPastedChains(acls, new[] { Chain("Idle") });
+
+        Assert.Equal(new[] { "Walk", "Run", "Idle" },
+            acls.AnimationChains.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void InsertPastedChains_EmptyInput_LeavesListUnchanged()
+    {
+        var acls = Acls("Walk", "Run");
+
+        ChainPasteLogic.InsertPastedChains(acls, System.Array.Empty<AnimationChainSave>());
+
+        Assert.Equal(new[] { "Walk", "Run" },
+            acls.AnimationChains.Select(c => c.Name).ToArray());
+    }
+}


### PR DESCRIPTION
## Problem

Copy/pasting an animation chain in the Animation Editor appended the copy to the **end** of the animation list, rather than next to its source.

## Fix

The pasted block now lands **directly below the lowest (last) source chain** the copy was made from. The source rows are identified by the names the pasted chains still carry from the clipboard (renaming-for-uniqueness happens after placement is decided). When no source chain is present — pasting into a different project, or the source was deleted between copy and paste — the block falls back to being appended at the end. Relative order within a multi-chain paste is preserved.

Tree selection already followed the last pasted chain (`_selectedState.SelectedChain = chains[^1]`); that behavior is unchanged.

## Implementation

Placement is extracted into a pure `ChainPasteLogic.InsertPastedChains` in `AnimationEditor.Core`, so the rule is unit-testable without the app layer or the system clipboard. `MainWindow.HandlePasteAsync` now just calls it.

## Tests

`ChainPasteLogicTests` covers: insert below single source, below the lowest of multiple (adjacent and non-adjacent) sources, append-when-no-match, and empty input. Full Core (898) and App (299) suites pass; clean build with 0 warnings.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)