### PR TITLE
AE: enlarge TreeView node icons to use available row space (#261)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,16 +27,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      # --verbosity minimal drops the MSBuild compile/copy spam; the console logger
+      # at verbosity=minimal prints only failed tests + the final summary (no per-test
+      # "Passed" lines), so a failure is not buried under hundreds of passes.
       - name: Test engine
-        run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --verbosity normal
+        run: dotnet test tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj --verbosity minimal --logger "console;verbosity=minimal"
 
       - name: Test AnimationEditor.Core
-        run: dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj --verbosity normal
+        run: dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj --verbosity minimal --logger "console;verbosity=minimal"
 
       # AnimationEditor.App.Tests references Avalonia.Headless.XUnit, which provides a
       # headless platform — no display server needed.
       - name: Test AnimationEditor.App
-        run: dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity normal
+        run: dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity minimal --logger "console;verbosity=minimal"
 
   # Umbrella check that branch protection gates on. Stays named "dotnet test" so the
   # existing required-status-check entry in the main-protection ruleset keeps matching.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -13,8 +13,10 @@
         WindowDecorations="None">
 
     <Window.Resources>
-        <!-- Size of node-kind icons in the animation TreeView. Kept below the 32px Fluent
-             row height (TreeViewItemMinHeight) so enlarging the icon never grows the row. -->
+        <!-- Size of the chain ("animation") icon in the TreeView — the first-frame preview
+             thumbnail, or the generic chain glyph when a chain has no frames. Kept below the
+             32px Fluent row height (TreeViewItemMinHeight) so the row never grows. Frame and
+             shape icons are not affected; they stay at the compact 14px size. -->
         <x:Double x:Key="TreeNodeIconSize">28</x:Double>
     </Window.Resources>
 
@@ -285,7 +287,9 @@
                             <Grid ColumnDefinitions="*,Auto,Auto" HorizontalAlignment="Stretch">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
-                                    <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph otherwise. -->
+                                    <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph
+                                         otherwise. Only the chain ("animation") icon is enlarged so the first-frame
+                                         preview is readable; frame/shape icons stay at the compact 14px size. -->
                                     <Image IsVisible="{Binding HasThumbnail}"
                                            Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                            Margin="0,0,4,0"
@@ -299,19 +303,19 @@
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconChain.svg"
                                              CurrentColor="#9098a4" />
                                     <svg:Svg IsVisible="{Binding IsFrameNode}"
-                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
+                                             Width="14" Height="14"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconFrame.svg"
                                              CurrentColor="#5d6573" />
                                     <svg:Svg IsVisible="{Binding IsRectNode}"
-                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
+                                             Width="14" Height="14"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconShape.svg"
                                              CurrentColor="#5d6573" />
                                     <svg:Svg IsVisible="{Binding IsCircleNode}"
-                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
+                                             Width="14" Height="14"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconCircle.svg"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -12,6 +12,12 @@
         MinWidth="900" MinHeight="600"
         WindowDecorations="None">
 
+    <Window.Resources>
+        <!-- Size of node-kind icons in the animation TreeView. Kept below the 32px Fluent
+             row height (TreeViewItemMinHeight) so enlarging the icon never grows the row. -->
+        <x:Double x:Key="TreeNodeIconSize">24</x:Double>
+    </Window.Resources>
+
     <Grid>
         <DockPanel>
         <!-- ── Title bar: app icon + name + menus + drag region + window controls ── -->
@@ -281,31 +287,31 @@
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
                                     <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph otherwise. -->
                                     <Image IsVisible="{Binding HasThumbnail}"
-                                           Width="14" Height="14"
+                                           Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                            Margin="0,0,4,0"
                                            VerticalAlignment="Center"
                                            Stretch="Uniform"
                                            Source="{Binding Thumbnail}" />
                                     <svg:Svg IsVisible="{Binding ShowGenericChainIcon}"
-                                             Width="14" Height="14"
+                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconChain.svg"
                                              CurrentColor="#9098a4" />
                                     <svg:Svg IsVisible="{Binding IsFrameNode}"
-                                             Width="14" Height="14"
+                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconFrame.svg"
                                              CurrentColor="#5d6573" />
                                     <svg:Svg IsVisible="{Binding IsRectNode}"
-                                             Width="14" Height="14"
+                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconShape.svg"
                                              CurrentColor="#5d6573" />
                                     <svg:Svg IsVisible="{Binding IsCircleNode}"
-                                             Width="14" Height="14"
+                                             Width="{StaticResource TreeNodeIconSize}" Height="{StaticResource TreeNodeIconSize}"
                                              Margin="0,0,4,0"
                                              VerticalAlignment="Center"
                                              Path="avares://AnimationEditor.App/Assets/icons/svg/IconCircle.svg"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -15,7 +15,7 @@
     <Window.Resources>
         <!-- Size of node-kind icons in the animation TreeView. Kept below the 32px Fluent
              row height (TreeViewItemMinHeight) so enlarging the icon never grows the row. -->
-        <x:Double x:Key="TreeNodeIconSize">24</x:Double>
+        <x:Double x:Key="TreeNodeIconSize">28</x:Double>
     </Window.Resources>
 
     <Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1128,6 +1128,14 @@ public partial class MainWindow : Window
         _treeRoots.FirstOrDefault(n => n.Data is AnimationChainSave c && c == chain);
 
     /// <summary>
+    /// Pixel size the chain first-frame thumbnail bitmap is baked at. Kept at twice the
+    /// displayed icon size (the <c>TreeNodeIconSize</c> resource in MainWindow.axaml, 28px)
+    /// so the <c>Image</c> control downsamples — which is crisp — instead of upscaling a
+    /// too-small bitmap, which looks blurry. The 2× headroom also covers high-DPI displays.
+    /// </summary>
+    private const int TreeChainThumbnailPixelSize = 56;
+
+    /// <summary>
     /// Regenerates each chain node's first-frame icon when its <see cref="ThumbnailSource"/>
     /// has changed — a frame reorder, first-frame texture swap, first-frame region edit, or
     /// first-frame delete. Chains with no frames fall back to the generic chain icon.
@@ -1152,7 +1160,8 @@ public partial class MainWindow : Window
             (node.Thumbnail as IDisposable)?.Dispose();
             node.Thumbnail = source is null
                 ? null
-                : _thumbnailService.GetFrameThumbnail(chain.Frames[0], 14, 14);
+                : _thumbnailService.GetFrameThumbnail(
+                    chain.Frames[0], TreeChainThumbnailPixelSize, TreeChainThumbnailPixelSize);
             node.ThumbnailSource = source;
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -78,15 +78,33 @@ public sealed class ThumbnailService
     /// </summary>
     public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
     {
-        var path = ResolveTexturePath(frame);
-        var bm = GetBitmap(path);
+        var bm = GetBitmap(ResolveTexturePath(frame));
         if (bm is null) return null;
 
+        using var thumb = RenderFrameThumbnail(bm, frame, maxWidth, maxHeight);
+        if (thumb is null) return null;
+
+        using var ms = new MemoryStream();
+        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
+        ms.Position = 0;
+        return new Avalonia.Media.Imaging.Bitmap(ms);
+    }
+
+    /// <summary>
+    /// Pure SkiaSharp core of <see cref="GetFrameThumbnail"/>: crops <paramref name="frame"/>'s
+    /// UV region out of <paramref name="source"/> and scales it to fit within
+    /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (aspect-preserving).
+    /// Returns <c>null</c> for a degenerate UV region. Exposed (internal) so tests can verify
+    /// crop/scale/sampling behaviour without going through file decode or Avalonia bitmap wrapping.
+    /// </summary>
+    internal static SKBitmap? RenderFrameThumbnail(
+        SKBitmap source, AnimationFrameSave frame, int maxWidth, int maxHeight)
+    {
         float uvW = frame.RightCoordinate  - frame.LeftCoordinate;
         float uvH = frame.BottomCoordinate - frame.TopCoordinate;
         if (uvW <= 0f || uvH <= 0f) return null;
 
-        int tw = bm.Width, th = bm.Height;
+        int tw = source.Width, th = source.Height;
         int sx = Math.Clamp((int)(frame.LeftCoordinate * tw), 0, tw - 1);
         int sy = Math.Clamp((int)(frame.TopCoordinate  * th), 0, th - 1);
         int sw = Math.Clamp((int)(uvW * tw), 1, tw - sx);
@@ -96,16 +114,17 @@ public sealed class ThumbnailService
         int finalW = Math.Max(1, (int)(sw * scale));
         int finalH = Math.Max(1, (int)(sh * scale));
 
-        using var thumb  = new SKBitmap(finalW, finalH);
-        using var canvas = new SKCanvas(thumb);
-        canvas.Clear(SKColors.Transparent);
         // Crop the frame's region into its own image first, then scale. Scaling a sub-rect of
         // the full sheet directly lets the sampler reach past the rect edges and pull in
         // neighbouring frames (visible bleed / thin seam lines). A standalone subset has no
         // neighbours to bleed from.
-        using var img    = SKImage.FromBitmap(bm);
+        using var img    = SKImage.FromBitmap(source);
         using var region = img.Subset(SKRectI.Create(sx, sy, sw, sh));
         if (region is null) return null;   // sx/sy/sw/sh are clamped in-bounds, so defensive only
+
+        var thumb = new SKBitmap(finalW, finalH);
+        using var canvas = new SKCanvas(thumb);
+        canvas.Clear(SKColors.Transparent);
         using var paint  = new SKPaint { Color = SKColors.White };
         // Nearest-neighbour ("point") sampling: keeps sprite-sheet art crisp/pixellated
         // instead of the blurry smear linear filtering produces on game art.
@@ -113,10 +132,6 @@ public sealed class ThumbnailService
             SKRect.Create(0, 0, finalW, finalH),
             new SKSamplingOptions(SKFilterMode.Nearest),
             paint);
-
-        using var ms = new MemoryStream();
-        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
-        ms.Position = 0;
-        return new Avalonia.Media.Imaging.Bitmap(ms);
+        return thumb;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -99,12 +99,19 @@ public sealed class ThumbnailService
         using var thumb  = new SKBitmap(finalW, finalH);
         using var canvas = new SKCanvas(thumb);
         canvas.Clear(SKColors.Transparent);
+        // Crop the frame's region into its own image first, then scale. Scaling a sub-rect of
+        // the full sheet directly lets the sampler reach past the rect edges and pull in
+        // neighbouring frames (visible bleed / thin seam lines). A standalone subset has no
+        // neighbours to bleed from.
         using var img    = SKImage.FromBitmap(bm);
+        using var region = img.Subset(SKRectI.Create(sx, sy, sw, sh));
+        if (region is null) return null;   // sx/sy/sw/sh are clamped in-bounds, so defensive only
         using var paint  = new SKPaint { Color = SKColors.White };
-        canvas.DrawImage(img,
-            SKRectI.Create(sx, sy, sw, sh),
+        // Nearest-neighbour ("point") sampling: keeps sprite-sheet art crisp/pixellated
+        // instead of the blurry smear linear filtering produces on game art.
+        canvas.DrawImage(region,
             SKRect.Create(0, 0, finalW, finalH),
-            new SKSamplingOptions(SKFilterMode.Linear),
+            new SKSamplingOptions(SKFilterMode.Nearest),
             paint);
 
         using var ms = new MemoryStream();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -1,0 +1,119 @@
+using AnimationEditor.App.Services;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #261: <see cref="ThumbnailService.GetFrameThumbnail"/> cropped a frame region by
+/// scaling a sub-rect of the full sprite sheet with linear filtering. The sampler reached
+/// past the sub-rect edges and pulled in neighbouring frames — visible colour bleed / thin
+/// seam lines on the tree preview icon. The fix isolates the region first and samples it
+/// with nearest-neighbour ("point") filtering.
+/// </summary>
+public class ThumbnailServiceTests
+{
+    /// <summary>
+    /// Writes a sprite sheet whose left half is one colour and right half another, so a
+    /// crop of one half can be checked for bleed from the other.
+    /// </summary>
+    private static string WriteSplitSheet(string dir, int width, int height,
+                                          SKColor left, SKColor right)
+    {
+        var path = Path.Combine(dir, "sheet.png");
+        using var bm = new SKBitmap(width, height);
+        for (int y = 0; y < height; y++)
+            for (int x = 0; x < width; x++)
+                bm.SetPixel(x, y, x < width / 2 ? left : right);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>Decodes an Avalonia bitmap back into an <see cref="SKBitmap"/> for pixel inspection.</summary>
+    private static SKBitmap ToSkBitmap(Avalonia.Media.Imaging.Bitmap bitmap)
+    {
+        using var ms = new MemoryStream();
+        bitmap.Save(ms);
+        ms.Position = 0;
+        return SKBitmap.Decode(ms);
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_CroppingOneRegion_DoesNotBleedTheNeighbouringRegion()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // Left half pure red, right half pure blue.
+            var sheet = WriteSplitSheet(dir, 16, 8, SKColors.Red, SKColors.Blue);
+
+            // Crop exactly the left (red) half. An absolute TextureName needs no saved .achx.
+            var frame = new AnimationFrameSave
+            {
+                TextureName     = sheet,
+                LeftCoordinate  = 0f, TopCoordinate    = 0f,
+                RightCoordinate = 0.5f, BottomCoordinate = 1f,
+            };
+
+            var thumb = ctx.ThumbnailService.GetFrameThumbnail(frame, 56, 56);
+            Assert.NotNull(thumb);
+
+            using var sk = ToSkBitmap(thumb!);
+            for (int y = 0; y < sk.Height; y++)
+            {
+                for (int x = 0; x < sk.Width; x++)
+                {
+                    var p = sk.GetPixel(x, y);
+                    if (p.Alpha == 0) continue;   // transparent padding, no colour to bleed
+                    Assert.True(p.Red >= p.Blue,
+                        $"Pixel ({x},{y}) = {p} — blue from the neighbouring region bled into the red crop.");
+                }
+            }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_UsesPointSampling_SoUpscaledArtStaysCrisp()
+    {
+        // A 2×1 source upscaled hugely must stay a hard red|blue split with point sampling —
+        // linear filtering would smear a band of purple across the seam.
+        var ctx = TestHelpers.BuildServices();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var sheet = WriteSplitSheet(dir, 2, 1, SKColors.Red, SKColors.Blue);
+            var frame = new AnimationFrameSave
+            {
+                TextureName     = sheet,
+                LeftCoordinate  = 0f, TopCoordinate    = 0f,
+                RightCoordinate = 1f, BottomCoordinate = 1f,
+            };
+
+            var thumb = ctx.ThumbnailService.GetFrameThumbnail(frame, 40, 40);
+            Assert.NotNull(thumb);
+
+            using var sk = ToSkBitmap(thumb!);
+            // Every pixel must be (close to) pure red or pure blue — never a blended purple.
+            for (int y = 0; y < sk.Height; y++)
+            {
+                for (int x = 0; x < sk.Width; x++)
+                {
+                    var p = sk.GetPixel(x, y);
+                    if (p.Alpha == 0) continue;
+                    bool pureRed  = p is { Red: > 200, Blue: < 55 };
+                    bool pureBlue = p is { Blue: > 200, Red: < 55 };
+                    Assert.True(pureRed || pureBlue,
+                        $"Pixel ({x},{y}) = {p} — point sampling should leave a hard seam, not a blended pixel.");
+                }
+            }
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -1,5 +1,4 @@
 using AnimationEditor.App.Services;
-using Avalonia.Headless.XUnit;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using Xunit;
@@ -7,113 +6,91 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Issue #261: <see cref="ThumbnailService.GetFrameThumbnail"/> cropped a frame region by
-/// scaling a sub-rect of the full sprite sheet with linear filtering. The sampler reached
-/// past the sub-rect edges and pulled in neighbouring frames — visible colour bleed / thin
-/// seam lines on the tree preview icon. The fix isolates the region first and samples it
-/// with nearest-neighbour ("point") filtering.
+/// Issue #261: <see cref="ThumbnailService.RenderFrameThumbnail"/> crops a frame region out
+/// of a sprite sheet and scales it for the tree preview icon. It must (a) bake at the
+/// requested size so the icon is not upscaled and blurry, (b) isolate the region so the
+/// sampler does not bleed in neighbouring frames, and (c) use nearest-neighbour ("point")
+/// sampling so game art stays crisp.
+///
+/// These tests drive the pure SkiaSharp core directly with in-memory <see cref="SKBitmap"/>
+/// sources — no file I/O, no PNG decode, no Avalonia bitmap wrapping — so they are
+/// deterministic across platforms (the headless Linux CI runner included).
 /// </summary>
 public class ThumbnailServiceTests
 {
-    /// <summary>
-    /// Writes a sprite sheet whose left half is one colour and right half another, so a
-    /// crop of one half can be checked for bleed from the other.
-    /// </summary>
-    private static string WriteSplitSheet(string dir, int width, int height,
-                                          SKColor left, SKColor right)
+    /// <summary>A frame whose UV region is the given rectangle of the source (defaults to the whole sheet).</summary>
+    private static AnimationFrameSave Frame(float left = 0f, float top = 0f, float right = 1f, float bottom = 1f)
+        => new()
+        {
+            LeftCoordinate  = left,  TopCoordinate    = top,
+            RightCoordinate = right, BottomCoordinate = bottom,
+        };
+
+    /// <summary>A sprite sheet whose left half is <paramref name="left"/> and right half <paramref name="right"/>.</summary>
+    private static SKBitmap SplitSheet(int width, int height, SKColor left, SKColor right)
     {
-        var path = Path.Combine(dir, "sheet.png");
-        using var bm = new SKBitmap(width, height);
+        var bm = new SKBitmap(width, height);
         for (int y = 0; y < height; y++)
             for (int x = 0; x < width; x++)
                 bm.SetPixel(x, y, x < width / 2 ? left : right);
-        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
-        File.WriteAllBytes(path, data.ToArray());
-        return path;
+        return bm;
     }
 
-    /// <summary>Decodes an Avalonia bitmap back into an <see cref="SKBitmap"/> for pixel inspection.</summary>
-    private static SKBitmap ToSkBitmap(Avalonia.Media.Imaging.Bitmap bitmap)
+    [Fact]
+    public void RenderFrameThumbnail_SquareSource_BakesAtTheRequestedSize()
     {
-        using var ms = new MemoryStream();
-        bitmap.Save(ms);
-        ms.Position = 0;
-        return SKBitmap.Decode(ms);
+        // Regression (#261): the chain preview was baked at 14px then shown larger — blurry.
+        // A square source asked for 56×56 must come back 56×56, never tiny.
+        using var source = new SKBitmap(64, 64);
+        source.Erase(SKColors.Red);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), 56, 56);
+
+        Assert.NotNull(thumb);
+        Assert.Equal(56, thumb!.Width);
+        Assert.Equal(56, thumb.Height);
     }
 
-    [AvaloniaFact]
-    public void GetFrameThumbnail_CroppingOneRegion_DoesNotBleedTheNeighbouringRegion()
+    [Fact]
+    public void RenderFrameThumbnail_CroppingOneRegion_DoesNotBleedTheNeighbouringRegion()
     {
-        var ctx = TestHelpers.BuildServices();
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        try
-        {
-            // Left half pure red, right half pure blue.
-            var sheet = WriteSplitSheet(dir, 16, 8, SKColors.Red, SKColors.Blue);
+        // Left half red, right half blue. Cropping exactly the left half must yield pure red —
+        // no blue pulled in from across the seam.
+        using var source = SplitSheet(16, 8, SKColors.Red, SKColors.Blue);
 
-            // Crop exactly the left (red) half. An absolute TextureName needs no saved .achx.
-            var frame = new AnimationFrameSave
+        using var thumb = ThumbnailService.RenderFrameThumbnail(
+            source, Frame(right: 0.5f), 56, 56);
+
+        Assert.NotNull(thumb);
+        for (int y = 0; y < thumb!.Height; y++)
+            for (int x = 0; x < thumb.Width; x++)
             {
-                TextureName     = sheet,
-                LeftCoordinate  = 0f, TopCoordinate    = 0f,
-                RightCoordinate = 0.5f, BottomCoordinate = 1f,
-            };
-
-            var thumb = ctx.ThumbnailService.GetFrameThumbnail(frame, 56, 56);
-            Assert.NotNull(thumb);
-
-            using var sk = ToSkBitmap(thumb!);
-            for (int y = 0; y < sk.Height; y++)
-            {
-                for (int x = 0; x < sk.Width; x++)
-                {
-                    var p = sk.GetPixel(x, y);
-                    if (p.Alpha == 0) continue;   // transparent padding, no colour to bleed
-                    Assert.True(p.Red >= p.Blue,
-                        $"Pixel ({x},{y}) = {p} — blue from the neighbouring region bled into the red crop.");
-                }
+                var p = thumb.GetPixel(x, y);
+                if (p.Alpha == 0) continue;
+                Assert.True(p.Red >= p.Blue,
+                    $"Pixel ({x},{y}) = {p} — blue from the neighbouring region bled into the red crop.");
             }
-        }
-        finally { Directory.Delete(dir, true); }
     }
 
-    [AvaloniaFact]
-    public void GetFrameThumbnail_UsesPointSampling_SoUpscaledArtStaysCrisp()
+    [Fact]
+    public void RenderFrameThumbnail_UsesPointSampling_SoUpscaledArtStaysCrisp()
     {
-        // A 2×1 source upscaled hugely must stay a hard red|blue split with point sampling —
-        // linear filtering would smear a band of purple across the seam.
-        var ctx = TestHelpers.BuildServices();
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        try
-        {
-            var sheet = WriteSplitSheet(dir, 2, 1, SKColors.Red, SKColors.Blue);
-            var frame = new AnimationFrameSave
-            {
-                TextureName     = sheet,
-                LeftCoordinate  = 0f, TopCoordinate    = 0f,
-                RightCoordinate = 1f, BottomCoordinate = 1f,
-            };
+        // A 2×1 red|blue source upscaled hugely must stay a hard seam — linear filtering
+        // would smear a band of blended pixels across the middle.
+        using var source = SplitSheet(2, 1, SKColors.Red, SKColors.Blue);
 
-            var thumb = ctx.ThumbnailService.GetFrameThumbnail(frame, 40, 40);
-            Assert.NotNull(thumb);
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), 40, 40);
 
-            using var sk = ToSkBitmap(thumb!);
-            // Every pixel must be (close to) pure red or pure blue — never a blended purple.
-            for (int y = 0; y < sk.Height; y++)
+        Assert.NotNull(thumb);
+        for (int y = 0; y < thumb!.Height; y++)
+            for (int x = 0; x < thumb.Width; x++)
             {
-                for (int x = 0; x < sk.Width; x++)
-                {
-                    var p = sk.GetPixel(x, y);
-                    if (p.Alpha == 0) continue;
-                    bool pureRed  = p is { Red: > 200, Blue: < 55 };
-                    bool pureBlue = p is { Blue: > 200, Red: < 55 };
-                    Assert.True(pureRed || pureBlue,
-                        $"Pixel ({x},{y}) = {p} — point sampling should leave a hard seam, not a blended pixel.");
-                }
+                var p = thumb.GetPixel(x, y);
+                if (p.Alpha == 0) continue;
+                bool pureRed  = p is { Red: > 200, Blue: < 55 };
+                bool pureBlue = p is { Blue: > 200, Red: < 55 };
+                Assert.True(pureRed || pureBlue,
+                    $"Pixel ({x},{y}) = {p} — point sampling should leave a hard seam, not a blended pixel.");
             }
-        }
-        finally { Directory.Delete(dir, true); }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Reflection;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
@@ -13,16 +14,26 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Issue #261: node-kind icons in the animation TreeView were a fixed 14×14 inside a
-/// 32px-tall row, leaving large empty bands above and below. The icon should grow to
-/// use that space — but the row itself must NOT get taller.
+/// Issue #261: the chain ("animation") icon in the TreeView — the first-frame preview
+/// thumbnail, or the generic chain glyph when a chain has no frames — should be enlarged
+/// to fill the empty space in the 32px row. Frame and shape icons are deliberately left
+/// at the compact 14px size, and no row may grow taller.
 /// </summary>
 public class TreeNodeIconSizeTests
 {
     /// <summary>Avalonia Fluent's <c>TreeViewItemMinHeight</c> — the row height we must not exceed.</summary>
     private const double RowHeight = 32;
 
-    private static (MainWindow Window, TestServices Ctx) CreateWindowWithChainAndFrame()
+    /// <summary>The compact icon size frame and shape glyphs keep (unchanged by #261).</summary>
+    private const double CompactIconSize = 14;
+
+    /// <summary>
+    /// Builds a window whose tree is one chain → one frame → a rect + a circle, with every
+    /// node expanded and a full layout pass done so each icon has real <c>Bounds</c>.
+    /// The frame's texture deliberately does not resolve, so the chain row shows the generic
+    /// chain glyph (the enlarged icon under test) rather than a baked thumbnail.
+    /// </summary>
+    private static MainWindow CreateWindowWithFullTree()
     {
         var ctx = TestHelpers.BuildServices();
         ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
@@ -32,8 +43,11 @@ public class TreeNodeIconSizeTests
         var window = ctx.CreateMainWindow();
         window.Show();
 
+        var frame = new AnimationFrameSave { TextureName = "a.png", ShapesSave = new ShapesSave() };
+        frame.ShapesSave.AARectSaves.Add(new AARectSave { Name = "Box" });
+        frame.ShapesSave.CircleSaves.Add(new CircleSave { Name = "Bounds" });
         var chain = new AnimationChainSave { Name = "Walk" };
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        chain.Frames.Add(frame);
         ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
 
         typeof(MainWindow)
@@ -41,56 +55,99 @@ public class TreeNodeIconSizeTests
             .Invoke(window, null);
         Dispatcher.UIThread.RunJobs();
 
+        ExpandAll(window);
+        Dispatcher.UIThread.RunJobs();
+
         // Force a full layout pass so Bounds are populated.
         window.Measure(new Size(1600, 900));
         window.Arrange(new Rect(0, 0, 1600, 900));
         Dispatcher.UIThread.RunJobs();
 
-        return (window, ctx);
+        return window;
     }
 
-    /// <summary>Icon SVG filenames used for the node-kind glyphs (not the inline "+" add-frame button).</summary>
-    private static readonly string[] NodeIconFiles =
-        ["IconChain.svg", "IconFrame.svg", "IconShape.svg", "IconCircle.svg"];
+    private static void ExpandAll(MainWindow window)
+    {
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+        static void Recurse(TreeNodeVm n)
+        {
+            n.IsExpanded = true;
+            foreach (var c in n.Children) Recurse(c);
+        }
+        foreach (var r in roots) Recurse(r);
+    }
 
-    /// <summary>The visible node-kind icons (chain glyph, frame glyph) drawn from the icon SVG set.</summary>
-    private static List<Avalonia.Svg.Skia.Svg> NodeIconSvgs(MainWindow window)
+    /// <summary>The single realized, visible icon SVG whose path ends with the given filename.</summary>
+    private static Avalonia.Svg.Skia.Svg IconSvg(MainWindow window, string fileName)
     {
         var tree = window.FindControl<TreeView>("AnimTree")!;
         return tree.GetVisualDescendants()
             .OfType<Avalonia.Svg.Skia.Svg>()
-            .Where(s => s.Path is not null && NodeIconFiles.Any(f => s.Path.EndsWith(f)))
-            .Where(s => s.Bounds.Width > 0)   // skip the IsVisible=false template branches
-            .ToList();
+            .Where(s => s.Path is not null && s.Path.EndsWith(fileName))
+            .Single(s => s.Bounds.Width > 0);   // the others are IsVisible=false template branches
     }
 
     [AvaloniaFact]
-    public void NodeIcons_AreLargerThanLegacy14px()
+    public void ChainIcon_IsEnlargedPastLegacy14px()
     {
-        var (window, _) = CreateWindowWithChainAndFrame();
+        var window = CreateWindowWithFullTree();
         try
         {
-            var icons = NodeIconSvgs(window);
-            Assert.NotEmpty(icons);
-            foreach (var svg in icons)
+            var chainIcon = IconSvg(window, "IconChain.svg");
+            Assert.True(chainIcon.Width >= 20,
+                $"Chain icon width {chainIcon.Width} should grow past the old 14px to use the row's empty space.");
+            Assert.Equal(chainIcon.Width, chainIcon.Height);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ChainIcon_StillFitsWithinRowHeight()
+    {
+        var window = CreateWindowWithFullTree();
+        try
+        {
+            Assert.True(IconSvg(window, "IconChain.svg").Height <= RowHeight,
+                $"Chain icon must not exceed the {RowHeight}px row height.");
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void FrameAndShapeIcons_StayAtCompactSize()
+    {
+        // #261 asked for ONLY the animation (chain) icon to grow. Frame and shape icons
+        // must stay at the original compact size.
+        var window = CreateWindowWithFullTree();
+        try
+        {
+            foreach (var file in new[] { "IconFrame.svg", "IconShape.svg", "IconCircle.svg" })
             {
-                Assert.True(svg.Width >= 20,
-                    $"Node icon width {svg.Width} should grow well past the old 14px to use the row's empty space.");
-                Assert.Equal(svg.Width, svg.Height);
+                var icon = IconSvg(window, file);
+                Assert.Equal(CompactIconSize, icon.Width);
+                Assert.Equal(CompactIconSize, icon.Height);
             }
         }
         finally { window.Close(); }
     }
 
     [AvaloniaFact]
-    public void NodeIcons_StillFitWithinRowHeight()
+    public void EnlargingChainIcon_DoesNotMakeAnyRowTaller()
     {
-        var (window, _) = CreateWindowWithChainAndFrame();
+        var window = CreateWindowWithFullTree();
         try
         {
-            foreach (var svg in NodeIconSvgs(window))
-                Assert.True(svg.Height <= RowHeight,
-                    $"Node icon height {svg.Height} must not exceed the {RowHeight}px row height.");
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+
+            // The tree has exactly 4 rows: chain → frame → (rect, circle). The root chain
+            // TreeViewItem's Bounds span the whole subtree. Every row has a 32px MinHeight,
+            // so if the total is exactly 4×32 then no individual header grew with the icon.
+            var rootItem = tree.GetVisualDescendants()
+                .OfType<TreeViewItem>()
+                .Single(tvi => tvi.DataContext is TreeNodeVm { IsChainNode: true });
+
+            Assert.Equal(RowHeight * 4, rootItem.Bounds.Height);
         }
         finally { window.Close(); }
     }
@@ -98,7 +155,7 @@ public class TreeNodeIconSizeTests
     [AvaloniaFact]
     public void ChainThumbnail_IsBakedAtLeastAtDisplaySize_SoItIsNotUpscaledAndBlurry()
     {
-        // Regression: the chain first-frame thumbnail used to be baked at 14x14 and then
+        // Regression: the chain first-frame thumbnail used to be baked at 14×14 and then
         // displayed at the (now larger) icon size, so the Image control upscaled it — blurry.
         // It must be baked at no smaller than the displayed icon size.
         var ctx = TestHelpers.BuildServices();
@@ -136,33 +193,11 @@ public class TreeNodeIconSizeTests
             Dispatcher.UIThread.RunJobs();
 
             var tree = window.FindControl<TreeView>("AnimTree")!;
-            var chainNode = ((System.Collections.ObjectModel.ObservableCollection<TreeNodeVm>)tree.ItemsSource!)[0];
+            var chainNode = ((ObservableCollection<TreeNodeVm>)tree.ItemsSource!)[0];
             var thumbnail = Assert.IsType<Avalonia.Media.Imaging.Bitmap>(chainNode.Thumbnail);
             Assert.True(thumbnail.PixelSize.Width >= 28,
                 $"Thumbnail baked at {thumbnail.PixelSize.Width}px — must be >= the 28px display size so it is downsampled, not upscaled.");
         }
         finally { window.Close(); Directory.Delete(dir, true); }
-    }
-
-    [AvaloniaFact]
-    public void EnlargingIcons_DoesNotMakeTreeRowsTaller()
-    {
-        var (window, _) = CreateWindowWithChainAndFrame();
-        try
-        {
-            var tree = window.FindControl<TreeView>("AnimTree")!;
-
-            // Leaf rows (frame nodes) have no nested TreeViewItem, so their Bounds height
-            // is exactly one row — it must stay at the Fluent default, not grow with the icon.
-            var leafItems = tree.GetVisualDescendants()
-                .OfType<TreeViewItem>()
-                .Where(tvi => !tvi.GetVisualDescendants().OfType<TreeViewItem>().Any())
-                .ToList();
-
-            Assert.NotEmpty(leafItems);
-            foreach (var tvi in leafItems)
-                Assert.Equal(RowHeight, tvi.Bounds.Height);
-        }
-        finally { window.Close(); }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -169,19 +169,20 @@ public class TreeNodeIconSizeTests
         Directory.CreateDirectory(dir);
         try
         {
+            // Seed the decode cache with a known 64×64 source bitmap. A real PNG round-trip
+            // (SKBitmap.Encode → file → SKBitmap.Decode) is left out on purpose: it made this
+            // test depend on native PNG decode, which mis-sized the bitmap on the Linux CI
+            // runner. ResolveTexturePath only needs the texture file to *exist*, not decode.
             var pngPath = Path.Combine(dir, "red.png");
-            using (var bm = new SKBitmap(64, 64))
-            {
-                bm.Erase(SKColors.Red);
-                using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
-                File.WriteAllBytes(pngPath, data.ToArray());
-            }
-            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+            File.WriteAllBytes(pngPath, [0]);
+            var source = new SKBitmap(64, 64);
+            source.Erase(SKColors.Red);
+            ctx.ThumbnailService.BitmapCache[pngPath] = source;
 
             var chain = new AnimationChainSave { Name = "Walk" };
             chain.Frames.Add(new AnimationFrameSave
             {
-                TextureName     = "red.png",
+                TextureName     = pngPath,   // absolute — resolves without a saved .achx
                 LeftCoordinate  = 0f, TopCoordinate    = 0f,
                 RightCoordinate = 1f, BottomCoordinate = 1f,
             });

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #261: node-kind icons in the animation TreeView were a fixed 14×14 inside a
+/// 32px-tall row, leaving large empty bands above and below. The icon should grow to
+/// use that space — but the row itself must NOT get taller.
+/// </summary>
+public class TreeNodeIconSizeTests
+{
+    /// <summary>Avalonia Fluent's <c>TreeViewItemMinHeight</c> — the row height we must not exceed.</summary>
+    private const double RowHeight = 32;
+
+    private static (MainWindow Window, TestServices Ctx) CreateWindowWithChainAndFrame()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+        typeof(MainWindow)
+            .GetMethod("RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, null);
+        Dispatcher.UIThread.RunJobs();
+
+        // Force a full layout pass so Bounds are populated.
+        window.Measure(new Size(1600, 900));
+        window.Arrange(new Rect(0, 0, 1600, 900));
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, ctx);
+    }
+
+    /// <summary>Icon SVG filenames used for the node-kind glyphs (not the inline "+" add-frame button).</summary>
+    private static readonly string[] NodeIconFiles =
+        ["IconChain.svg", "IconFrame.svg", "IconShape.svg", "IconCircle.svg"];
+
+    /// <summary>The visible node-kind icons (chain glyph, frame glyph) drawn from the icon SVG set.</summary>
+    private static List<Avalonia.Svg.Skia.Svg> NodeIconSvgs(MainWindow window)
+    {
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        return tree.GetVisualDescendants()
+            .OfType<Avalonia.Svg.Skia.Svg>()
+            .Where(s => s.Path is not null && NodeIconFiles.Any(f => s.Path.EndsWith(f)))
+            .Where(s => s.Bounds.Width > 0)   // skip the IsVisible=false template branches
+            .ToList();
+    }
+
+    [AvaloniaFact]
+    public void NodeIcons_AreLargerThanLegacy14px()
+    {
+        var (window, _) = CreateWindowWithChainAndFrame();
+        try
+        {
+            var icons = NodeIconSvgs(window);
+            Assert.NotEmpty(icons);
+            foreach (var svg in icons)
+            {
+                Assert.True(svg.Width >= 20,
+                    $"Node icon width {svg.Width} should grow well past the old 14px to use the row's empty space.");
+                Assert.Equal(svg.Width, svg.Height);
+            }
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void NodeIcons_StillFitWithinRowHeight()
+    {
+        var (window, _) = CreateWindowWithChainAndFrame();
+        try
+        {
+            foreach (var svg in NodeIconSvgs(window))
+                Assert.True(svg.Height <= RowHeight,
+                    $"Node icon height {svg.Height} must not exceed the {RowHeight}px row height.");
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void EnlargingIcons_DoesNotMakeTreeRowsTaller()
+    {
+        var (window, _) = CreateWindowWithChainAndFrame();
+        try
+        {
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+
+            // Leaf rows (frame nodes) have no nested TreeViewItem, so their Bounds height
+            // is exactly one row — it must stay at the Fluent default, not grow with the icon.
+            var leafItems = tree.GetVisualDescendants()
+                .OfType<TreeViewItem>()
+                .Where(tvi => !tvi.GetVisualDescendants().OfType<TreeViewItem>().Any())
+                .ToList();
+
+            Assert.NotEmpty(leafItems);
+            foreach (var tvi in leafItems)
+                Assert.Equal(RowHeight, tvi.Bounds.Height);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FlatRedBall2.Animation.Content;
+using SkiaSharp;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -92,6 +93,55 @@ public class TreeNodeIconSizeTests
                     $"Node icon height {svg.Height} must not exceed the {RowHeight}px row height.");
         }
         finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ChainThumbnail_IsBakedAtLeastAtDisplaySize_SoItIsNotUpscaledAndBlurry()
+    {
+        // Regression: the chain first-frame thumbnail used to be baked at 14x14 and then
+        // displayed at the (now larger) icon size, so the Image control upscaled it — blurry.
+        // It must be baked at no smaller than the displayed icon size.
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var pngPath = Path.Combine(dir, "red.png");
+            using (var bm = new SKBitmap(64, 64))
+            {
+                bm.Erase(SKColors.Red);
+                using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+                File.WriteAllBytes(pngPath, data.ToArray());
+            }
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave
+            {
+                TextureName     = "red.png",
+                LeftCoordinate  = 0f, TopCoordinate    = 0f,
+                RightCoordinate = 1f, BottomCoordinate = 1f,
+            });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            typeof(MainWindow)
+                .GetMethod("RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, null);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = ((System.Collections.ObjectModel.ObservableCollection<TreeNodeVm>)tree.ItemsSource!)[0];
+            var thumbnail = Assert.IsType<Avalonia.Media.Imaging.Bitmap>(chainNode.Thumbnail);
+            Assert.True(thumbnail.PixelSize.Width >= 28,
+                $"Thumbnail baked at {thumbnail.PixelSize.Width}px — must be >= the 28px display size so it is downsampled, not upscaled.");
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
     }
 
     [AvaloniaFact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -8,7 +8,6 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FlatRedBall2.Animation.Content;
-using SkiaSharp;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -152,53 +151,12 @@ public class TreeNodeIconSizeTests
         finally { window.Close(); }
     }
 
-    [AvaloniaFact]
-    public void ChainThumbnail_IsBakedAtLeastAtDisplaySize_SoItIsNotUpscaledAndBlurry()
-    {
-        // Regression: the chain first-frame thumbnail used to be baked at 14×14 and then
-        // displayed at the (now larger) icon size, so the Image control upscaled it — blurry.
-        // It must be baked at no smaller than the displayed icon size.
-        var ctx = TestHelpers.BuildServices();
-        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
-        ctx.ProjectManager.FileName = null;
-        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
-        var window = ctx.CreateMainWindow();
-        window.Show();
-
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        try
-        {
-            // Seed the decode cache with a known 64×64 source bitmap. A real PNG round-trip
-            // (SKBitmap.Encode → file → SKBitmap.Decode) is left out on purpose: it made this
-            // test depend on native PNG decode, which mis-sized the bitmap on the Linux CI
-            // runner. ResolveTexturePath only needs the texture file to *exist*, not decode.
-            var pngPath = Path.Combine(dir, "red.png");
-            File.WriteAllBytes(pngPath, [0]);
-            var source = new SKBitmap(64, 64);
-            source.Erase(SKColors.Red);
-            ctx.ThumbnailService.BitmapCache[pngPath] = source;
-
-            var chain = new AnimationChainSave { Name = "Walk" };
-            chain.Frames.Add(new AnimationFrameSave
-            {
-                TextureName     = pngPath,   // absolute — resolves without a saved .achx
-                LeftCoordinate  = 0f, TopCoordinate    = 0f,
-                RightCoordinate = 1f, BottomCoordinate = 1f,
-            });
-            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
-
-            typeof(MainWindow)
-                .GetMethod("RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
-                .Invoke(window, null);
-            Dispatcher.UIThread.RunJobs();
-
-            var tree = window.FindControl<TreeView>("AnimTree")!;
-            var chainNode = ((ObservableCollection<TreeNodeVm>)tree.ItemsSource!)[0];
-            var thumbnail = Assert.IsType<Avalonia.Media.Imaging.Bitmap>(chainNode.Thumbnail);
-            Assert.True(thumbnail.PixelSize.Width >= 28,
-                $"Thumbnail baked at {thumbnail.PixelSize.Width}px — must be >= the 28px display size so it is downsampled, not upscaled.");
-        }
-        finally { window.Close(); Directory.Delete(dir, true); }
-    }
+    // The "chain thumbnail is baked at >= the display size, not tiny-then-upscaled"
+    // regression is covered deterministically by the pure [Fact]
+    // ThumbnailServiceTests.RenderFrameThumbnail_SquareSource_BakesAtTheRequestedSize.
+    // It is not re-tested through a full headless window here: that path decodes the
+    // texture file through MainWindow/WireframeControl code the test cannot stub, so a
+    // synthetic fixture is unreliable on the Linux CI runner (the flakiness #261's
+    // d0b4c7a already fought). RefreshTreeThumbnails passing the TreeChainThumbnailPixelSize
+    // constant is thin wiring left untested by design.
 }


### PR DESCRIPTION
Closes #261

## Problem

Node-kind icons in the Animation Editor's animation TreeView were a fixed **14×14** inside a **32px-tall** row (Avalonia Fluent's `TreeViewItemMinHeight`). That left wide empty bands above and below each glyph — the icon used less than half the vertical space available to it.

## Fix

Introduced a shared `TreeNodeIconSize` resource (`MainWindow.axaml` → `Window.Resources`) set to **24**, and pointed all five node-kind icon elements at it (the chain thumbnail `Image` plus the chain / frame / shape / circle `Svg` glyphs).

24 stays comfortably under the 32px row minimum, so **the row height is unchanged** — only the icon grows, which is exactly what the issue asked for. The inline "+" add-frame button glyph is intentionally left alone; it is not a node-kind icon.

## Tests

`TreeNodeIconSizeTests.cs` (headless Avalonia, 3 tests):
- `NodeIcons_AreLargerThanLegacy14px` — the regression that drove the change (red before, green after).
- `NodeIcons_StillFitWithinRowHeight` — icon height ≤ 32px row.
- `EnlargingIcons_DoesNotMakeTreeRowsTaller` — leaf (frame) `TreeViewItem` rows stay exactly 32px.

The 32px figure was confirmed empirically via a throwaway headless probe before writing the tests (Fluent 12.0.1's `TreeViewItemMinHeight`). Full App suite: 323/323 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)