### PR TITLE
AE: Wire every mutating command into the undo stack + undo-coverage guardrail

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
@@ -1,0 +1,49 @@
+using FlatRedBall2.Animation.Content;
+using System;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Undo/redo record for adding several frames to a chain in one operation
+    /// (Add Multiple Frames). Recorded as a single entry so one user action is
+    /// one undo step, rather than one step per frame.
+    /// </summary>
+    internal sealed class AddFramesCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave[] _frames;
+        private readonly AnimationChainSave _chain;
+        private readonly int _insertedAtIndex;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public AddFramesCommand(
+            AnimationFrameSave[] frames, AnimationChainSave chain, int insertedAtIndex,
+            IAppCommands commands, IApplicationEvents events)
+        {
+            _frames = frames;
+            _chain = chain;
+            _insertedAtIndex = insertedAtIndex;
+            _commands = commands;
+            _events = events;
+        }
+
+        public void Undo()
+        {
+            foreach (var frame in _frames)
+                _chain.Frames.Remove(frame);
+            _commands.RefreshTreeNode(_chain);
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+
+        public void Redo()
+        {
+            int idx = Math.Min(_insertedAtIndex, _chain.Frames.Count);
+            for (int i = 0; i < _frames.Length; i++)
+                _chain.Frames.Insert(idx + i, _frames[i]);
+            _commands.RefreshTreeNode(_chain);
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -229,7 +229,7 @@ namespace AnimationEditor.Core.CommandsAndState
                     GetSelectedFrameShapeNames())
             };
 
-            MatchRectangleToFrame(rectangleSave, frame);
+            ApplyRectangleMatch(rectangleSave, frame);
             frame.ShapesSave!.AARectSaves.Add(rectangleSave);
 
             RefreshAnimationFrameDisplayRequested?.Invoke();
@@ -248,7 +248,7 @@ namespace AnimationEditor.Core.CommandsAndState
                     GetSelectedFrameShapeNames())
             };
 
-            MatchCircleToFrame(circleSave, frame);
+            ApplyCircleMatch(circleSave, frame);
             frame.ShapesSave!.CircleSaves.Add(circleSave);
 
             RefreshAnimationFrameDisplayRequested?.Invoke();
@@ -258,18 +258,67 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Record(new AddCircleCommand(circleSave, frame, this, _events));
         }
 
+        /// <summary>
+        /// Moves <paramref name="rectangle"/> to <paramref name="animationFrame"/>'s offset
+        /// (the "Match Frame Size" command). Records an undo entry; callers refresh the UI.
+        /// </summary>
         public void MatchRectangleToFrame(AARectSave rectangle, AnimationFrameSave animationFrame)
         {
-            // Texture width/height are not available at Core layer; the rendering layer should
-            // override via AfterMatchRectangleToFrame if it wants pixel-accurate sizing.
+            float oldX = rectangle.X, oldY = rectangle.Y;
+            ApplyRectangleMatch(rectangle, animationFrame);
+            _undoManager.Record(new MoveShapeCommand(
+                animationFrame, rectangle, oldX, oldY, rectangle.X, rectangle.Y, this, _events));
+        }
+
+        /// <summary>
+        /// Moves <paramref name="circle"/> to <paramref name="animationFrame"/>'s offset.
+        /// Records an undo entry; callers refresh the UI.
+        /// </summary>
+        public void MatchCircleToFrame(CircleSave circle, AnimationFrameSave animationFrame)
+        {
+            float oldX = circle.X, oldY = circle.Y;
+            ApplyCircleMatch(circle, animationFrame);
+            _undoManager.Record(new MoveShapeCommand(
+                animationFrame, circle, oldX, oldY, circle.X, circle.Y, this, _events));
+        }
+
+        // Raw position assignment shared by the public Match* commands and the internal
+        // shape-creation paths (which record their own combined undo entry instead).
+        private static void ApplyRectangleMatch(AARectSave rectangle, AnimationFrameSave animationFrame)
+        {
             rectangle.X = animationFrame.RelativeX;
             rectangle.Y = animationFrame.RelativeY;
         }
 
-        public void MatchCircleToFrame(CircleSave circle, AnimationFrameSave animationFrame)
+        private static void ApplyCircleMatch(CircleSave circle, AnimationFrameSave animationFrame)
         {
             circle.X = animationFrame.RelativeX;
             circle.Y = animationFrame.RelativeY;
+        }
+
+        // ── Undo recording helpers ────────────────────────────────────────────
+
+        /// <summary>
+        /// Records a <see cref="ReorderCommand{T}"/> capturing the list's order before
+        /// (passed in) and after (read from <paramref name="list"/> now). No-op when the
+        /// order is unchanged, so callers can invoke it unconditionally.
+        /// </summary>
+        private void RecordReorder<T>(IList<T> list, T[] before, Action refresh)
+        {
+            var after = list.ToArray();
+            if (before.SequenceEqual(after)) return;
+            _undoManager.Record(new ReorderCommand<T>(list, before, after, this, _events, refresh));
+        }
+
+        /// <summary>
+        /// Records a <see cref="BulkFrameEditCommand"/> capturing the frames' numeric fields
+        /// before (passed in) and after (read from <paramref name="frames"/> now).
+        /// </summary>
+        private void RecordBulkFrameEdit(
+            FrameFieldSnapshot[] before, IEnumerable<AnimationFrameSave> frames, bool refreshWireframe)
+        {
+            var after = frames.Select(FrameFieldSnapshot.Capture).ToArray();
+            _undoManager.Record(new BulkFrameEditCommand(before, after, this, _events, refreshWireframe));
         }
 
         public void DeleteCircle(CircleSave circle, AnimationFrameSave owner)
@@ -466,33 +515,39 @@ namespace AnimationEditor.Core.CommandsAndState
             int idx    = chains.IndexOf(chain);
             int newIdx = Math.Clamp(idx + delta, 0, chains.Count - 1);
             if (newIdx == idx) return;
+            var before = chains.ToArray();
             chains.RemoveAt(idx);
             chains.Insert(newIdx, chain);
             RefreshTreeViewRequested?.Invoke();
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chains, before, RefreshTreeView);
         }
 
         public void MoveChainToTop(AnimationChainSave chain)
         {
             var chains = _pm.AnimationChainListSave?.AnimationChains;
             if (chains is null) return;
+            var before = chains.ToArray();
             chains.Remove(chain);
             chains.Insert(0, chain);
             RefreshTreeViewRequested?.Invoke();
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chains, before, RefreshTreeView);
         }
 
         public void MoveChainToBottom(AnimationChainSave chain)
         {
             var chains = _pm.AnimationChainListSave?.AnimationChains;
             if (chains is null) return;
+            var before = chains.ToArray();
             chains.Remove(chain);
             chains.Add(chain);
             RefreshTreeViewRequested?.Invoke();
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chains, before, RefreshTreeView);
         }
 
         public void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta)
@@ -500,29 +555,35 @@ namespace AnimationEditor.Core.CommandsAndState
             int idx    = chain.Frames.IndexOf(frame);
             int newIdx = Math.Clamp(idx + delta, 0, chain.Frames.Count - 1);
             if (newIdx == idx) return;
+            var before = chain.Frames.ToArray();
             chain.Frames.RemoveAt(idx);
             chain.Frames.Insert(newIdx, frame);
             RefreshChainNodeRequested?.Invoke(chain);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chain.Frames, before, () => RefreshTreeNode(chain));
         }
 
         public void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain)
         {
+            var before = chain.Frames.ToArray();
             chain.Frames.Remove(frame);
             chain.Frames.Insert(0, frame);
             RefreshChainNodeRequested?.Invoke(chain);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chain.Frames, before, () => RefreshTreeNode(chain));
         }
 
         public void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain)
         {
+            var before = chain.Frames.ToArray();
             chain.Frames.Remove(frame);
             chain.Frames.Add(frame);
             RefreshChainNodeRequested?.Invoke(chain);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chain.Frames, before, () => RefreshTreeNode(chain));
         }
 
         /// <summary>
@@ -548,6 +609,8 @@ namespace AnimationEditor.Core.CommandsAndState
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            _undoManager.Record(new FlipCommand(
+                new[] { frame }, horizontal: true, this, _events, RefreshWireframe));
         }
 
         public void FlipFrameVertically(AnimationFrameSave frame)
@@ -556,6 +619,8 @@ namespace AnimationEditor.Core.CommandsAndState
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            _undoManager.Record(new FlipCommand(
+                new[] { frame }, horizontal: false, this, _events, RefreshWireframe));
         }
 
         public void FlipChainHorizontally(AnimationChainSave chain)
@@ -566,6 +631,9 @@ namespace AnimationEditor.Core.CommandsAndState
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            _undoManager.Record(new FlipCommand(
+                chain.Frames.ToArray(), horizontal: true, this, _events,
+                () => { RefreshTreeNode(chain); RefreshWireframe(); }));
         }
 
         public void FlipChainVertically(AnimationChainSave chain)
@@ -576,22 +644,29 @@ namespace AnimationEditor.Core.CommandsAndState
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            _undoManager.Record(new FlipCommand(
+                chain.Frames.ToArray(), horizontal: false, this, _events,
+                () => { RefreshTreeNode(chain); RefreshWireframe(); }));
         }
 
         public void InvertFrameOrder(AnimationChainSave chain)
         {
+            var before = chain.Frames.ToArray();
             chain.Frames.Reverse();
             RefreshChainNodeRequested?.Invoke(chain);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(chain.Frames, before, () => RefreshTreeNode(chain));
         }
 
         public void SetAllFrameLengths(AnimationChainSave chain, float frameLength)
         {
+            var before = chain.Frames.Select(FrameFieldSnapshot.Capture).ToArray();
             foreach (var frame in chain.Frames)
                 frame.FrameLength = frameLength;
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordBulkFrameEdit(before, chain.Frames, refreshWireframe: false);
         }
 
         public AnimationChainSave? DuplicateChain(
@@ -639,10 +714,12 @@ namespace AnimationEditor.Core.CommandsAndState
             }
 
             acls.AnimationChains.Add(copy);
+            int insertedAtIndex = acls.AnimationChains.Count - 1;
             RefreshTreeViewRequested?.Invoke();
             _selectedState.SelectedChain = copy;
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            _undoManager.Record(new AddChainCommand(copy, acls, insertedAtIndex, this, _events));
             return copy;
         }
 
@@ -650,6 +727,7 @@ namespace AnimationEditor.Core.CommandsAndState
         {
             var acls = _pm.AnimationChainListSave;
             if (acls is null) return;
+            var before = acls.AnimationChains.ToArray();
             var sorted = acls.AnimationChains.OrderBy(c => c.Name).ToList();
             acls.AnimationChains.Clear();
             foreach (var c in sorted)
@@ -657,6 +735,7 @@ namespace AnimationEditor.Core.CommandsAndState
             RefreshTreeViewRequested?.Invoke();
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordReorder(acls.AnimationChains, before, RefreshTreeView);
         }
 
         // ── A16: Adjust Offsets ───────────────────────────────────────────────
@@ -678,6 +757,7 @@ namespace AnimationEditor.Core.CommandsAndState
             Func<AnimationFrameSave, float?> getTextureHeight,
             float offsetMultiplier = 1f)
         {
+            var before = chain.Frames.Select(FrameFieldSnapshot.Capture).ToArray();
             foreach (var frame in chain.Frames)
             {
                 var height = getTextureHeight(frame);
@@ -687,6 +767,7 @@ namespace AnimationEditor.Core.CommandsAndState
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            RecordBulkFrameEdit(before, chain.Frames, refreshWireframe: true);
         }
 
         /// <summary>
@@ -699,10 +780,12 @@ namespace AnimationEditor.Core.CommandsAndState
             float? deltaY,
             bool relative)
         {
+            var before = chain.Frames.Select(FrameFieldSnapshot.Capture).ToArray();
             AdjustOffsetCalculator.ApplyAdjustAll(chain.Frames, deltaX, deltaY, relative);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
             RefreshWireframeRequested?.Invoke();
+            RecordBulkFrameEdit(before, chain.Frames, refreshWireframe: true);
         }
 
         // ── A17: Scale Frame Times ────────────────────────────────────────────
@@ -715,9 +798,11 @@ namespace AnimationEditor.Core.CommandsAndState
             AnimationChainSave chain,
             float targetTotalDuration)
         {
+            var before = chain.Frames.Select(FrameFieldSnapshot.Capture).ToArray();
             FrameTimeScaler.ApplyKeepProportional(chain.Frames, targetTotalDuration);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordBulkFrameEdit(before, chain.Frames, refreshWireframe: false);
         }
 
         /// <summary>
@@ -728,9 +813,11 @@ namespace AnimationEditor.Core.CommandsAndState
             AnimationChainSave chain,
             float targetTotalDuration)
         {
+            var before = chain.Frames.Select(FrameFieldSnapshot.Capture).ToArray();
             FrameTimeScaler.ApplySetAllSame(chain.Frames, targetTotalDuration);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+            RecordBulkFrameEdit(before, chain.Frames, refreshWireframe: false);
         }
 
         // ── F12: Add Multiple Frames ──────────────────────────────────────────
@@ -749,7 +836,9 @@ namespace AnimationEditor.Core.CommandsAndState
             var lastFrame = chain.Frames.Count > 0 ? chain.Frames[^1] : null;
             var result    = BatchFrameBuilder.BuildBatch(lastFrame, count, incrementUV);
 
-            foreach (var frame in result.Frames)
+            int insertedAtIndex = chain.Frames.Count;
+            var added = result.Frames.ToArray();
+            foreach (var frame in added)
             {
                 chain.Frames.Add(frame);
                 _selectedState.SelectedFrame = frame;
@@ -758,6 +847,9 @@ namespace AnimationEditor.Core.CommandsAndState
             RefreshChainNodeRequested?.Invoke(chain);
             SaveCurrentAnimationChainList();
             _events.RaiseAnimationChainsChanged();
+
+            if (added.Length > 0)
+                _undoManager.Record(new AddFramesCommand(added, chain, insertedAtIndex, this, _events));
 
             return result.ExceededTextureBounds;
         }
@@ -783,6 +875,11 @@ namespace AnimationEditor.Core.CommandsAndState
                 ? string.Empty
                 : System.IO.Path.GetDirectoryName(_pm.FileName) ?? string.Empty;
 
+            // Snapshot every frame before the resize; unmodified frames have identical
+            // before/after snapshots and are harmless no-ops on undo/redo.
+            var allFrames = acls.AnimationChains.SelectMany(c => c.Frames).ToArray();
+            var before = allFrames.Select(FrameFieldSnapshot.Capture).ToArray();
+
             var modified = TextureResizeAdjuster.AdjustAll(
                 acls, aclsDir, absoluteTextureFilePath,
                 oldWidth, oldHeight, newWidth, newHeight);
@@ -792,6 +889,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 SaveCurrentAnimationChainList();
                 _events.RaiseAnimationChainsChanged();
                 RefreshWireframeRequested?.Invoke();
+                var after = allFrames.Select(FrameFieldSnapshot.Capture).ToArray();
+                _undoManager.Record(new BulkFrameEditCommand(
+                    before, after, this, _events, refreshWireframe: true));
             }
 
             return modified;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -1,0 +1,71 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Captured values of every numeric field a bulk frame-edit operation can touch
+    /// (frame length, offsets, UV coordinates). Used by <see cref="BulkFrameEditCommand"/>
+    /// to snapshot a frame before and after the operation.
+    /// </summary>
+    internal readonly record struct FrameFieldSnapshot(
+        AnimationFrameSave Frame,
+        float FrameLength,
+        float RelativeX, float RelativeY,
+        float Left, float Right, float Top, float Bottom)
+    {
+        public static FrameFieldSnapshot Capture(AnimationFrameSave f) =>
+            new(f, f.FrameLength, f.RelativeX, f.RelativeY,
+                f.LeftCoordinate, f.RightCoordinate, f.TopCoordinate, f.BottomCoordinate);
+
+        public void RestoreToFrame()
+        {
+            Frame.FrameLength      = FrameLength;
+            Frame.RelativeX        = RelativeX;
+            Frame.RelativeY        = RelativeY;
+            Frame.LeftCoordinate   = Left;
+            Frame.RightCoordinate  = Right;
+            Frame.TopCoordinate    = Top;
+            Frame.BottomCoordinate = Bottom;
+        }
+    }
+
+    /// <summary>
+    /// Undo/redo record for an operation that edits numeric fields across many frames
+    /// at once — set-all-frame-lengths, adjust-offsets, scale-frame-times,
+    /// adjust-UV-after-resize. The caller snapshots the affected frames before and
+    /// after running the operation; this command just replays whichever snapshot set.
+    /// </summary>
+    internal sealed class BulkFrameEditCommand : IUndoableCommand
+    {
+        private readonly FrameFieldSnapshot[] _before;
+        private readonly FrameFieldSnapshot[] _after;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+        private readonly bool _refreshWireframe;
+
+        public BulkFrameEditCommand(
+            FrameFieldSnapshot[] before, FrameFieldSnapshot[] after,
+            IAppCommands commands, IApplicationEvents events, bool refreshWireframe)
+        {
+            _before = before;
+            _after = after;
+            _commands = commands;
+            _events = events;
+            _refreshWireframe = refreshWireframe;
+        }
+
+        public void Undo() => Apply(_before);
+        public void Redo() => Apply(_after);
+
+        private void Apply(FrameFieldSnapshot[] snapshots)
+        {
+            foreach (var snapshot in snapshots)
+                snapshot.RestoreToFrame();
+            _events.RaiseAnimationChainsChanged();
+            if (_refreshWireframe)
+                _commands.RefreshWireframe();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
@@ -1,0 +1,45 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Undo/redo record for toggling the horizontal or vertical flip flag on a set
+    /// of frames (frame flip, or whole-chain flip). A flip is its own inverse, so
+    /// <see cref="Undo"/> and <see cref="Redo"/> both re-toggle the same frames.
+    /// </summary>
+    internal sealed class FlipCommand : IUndoableCommand
+    {
+        private readonly IReadOnlyList<AnimationFrameSave> _frames;
+        private readonly bool _horizontal;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+        private readonly System.Action _refresh;
+
+        public FlipCommand(
+            IReadOnlyList<AnimationFrameSave> frames, bool horizontal,
+            IAppCommands commands, IApplicationEvents events, System.Action refresh)
+        {
+            _frames = frames;
+            _horizontal = horizontal;
+            _commands = commands;
+            _events = events;
+            _refresh = refresh;
+        }
+
+        public void Undo() => Toggle();
+        public void Redo() => Toggle();
+
+        private void Toggle()
+        {
+            foreach (var frame in _frames)
+            {
+                if (_horizontal) frame.FlipHorizontal = !frame.FlipHorizontal;
+                else frame.FlipVertical = !frame.FlipVertical;
+            }
+            _refresh();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ReorderCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ReorderCommand.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Undo/redo record for any operation that reorders the elements of a list
+    /// (move up/down, move to top/bottom, invert, sort). Snapshots the full
+    /// before/after order, so it is correct regardless of how the reorder was
+    /// computed — the command never has to know the specific move that happened.
+    /// </summary>
+    internal sealed class ReorderCommand<T> : IUndoableCommand
+    {
+        private readonly IList<T> _list;
+        private readonly T[] _before;
+        private readonly T[] _after;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+        private readonly System.Action _refresh;
+
+        public ReorderCommand(
+            IList<T> list, T[] before, T[] after,
+            IAppCommands commands, IApplicationEvents events, System.Action refresh)
+        {
+            _list = list;
+            _before = before;
+            _after = after;
+            _commands = commands;
+            _events = events;
+            _refresh = refresh;
+        }
+
+        public void Undo() => Apply(_before);
+        public void Redo() => Apply(_after);
+
+        private void Apply(T[] order)
+        {
+            _list.Clear();
+            foreach (var item in order)
+                _list.Add(item);
+            _refresh();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InvertFrameOrderUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InvertFrameOrderUndoTests.cs
@@ -1,0 +1,43 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class InvertFrameOrderUndoTests
+{
+    [Fact]
+    public void InvertFrameOrder_Undo_RestoresOriginalOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var frame0 = chain.Frames[0];
+        var frame1 = chain.Frames[1];
+        var frame2 = chain.Frames[2];
+
+        ctx.AppCommands.InvertFrameOrder(chain);
+        Assert.Equal(new[] { frame2, frame1, frame0 }, chain.Frames);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(new[] { frame0, frame1, frame2 }, chain.Frames);
+    }
+
+    [Fact]
+    public void InvertFrameOrder_UndoThenRedo_RestoresInvertedOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var frame0 = chain.Frames[0];
+        var frame1 = chain.Frames[1];
+        var frame2 = chain.Frames[2];
+
+        ctx.AppCommands.InvertFrameOrder(chain);
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Equal(new[] { frame2, frame1, frame0 }, chain.Frames);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -1,0 +1,320 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Guardrail tests for undo coverage across <see cref="IAppCommands"/>.
+///
+/// <para><see cref="CompleteRoster_EveryIAppCommandsMethodIsCategorized"/> uses reflection so a
+/// NEW method added to <see cref="IAppCommands"/> fails the build until it is consciously
+/// categorized in <see cref="Roster"/>. That is the mechanism that catches "a feature shipped
+/// without an undo decision" — the failure forces the author to classify the method.</para>
+///
+/// <para><see cref="UndoableCommand_RoundTrips"/> then verifies, for every method categorized
+/// <see cref="Category.MutatingUndoable"/>, that invoking it records an entry and that Undo/Redo
+/// restore the project state exactly (compared via .achx serialization).</para>
+/// </summary>
+[Collection("SequentialSingletons")]
+public class UndoCoverageRosterTests
+{
+    private enum Category
+    {
+        /// <summary>Mutates the project and must push an undo entry.</summary>
+        MutatingUndoable,
+        /// <summary>Mutates the project but is deliberately not undoable (e.g. clears the stack).</summary>
+        MutatingNotUndoable,
+        /// <summary>Does not mutate project state (refresh/notify only).</summary>
+        NonMutating,
+    }
+
+    // Every method on IAppCommands must appear here. See the class summary for why.
+    private static readonly Dictionary<string, Category> Roster = new()
+    {
+        // Mutating, deliberately NOT undoable -------------------------------------
+        [nameof(IAppCommands.OpenAchxWorkflow)]                   = Category.MutatingNotUndoable, // loads a file; clears the undo stack
+        [nameof(IAppCommands.LoadAnimationChain)]                 = Category.MutatingNotUndoable, // loads a file; clears the undo stack
+        [nameof(IAppCommands.NewFile)]                            = Category.MutatingNotUndoable, // resets the project; clears the undo stack
+        [nameof(IAppCommands.SaveCurrentAnimationChainList)]      = Category.MutatingNotUndoable, // writes a file; no model change
+        [nameof(IAppCommands.SaveCurrentAnimationChainListAsync)] = Category.MutatingNotUndoable, // writes a file; no model change
+
+        // Non-mutating -----------------------------------------------------------
+        [nameof(IAppCommands.RefreshTreeNode)]              = Category.NonMutating,
+        [nameof(IAppCommands.RefreshAnimationFrameDisplay)] = Category.NonMutating,
+        [nameof(IAppCommands.RefreshWireframe)]             = Category.NonMutating,
+        [nameof(IAppCommands.RefreshTreeView)]              = Category.NonMutating,
+
+        // Mutating + undoable ----------------------------------------------------
+        [nameof(IAppCommands.DeleteAnimationChains)]        = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddAxisAlignedRectangle)]      = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddCircle)]                    = Category.MutatingUndoable,
+        [nameof(IAppCommands.MatchRectangleToFrame)]        = Category.MutatingUndoable,
+        [nameof(IAppCommands.MatchCircleToFrame)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.DeleteCircle)]                 = Category.MutatingUndoable,
+        [nameof(IAppCommands.DeleteAxisAlignedRectangle)]   = Category.MutatingUndoable,
+        [nameof(IAppCommands.AskToDeleteRectangles)]        = Category.MutatingUndoable,
+        [nameof(IAppCommands.AskToDeleteCircles)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.AskToDeleteAnimationChains)]   = Category.MutatingUndoable,
+        [nameof(IAppCommands.AskToDeleteFrames)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddAnimationChainWithName)]    = Category.MutatingUndoable,
+        [nameof(IAppCommands.RenameChain)]                  = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddFrame)]                     = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChain)]                    = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChainToTop)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChainToBottom)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.HandleReorder)]                = Category.MutatingUndoable,
+        [nameof(IAppCommands.FlipFrameHorizontally)]        = Category.MutatingUndoable,
+        [nameof(IAppCommands.FlipFrameVertically)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.FlipChainHorizontally)]        = Category.MutatingUndoable,
+        [nameof(IAppCommands.FlipChainVertically)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.InvertFrameOrder)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetAllFrameLengths)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.DuplicateChain)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.SortAnimationsAlphabetically)] = Category.MutatingUndoable,
+        [nameof(IAppCommands.AdjustOffsetsJustifyBottom)]   = Category.MutatingUndoable,
+        [nameof(IAppCommands.AdjustOffsetsAdjustAll)]       = Category.MutatingUndoable,
+        [nameof(IAppCommands.ScaleFrameTimesProportional)]  = Category.MutatingUndoable,
+        [nameof(IAppCommands.ScaleFrameTimesSetAllSame)]    = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddMultipleFrames)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.AdjustUVAfterResize)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddFrameFromPixelBounds)]      = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameTextureName)]          = Category.MutatingUndoable,
+    };
+
+    // ── Reflection guardrails ─────────────────────────────────────────────────
+
+    [Fact]
+    public void CompleteRoster_EveryIAppCommandsMethodIsCategorized()
+    {
+        var missing = IAppCommandsMethodNames()
+            .Where(name => !Roster.ContainsKey(name))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "IAppCommands methods not categorized in the undo-coverage Roster — add each to " +
+            "Roster with a deliberate Category: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void CompleteRoster_HasNoStaleEntries()
+    {
+        var existing = IAppCommandsMethodNames().ToHashSet();
+        var stale = Roster.Keys.Where(name => !existing.Contains(name)).ToList();
+
+        Assert.True(stale.Count == 0,
+            "Roster entries that no longer exist on IAppCommands: " + string.Join(", ", stale));
+    }
+
+    [Fact]
+    public void EveryUndoableMethod_HasARoundTripInvocation()
+    {
+        var invoked = UndoableInvocations().Select(row => (string)row[0]).ToHashSet();
+        var missing = Roster
+            .Where(kv => kv.Value == Category.MutatingUndoable)
+            .Select(kv => kv.Key)
+            .Where(name => !invoked.Contains(name))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "MutatingUndoable methods with no round-trip invocation in UndoableInvocations(): " +
+            string.Join(", ", missing));
+    }
+
+    // ── Round-trip correctness for every undoable command ─────────────────────
+
+    [Theory]
+    [MemberData(nameof(UndoableInvocations))]
+    public async Task UndoableCommand_RoundTrips(string methodName, object invokeObj)
+    {
+        var invoke = (Func<TestServices, Task>)invokeObj;
+        var ctx = TestHelpers.SetupFreshAcls();
+        Arrange(ctx);
+        string before = Serialize(ctx.Acls);
+
+        await invoke(ctx);
+
+        Assert.True(ctx.UndoManager.CanUndo, $"{methodName} did not record an undo entry");
+        string afterCommand = Serialize(ctx.Acls);
+        Assert.True(before != afterCommand,
+            $"{methodName} did not change project state — the round-trip test cannot verify undo");
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(before, Serialize(ctx.Acls));
+
+        ctx.UndoManager.Redo();
+        Assert.Equal(afterCommand, Serialize(ctx.Acls));
+    }
+
+    public static IEnumerable<object[]> UndoableInvocations()
+    {
+        yield return Row(nameof(IAppCommands.DeleteAnimationChains),
+            ctx => Sync(() => ctx.AppCommands.DeleteAnimationChains(new() { Alpha(ctx) })));
+        yield return Row(nameof(IAppCommands.AddAxisAlignedRectangle),
+            ctx => Sync(() => ctx.AppCommands.AddAxisAlignedRectangle(Zebra(ctx).Frames[1])));
+        yield return Row(nameof(IAppCommands.AddCircle),
+            ctx => Sync(() => ctx.AppCommands.AddCircle(Zebra(ctx).Frames[1])));
+        yield return Row(nameof(IAppCommands.MatchRectangleToFrame),
+            ctx => Sync(() => ctx.AppCommands.MatchRectangleToFrame(Rect(ctx), Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.MatchCircleToFrame),
+            ctx => Sync(() => ctx.AppCommands.MatchCircleToFrame(Circle(ctx), Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.DeleteCircle),
+            ctx => Sync(() => ctx.AppCommands.DeleteCircle(Circle(ctx), Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.DeleteAxisAlignedRectangle),
+            ctx => Sync(() => ctx.AppCommands.DeleteAxisAlignedRectangle(Rect(ctx), Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.AskToDeleteRectangles),
+            ctx => ctx.AppCommands.AskToDeleteRectangles(new() { Rect(ctx) }));
+        yield return Row(nameof(IAppCommands.AskToDeleteCircles),
+            ctx => ctx.AppCommands.AskToDeleteCircles(new() { Circle(ctx) }));
+        yield return Row(nameof(IAppCommands.AskToDeleteAnimationChains),
+            ctx => ctx.AppCommands.AskToDeleteAnimationChains(new() { Alpha(ctx) }));
+        yield return Row(nameof(IAppCommands.AskToDeleteFrames),
+            ctx => ctx.AppCommands.AskToDeleteFrames(new() { Zebra(ctx).Frames[1] }));
+        yield return Row(nameof(IAppCommands.AddAnimationChain),
+            ctx => ctx.AppCommands.AddAnimationChain());
+        yield return Row(nameof(IAppCommands.AddAnimationChainWithName),
+            ctx => Sync(() => ctx.AppCommands.AddAnimationChainWithName("Brand New")));
+        yield return Row(nameof(IAppCommands.RenameChain),
+            ctx => Sync(() => ctx.AppCommands.RenameChain(Zebra(ctx), "Renamed")));
+        yield return Row(nameof(IAppCommands.AddFrame),
+            ctx => Sync(() => ctx.AppCommands.AddFrame(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.MoveChain),
+            ctx => Sync(() => ctx.AppCommands.MoveChain(Zebra(ctx), +1)));
+        yield return Row(nameof(IAppCommands.MoveChainToTop),
+            ctx => Sync(() => ctx.AppCommands.MoveChainToTop(Alpha(ctx))));
+        yield return Row(nameof(IAppCommands.MoveChainToBottom),
+            ctx => Sync(() => ctx.AppCommands.MoveChainToBottom(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.MoveFrame),
+            ctx => Sync(() => ctx.AppCommands.MoveFrame(Zebra(ctx).Frames[0], Zebra(ctx), +1)));
+        yield return Row(nameof(IAppCommands.MoveFrameToTop),
+            ctx => Sync(() => ctx.AppCommands.MoveFrameToTop(Zebra(ctx).Frames[2], Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.MoveFrameToBottom),
+            ctx => Sync(() => ctx.AppCommands.MoveFrameToBottom(Zebra(ctx).Frames[0], Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.HandleReorder),
+            ctx => Sync(() => ctx.AppCommands.HandleReorder(+1))); // selection is set up by Arrange
+        yield return Row(nameof(IAppCommands.FlipFrameHorizontally),
+            ctx => Sync(() => ctx.AppCommands.FlipFrameHorizontally(Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.FlipFrameVertically),
+            ctx => Sync(() => ctx.AppCommands.FlipFrameVertically(Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.FlipChainHorizontally),
+            ctx => Sync(() => ctx.AppCommands.FlipChainHorizontally(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.FlipChainVertically),
+            ctx => Sync(() => ctx.AppCommands.FlipChainVertically(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.InvertFrameOrder),
+            ctx => Sync(() => ctx.AppCommands.InvertFrameOrder(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.SetAllFrameLengths),
+            ctx => Sync(() => ctx.AppCommands.SetAllFrameLengths(Zebra(ctx), 0.5f)));
+        yield return Row(nameof(IAppCommands.DuplicateChain),
+            ctx => Sync(() => ctx.AppCommands.DuplicateChain(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.SortAnimationsAlphabetically),
+            ctx => Sync(() => ctx.AppCommands.SortAnimationsAlphabetically())); // Zebra,Alpha -> Alpha,Zebra
+        yield return Row(nameof(IAppCommands.AdjustOffsetsJustifyBottom),
+            ctx => Sync(() => ctx.AppCommands.AdjustOffsetsJustifyBottom(Zebra(ctx), _ => 32f)));
+        yield return Row(nameof(IAppCommands.AdjustOffsetsAdjustAll),
+            ctx => Sync(() => ctx.AppCommands.AdjustOffsetsAdjustAll(Zebra(ctx), 5f, 5f, relative: true)));
+        yield return Row(nameof(IAppCommands.ScaleFrameTimesProportional),
+            ctx => Sync(() => ctx.AppCommands.ScaleFrameTimesProportional(Zebra(ctx), 3f)));
+        yield return Row(nameof(IAppCommands.ScaleFrameTimesSetAllSame),
+            ctx => Sync(() => ctx.AppCommands.ScaleFrameTimesSetAllSame(Zebra(ctx), 3f)));
+        yield return Row(nameof(IAppCommands.AddMultipleFrames),
+            ctx => Sync(() => ctx.AppCommands.AddMultipleFrames(Zebra(ctx), 2, incrementUV: false)));
+        yield return Row(nameof(IAppCommands.AdjustUVAfterResize),
+            ctx => Sync(() => ctx.AppCommands.AdjustUVAfterResize("sheet.png", 64, 64, 128, 128)));
+        yield return Row(nameof(IAppCommands.AddFrameFromPixelBounds),
+            ctx => Sync(() => ctx.AppCommands.AddFrameFromPixelBounds(Zebra(ctx), "sheet.png", 0, 0, 8, 8, 64, 64)));
+        yield return Row(nameof(IAppCommands.SetFrameTextureName),
+            ctx => Sync(() => ctx.AppCommands.SetFrameTextureName(Zebra(ctx).Frames[0], "set.png")));
+    }
+
+    // ── Fixture ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a standard two-chain project: "Zebra" (3 distinguishable frames, with a
+    /// rectangle and circle on frame 0) and "Alpha" (1 frame). Selection points at Zebra
+    /// and its first frame. Chain names are deliberately out of alphabetical order so
+    /// SortAnimationsAlphabetically actually reorders.
+    /// </summary>
+    private static void Arrange(TestServices ctx)
+    {
+        var zebra = new AnimationChainSave { Name = "Zebra" };
+        for (int i = 0; i < 3; i++)
+        {
+            zebra.Frames.Add(new AnimationFrameSave
+            {
+                TextureName      = "sheet.png",
+                Name             = $"Frame{i}",
+                FrameLength      = 0.1f * (i + 1),
+                LeftCoordinate   = 0.25f,
+                RightCoordinate  = 0.5f,
+                TopCoordinate    = 0.25f,
+                BottomCoordinate = 0.5f,
+                RelativeX        = 10f + i,
+                RelativeY        = 20f + i,
+                ShapesSave       = new ShapesSave(),
+            });
+        }
+        zebra.Frames[0].ShapesSave!.AARectSaves.Add(
+            new AARectSave { Name = "Rect", X = 0f, Y = 0f, ScaleX = 4f, ScaleY = 4f });
+        zebra.Frames[0].ShapesSave!.CircleSaves.Add(
+            new CircleSave { Name = "Circle", X = 0f, Y = 0f, Radius = 4f });
+
+        var alpha = new AnimationChainSave { Name = "Alpha" };
+        alpha.Frames.Add(new AnimationFrameSave
+        {
+            TextureName      = "sheet.png",
+            Name             = "Frame0",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0.1f,
+            RightCoordinate  = 0.2f,
+            TopCoordinate    = 0.1f,
+            BottomCoordinate = 0.2f,
+            ShapesSave       = new ShapesSave(),
+        });
+
+        ctx.Acls.AnimationChains.Add(zebra);
+        ctx.Acls.AnimationChains.Add(alpha);
+        ctx.SelectedState.SelectedChain = zebra;
+        ctx.SelectedState.SelectedFrame = zebra.Frames[0];
+    }
+
+    private static AnimationChainSave Zebra(TestServices ctx) => ctx.Acls.AnimationChains[0];
+    private static AnimationChainSave Alpha(TestServices ctx) => ctx.Acls.AnimationChains[1];
+    private static AARectSave Rect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves[0];
+    private static CircleSave Circle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves[0];
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IEnumerable<string> IAppCommandsMethodNames() =>
+        typeof(IAppCommands).GetMethods()
+            .Where(m => !m.IsSpecialName) // exclude property/event accessors
+            .Select(m => m.Name)
+            .Distinct();
+
+    /// <summary>Serializes the project to .achx text — the comparison key for round-trip checks.</summary>
+    private static string Serialize(AnimationChainListSave acls)
+    {
+        using var dir = new TestHelpers.TempDir();
+        var path = Path.Combine(dir.Path, "state.achx");
+        acls.Save(path);
+        return File.ReadAllText(path);
+    }
+
+    private static object[] Row(string methodName, Func<TestServices, Task> invoke) =>
+        new object[] { methodName, invoke };
+
+    /// <summary>Adapts a synchronous command call to the <see cref="Task"/>-returning invoke shape.</summary>
+    private static Task Sync(Action call)
+    {
+        call();
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Problem

Issue #250 reported that **Invert Frame Order** could not be undone. Auditing `IAppCommands` showed it was far from the only offender — roughly **16 mutating commands never recorded an undo entry**:

- all chain/frame reorders (`MoveChain`, `MoveChainToTop/Bottom`, `MoveFrame`, `MoveFrameToTop/Bottom`, `HandleReorder`)
- all flips (`FlipFrame*`, `FlipChain*`)
- `InvertFrameOrder`, `SetAllFrameLengths`, `DuplicateChain`, `SortAnimationsAlphabetically`
- `AdjustOffsets*`, `ScaleFrameTimes*`, `AddMultipleFrames`, `AdjustUVAfterResize`
- `MatchRectangleToFrame` / `MatchCircleToFrame` (the "Match Frame Size" context-menu command)

A partially-wired undo stack is worse than none — users learn to trust Ctrl+Z and then lose work on the one command that didn't register.

## Changes

**Production** — `AppCommands` now records an undo entry for every mutating command. Four new generic commands cover the gap with minimal surface area:

| Command | Covers |
|---|---|
| `ReorderCommand<T>` | all list reorders (move/invert/sort) — snapshots before/after order |
| `FlipCommand` | flip toggles (a flip is its own inverse) |
| `BulkFrameEditCommand` | bulk numeric frame-field edits (offsets, frame times, UV-after-resize) |
| `AddFramesCommand` | multi-frame add — one user action, one undo step |

`DuplicateChain` reuses `AddChainCommand`; `Match*ToFrame` reuse `MoveShapeCommand`. The shape-creation paths call private `ApplyRectangleMatch`/`ApplyCircleMatch` helpers so they keep recording a single combined entry rather than two. Also removed a stale XML-doc reference to a non-existent `AfterMatchRectangleToFrame` override.

**Tests**

- **`UndoCoverageRosterTests`** — the future-proofing guardrail. A reflection test enumerates every `IAppCommands` method against a categorized roster (`MutatingUndoable` / `MutatingNotUndoable` / `NonMutating`); a **new method that isn't categorized fails the build**, forcing a deliberate undo decision. A parametrized round-trip test then invokes every `MutatingUndoable` command and asserts it (a) records an entry, (b) actually mutates state, and (c) round-trips exactly through Undo/Redo (compared via `.achx` serialization).
- **`InvertFrameOrderUndoTests`** — covers the originally-reported bug directly (written test-first).

All **947 Core + 328 App** tests pass.

## Follow-up (not in this PR)

The deeper fix — making it *structurally impossible* to mutate project state without going through the undo stack (execute-through-command) — and the History tab UI are filed separately.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
