### PR TITLE
fix(AE): make delete-confirmation popup keyboard-accessible

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1414,15 +1414,7 @@ public partial class MainWindow : Window
         panel.Children.Add(radioSetAll);
         panel.Children.Add(perFrameLabel);
 
-        var okBtn = new Button
-        {
-            Content = "OK",
-            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
-        };
-        panel.Children.Add(okBtn);
-        dialog.Content = panel;
-
-        okBtn.Click += (_, _) =>
+        void Apply()
         {
             if (durationInput.Value.HasValue)
             {
@@ -1433,7 +1425,25 @@ public partial class MainWindow : Window
                     _appCommands.ScaleFrameTimesSetAllSame(chain, newTotal);
             }
             dialog.Close();
+        }
+
+        var okBtn     = new Button { Content = "OK" };
+        var cancelBtn = new Button { Content = "Cancel" };
+        okBtn.Click     += (_, _) => Apply();
+        cancelBtn.Click += (_, _) => dialog.Close();
+
+        var btns = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            Spacing = 8,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
         };
+        btns.Children.Add(okBtn);
+        btns.Children.Add(cancelBtn);
+        panel.Children.Add(btns);
+        dialog.Content = panel;
+
+        WireDialogKeyboard(dialog, onConfirm: Apply, onCancel: dialog.Close);
 
         _ = dialog.ShowDialog(this);
     }
@@ -1959,9 +1969,9 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Builds the yes/no confirmation dialog. "Yes" is the default action (ENTER)
-    /// and "No" is the cancel action (ESC); closing the window by any other means
-    /// resolves <paramref name="tcs"/> to false. Extracted for testability.
+    /// Builds the yes/no confirmation dialog. ENTER confirms (Yes), ESC cancels
+    /// (No), and closing the window by any other means resolves
+    /// <paramref name="tcs"/> to false. Extracted for testability.
     /// </summary>
     internal static Window BuildConfirmDialog(string message, string title, TaskCompletionSource<bool> tcs)
     {
@@ -1987,8 +1997,8 @@ public partial class MainWindow : Window
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
         };
 
-        var yesBtn = new Button { Content = "Yes", IsDefault = true };
-        var noBtn  = new Button { Content = "No", IsCancel = true };
+        var yesBtn = new Button { Content = "Yes" };
+        var noBtn  = new Button { Content = "No" };
         yesBtn.Click += (_, _) => { tcs.TrySetResult(true);  dialog.Close(); };
         noBtn.Click  += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
         buttons.Children.Add(yesBtn);
@@ -1998,7 +2008,28 @@ public partial class MainWindow : Window
         dialog.Content = panel;
         dialog.Closed += (_, _) => tcs.TrySetResult(false);
 
+        WireDialogKeyboard(dialog,
+            onConfirm: () => { tcs.TrySetResult(true);  dialog.Close(); },
+            onCancel:  () => { tcs.TrySetResult(false); dialog.Close(); });
+
         return dialog;
+    }
+
+    /// <summary>
+    /// Wires ENTER → <paramref name="onConfirm"/> and ESC → <paramref name="onCancel"/>
+    /// on a modal dialog. The handler is attached at the window with
+    /// <c>handledEventsToo: true</c> so it still fires when a focused input control
+    /// (e.g. <see cref="NumericUpDown"/>) has already marked the key event handled —
+    /// which is why <see cref="Button.IsDefault"/>/<see cref="Button.IsCancel"/> alone
+    /// are unreliable for dialogs that contain text or numeric inputs.
+    /// </summary>
+    internal static void WireDialogKeyboard(Window dialog, Action onConfirm, Action onCancel)
+    {
+        dialog.AddHandler(InputElement.KeyDownEvent, (_, e) =>
+        {
+            if (e.Key == Key.Enter)       { onConfirm(); e.Handled = true; }
+            else if (e.Key == Key.Escape) { onCancel();  e.Handled = true; }
+        }, RoutingStrategies.Bubble, handledEventsToo: true);
     }
 
     // ── String-input dialog helper ────────────────────────────────────────────
@@ -2362,9 +2393,11 @@ public partial class MainWindow : Window
         offsetModeRow.IsVisible = false;
 
         bool confirmed = false;
-        var ok = new Button { Content = "OK", IsDefault = true };
-        ok.Click += (_, _) => { confirmed = true; dialog.Close(); };
-        var cancel = new Button { Content = "Cancel", IsCancel = true };
+        void Confirm() { confirmed = true; dialog.Close(); }
+
+        var ok = new Button { Content = "OK" };
+        ok.Click += (_, _) => Confirm();
+        var cancel = new Button { Content = "Cancel" };
         cancel.Click += (_, _) => dialog.Close();
 
         var btns = new StackPanel
@@ -2383,6 +2416,8 @@ public partial class MainWindow : Window
         panel.Children.Add(offsetModeRow);
         panel.Children.Add(btns);
         dialog.Content = panel;
+
+        WireDialogKeyboard(dialog, onConfirm: Confirm, onCancel: dialog.Close);
 
         await dialog.ShowDialog(this);
         if (!confirmed) return;
@@ -2498,9 +2533,11 @@ public partial class MainWindow : Window
         var hInput = new NumericUpDown { Value = oldH, Minimum = 1, Maximum = 65536, FormatString = "0", Width = 90 };
 
         bool confirmed = false;
-        var ok     = new Button { Content = "OK", IsDefault = true };
-        var cancel = new Button { Content = "Cancel", IsCancel = true };
-        ok.Click     += (_, _) => { confirmed = true; dialog.Close(); };
+        void Confirm() { confirmed = true; dialog.Close(); }
+
+        var ok     = new Button { Content = "OK" };
+        var cancel = new Button { Content = "Cancel" };
+        ok.Click     += (_, _) => Confirm();
         cancel.Click += (_, _) => dialog.Close();
 
         var btns = new StackPanel
@@ -2526,6 +2563,8 @@ public partial class MainWindow : Window
         panel.Children.Add(hRow);
         panel.Children.Add(btns);
         dialog.Content = panel;
+
+        WireDialogKeyboard(dialog, onConfirm: Confirm, onCancel: dialog.Close);
 
         await dialog.ShowDialog(this);
         if (!confirmed) return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1953,7 +1953,18 @@ public partial class MainWindow : Window
     private async Task<bool> ShowConfirmDialogAsync(string message, string title)
     {
         var tcs = new TaskCompletionSource<bool>();
+        var dialog = BuildConfirmDialog(message, title, tcs);
+        await dialog.ShowDialog(this);
+        return await tcs.Task;
+    }
 
+    /// <summary>
+    /// Builds the yes/no confirmation dialog. "Yes" is the default action (ENTER)
+    /// and "No" is the cancel action (ESC); closing the window by any other means
+    /// resolves <paramref name="tcs"/> to false. Extracted for testability.
+    /// </summary>
+    internal static Window BuildConfirmDialog(string message, string title, TaskCompletionSource<bool> tcs)
+    {
         var dialog = new Window
         {
             Title = title,
@@ -1976,8 +1987,8 @@ public partial class MainWindow : Window
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
         };
 
-        var yesBtn = new Button { Content = "Yes" };
-        var noBtn  = new Button { Content = "No" };
+        var yesBtn = new Button { Content = "Yes", IsDefault = true };
+        var noBtn  = new Button { Content = "No", IsCancel = true };
         yesBtn.Click += (_, _) => { tcs.TrySetResult(true);  dialog.Close(); };
         noBtn.Click  += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
         buttons.Children.Add(yesBtn);
@@ -1987,8 +1998,7 @@ public partial class MainWindow : Window
         dialog.Content = panel;
         dialog.Closed += (_, _) => tcs.TrySetResult(false);
 
-        await dialog.ShowDialog(this);
-        return await tcs.Task;
+        return dialog;
     }
 
     // ── String-input dialog helper ────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2022,6 +2022,9 @@ public partial class MainWindow : Window
     /// (e.g. <see cref="NumericUpDown"/>) has already marked the key event handled —
     /// which is why <see cref="Button.IsDefault"/>/<see cref="Button.IsCancel"/> alone
     /// are unreliable for dialogs that contain text or numeric inputs.
+    /// Also moves focus into the dialog on open: a freshly-shown window has no
+    /// focused element, and keyboard input is not routed anywhere until something
+    /// is focused, so without this ENTER/ESC do nothing until the user clicks.
     /// </summary>
     internal static void WireDialogKeyboard(Window dialog, Action onConfirm, Action onCancel)
     {
@@ -2030,6 +2033,12 @@ public partial class MainWindow : Window
             if (e.Key == Key.Enter)       { onConfirm(); e.Handled = true; }
             else if (e.Key == Key.Escape) { onCancel();  e.Handled = true; }
         }, RoutingStrategies.Bubble, handledEventsToo: true);
+
+        dialog.Opened += (_, _) =>
+            dialog.GetVisualDescendants()
+                  .OfType<InputElement>()
+                  .FirstOrDefault(x => x is { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true })
+                  ?.Focus();
     }
 
     // ── String-input dialog helper ────────────────────────────────────────────
@@ -2319,11 +2328,13 @@ public partial class MainWindow : Window
         };
         var incrToggle = new CheckBox { Content = "Increment UV", IsChecked = true };
 
-        var ok     = new Button { Content = "OK", IsDefault = true };
+        // Cancelling zeroes the count; the post-dialog code treats count <= 0 as "do nothing".
+        void Cancel() { countInput.Value = 0; dialog.Close(); }
+
+        var ok     = new Button { Content = "OK" };
         var cancel = new Button { Content = "Cancel" };
         ok.Click     += (_, _) => dialog.Close();
-        cancel.Click += (_, _) => { countInput.Value = 0; dialog.Close(); };
-        dialog.Closed += (_, _) => { };
+        cancel.Click += (_, _) => Cancel();
 
         var btns = new StackPanel
         {
@@ -2340,6 +2351,8 @@ public partial class MainWindow : Window
         panel.Children.Add(incrToggle);
         panel.Children.Add(btns);
         dialog.Content = panel;
+
+        WireDialogKeyboard(dialog, onConfirm: dialog.Close, onCancel: Cancel);
 
         await dialog.ShowDialog(this);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2364,7 +2364,7 @@ public partial class MainWindow : Window
         bool confirmed = false;
         var ok = new Button { Content = "OK", IsDefault = true };
         ok.Click += (_, _) => { confirmed = true; dialog.Close(); };
-        var cancel = new Button { Content = "Cancel" };
+        var cancel = new Button { Content = "Cancel", IsCancel = true };
         cancel.Click += (_, _) => dialog.Close();
 
         var btns = new StackPanel
@@ -2499,7 +2499,7 @@ public partial class MainWindow : Window
 
         bool confirmed = false;
         var ok     = new Button { Content = "OK", IsDefault = true };
-        var cancel = new Button { Content = "Cancel" };
+        var cancel = new Button { Content = "Cancel", IsCancel = true };
         ok.Click     += (_, _) => { confirmed = true; dialog.Close(); };
         cancel.Click += (_, _) => dialog.Close();
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Xunit;
@@ -8,16 +10,18 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Regression tests for issue #239: the yes/no confirmation dialog (delete
-/// confirmation) must be keyboard-accessible — ENTER confirms, ESC cancels.
+/// Regression tests for issue #239: modal confirmation dialogs must be
+/// keyboard-accessible — ENTER confirms, ESC cancels. Covers the yes/no
+/// confirmation dialog and the shared <see cref="MainWindow.WireDialogKeyboard"/>
+/// helper used by the dialogs that contain input controls.
 /// </summary>
 public class ConfirmDialogKeyboardTests
 {
-    private static void RaiseKey(Window dialog, Key key) =>
-        dialog.RaiseEvent(new KeyEventArgs
+    private static void RaiseKey(InputElement target, Key key) =>
+        target.RaiseEvent(new KeyEventArgs
         {
             RoutedEvent = InputElement.KeyDownEvent,
-            Source = dialog,
+            Source = target,
             Key = key,
         });
 
@@ -64,5 +68,57 @@ public class ConfirmDialogKeyboardTests
 
         Assert.True(tcs.Task.IsCompletedSuccessfully);
         Assert.False(tcs.Task.Result, "Closing the dialog without choosing must not delete");
+    }
+
+    // ── WireDialogKeyboard ────────────────────────────────────────────────────
+    // The Adjust Offsets / Resize Texture / Adjust Frame Time dialogs contain
+    // input controls (NumericUpDown) whose focused inner control can mark the
+    // Escape KeyDown handled before it bubbles to the window — so Button.IsCancel
+    // never fires. WireDialogKeyboard attaches at the window with
+    // handledEventsToo:true to survive that.
+
+    [AvaloniaFact]
+    public void WireDialogKeyboard_EscapeHandledByChild_StillCancels()
+    {
+        bool confirmed = false, cancelled = false;
+        var inner = new Button();                       // a focusable child
+        var dialog = new Window { Content = inner };
+        MainWindow.WireDialogKeyboard(dialog,
+            onConfirm: () => confirmed = true,
+            onCancel:  () => cancelled = true);
+        // Simulate an input control that swallows Escape before it bubbles up.
+        inner.AddHandler(InputElement.KeyDownEvent,
+            (object? _, KeyEventArgs e) => { if (e.Key == Key.Escape) e.Handled = true; });
+
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+        RaiseKey(inner, Key.Escape);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(cancelled, "ESC must cancel even when a focused child marks the event handled");
+        Assert.False(confirmed);
+        dialog.Close();
+    }
+
+    [AvaloniaFact]
+    public void WireDialogKeyboard_EnterHandledByChild_StillConfirms()
+    {
+        bool confirmed = false, cancelled = false;
+        var inner = new Button();
+        var dialog = new Window { Content = inner };
+        MainWindow.WireDialogKeyboard(dialog,
+            onConfirm: () => confirmed = true,
+            onCancel:  () => cancelled = true);
+        inner.AddHandler(InputElement.KeyDownEvent,
+            (object? _, KeyEventArgs e) => { if (e.Key == Key.Enter) e.Handled = true; });
+
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+        RaiseKey(inner, Key.Enter);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(confirmed, "ENTER must confirm even when a focused child marks the event handled");
+        Assert.False(cancelled);
+        dialog.Close();
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #239: the yes/no confirmation dialog (delete
+/// confirmation) must be keyboard-accessible — ENTER confirms, ESC cancels.
+/// </summary>
+public class ConfirmDialogKeyboardTests
+{
+    private static void RaiseKey(Window dialog, Key key) =>
+        dialog.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Source = dialog,
+            Key = key,
+        });
+
+    [AvaloniaFact]
+    public void BuildConfirmDialog_EnterKey_ResolvesTrue()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var dialog = MainWindow.BuildConfirmDialog("Delete this frame?", "Delete?", tcs);
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        RaiseKey(dialog, Key.Enter);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(tcs.Task.IsCompletedSuccessfully, "ENTER should dismiss the dialog");
+        Assert.True(tcs.Task.Result, "ENTER should confirm (Yes)");
+    }
+
+    [AvaloniaFact]
+    public void BuildConfirmDialog_EscapeKey_ResolvesFalse()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var dialog = MainWindow.BuildConfirmDialog("Delete this frame?", "Delete?", tcs);
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        RaiseKey(dialog, Key.Escape);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(tcs.Task.IsCompletedSuccessfully, "ESC should dismiss the dialog");
+        Assert.False(tcs.Task.Result, "ESC should cancel (No)");
+    }
+
+    [AvaloniaFact]
+    public void BuildConfirmDialog_ClosedWithoutChoice_ResolvesFalse()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var dialog = MainWindow.BuildConfirmDialog("Delete this frame?", "Delete?", tcs);
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(tcs.Task.IsCompletedSuccessfully);
+        Assert.False(tcs.Task.Result, "Closing the dialog without choosing must not delete");
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ConfirmDialogKeyboardTests.cs
@@ -1,19 +1,22 @@
-using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Interactivity;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
 /// Regression tests for issue #239: modal confirmation dialogs must be
-/// keyboard-accessible — ENTER confirms, ESC cancels. Covers the yes/no
-/// confirmation dialog and the shared <see cref="MainWindow.WireDialogKeyboard"/>
-/// helper used by the dialogs that contain input controls.
+/// keyboard-accessible — ENTER confirms, ESC cancels, immediately on open
+/// without a prior click. Covers the yes/no confirmation dialog and the shared
+/// <see cref="MainWindow.WireDialogKeyboard"/> helper used by the dialogs that
+/// contain input controls.
 /// </summary>
 public class ConfirmDialogKeyboardTests
 {
@@ -25,6 +28,11 @@ public class ConfirmDialogKeyboardTests
             Key = key,
         });
 
+    // Simulates real keyboard input through the focus pipeline — unlike RaiseEvent,
+    // this only reaches a handler if something inside the window is actually focused.
+    private static void PressKey(Window dialog, Key key) =>
+        dialog.KeyPress(key, RawInputModifiers.None, PhysicalKey.None, null);
+
     [AvaloniaFact]
     public void BuildConfirmDialog_EnterKey_ResolvesTrue()
     {
@@ -33,7 +41,7 @@ public class ConfirmDialogKeyboardTests
         dialog.Show();
         Dispatcher.UIThread.RunJobs();
 
-        RaiseKey(dialog, Key.Enter);
+        PressKey(dialog, Key.Enter);
         Dispatcher.UIThread.RunJobs();
 
         Assert.True(tcs.Task.IsCompletedSuccessfully, "ENTER should dismiss the dialog");
@@ -48,7 +56,7 @@ public class ConfirmDialogKeyboardTests
         dialog.Show();
         Dispatcher.UIThread.RunJobs();
 
-        RaiseKey(dialog, Key.Escape);
+        PressKey(dialog, Key.Escape);
         Dispatcher.UIThread.RunJobs();
 
         Assert.True(tcs.Task.IsCompletedSuccessfully, "ESC should dismiss the dialog");
@@ -71,9 +79,64 @@ public class ConfirmDialogKeyboardTests
     }
 
     // ── WireDialogKeyboard ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A freshly-opened window has no focused element, so keyboard input is not
+    /// routed anywhere. WireDialogKeyboard must move focus into the dialog on open
+    /// so ENTER/ESC work without the user clicking a control first.
+    /// </summary>
+    [AvaloniaFact]
+    public void WireDialogKeyboard_OnOpen_MovesFocusIntoDialog()
+    {
+        var dialog = new Window
+        {
+            Content = new StackPanel
+            {
+                Children = { new Button { Content = "OK" }, new Button { Content = "Cancel" } }
+            }
+        };
+        MainWindow.WireDialogKeyboard(dialog, onConfirm: () => { }, onCancel: () => { });
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var focused = dialog.FocusManager?.GetFocusedElement();
+        Assert.NotNull(focused);
+        Assert.Contains((Visual)focused!, dialog.GetVisualDescendants());
+        dialog.Close();
+    }
+
+    /// <summary>
+    /// Drives real keyboard input through the focus pipeline on an untouched
+    /// dialog containing a NumericUpDown — ESC must cancel. (The headless input
+    /// backend routes unfocused keys to the window, so the no-focus gap itself is
+    /// guarded by <see cref="WireDialogKeyboard_OnOpen_MovesFocusIntoDialog"/>;
+    /// this covers the input path end-to-end.)
+    /// </summary>
+    [AvaloniaFact]
+    public void WireDialogKeyboard_FreshDialog_EscapeCancelsWithoutClickingFirst()
+    {
+        bool cancelled = false;
+        var dialog = new Window
+        {
+            Content = new StackPanel
+            {
+                Children = { new NumericUpDown { Value = 1 }, new Button { Content = "OK" } }
+            }
+        };
+        MainWindow.WireDialogKeyboard(dialog, onConfirm: () => { }, onCancel: () => cancelled = true);
+        dialog.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        PressKey(dialog, Key.Escape);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(cancelled, "ESC must cancel a freshly-opened dialog without a prior click");
+        dialog.Close();
+    }
+
     // The Adjust Offsets / Resize Texture / Adjust Frame Time dialogs contain
     // input controls (NumericUpDown) whose focused inner control can mark the
-    // Escape KeyDown handled before it bubbles to the window — so Button.IsCancel
+    // key event handled before it bubbles to the window — so Button.IsCancel
     // never fires. WireDialogKeyboard attaches at the window with
     // handledEventsToo:true to survive that.
 


### PR DESCRIPTION
## Problem

When a frame is selected and the user presses DEL, a confirmation popup appears. It could only be dismissed by **clicking** a button — ENTER/ESC did nothing, forcing a mouse switch mid-keyboard-flow. The issue also asks that *every* modal confirmation dialog follow the ENTER=default / ESC=cancel convention.

## Fix

Two root causes, fixed across all of the editor's inline modal dialogs (delete confirmation, Adjust Offsets, Adjust Frame Time, Resize Texture, Add Multiple Frames):

1. **`Button.IsDefault`/`IsCancel` only fire if the key event bubbles to the window root unhandled.** The input-bearing dialogs contain `NumericUpDown` controls whose focused inner control consumes the key first, so the root handler never sees it. (The pure-button delete confirmation worked because it has no such control.)
2. **A freshly-shown window has no focused element**, and the windowing backend routes keyboard input nowhere until something is focused — so even a window-level handler got nothing until the user clicked a control first.

New shared helper `MainWindow.WireDialogKeyboard(dialog, onConfirm, onCancel)`:
- Attaches the ENTER/ESC handler at the window with `handledEventsToo: true`, so it fires regardless of what a focused child does with the event.
- On `Opened`, moves focus to the first focusable control — the same pattern `ShowStringInputDialogAsync` already uses — so the keys work immediately.

All five dialogs route through it. The delete-confirmation dialog's now-redundant `IsDefault`/`IsCancel` are dropped; Adjust Frame Time gained a Cancel button (it previously had only OK).

## Tests

`ConfirmDialogKeyboardTests` (headless Avalonia):
- `BuildConfirmDialog_{Enter,Escape}Key_*`, `_ClosedWithoutChoice_*` — confirm-dialog ENTER/ESC/close semantics.
- `WireDialogKeyboard_{Enter,Escape}HandledByChild_Still*` — handler still fires when a focused child marks the event handled (guards root cause 1; fails against an `IsCancel`-only approach).
- `WireDialogKeyboard_OnOpen_MovesFocusIntoDialog` — focus lands inside the dialog on open (guards root cause 2; fails without the focus-on-open line).
- `WireDialogKeyboard_FreshDialog_EscapeCancelsWithoutClickingFirst` — ESC cancels an untouched dialog through the real input path.

All 306 `AnimationEditor.App.Tests` pass.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)