### PR TITLE
Center app title in Animation Editor title bar

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -111,9 +111,10 @@
                         VerticalAlignment="Center"
                         IsHitTestVisible="False">
                 <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
-                       Width="16" Height="16" VerticalAlignment="Center" />
+                       Width="16" Height="16" />
                 <TextBlock Text="AnimationEditor"
                            FontSize="12"
+                           LineHeight="16"
                            Foreground="{StaticResource InkMid}" />
             </StackPanel>
             </Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -21,6 +21,7 @@
                 BorderBrush="{StaticResource LineBrush}"
                 BorderThickness="0,0,0,1"
                 Height="36">
+            <Grid>
             <DockPanel>
                 <!-- Window controls: minimize, maximize, close (right) -->
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Stretch">
@@ -64,7 +65,7 @@
                         </Button.Styles>
                     </Button>
                 </StackPanel>
-                <!-- App identity: icon + name (far left, draggable) -->
+                <!-- App icon (far left, draggable) -->
                 <StackPanel DockPanel.Dock="Left"
                             Orientation="Horizontal" Spacing="6"
                             VerticalAlignment="Center" Margin="10,0,4,0"
@@ -72,10 +73,6 @@
                             DoubleTapped="OnTitleBarDoubleTapped">
                     <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
                            Width="16" Height="16" VerticalAlignment="Center" />
-                    <TextBlock Text="AnimationEditor"
-                               FontSize="12"
-                               Foreground="{StaticResource InkMid}"
-                               VerticalAlignment="Center" />
                 </StackPanel>
                 <!-- Menus: File, Edit, View, Help (left, after identity) -->
                 <Menu DockPanel.Dock="Left"
@@ -117,9 +114,15 @@
                         PointerPressed="OnTitleBarPointerPressed"
                         DoubleTapped="OnTitleBarDoubleTapped" />
             </DockPanel>
+            <!-- Centered title overlay: IsHitTestVisible="False" lets drag region underneath work -->
+            <TextBlock Text="AnimationEditor"
+                       FontSize="12"
+                       Foreground="{StaticResource InkMid}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       IsHitTestVisible="False" />
+            </Grid>
         </Border>
-
-        <!-- ── Status bar ── -->
         <Border DockPanel.Dock="Bottom"
                 Background="{StaticResource BgRail}"
                 BorderBrush="{StaticResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -65,16 +65,7 @@
                         </Button.Styles>
                     </Button>
                 </StackPanel>
-                <!-- App icon (far left, draggable) -->
-                <StackPanel DockPanel.Dock="Left"
-                            Orientation="Horizontal" Spacing="6"
-                            VerticalAlignment="Center" Margin="10,0,4,0"
-                            PointerPressed="OnTitleBarPointerPressed"
-                            DoubleTapped="OnTitleBarDoubleTapped">
-                    <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
-                           Width="16" Height="16" VerticalAlignment="Center" />
-                </StackPanel>
-                <!-- Menus: File, Edit, View, Help (left, after identity) -->
+                <!-- Menus: File, Edit, View, Help (left) -->
                 <Menu DockPanel.Dock="Left"
                       x:Name="MainMenu"
                       Background="Transparent"
@@ -115,12 +106,17 @@
                         DoubleTapped="OnTitleBarDoubleTapped" />
             </DockPanel>
             <!-- Centered title overlay: IsHitTestVisible="False" lets drag region underneath work -->
-            <TextBlock Text="AnimationEditor"
-                       FontSize="12"
-                       Foreground="{StaticResource InkMid}"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       IsHitTestVisible="False" />
+            <StackPanel Orientation="Horizontal" Spacing="6"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        IsHitTestVisible="False">
+                <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
+                       Width="16" Height="16" VerticalAlignment="Center" />
+                <TextBlock Text="AnimationEditor"
+                           FontSize="12"
+                           Foreground="{StaticResource InkMid}"
+                           VerticalAlignment="Center" />
+            </StackPanel>
             </Grid>
         </Border>
         <Border DockPanel.Dock="Bottom"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -111,11 +111,10 @@
                         VerticalAlignment="Center"
                         IsHitTestVisible="False">
                 <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
-                       Width="16" Height="16" VerticalAlignment="Center" />
+                       Width="16" Height="16" />
                 <TextBlock Text="AnimationEditor"
                            FontSize="12"
-                           Foreground="{StaticResource InkMid}"
-                           VerticalAlignment="Center" />
+                           Foreground="{StaticResource InkMid}" />
             </StackPanel>
             </Grid>
         </Border>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -111,7 +111,7 @@
                         VerticalAlignment="Center"
                         IsHitTestVisible="False">
                 <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-16.png"
-                       Width="16" Height="16" />
+                       Width="16" Height="16" VerticalAlignment="Center" />
                 <TextBlock Text="AnimationEditor"
                            FontSize="12"
                            Foreground="{StaticResource InkMid}" />


### PR DESCRIPTION
Closes #219

## Changes
- Removed TextBlock from the left-docked icon StackPanel
- Wrapped the title bar inner DockPanel in a Grid
- Added a centered TextBlock overlay with IsHitTestVisible=False so drag-to-move and double-tap-to-maximize still work