### PR TITLE
feat(AE): UV-format load gate — reject missing textures, prompt to convert

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -109,7 +109,7 @@ public partial class MainWindow : Window
         var args = Environment.GetCommandLineArgs();
         if (args.Length >= 2 && File.Exists(args[1]))
         {
-            LoadAnimationFile(args[1]);
+            _ = LoadAnimationFileAsync(args[1]);
         }
         else
         {
@@ -580,7 +580,7 @@ public partial class MainWindow : Window
         {
             var item = new MenuItem { Header = file };
             var captured = file;
-            item.Click += (_, _) => LoadAnimationFile(captured);
+            item.Click += async (_, _) => await LoadAnimationFileAsync(captured);
             MenuLoadRecent.Items.Add(item);
         }
     }
@@ -611,7 +611,7 @@ public partial class MainWindow : Window
         });
 
         if (files.Count > 0)
-            LoadAnimationFile(files[0].Path.LocalPath);
+            await LoadAnimationFileAsync(files[0].Path.LocalPath);
     }
 
     private void OnSaveClick(object? sender, RoutedEventArgs e)
@@ -1965,10 +1965,10 @@ public partial class MainWindow : Window
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private void LoadAnimationFile(string fileName)
+    private async Task LoadAnimationFileAsync(string fileName)
     {
         if (!string.IsNullOrEmpty(fileName))
-            _appCommands.OpenAchxWorkflow(fileName);
+            await _appCommands.OpenAchxWorkflowAsync(fileName);
     }
 
     private void UpdateTitle()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -106,9 +106,46 @@ namespace AnimationEditor.Core.CommandsAndState
 
         // ── Open workflow ─────────────────────────────────────────────────────────
 
-        /// <inheritdoc cref="IAppCommands.OpenAchxWorkflow"/>
-        public void OpenAchxWorkflow(string path)
+        /// <inheritdoc cref="IAppCommands.OpenAchxWorkflowAsync"/>
+        public async Task OpenAchxWorkflowAsync(string path)
         {
+            // Quick-parse to read CoordinateType without committing to a full load.
+            AnimationChainListSave preview;
+            try { preview = AnimationChainListSave.FromFile(path); }
+            catch (Exception ex) { LoadFailed?.Invoke(path, ex); return; }
+
+            string achxDir = System.IO.Path.GetDirectoryName(path) ?? string.Empty;
+            var missing = _pm.FindMissingTextures(preview, achxDir);
+
+            var outcome = IO.UvLoadGate.DecideOutcome(
+                preview.CoordinateType,
+                allTexturesResolvable: missing.Count == 0,
+                userConfirmed: false);
+
+            if (outcome == IO.UvLoadOutcome.RefuseMissingTextures)
+            {
+                var names = string.Join(", ", missing);
+                LoadFailed?.Invoke(path,
+                    new InvalidOperationException(
+                        $"Cannot open '{System.IO.Path.GetFileName(path)}' — the following texture(s) could not be found or decoded: {names}. " +
+                        "All textures must be present to convert UV coordinates to pixel coordinates."));
+                return;
+            }
+
+            if (outcome == IO.UvLoadOutcome.ConvertAndLoad || outcome == IO.UvLoadOutcome.RefuseUserDeclined)
+            {
+                // UV file, textures all present — ask user.
+                bool confirmed = await ConfirmAsync(
+                    "This animation uses legacy texture-coordinate (UV) data and must be converted " +
+                    "to pixel coordinates before editing. Convert and open? " +
+                    "(No leaves the file untouched and does not open it.)",
+                    "Convert to Pixel Coordinates");
+
+                outcome = IO.UvLoadGate.DecideOutcome(preview.CoordinateType, allTexturesResolvable: true, userConfirmed: confirmed);
+            }
+
+            if (outcome == IO.UvLoadOutcome.RefuseUserDeclined) return;
+
             bool failed = false;
             void OnFail(string _, Exception __) => failed = true;
             LoadFailed += OnFail;
@@ -116,6 +153,9 @@ namespace AnimationEditor.Core.CommandsAndState
             finally { LoadFailed -= OnFail; }
 
             if (failed) return;
+
+            if (outcome == IO.UvLoadOutcome.ConvertAndLoad)
+                _pm.OnDiskCoordinateType = FlatRedBall2.Animation.Content.TextureCoordinateType.Pixel;
 
             _events.CallAchxLoaded(path);
             _events.RaiseCurrentFileChanged(path);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -48,8 +48,11 @@ namespace AnimationEditor.Core.CommandsAndState
         /// Full open workflow: loads the .achx, fires <c>AchxLoaded</c> (post-load),
         /// then fires <c>CurrentFileChanged</c> and <c>AvailableTexturesChanged</c>
         /// so the UI can update its title, recent-files list, and texture combo.
+        /// UV-format files require all referenced textures to be resolvable; missing
+        /// textures fire <see cref="LoadFailed"/> and abort the load. UV files with all
+        /// textures present prompt via <see cref="AppCommands.ConfirmAsync"/> before converting.
         /// </summary>
-        void OpenAchxWorkflow(string path);
+        Task OpenAchxWorkflowAsync(string path);
         void LoadAnimationChain(string fileName);
         void RefreshTreeNode(AnimationChainSave animationChain);
         void RefreshTreeNode(AnimationFrameSave animationFrame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/UvLoadGate.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/UvLoadGate.cs
@@ -1,0 +1,33 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.IO;
+
+public enum UvLoadOutcome
+{
+    LoadAsIs,
+    ConvertAndLoad,
+    RefuseUserDeclined,
+    RefuseMissingTextures,
+}
+
+/// <summary>
+/// Pure decision function for the UV-coordinate load gate. Callers gather the facts
+/// (coordinate type, texture availability, user answer) and pass them in; this method
+/// returns the outcome without performing any I/O or showing dialogs.
+/// </summary>
+public static class UvLoadGate
+{
+    public static UvLoadOutcome DecideOutcome(
+        TextureCoordinateType coordinateType,
+        bool allTexturesResolvable,
+        bool userConfirmed)
+    {
+        if (coordinateType == TextureCoordinateType.Pixel)
+            return UvLoadOutcome.LoadAsIs;
+
+        if (!allTexturesResolvable)
+            return UvLoadOutcome.RefuseMissingTextures;
+
+        return userConfirmed ? UvLoadOutcome.ConvertAndLoad : UvLoadOutcome.RefuseUserDeclined;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
@@ -14,5 +14,13 @@ namespace AnimationEditor.Core
 
         void LoadAnimationChain(FilePath fileName);
         void SaveAnimationChainList(string targetPath);
+
+        /// <summary>
+        /// Returns the texture names referenced by <paramref name="acls"/> that cannot be
+        /// decoded from <paramref name="achxDirectory"/>. An empty list means all textures
+        /// are present and valid. Only non-empty texture names are checked; each unique name
+        /// is checked at most once.
+        /// </summary>
+        IReadOnlyList<string> FindMissingTextures(AnimationChainListSave acls, string achxDirectory);
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -271,6 +271,28 @@ namespace AnimationEditor.Core
             }
         }
 
+        public IReadOnlyList<string> FindMissingTextures(AnimationChainListSave acls, string achxDirectory)
+        {
+            var missing = new List<string>();
+            var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+            foreach (var chain in acls.AnimationChains)
+            foreach (var frame in chain.Frames)
+            {
+                if (string.IsNullOrEmpty(frame.TextureName)) continue;
+                if (!seen.Add(frame.TextureName)) continue;
+
+                var path = System.IO.Path.IsPathRooted(frame.TextureName)
+                    ? frame.TextureName
+                    : System.IO.Path.Combine(achxDirectory, frame.TextureName);
+
+                if (TryReadPngSize(path) == null)
+                    missing.Add(frame.TextureName);
+            }
+
+            return missing;
+        }
+
         internal void LoadTileMapInformation(string fileName)
         {
             TileMapInformationList = XmlFile.Deserialize<TileMapInformationList>(fileName);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
@@ -75,7 +75,7 @@ public class MainWindowMenuFlowTests
     private static string WriteAchx(string dir, params string[] chainNames)
     {
         var path = Path.Combine(dir, "test.achx");
-        var acls = new AnimationChainListSave();
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
         foreach (var name in chainNames)
             acls.AnimationChains.Add(new AnimationChainSave { Name = name });
         acls.Save(path);
@@ -99,7 +99,7 @@ public class MainWindowMenuFlowTests
             var path = WriteAchx(dir, "Walk", "Run");
 
             typeof(MainWindow)
-                .GetMethod("LoadAnimationFile", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetMethod("LoadAnimationFileAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .Invoke(window, [path]);
 
             Dispatcher.UIThread.RunJobs();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAndLoadResetTests.cs
@@ -41,7 +41,7 @@ public class NewAndLoadResetTests
     private static string WriteAchx(string dir, params string[] chainNames)
     {
         var path = Path.Combine(dir, "test.achx");
-        var acls = new AnimationChainListSave();
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
         foreach (var name in chainNames)
         {
             var chain = new AnimationChainSave { Name = name };
@@ -160,7 +160,7 @@ public class NewAndLoadResetTests
             // Load a different .achx
             var path = WriteAchx(dir, "NewRun");
             typeof(MainWindow)
-                .GetMethod("LoadAnimationFile", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetMethod("LoadAnimationFileAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .Invoke(window, [path]);
             Dispatcher.UIThread.RunJobs();
 
@@ -189,7 +189,7 @@ public class NewAndLoadResetTests
         {
             var path = WriteAchx(dir, "Walk", "Run", "Idle");
             typeof(MainWindow)
-                .GetMethod("LoadAnimationFile", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetMethod("LoadAnimationFileAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .Invoke(window, [path]);
             Dispatcher.UIThread.RunJobs();
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace AnimationEditor.Core.Tests;
 
 /// <summary>
-/// Verifies that <see cref="IAppCommands.OpenAchxWorkflow"/> correctly sequences
+/// Verifies that <see cref="IAppCommands.OpenAchxWorkflowAsync"/> correctly sequences
 /// the open flow (load data, notify WireframeCtrl/PreviewCtrl via AchxLoaded,
 /// then raise CurrentFileChanged and AvailableTexturesChanged for the UI layer)
 /// — all without any Avalonia dependency.
@@ -29,10 +29,14 @@ public class OpenAchxWorkflowTests : IDisposable
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Writes a minimal pixel-format .achx (no frames, no textures) so the UV gate
+    /// is bypassed and the tests focus purely on workflow sequencing.
+    /// </summary>
     private string WriteMinimalAchx(string chainName = "Idle")
     {
         var path = Path.Combine(_dir.Path, "test.achx");
-        var acls = new AnimationChainListSave();
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
         acls.AnimationChains.Add(new AnimationChainSave { Name = chainName });
         acls.Save(path);
         return path;
@@ -41,11 +45,11 @@ public class OpenAchxWorkflowTests : IDisposable
     // ── Data loading ──────────────────────────────────────────────────────────
 
     [Fact]
-    public void OpenAchxWorkflow_WithValidFile_LoadsChainIntoProjectManager()
+    public async Task OpenAchxWorkflow_WithValidFile_LoadsChainIntoProjectManager()
     {
         var path = WriteMinimalAchx("Walk");
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.NotNull(_ctx.ProjectManager.AnimationChainListSave);
         Assert.Single(_ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
@@ -53,11 +57,11 @@ public class OpenAchxWorkflowTests : IDisposable
     }
 
     [Fact]
-    public void OpenAchxWorkflow_WithValidFile_SetsProjectManagerFileName()
+    public async Task OpenAchxWorkflow_WithValidFile_SetsProjectManagerFileName()
     {
         var path = WriteMinimalAchx();
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.Equal(new FilePath(path), new FilePath(_ctx.ProjectManager.FileName!));
     }
@@ -65,27 +69,27 @@ public class OpenAchxWorkflowTests : IDisposable
     // ── Event ordering ────────────────────────────────────────────────────────
 
     [Fact]
-    public void OpenAchxWorkflow_AchxLoadedFiresAfterDataIsLoaded()
+    public async Task OpenAchxWorkflow_AchxLoadedFiresAfterDataIsLoaded()
     {
         var path = WriteMinimalAchx("Run");
         FilePath? fileNameAtNotification = null;
         _ctx.ApplicationEvents.AchxLoaded += _ =>
             fileNameAtNotification = _ctx.ProjectManager.FileName;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         // AchxLoaded fires after LoadAnimationChain sets the FileName
         Assert.Equal(new FilePath(path), fileNameAtNotification);
     }
 
     [Fact]
-    public void OpenAchxWorkflow_WithValidFile_FiresAchxLoadedWithPath()
+    public async Task OpenAchxWorkflow_WithValidFile_FiresAchxLoadedWithPath()
     {
         var path = WriteMinimalAchx();
         string? received = null;
         _ctx.ApplicationEvents.AchxLoaded += p => received = p;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.Equal(new FilePath(path), new FilePath(received!));
     }
@@ -93,26 +97,26 @@ public class OpenAchxWorkflowTests : IDisposable
     // ── CurrentFileChanged ────────────────────────────────────────────────────
 
     [Fact]
-    public void OpenAchxWorkflow_WithValidFile_FiresCurrentFileChangedWithPath()
+    public async Task OpenAchxWorkflow_WithValidFile_FiresCurrentFileChangedWithPath()
     {
         var path = WriteMinimalAchx();
         string? received = null;
         _ctx.ApplicationEvents.CurrentFileChanged += p => received = p;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.Equal(new FilePath(path), new FilePath(received!));
     }
 
     [Fact]
-    public void OpenAchxWorkflow_CurrentFileChangedFiresAfterDataIsLoaded()
+    public async Task OpenAchxWorkflow_CurrentFileChangedFiresAfterDataIsLoaded()
     {
         var path = WriteMinimalAchx("Jump");
         FilePath? fileNameAtNotification = null;
         _ctx.ApplicationEvents.CurrentFileChanged += _ =>
             fileNameAtNotification = _ctx.ProjectManager.FileName;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.Equal(new FilePath(path), fileNameAtNotification);
     }
@@ -120,13 +124,13 @@ public class OpenAchxWorkflowTests : IDisposable
     // ── AvailableTexturesChanged ───────────────────────────────────────────────
 
     [Fact]
-    public void OpenAchxWorkflow_WithValidFile_FiresAvailableTexturesChanged()
+    public async Task OpenAchxWorkflow_WithValidFile_FiresAvailableTexturesChanged()
     {
         var path = WriteMinimalAchx();
         bool fired = false;
         _ctx.ApplicationEvents.AvailableTexturesChanged += () => fired = true;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.True(fired);
     }
@@ -134,19 +138,19 @@ public class OpenAchxWorkflowTests : IDisposable
     // ── Load failure (corrupt / missing file) ─────────────────────────────────
 
     [Fact]
-    public void OpenAchxWorkflow_WithNonExistentFile_FiresLoadFailed()
+    public async Task OpenAchxWorkflow_WithNonExistentFile_FiresLoadFailed()
     {
         var path = Path.Combine(_dir.Path, "ghost.achx");
         bool loadFailedFired = false;
         _ctx.AppCommands.LoadFailed += (_, _) => loadFailedFired = true;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.True(loadFailedFired);
     }
 
     [Fact]
-    public void OpenAchxWorkflow_WithNonExistentFile_DoesNotFireSuccessEvents()
+    public async Task OpenAchxWorkflow_WithNonExistentFile_DoesNotFireSuccessEvents()
     {
         var path = Path.Combine(_dir.Path, "ghost.achx");
         bool currentFileFired = false;
@@ -154,7 +158,7 @@ public class OpenAchxWorkflowTests : IDisposable
         _ctx.ApplicationEvents.CurrentFileChanged += _ => currentFileFired = true;
         _ctx.ApplicationEvents.AvailableTexturesChanged += () => texturesFired = true;
 
-        _ctx.AppCommands.OpenAchxWorkflow(path);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.False(currentFileFired);
         Assert.False(texturesFired);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowUvGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowUvGateTests.cs
@@ -1,0 +1,231 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies the UV-coordinate gate in OpenAchxWorkflowAsync:
+/// UV files with all textures present prompt for conversion; UV files
+/// with missing textures are refused; pixel files load normally.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class OpenAchxWorkflowUvGateTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir;
+    private readonly TestServices _ctx;
+
+    public OpenAchxWorkflowUvGateTests()
+    {
+        _dir = new TestHelpers.TempDir();
+        _ctx = TestHelpers.SetupFreshAcls();
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    // Minimal 24-byte fake PNG (valid signature + IHDR width/height).
+    private static byte[] MakeFakePng(int width = 64, int height = 64)
+    {
+        var b = new byte[24];
+        b[0] = 0x89; b[1] = 0x50; b[2] = 0x4E; b[3] = 0x47;
+        b[4] = 0x0D; b[5] = 0x0A; b[6] = 0x1A; b[7] = 0x0A;
+        b[8] = 0; b[9] = 0; b[10] = 0; b[11] = 13;
+        b[12] = 0x49; b[13] = 0x48; b[14] = 0x44; b[15] = 0x52;
+        b[16] = (byte)(width >> 24); b[17] = (byte)(width >> 16);
+        b[18] = (byte)(width >> 8);  b[19] = (byte)width;
+        b[20] = (byte)(height >> 24); b[21] = (byte)(height >> 16);
+        b[22] = (byte)(height >> 8);  b[23] = (byte)height;
+        return b;
+    }
+
+    private string WriteUvAchx(string chainName, string textureName)
+    {
+        var path = Path.Combine(_dir.Path, "test.achx");
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.UV };
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName      = textureName,
+            LeftCoordinate   = 0.25f,
+            RightCoordinate  = 0.50f,
+            TopCoordinate    = 0.0f,
+            BottomCoordinate = 0.25f,
+            FrameLength      = 0.1f,
+        });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    private string WritePixelAchx(string textureName)
+    {
+        var path = Path.Combine(_dir.Path, "pixel.achx");
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName      = textureName,
+            LeftCoordinate   = 16f,
+            RightCoordinate  = 32f,
+            TopCoordinate    = 0f,
+            BottomCoordinate = 16f,
+            FrameLength      = 0.1f,
+        });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    // ── UV file, all textures present, user confirms ──────────────────────────
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_AllPresent_UserConfirms_LoadsFile()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "sheet.png"), MakeFakePng());
+        var achxPath = WriteUvAchx("Walk", "sheet.png");
+        _ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.NotNull(_ctx.ProjectManager.AnimationChainListSave);
+        Assert.Equal("Walk", _ctx.ProjectManager.AnimationChainListSave!.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_AllPresent_UserConfirms_SetsOnDiskCoordinateTypeToPixel()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "sheet.png"), MakeFakePng());
+        var achxPath = WriteUvAchx("Walk", "sheet.png");
+        _ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.Equal(TextureCoordinateType.Pixel, _ctx.ProjectManager.OnDiskCoordinateType);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_AllPresent_UserConfirms_FiresSuccessEvents()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "sheet.png"), MakeFakePng());
+        var achxPath = WriteUvAchx("Walk", "sheet.png");
+        _ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        bool achxLoaded = false;
+        bool currentFileChanged = false;
+        _ctx.ApplicationEvents.AchxLoaded += _ => achxLoaded = true;
+        _ctx.ApplicationEvents.CurrentFileChanged += _ => currentFileChanged = true;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.True(achxLoaded);
+        Assert.True(currentFileChanged);
+    }
+
+    // ── UV file, all textures present, user declines ──────────────────────────
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_AllPresent_UserDeclines_DoesNotLoadFile()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "sheet.png"), MakeFakePng());
+        var achxPath = WriteUvAchx("Walk", "sheet.png");
+        _ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(false);
+        var sentinel = new AnimationChainListSave();
+        _ctx.ProjectManager.AnimationChainListSave = sentinel;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.Same(sentinel, _ctx.ProjectManager.AnimationChainListSave);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_AllPresent_UserDeclines_DoesNotFireSuccessEvents()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "sheet.png"), MakeFakePng());
+        var achxPath = WriteUvAchx("Walk", "sheet.png");
+        _ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(false);
+        bool anyEventFired = false;
+        _ctx.ApplicationEvents.AchxLoaded += _ => anyEventFired = true;
+        _ctx.ApplicationEvents.CurrentFileChanged += _ => anyEventFired = true;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.False(anyEventFired);
+    }
+
+    // ── UV file, missing texture ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_MissingTexture_FiresLoadFailed()
+    {
+        var achxPath = WriteUvAchx("Walk", "ghost.png"); // ghost.png not written to disk
+        bool loadFailedFired = false;
+        _ctx.AppCommands.LoadFailed += (_, _) => loadFailedFired = true;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.True(loadFailedFired);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_MissingTexture_ErrorMessageContainsMissingFileName()
+    {
+        var achxPath = WriteUvAchx("Walk", "ghost.png");
+        string? errorMessage = null;
+        _ctx.AppCommands.LoadFailed += (_, ex) => errorMessage = ex.Message;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.NotNull(errorMessage);
+        Assert.Contains("ghost.png", errorMessage);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_MissingTexture_DoesNotLoadFile()
+    {
+        var achxPath = WriteUvAchx("Walk", "ghost.png");
+        var sentinel = new AnimationChainListSave();
+        _ctx.ProjectManager.AnimationChainListSave = sentinel;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.Same(sentinel, _ctx.ProjectManager.AnimationChainListSave);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_UvFile_MissingTexture_DoesNotShowConfirmPrompt()
+    {
+        var achxPath = WriteUvAchx("Walk", "ghost.png");
+        bool promptShown = false;
+        _ctx.AppCommands.ConfirmAsync = (_, _) => { promptShown = true; return Task.FromResult(true); };
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.False(promptShown);
+    }
+
+    // ── Pixel file, missing texture ───────────────────────────────────────────
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_PixelFile_MissingTexture_LoadsNormally()
+    {
+        // ghost.png intentionally not written to disk
+        var achxPath = WritePixelAchx("ghost.png");
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.NotNull(_ctx.ProjectManager.AnimationChainListSave);
+        Assert.Equal("Run", _ctx.ProjectManager.AnimationChainListSave!.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflowAsync_PixelFile_MissingTexture_DoesNotShowConfirmPrompt()
+    {
+        var achxPath = WritePixelAchx("ghost.png");
+        bool promptShown = false;
+        _ctx.AppCommands.ConfirmAsync = (_, _) => { promptShown = true; return Task.FromResult(true); };
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(achxPath);
+
+        Assert.False(promptShown);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFindMissingTexturesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFindMissingTexturesTests.cs
@@ -1,0 +1,108 @@
+using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ProjectManagerFindMissingTexturesTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir = new();
+
+    public void Dispose() => _dir.Dispose();
+
+    // Minimal 24-byte fake PNG (valid signature + IHDR width/height fields).
+    private static byte[] MakeFakePng(int width = 64, int height = 64)
+    {
+        var b = new byte[24];
+        b[0] = 0x89; b[1] = 0x50; b[2] = 0x4E; b[3] = 0x47;
+        b[4] = 0x0D; b[5] = 0x0A; b[6] = 0x1A; b[7] = 0x0A;
+        b[8] = 0; b[9] = 0; b[10] = 0; b[11] = 13;
+        b[12] = 0x49; b[13] = 0x48; b[14] = 0x44; b[15] = 0x52;
+        b[16] = (byte)(width >> 24); b[17] = (byte)(width >> 16);
+        b[18] = (byte)(width >> 8);  b[19] = (byte)width;
+        b[20] = (byte)(height >> 24); b[21] = (byte)(height >> 16);
+        b[22] = (byte)(height >> 8);  b[23] = (byte)height;
+        return b;
+    }
+
+    private AnimationChainListSave MakeAcls(params string[] textureNames)
+    {
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Idle" };
+        foreach (var name in textureNames)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = name, FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
+        return acls;
+    }
+
+    [Fact]
+    public void FindMissingTextures_NoFrames_ReturnsEmpty()
+    {
+        var pm = new ProjectManager();
+        var acls = new AnimationChainListSave();
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void FindMissingTextures_AllPresent_ReturnsEmpty()
+    {
+        File.WriteAllBytes(Path.Combine(_dir.Path, "hero.png"), MakeFakePng());
+        var pm = new ProjectManager();
+        var acls = MakeAcls("hero.png");
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void FindMissingTextures_OneMissing_ReturnsItsName()
+    {
+        var pm = new ProjectManager();
+        var acls = MakeAcls("ghost.png");
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Single(missing);
+        Assert.Equal("ghost.png", missing[0]);
+    }
+
+    [Fact]
+    public void FindMissingTextures_CorruptFile_ReturnsItsName()
+    {
+        File.WriteAllText(Path.Combine(_dir.Path, "corrupt.png"), "not a png");
+        var pm = new ProjectManager();
+        var acls = MakeAcls("corrupt.png");
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Single(missing);
+        Assert.Equal("corrupt.png", missing[0]);
+    }
+
+    [Fact]
+    public void FindMissingTextures_EmptyTextureName_Skipped()
+    {
+        var pm = new ProjectManager();
+        var acls = MakeAcls(string.Empty);
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void FindMissingTextures_DuplicateTextureName_CheckedOnce()
+    {
+        // Both frames reference the same missing texture — it should appear once in results.
+        var pm = new ProjectManager();
+        var acls = MakeAcls("sheet.png", "sheet.png");
+
+        var missing = pm.FindMissingTextures(acls, _dir.Path);
+
+        Assert.Single(missing);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UvLoadGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UvLoadGateTests.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class UvLoadGateTests
+{
+    [Fact]
+    public void DecideOutcome_PixelFile_MissingTextures_NotConfirmed_ReturnsLoadAsIs()
+    {
+        // Pixel files bypass the gate entirely — texture state and user answer don't matter.
+        Assert.Equal(UvLoadOutcome.LoadAsIs,
+            UvLoadGate.DecideOutcome(TextureCoordinateType.Pixel, allTexturesResolvable: false, userConfirmed: false));
+    }
+
+    [Fact]
+    public void DecideOutcome_UvFile_MissingTextures_ReturnsRefuseMissingTextures()
+    {
+        Assert.Equal(UvLoadOutcome.RefuseMissingTextures,
+            UvLoadGate.DecideOutcome(TextureCoordinateType.UV, allTexturesResolvable: false, userConfirmed: false));
+    }
+
+    [Fact]
+    public void DecideOutcome_UvFile_AllPresent_UserDeclined_ReturnsRefuseUserDeclined()
+    {
+        Assert.Equal(UvLoadOutcome.RefuseUserDeclined,
+            UvLoadGate.DecideOutcome(TextureCoordinateType.UV, allTexturesResolvable: true, userConfirmed: false));
+    }
+
+    [Fact]
+    public void DecideOutcome_UvFile_AllPresent_UserConfirmed_ReturnsConvertAndLoad()
+    {
+        Assert.Equal(UvLoadOutcome.ConvertAndLoad,
+            UvLoadGate.DecideOutcome(TextureCoordinateType.UV, allTexturesResolvable: true, userConfirmed: true));
+    }
+
+    [Fact]
+    public void DecideOutcome_UvFile_MissingTextures_UserConfirmed_StillRefusesMissingTextures()
+    {
+        // User confirmation doesn't override a missing-texture refusal.
+        Assert.Equal(UvLoadOutcome.RefuseMissingTextures,
+            UvLoadGate.DecideOutcome(TextureCoordinateType.UV, allTexturesResolvable: false, userConfirmed: true));
+    }
+}


### PR DESCRIPTION
## Summary

- When opening a UV-coordinate `.achx` with **all referenced PNGs present**: prompt the user to convert to Pixel format before loading
- When opening a UV-coordinate `.achx` with **any PNG missing**: refuse the load and fire `LoadFailed` naming each missing file
- Pixel-format `.achx` files load unconditionally (no gate, no prompt)

## Implementation

- `UvLoadGate.DecideOutcome(coordinateType, allTexturesResolvable, userConfirmed)` — pure function, no I/O, fully unit-tested
- `ProjectManager.FindMissingTextures()` — checks each unique `TextureName` via PNG header read (reuses existing `TryReadPngSize`)
- `AppCommands.OpenAchxWorkflow` renamed to `OpenAchxWorkflowAsync` to support the async confirm prompt
- `MainWindow.LoadAnimationFile` renamed to `LoadAnimationFileAsync` to match

## Test plan

- [x] `UvLoadGateTests` — 5 tests covering all `DecideOutcome` branches
- [x] `ProjectManagerFindMissingTexturesTests` — 6 tests (no frames, all present, missing, corrupt, empty name, dedup)
- [x] `OpenAchxWorkflowUvGateTests` — 12 integration tests covering all gate scenarios end-to-end
- [x] `OpenAchxWorkflowTests` — existing workflow tests updated to use `Pixel` format so UV gate is bypassed
- [x] `NewAndLoadResetTests` / `MainWindowMenuFlowTests` — updated reflection calls; WriteAchx helpers set `CoordinateType = Pixel`
- [x] All 1,254 tests pass (926 Core + 328 App)

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)