### PR TITLE
fix(AE): load .achx with all chains collapsed

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -129,6 +129,7 @@ public partial class MainWindow : Window
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
+        _appCommands.RebuildTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RebuildTreeView);
         _appCommands.RefreshChainNodeRequested          += c  => Dispatcher.UIThread.InvokeAsync(() => RefreshChainNode(c));
         _appCommands.RefreshFrameNodeRequested          += f  => Dispatcher.UIThread.InvokeAsync(() => RefreshFrameNode(f));
         _appCommands.RefreshAnimationFrameDisplayRequested += () => { };
@@ -1058,6 +1059,36 @@ public partial class MainWindow : Window
             TreeBuilder.SyncChainsInto(_treeRoots, acls.AnimationChains);
 
             // Re-select to keep visual state
+            SyncTreeSelection();
+        }
+        finally
+        {
+            _suppressTreeSelectionHandling = false;
+        }
+    }
+
+    /// <summary>
+    /// Fully rebuilds the tree from scratch with every chain collapsed. Used on
+    /// .achx load (File &gt; Open, recent files, drag-drop, startup reopen) so a
+    /// freshly-opened file presents a scannable, collapsed overview. Contrast with
+    /// <see cref="RefreshTreeView"/>, which diff-updates and preserves each chain's
+    /// collapse state across edits.
+    /// </summary>
+    private void RebuildTreeView()
+    {
+        _suppressTreeSelectionHandling = true;
+        try
+        {
+            _treeRoots.Clear();
+
+            var acls = _projectManager.AnimationChainListSave;
+            if (acls is null) return;
+
+            // Empty expandedChainNames (not null) collapses every chain; null would
+            // default them all to expanded.
+            foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
+                _treeRoots.Add(node);
+
             SyncTreeSelection();
         }
         finally

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -66,6 +66,9 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         public event Action? RefreshTreeViewRequested;
 
+        /// <inheritdoc cref="IAppCommands.RebuildTreeViewRequested"/>
+        public event Action? RebuildTreeViewRequested;
+
         /// <summary>
         /// Request a single chain's tree node to refresh.
         /// </summary>
@@ -136,7 +139,9 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Clear();
             _selectedState.Reset();
             _selectedState.SelectedChain = _pm.AnimationChainListSave?.AnimationChains.FirstOrDefault();
-            RefreshTreeViewRequested?.Invoke();
+            // Rebuild (not refresh): a freshly-opened file should present a collapsed,
+            // scannable overview rather than every chain's frames expanded.
+            RebuildTreeViewRequested?.Invoke();
             _ioManager.LoadAndApplyCompanionFileFor(fileName);
             RefreshWireframeRequested?.Invoke();
             RefreshAnimationFrameDisplayRequested?.Invoke();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -19,6 +19,15 @@ namespace AnimationEditor.Core.CommandsAndState
         // ── Events ────────────────────────────────────────────────────────────
 
         event Action RefreshTreeViewRequested;
+
+        /// <summary>
+        /// Request a full tree-view rebuild from scratch with every chain collapsed.
+        /// Raised on .achx load (File &gt; Open, recent files, drag-drop, startup reopen).
+        /// Differs from <see cref="RefreshTreeViewRequested"/>, which diff-updates the
+        /// existing tree and preserves each chain's collapse state across edits.
+        /// </summary>
+        event Action RebuildTreeViewRequested;
+
         event Action<AnimationChainSave> RefreshChainNodeRequested;
         event Action<AnimationFrameSave> RefreshFrameNodeRequested;
         event Action RefreshAnimationFrameDisplayRequested;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
@@ -43,7 +43,12 @@ public class NewAndLoadResetTests
         var path = Path.Combine(dir, "test.achx");
         var acls = new AnimationChainListSave();
         foreach (var name in chainNames)
-            acls.AnimationChains.Add(new AnimationChainSave { Name = name });
+        {
+            var chain = new AnimationChainSave { Name = name };
+            // Give each chain a frame so expand/collapse state is meaningful.
+            chain.Frames.Add(new AnimationFrameSave { TextureName = name + ".png", FrameLength = 0.1f });
+            acls.AnimationChains.Add(chain);
+        }
         acls.Save(path);
         return path;
     }
@@ -162,6 +167,37 @@ public class NewAndLoadResetTests
             Assert.Null(ctx.SelectedState.SelectedFrame);
             // SelectedChain should be the first chain of the *new* file, not the old one
             Assert.Equal("NewRun", ctx.SelectedState.SelectedChain?.Name);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Loading a .achx must present every chain collapsed so the tree is scannable
+    /// — even with many chains — instead of force-expanding every chain's frames.
+    /// </summary>
+    [AvaloniaFact]
+    public void Load_CollapsesAllChains()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var path = WriteAchx(dir, "Walk", "Run", "Idle");
+            typeof(MainWindow)
+                .GetMethod("LoadAnimationFile", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, [path]);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree  = window.FindControl<TreeView>("AnimTree")!;
+            var roots = (System.Collections.ObjectModel.ObservableCollection<AnimationEditor.Core.ViewModels.TreeNodeVm>)tree.ItemsSource!;
+
+            Assert.Equal(3, roots.Count);
+            Assert.All(roots, node => Assert.False(node.IsExpanded));
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
@@ -42,11 +42,11 @@ public class AppCommandsLoadFailureTests : IDisposable
     }
 
     [Fact]
-    public void LoadAnimationChain_MissingFile_DoesNotFireRefreshTreeViewRequested()
+    public void LoadAnimationChain_MissingFile_DoesNotFireRebuildTreeViewRequested()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         bool fired = false;
-        ctx.AppCommands.RefreshTreeViewRequested += () => fired = true;
+        ctx.AppCommands.RebuildTreeViewRequested += () => fired = true;
 
         ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
 
@@ -94,13 +94,13 @@ public class AppCommandsLoadFailureTests : IDisposable
     }
 
     [Fact]
-    public void LoadAnimationChain_CorruptFile_DoesNotFireRefreshTreeViewRequested()
+    public void LoadAnimationChain_CorruptFile_DoesNotFireRebuildTreeViewRequested()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var badFile = Path.Combine(_dir.Path, "bad2.achx");
         File.WriteAllText(badFile, "this is not valid xml");
         bool fired = false;
-        ctx.AppCommands.RefreshTreeViewRequested += () => fired = true;
+        ctx.AppCommands.RebuildTreeViewRequested += () => fired = true;
 
         ctx.AppCommands.LoadAnimationChain(badFile);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
@@ -125,20 +125,52 @@ public class AppCommandsLoadTests : IDisposable
     }
 
     /// <summary>
-    /// SelectedChain must be set BEFORE RefreshTreeViewRequested fires so
+    /// SelectedChain must be set BEFORE RebuildTreeViewRequested fires so
     /// any tree subscriber can reflect the selection immediately.
     /// </summary>
     [Fact]
-    public void LoadAnimationChain_SelectedChainIsSetBeforeTreeRefresh()
+    public void LoadAnimationChain_SelectedChainIsSetBeforeTreeRebuild()
     {
         var path = WriteAchx("Walk");
-        AnimationChainSave? observedDuringRefresh = null;
-        _ctx.AppCommands.RefreshTreeViewRequested += () =>
-            observedDuringRefresh = _ctx.SelectedState.SelectedChain;
+        AnimationChainSave? observedDuringRebuild = null;
+        _ctx.AppCommands.RebuildTreeViewRequested += () =>
+            observedDuringRebuild = _ctx.SelectedState.SelectedChain;
 
         _ctx.AppCommands.LoadAnimationChain(path);
 
-        Assert.NotNull(observedDuringRefresh);
-        Assert.Equal("Walk", observedDuringRefresh!.Name);
+        Assert.NotNull(observedDuringRebuild);
+        Assert.Equal("Walk", observedDuringRebuild!.Name);
+    }
+
+    // ── Tree rebuild (collapsed-on-load) ─────────────────────────────────────
+
+    /// <summary>
+    /// Loading a file must raise <see cref="IAppCommands.RebuildTreeViewRequested"/>
+    /// — the rebuild path collapses every chain — rather than the diff-update
+    /// <see cref="IAppCommands.RefreshTreeViewRequested"/> path, which would
+    /// re-expand every freshly-built chain node.
+    /// </summary>
+    [Fact]
+    public void LoadAnimationChain_FiresRebuildTreeViewRequested()
+    {
+        var path = WriteAchx("Walk");
+        bool rebuildFired = false;
+        _ctx.AppCommands.RebuildTreeViewRequested += () => rebuildFired = true;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.True(rebuildFired);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_DoesNotFireRefreshTreeViewRequested()
+    {
+        var path = WriteAchx("Walk");
+        bool refreshFired = false;
+        _ctx.AppCommands.RefreshTreeViewRequested += () => refreshFired = true;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.False(refreshFired);
     }
 }


### PR DESCRIPTION
## Problem

When the Animation Editor opens a `.achx`, every animation chain in the tree loads **expanded** (all frames visible). For files with many chains this is noisy and hard to scan.

## Root cause

All `.achx` load paths funnel through `AppCommands.LoadAnimationChain`, which fired `RefreshTreeViewRequested`. That event's handler diff-updates the tree via `TreeBuilder.SyncChainsInto`, and any chain it hasn't seen before is built by `BuildChainNode` with `IsExpanded = true`. On a fresh load *every* chain is new, so the whole tree opens fully expanded.

`RefreshTreeViewRequested` can't simply be changed to collapse — its diff-update semantics are deliberate, so copy/paste/reorder preserve each chain's collapse state (#237). Load and edit are genuinely two different operations.

## Fix

- New `RebuildTreeViewRequested` event on `IAppCommands` for the load path: "throw the tree away and rebuild it collapsed."
- `LoadAnimationChain` fires `RebuildTreeViewRequested` instead of `RefreshTreeViewRequested`.
- `MainWindow.RebuildTreeView` clears `_treeRoots` and repopulates via `TreeBuilder.BuildTree(acls, expandedChainNames: [])` — an empty (non-null) set collapses every chain.

Covers File > Open, recent files, drag-drop, and startup reopen — all go through `LoadAnimationChain`.

Per-chain expand/collapse restoration from a persistence file is intentionally **not** built here, per the issue — collapsed is the better default regardless.

## Tests

- `NewAndLoadResetTests.Load_CollapsesAllChains` (App, headless) — loads a 3-chain `.achx`, asserts all root nodes are collapsed.
- `AppCommandsLoadTests` — load fires `RebuildTreeViewRequested`, not `RefreshTreeViewRequested`.
- Updated `AppCommandsLoad*`/`AppCommandsLoadFailure*` tests that keyed on the old event.

Full suite green: 895 Core + 300 App.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)