### PR TITLE
feat(AE): show first frame as the animation tree icon

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -1,3 +1,4 @@
+using AnimationEditor.App.Services;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
@@ -68,6 +69,9 @@ public partial class App : Application
                 sp.GetRequiredService<IUndoManager>()));
         sc.AddSingleton<IAppCommands>(sp => sp.GetRequiredService<AppCommands>());
 
+        sc.AddSingleton<ThumbnailService>(sp =>
+            new ThumbnailService(sp.GetRequiredService<IProjectManager>()));
+
         sc.AddTransient<MainWindow>(sp => new MainWindow(
             sp.GetRequiredService<IProjectManager>(),
             sp.GetRequiredService<ISelectedState>(),
@@ -76,7 +80,8 @@ public partial class App : Application
             sp.GetRequiredService<IApplicationEvents>(),
             sp.GetRequiredService<IIoManager>(),
             sp.GetRequiredService<IObjectFinder>(),
-            sp.GetRequiredService<IUndoManager>()));
+            sp.GetRequiredService<IUndoManager>(),
+            sp.GetRequiredService<ThumbnailService>()));
 
         return sc.BuildServiceProvider();
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1,3 +1,4 @@
+using AnimationEditor.App.Services;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
@@ -29,10 +30,6 @@ public class PreviewControl : Control
     // -- Animation state -------------------------------------------------------
     private readonly DispatcherTimer _timer;
     private readonly AnimationEditor.Core.CommandsAndState.PlaybackController _playback = new();
-
-    // -- Bitmap cache ----------------------------------------------------------
-    private readonly Dictionary<string, SKBitmap?> _bitmapCache =
-        new(StringComparer.OrdinalIgnoreCase);
 
     // -- Camera ----------------------------------------------------------------
     private float _zoom = 1f;
@@ -145,10 +142,10 @@ public class PreviewControl : Control
             displayFrame = chain.Frames[idx];
         }
 
-        string? texPath   = ResolveTexturePath(displayFrame);
-        string? onionPath = ResolveTexturePath(onionFrame);
-        GetBitmap(texPath);
-        GetBitmap(onionPath);
+        string? texPath   = _thumbnailService!.ResolveTexturePath(displayFrame);
+        string? onionPath = _thumbnailService!.ResolveTexturePath(onionFrame);
+        _thumbnailService.GetBitmap(texPath);
+        _thumbnailService.GetBitmap(onionPath);
 
         var snap   = new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
                                         _showGuides, texPath, onionPath, width, height,
@@ -158,50 +155,8 @@ public class PreviewControl : Control
                                         BuildShapeInfos());
         var bitmap = new SKBitmap(width, height);
         using var canvas = new SKCanvas(bitmap);
-        RenderSkCore(canvas, snap, _bitmapCache);
+        RenderSkCore(canvas, snap, _thumbnailService.BitmapCache);
         return bitmap;
-    }
-
-    /// <summary>
-    /// Returns an Avalonia Bitmap of the frame's texture region, scaled to fit within
-    /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (preserving aspect ratio).
-    /// Returns null if the texture cannot be resolved, is not loaded, or the frame has no valid UV region.
-    /// </summary>
-    public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
-    {
-        var path = ResolveTexturePath(frame);
-        var bm = GetBitmap(path);
-        if (bm is null) return null;
-
-        float uvW = frame.RightCoordinate  - frame.LeftCoordinate;
-        float uvH = frame.BottomCoordinate - frame.TopCoordinate;
-        if (uvW <= 0f || uvH <= 0f) return null;
-
-        int tw = bm.Width, th = bm.Height;
-        int sx = Math.Clamp((int)(frame.LeftCoordinate * tw), 0, tw - 1);
-        int sy = Math.Clamp((int)(frame.TopCoordinate  * th), 0, th - 1);
-        int sw = Math.Clamp((int)(uvW * tw), 1, tw - sx);
-        int sh = Math.Clamp((int)(uvH * th), 1, th - sy);
-
-        float scale = Math.Min((float)maxWidth / sw, (float)maxHeight / sh);
-        int finalW = Math.Max(1, (int)(sw * scale));
-        int finalH = Math.Max(1, (int)(sh * scale));
-
-        using var thumb  = new SKBitmap(finalW, finalH);
-        using var canvas = new SKCanvas(thumb);
-        canvas.Clear(SKColors.Transparent);
-        using var img    = SKImage.FromBitmap(bm);
-        using var paint  = new SKPaint { Color = SKColors.White };
-        canvas.DrawImage(img,
-            SKRectI.Create(sx, sy, sw, sh),
-            SKRect.Create(0, 0, finalW, finalH),
-            new SKSamplingOptions(SKFilterMode.Linear),
-            paint);
-
-        using var ms = new MemoryStream();
-        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
-        ms.Position = 0;
-        return new Avalonia.Media.Imaging.Bitmap(ms);
     }
 
     // -- Injected services -----------------------------------------------------
@@ -212,6 +167,7 @@ public class PreviewControl : Control
     private IApplicationEvents? _events;
     private IProjectManager? _projectManager;
     private IUndoManager? _undoManager;
+    private ThumbnailService? _thumbnailService;
 
     /// <summary>
     /// Called from MainWindow after DI container wires all services.
@@ -223,7 +179,8 @@ public class PreviewControl : Control
         IAppCommands appCommands,
         IApplicationEvents events,
         IProjectManager projectManager,
-        IUndoManager undoManager)
+        IUndoManager undoManager,
+        ThumbnailService thumbnailService)
     {
         _selectedState  = selectedState;
         _appState       = appState;
@@ -231,6 +188,7 @@ public class PreviewControl : Control
         _events         = events;
         _projectManager = projectManager;
         _undoManager    = undoManager;
+        _thumbnailService = thumbnailService;
 
         _selectedState.SelectionChanged                        += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
         _events.AnimationChainsChanged                         += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
@@ -420,43 +378,6 @@ public class PreviewControl : Control
         InvalidateVisual();
     }
 
-    // -- Bitmap cache helpers --------------------------------------------------
-
-    private SKBitmap? GetBitmap(string? path)
-    {
-        if (string.IsNullOrEmpty(path)) return null;
-        if (_bitmapCache.TryGetValue(path, out var cached)) return cached;
-        try
-        {
-            var bm = SKBitmap.Decode(path);
-            _bitmapCache[path] = bm;
-            return bm;
-        }
-        catch
-        {
-            _bitmapCache[path] = null;
-            return null;
-        }
-    }
-
-    private string? ResolveTexturePath(AnimationFrameSave? frame)
-    {
-        if (frame is null || string.IsNullOrEmpty(frame.TextureName)) return null;
-
-        // Absolute path (e.g. drag-dropped textures before an ACHX file is saved).
-        if (Path.IsPathRooted(frame.TextureName))
-            return File.Exists(frame.TextureName) ? frame.TextureName : null;
-
-        // Relative path: requires a saved ACHX to derive the base folder.
-        if (string.IsNullOrEmpty(_projectManager!.FileName))
-            return null;
-        string achxFolder = (Path.GetDirectoryName(_projectManager!.FileName) ?? string.Empty);
-        string full = new FilePath(Path.Combine(achxFolder, frame.TextureName)).FullPath;
-        if (!File.Exists(full))
-            return null;
-        return full;
-    }
-
     // -- Avalonia rendering ----------------------------------------------------
 
     public override void Render(DrawingContext ctx)
@@ -489,10 +410,10 @@ public class PreviewControl : Control
         if (w <= 0 || h <= 0) return;
 
         // Pre-fill bitmap cache synchronously before handing off to render thread
-        string? texPath   = ResolveTexturePath(displayFrame);
-        string? onionPath = ResolveTexturePath(onionFrame);
-        GetBitmap(texPath);
-        GetBitmap(onionPath);
+        string? texPath   = _thumbnailService!.ResolveTexturePath(displayFrame);
+        string? onionPath = _thumbnailService!.ResolveTexturePath(onionFrame);
+        _thumbnailService.GetBitmap(texPath);
+        _thumbnailService.GetBitmap(onionPath);
 
         ctx.Custom(new DrawOp(
             new RenderSnapshot(
@@ -502,7 +423,7 @@ public class PreviewControl : Control
                 _hGuides.ToArray(), _vGuides.ToArray(),
                 _draggedGuideIdx, _draggingHGuide,
                 BuildShapeInfos()),
-            _bitmapCache));
+            _thumbnailService.BitmapCache));
     }
 
     // -- Guide helpers ---------------------------------------------------------

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -279,7 +279,14 @@
                             <Grid ColumnDefinitions="*,Auto,Auto" HorizontalAlignment="Stretch">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
-                                    <svg:Svg IsVisible="{Binding IsChainNode}"
+                                    <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph otherwise. -->
+                                    <Image IsVisible="{Binding HasThumbnail}"
+                                           Width="14" Height="14"
+                                           Margin="0,0,4,0"
+                                           VerticalAlignment="Center"
+                                           Stretch="Uniform"
+                                           Source="{Binding Thumbnail}" />
+                                    <svg:Svg IsVisible="{Binding ShowGenericChainIcon}"
                                              Width="14" Height="14"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -40,6 +40,7 @@ public partial class MainWindow : Window
     private readonly IIoManager _ioManager;
     private readonly IObjectFinder _objectFinder;
     private readonly IUndoManager _undoManager;
+    private readonly Services.ThumbnailService _thumbnailService;
 
     private AppSettingsModel _appSettings = new();
     private bool _suppressPropRefresh;
@@ -60,7 +61,8 @@ public partial class MainWindow : Window
         IApplicationEvents events,
         IIoManager ioManager,
         IObjectFinder objectFinder,
-        IUndoManager undoManager)
+        IUndoManager undoManager,
+        Services.ThumbnailService thumbnailService)
     {
         _projectManager = projectManager;
         _selectedState = selectedState;
@@ -70,6 +72,7 @@ public partial class MainWindow : Window
         _ioManager = ioManager;
         _objectFinder = objectFinder;
         _undoManager = undoManager;
+        _thumbnailService = thumbnailService;
 
         InitializeComponent();
         PropertyChanged += (_, e) => { if (e.Property == OffScreenMarginProperty) Padding = OffScreenMargin; };
@@ -87,7 +90,7 @@ public partial class MainWindow : Window
         WireKeyboard();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
-        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
+        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService);
 
         Opened += OnOpened;
         Closed += (_, _) =>
@@ -95,6 +98,7 @@ public partial class MainWindow : Window
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
             foreach (var vm in _timelineFrames)
                 (vm.Thumbnail as IDisposable)?.Dispose();
+            DisposeTreeThumbnails();
         };
     }
 
@@ -1052,11 +1056,12 @@ public partial class MainWindow : Window
         try
         {
             var acls = _projectManager.AnimationChainListSave;
-            if (acls is null) { _treeRoots.Clear(); return; }
+            if (acls is null) { DisposeTreeThumbnails(); _treeRoots.Clear(); return; }
 
             // Diff-update the root nodes instead of clearing and rebuilding, so each
             // chain's collapse state (and selection) survives copy/paste and reorder.
             TreeBuilder.SyncChainsInto(_treeRoots, acls.AnimationChains);
+            RefreshTreeThumbnails();
 
             // Re-select to keep visual state
             SyncTreeSelection();
@@ -1079,6 +1084,7 @@ public partial class MainWindow : Window
         _suppressTreeSelectionHandling = true;
         try
         {
+            DisposeTreeThumbnails();
             _treeRoots.Clear();
 
             var acls = _projectManager.AnimationChainListSave;
@@ -1089,6 +1095,7 @@ public partial class MainWindow : Window
             foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
                 _treeRoots.Add(node);
 
+            RefreshTreeThumbnails();
             SyncTreeSelection();
         }
         finally
@@ -1110,6 +1117,7 @@ public partial class MainWindow : Window
             node.Meta   = $"{chain.Frames.Count} fr";
             TreeBuilder.SyncFramesInto(node, chain.Frames);
         }
+        RefreshTreeThumbnails();
     }
 
     private void RefreshFrameNode(AnimationFrameSave frame)
@@ -1136,10 +1144,49 @@ public partial class MainWindow : Window
             frameNode.Meta       = rebuiltFrameNode.Meta;
             TreeBuilder.SyncShapesInto(frameNode, frame.ShapesSave);
         }
+        RefreshTreeThumbnails();
     }
 
     private TreeNodeVm? FindChainNode(AnimationChainSave chain) =>
         _treeRoots.FirstOrDefault(n => n.Data is AnimationChainSave c && c == chain);
+
+    /// <summary>
+    /// Regenerates each chain node's first-frame icon when its <see cref="ThumbnailSource"/>
+    /// has changed — a frame reorder, first-frame texture swap, first-frame region edit, or
+    /// first-frame delete. Chains with no frames fall back to the generic chain icon.
+    /// Change-detected, so calling it from every tree-refresh path is cheap when nothing
+    /// about a chain's first frame actually changed.
+    /// </summary>
+    private void RefreshTreeThumbnails()
+    {
+        foreach (var node in _treeRoots)
+        {
+            if (node.Data is not AnimationChainSave chain)
+                continue;
+
+            var source = ThumbnailSource.FromChain(chain);
+            // Regenerate when the first-frame visual changed, or when we have a source
+            // but no thumbnail yet (e.g. the texture was unresolvable on a prior pass).
+            bool needsRegen = !Equals(source, node.ThumbnailSource)
+                           || (source is not null && node.Thumbnail is null);
+            if (!needsRegen)
+                continue;
+
+            (node.Thumbnail as IDisposable)?.Dispose();
+            node.Thumbnail = source is null
+                ? null
+                : _thumbnailService.GetFrameThumbnail(chain.Frames[0], 14, 14);
+            node.ThumbnailSource = source;
+        }
+    }
+
+    /// <summary>Releases every chain node's first-frame thumbnail bitmap. Call before clearing
+    /// <c>_treeRoots</c> or on window close so the cropped bitmaps are not leaked.</summary>
+    private void DisposeTreeThumbnails()
+    {
+        foreach (var node in _treeRoots)
+            (node.Thumbnail as IDisposable)?.Dispose();
+    }
 
     private void SyncTreeSelection()
     {
@@ -1174,7 +1221,7 @@ public partial class MainWindow : Window
         if (chain is not null)
         {
             for (int i = 0; i < chain.Frames.Count && i < _timelineFrames.Count; i++)
-                _timelineFrames[i].Thumbnail = PreviewCtrl.GetFrameThumbnail(chain.Frames[i], 22, 18);
+                _timelineFrames[i].Thumbnail = _thumbnailService.GetFrameThumbnail(chain.Frames[i], 22, 18);
         }
 
         _currentTimelineFrameIndex = -1;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Decodes texture PNGs once, caches them, and crops frame-region thumbnails.
+/// Shared by the preview render path, the timeline strip, and the animation-tree
+/// first-frame chain icons so a sprite sheet is only decoded a single time.
+/// </summary>
+public sealed class ThumbnailService
+{
+    private readonly IProjectManager _projectManager;
+
+    /// <summary>
+    /// Decoded-bitmap cache keyed by absolute file path (case-insensitive). One decode per
+    /// file. Exposed so the preview render path can hand it to its off-thread draw op.
+    /// </summary>
+    public Dictionary<string, SKBitmap?> BitmapCache { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public ThumbnailService(IProjectManager projectManager) =>
+        _projectManager = projectManager;
+
+    /// <summary>
+    /// Returns the cached decode of <paramref name="path"/>, decoding on first access.
+    /// Returns <c>null</c> for a null/empty path or a file that fails to decode (the
+    /// failure is cached too, so a missing texture is not retried every frame).
+    /// </summary>
+    public SKBitmap? GetBitmap(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        if (BitmapCache.TryGetValue(path, out var cached)) return cached;
+        try
+        {
+            var bm = SKBitmap.Decode(path);
+            BitmapCache[path] = bm;
+            return bm;
+        }
+        catch
+        {
+            BitmapCache[path] = null;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a frame's <see cref="AnimationFrameSave.TextureName"/> to an absolute file
+    /// path. Relative names require a saved .achx to derive the base folder. Returns
+    /// <c>null</c> when the texture cannot be located on disk.
+    /// </summary>
+    public string? ResolveTexturePath(AnimationFrameSave? frame)
+    {
+        if (frame is null || string.IsNullOrEmpty(frame.TextureName)) return null;
+
+        // Absolute path (e.g. drag-dropped textures before an ACHX file is saved).
+        if (Path.IsPathRooted(frame.TextureName))
+            return File.Exists(frame.TextureName) ? frame.TextureName : null;
+
+        // Relative path: requires a saved ACHX to derive the base folder.
+        if (string.IsNullOrEmpty(_projectManager.FileName))
+            return null;
+        string achxFolder = Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty;
+        string full = new FilePath(Path.Combine(achxFolder, frame.TextureName)).FullPath;
+        return File.Exists(full) ? full : null;
+    }
+
+    /// <summary>
+    /// Returns an Avalonia Bitmap of the frame's texture region, scaled to fit within
+    /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (preserving aspect ratio).
+    /// Returns <c>null</c> if the texture cannot be resolved, is not loaded, or the frame
+    /// has no valid UV region. Caller owns the returned bitmap.
+    /// </summary>
+    public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
+    {
+        var path = ResolveTexturePath(frame);
+        var bm = GetBitmap(path);
+        if (bm is null) return null;
+
+        float uvW = frame.RightCoordinate  - frame.LeftCoordinate;
+        float uvH = frame.BottomCoordinate - frame.TopCoordinate;
+        if (uvW <= 0f || uvH <= 0f) return null;
+
+        int tw = bm.Width, th = bm.Height;
+        int sx = Math.Clamp((int)(frame.LeftCoordinate * tw), 0, tw - 1);
+        int sy = Math.Clamp((int)(frame.TopCoordinate  * th), 0, th - 1);
+        int sw = Math.Clamp((int)(uvW * tw), 1, tw - sx);
+        int sh = Math.Clamp((int)(uvH * th), 1, th - sy);
+
+        float scale = Math.Min((float)maxWidth / sw, (float)maxHeight / sh);
+        int finalW = Math.Max(1, (int)(sw * scale));
+        int finalH = Math.Max(1, (int)(sh * scale));
+
+        using var thumb  = new SKBitmap(finalW, finalH);
+        using var canvas = new SKCanvas(thumb);
+        canvas.Clear(SKColors.Transparent);
+        using var img    = SKImage.FromBitmap(bm);
+        using var paint  = new SKPaint { Color = SKColors.White };
+        canvas.DrawImage(img,
+            SKRectI.Create(sx, sy, sw, sh),
+            SKRect.Create(0, 0, finalW, finalH),
+            new SKSamplingOptions(SKFilterMode.Linear),
+            paint);
+
+        using var ms = new MemoryStream();
+        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
+        ms.Position = 0;
+        return new Avalonia.Media.Imaging.Bitmap(ms);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
@@ -1,0 +1,36 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.ViewModels;
+
+/// <summary>
+/// Value signature of the visual a chain's first-frame thumbnail is rendered from.
+/// Two equal <see cref="ThumbnailSource"/> values produce an identical thumbnail, so the
+/// animation tree only regenerates a chain icon when this changes — which happens on a
+/// frame reorder, a first-frame texture swap, a first-frame region edit, or a first-frame
+/// delete.
+/// </summary>
+public readonly record struct ThumbnailSource(
+    string? TextureName,
+    float Left,
+    float Right,
+    float Top,
+    float Bottom)
+{
+    /// <summary>
+    /// Returns the signature of <paramref name="chain"/>'s first frame, or <c>null</c>
+    /// when the chain has no frames (the tree falls back to the generic chain icon).
+    /// </summary>
+    public static ThumbnailSource? FromChain(AnimationChainSave chain)
+    {
+        if (chain.Frames.Count == 0)
+            return null;
+
+        var frame = chain.Frames[0];
+        return new ThumbnailSource(
+            frame.TextureName,
+            frame.LeftCoordinate,
+            frame.RightCoordinate,
+            frame.TopCoordinate,
+            frame.BottomCoordinate);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -256,7 +256,11 @@ public static class TreeBuilder
         var chainSet = new HashSet<AnimationChainSave>(chains, ReferenceEqualityComparer.Instance);
         for (int i = roots.Count - 1; i >= 0; i--)
             if (roots[i].Data is AnimationChainSave c && !chainSet.Contains(c))
+            {
+                // Release the chain's first-frame thumbnail bitmap before dropping the node.
+                (roots[i].Thumbnail as System.IDisposable)?.Dispose();
                 roots.RemoveAt(i);
+            }
 
         // Build a lookup of surviving VMs keyed by chain reference.
         var existingByChain = new Dictionary<AnimationChainSave, TreeNodeVm>(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -89,6 +89,44 @@ public class TreeNodeVm : INotifyPropertyChanged
     /// <summary>True when this node represents a CircleSave shape. Set once at construction time.</summary>
     public bool IsCircleNode { get; set; }
 
+    private object? _thumbnail;
+    /// <summary>
+    /// First-frame thumbnail for a chain node, set by the App layer once the texture is
+    /// resolved. Holds an <c>Avalonia.Media.Imaging.Bitmap</c> at runtime; <c>null</c> for
+    /// chains with no frames (or an unresolvable first-frame texture), in which case the
+    /// tree shows the generic chain icon. Always <c>null</c> on non-chain nodes.
+    /// </summary>
+    public object? Thumbnail
+    {
+        get => _thumbnail;
+        set
+        {
+            if (!ReferenceEquals(_thumbnail, value))
+            {
+                _thumbnail = value;
+                Notify();
+                Notify(nameof(HasThumbnail));
+                Notify(nameof(ShowGenericChainIcon));
+            }
+        }
+    }
+
+    /// <summary>True when a first-frame <see cref="Thumbnail"/> is available to show.</summary>
+    public bool HasThumbnail => _thumbnail is not null;
+
+    /// <summary>
+    /// True when the tree should show the generic chain icon — a chain node that has no
+    /// first-frame thumbnail. Drives the SVG-vs-thumbnail swap in the tree item template.
+    /// </summary>
+    public bool ShowGenericChainIcon => IsChainNode && _thumbnail is null;
+
+    /// <summary>
+    /// Signature of the first frame the current <see cref="Thumbnail"/> was rendered from.
+    /// The App layer compares this against <see cref="ThumbnailSource.FromChain"/> to skip
+    /// regenerating a chain icon whose first-frame visual is unchanged.
+    /// </summary>
+    public ThumbnailSource? ThumbnailSource { get; set; }
+
     public ObservableCollection<TreeNodeVm> Children { get; } = new();
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.App.Controls;
+using AnimationEditor.App.Services;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
@@ -21,6 +22,7 @@ internal sealed class TestServices
     public ObjectFinder ObjectFinder { get; }
     public UndoManager UndoManager { get; }
     public AppCommands AppCommands { get; }
+    public ThumbnailService ThumbnailService { get; }
 
     public TestServices()
     {
@@ -33,12 +35,13 @@ internal sealed class TestServices
         UndoManager       = new UndoManager();
         AppCommands       = new AppCommands(ProjectManager, SelectedState, ApplicationEvents,
                                             IoManager, ObjectFinder, UndoManager);
+        ThumbnailService  = new ThumbnailService(ProjectManager);
     }
 
     public MainWindow CreateMainWindow() =>
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
-            ApplicationEvents, IoManager, ObjectFinder, UndoManager);
+            ApplicationEvents, IoManager, ObjectFinder, UndoManager, ThumbnailService);
 
     public WireframeControl CreateWireframeControl()
     {
@@ -50,7 +53,7 @@ internal sealed class TestServices
     public PreviewControl CreatePreviewControl()
     {
         var ctrl = new PreviewControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, ThumbnailService);
         return ctrl;
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeThumbnailTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeThumbnailTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Headless Avalonia tests for issue #236: a chain's tree-node icon shows a thumbnail
+/// of its first frame, falling back to the generic chain icon when the chain is empty,
+/// and regenerating when the first frame's visual changes.
+/// </summary>
+public class TreeThumbnailTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static ObservableCollection<TreeNodeVm> GetRoots(MainWindow w)
+    {
+        var tree = w.FindControl<TreeView>("AnimTree")
+            ?? throw new InvalidOperationException("AnimTree control not found");
+        return (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+    }
+
+    private static void TriggerRefreshTreeView(MainWindow window)
+    {
+        var method = typeof(MainWindow).GetMethod(
+            "RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("RefreshTreeView not found");
+        method.Invoke(window, null);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static string WriteSolidPng(string dir, string name, SKColor color, int size = 16)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>A frame whose full texture is the thumbnail source (UV region 0,0 → 1,1).</summary>
+    private static AnimationFrameSave FullFrame(string textureName) => new()
+    {
+        TextureName     = textureName,
+        LeftCoordinate  = 0f, TopCoordinate    = 0f,
+        RightCoordinate = 1f, BottomCoordinate = 1f,
+    };
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void RefreshTreeView_ChainWithFirstFrame_SetsChainNodeThumbnail()
+    {
+        var (window, ctx) = CreateWindow();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            WriteSolidPng(dir, "red.png", SKColors.Red);
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(FullFrame("red.png"));
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+
+            var chainNode = GetRoots(window)[0];
+            Assert.NotNull(chainNode.Thumbnail);
+            Assert.True(chainNode.HasThumbnail);
+            Assert.False(chainNode.ShowGenericChainIcon);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTreeView_ChainWithNoFrames_LeavesChainNodeThumbnailNull()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Empty" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+
+            var chainNode = GetRoots(window)[0];
+            Assert.Null(chainNode.Thumbnail);
+            // No first frame → the tree must show the generic chain glyph.
+            Assert.True(chainNode.ShowGenericChainIcon);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTreeView_AfterFirstFrameTextureChange_RegeneratesThumbnail()
+    {
+        var (window, ctx) = CreateWindow();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            WriteSolidPng(dir, "red.png",  SKColors.Red);
+            WriteSolidPng(dir, "blue.png", SKColors.Blue);
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var firstFrame = FullFrame("red.png");
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(firstFrame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            var chainNode = GetRoots(window)[0];
+            var firstThumbnail = chainNode.Thumbnail;
+            Assert.NotNull(firstThumbnail);
+
+            // Swap the first frame's texture — the icon must regenerate.
+            firstFrame.TextureName = "blue.png";
+            TriggerRefreshTreeView(window);
+
+            Assert.NotNull(chainNode.Thumbnail);
+            Assert.NotSame(firstThumbnail, chainNode.Thumbnail);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
@@ -1,0 +1,66 @@
+using AnimationEditor.Core.ViewModels;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ThumbnailSourceTests
+{
+    // ── FromChain ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FromChain_ChainWithNoFrames_ReturnsNull()
+    {
+        var chain = new AnimationChainSave { Name = "Empty" };
+
+        Assert.Null(ThumbnailSource.FromChain(chain));
+    }
+
+    [Fact]
+    public void FromChain_CapturesFirstFrameTextureAndRegion()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName     = "sheet.png",
+            LeftCoordinate  = 0f,   TopCoordinate    = 0f,
+            RightCoordinate = 0.5f, BottomCoordinate = 1f,
+        });
+        // Second frame must not influence the signature.
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "other.png" });
+
+        var source = ThumbnailSource.FromChain(chain);
+
+        Assert.Equal(new ThumbnailSource("sheet.png", 0f, 0.5f, 0f, 1f), source);
+    }
+
+    [Fact]
+    public void FromChain_DifferentFirstFrameTexture_ProducesUnequalSignature()
+    {
+        var red = new AnimationChainSave { Name = "Red" };
+        red.Frames.Add(new AnimationFrameSave { TextureName = "red.png" });
+        var blue = new AnimationChainSave { Name = "Blue" };
+        blue.Frames.Add(new AnimationFrameSave { TextureName = "blue.png" });
+
+        Assert.NotEqual(ThumbnailSource.FromChain(red), ThumbnailSource.FromChain(blue));
+    }
+
+    [Fact]
+    public void FromChain_SameTextureDifferentRegion_ProducesUnequalSignature()
+    {
+        // Two frames on the same sheet but different UV regions — a region edit on the
+        // first frame must be detected as a change.
+        var leftHalf = new AnimationChainSave { Name = "Left" };
+        leftHalf.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 0.5f, BottomCoordinate = 1f,
+        });
+        var rightHalf = new AnimationChainSave { Name = "Right" };
+        rightHalf.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", LeftCoordinate = 0.5f, RightCoordinate = 1f, BottomCoordinate = 1f,
+        });
+
+        Assert.NotEqual(ThumbnailSource.FromChain(leftHalf), ThumbnailSource.FromChain(rightHalf));
+    }
+}


### PR DESCRIPTION
## What

Implements #236: in the Animation Editor tree, each `AnimationChainSave` node now shows a thumbnail of its **first frame** instead of a generic icon, falling back to the generic chain glyph when the chain has no frames. The icon regenerates reactively on a frame reorder, first-frame texture swap, first-frame region edit, or first-frame delete.

## How

- **New `ThumbnailService`** (App layer, DI singleton) — extracts texture-PNG decoding and frame-region cropping out of `PreviewControl`. The preview render path, the timeline strip, and the new tree icons now all share **one path-keyed bitmap cache**, so a sprite sheet is decoded only once regardless of how many chains reference it.
- **New `ThumbnailSource`** (Core) — a value signature `(TextureName, Left, Right, Top, Bottom)` of a chain's first frame. `MainWindow.RefreshTreeThumbnails` compares it against the last-generated signature and only re-crops when the first-frame visual actually changed, so the call is free on tree refreshes that don't touch a chain's first frame. It's wired into every tree-refresh path (`RefreshTreeView`, `RebuildTreeView`, `RefreshChainNode`, `RefreshFrameNode`).
- **`TreeNodeVm`** gains `Thumbnail` / `HasThumbnail` / `ShowGenericChainIcon` / `ThumbnailSource`; the tree item template swaps the chain SVG for an `Image` when a thumbnail is present.
- Thumbnail bitmaps are disposed on regeneration, on chain-node removal, and on window close.

## Cost / caching note

The expensive work (PNG decode) was already cached in `PreviewControl` and is now shared via `ThumbnailService` — generating first-frame icons for every chain reuses the already-decoded bitmaps. The per-thumbnail crop+scale+encode is change-detected, so idle tree refreshes cost nothing.

## Out of scope (deferred)

Re-decoding when a source PNG **changes on disk** is intentionally not handled here — it's a pre-existing editor-wide limitation (the timeline strip and preview panel are already stale on external file edits, since the bitmap cache is never invalidated). #236's "reactive update" requirement is about data-model changes, which this PR covers. A follow-up issue should add disk-watch cache invalidation for the whole editor at once.

## Testing

- `ThumbnailSourceTests` (Core) — signature capture, empty-chain → null, change detection.
- `TreeThumbnailTests` (App, headless Avalonia) — chain with a first frame gets a thumbnail; empty chain shows the generic icon; first-frame texture swap regenerates.
- Full suites green: Core 904 passed, App 303 passed (the `ThumbnailService` extraction is covered by existing `PreviewControl` / timeline / render tests).

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
