### PR TITLE
Animation Editor: mouse-wheel zoom steps through round-number presets

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -233,11 +233,19 @@ public class PreviewControl : Control
 
     /// <summary>
     /// Fired after every zoom change. Payload is the new zoom as a percentage
-    /// (e.g. 100f = 100 %). Wheel-zoom can land on values that are not present
-    /// in any preset combo box bound to this control; subscribers should be
-    /// prepared to display arbitrary percentages.
+    /// (e.g. 100f = 100 %).
     /// </summary>
     public event Action<float>? ZoomChanged;
+
+    /// <summary>
+    /// When non-null, mouse-wheel zoom steps through these preset percentages instead
+    /// of applying a raw ×1.25/×0.8 multiplier.  Set by <c>MainWindow</c> on startup.
+    /// <para>
+    /// Standalone controls (no <c>MainWindow</c>) leave this null and retain the legacy
+    /// multiplier behaviour, which is still useful in precision-zoom tests.
+    /// </para>
+    /// </summary>
+    public int[]? WheelZoomPresets { get; set; }
 
     public void SetZoomPercent(int pct)
     {
@@ -355,13 +363,21 @@ public class PreviewControl : Control
     /// </summary>
     public void SimulateWheelZoom(double x, double y, bool zoomIn)
     {
-        ApplyWheelZoom(x, y, zoomIn ? 1.25f : 0.8f);
+        ApplyWheelZoom(x, y, zoomIn);
     }
 
-    private void ApplyWheelZoom(double x, double y, float factor)
+    private void ApplyWheelZoom(double x, double y, bool zoomIn)
     {
         float oldZoom = _zoom;
-        _zoom = Math.Clamp(_zoom * factor, 0.05f, 32f);
+        if (WheelZoomPresets is { Length: > 0 } presets)
+        {
+            int newPct = ZoomPresetStepper.StepToNextPreset(_zoom * 100f, presets, zoomIn ? +1 : -1);
+            _zoom = Math.Clamp(newPct / 100f, 0.05f, 32f);
+        }
+        else
+        {
+            _zoom = Math.Clamp(_zoom * (zoomIn ? 1.25f : 0.8f), 0.05f, 32f);
+        }
         float ratio = _zoom / oldZoom;
         float cx0 = (float)((Bounds.Width  - RulerSize) / 2f + RulerSize);
         float cy0 = (float)((Bounds.Height - RulerSize) / 2f + RulerSize);
@@ -937,10 +953,8 @@ public class PreviewControl : Control
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
-        float factor = e.Delta.Y > 0 ? 1.25f : 0.8f;
         var pt = e.GetPosition(this);
-        // Zoom toward the cursor: the world coordinate under pt must stay fixed.
-        ApplyWheelZoom(pt.X, pt.Y, factor);
+        ApplyWheelZoom(pt.X, pt.Y, e.Delta.Y > 0);
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -446,6 +446,16 @@ public class WireframeControl : Control
     public event Action<float>? ZoomChanged;
 
     /// <summary>
+    /// When non-null, mouse-wheel zoom steps through these preset percentages instead of
+    /// applying a raw ×1.25 / ÷1.25 multiplier.  Set by <c>MainWindow</c> on startup.
+    /// <para>
+    /// Standalone controls (no <c>MainWindow</c>) leave this null and retain the legacy
+    /// multiplier behaviour, which is still useful in precision-zoom tests.
+    /// </para>
+    /// </summary>
+    public int[]? WheelZoomPresets { get; set; }
+
+    /// <summary>
     /// Fired when the user ctrl+clicks to add a new frame
     /// (minX, minY, maxX, maxY in texture pixel coords).
     /// </summary>
@@ -1208,13 +1218,27 @@ public class WireframeControl : Control
     /// exactly: converts the viewport-space pivot to content-space by adding
     /// <c>_scrollTargetX/Y</c>, then calls <see cref="ZoomToward"/>.
     /// <para><paramref name="factor"/> is the zoom scale factor (e.g. 1.25 to
-    /// zoom in by one wheel notch, 1/1.25 to zoom out).</para>
+    /// zoom in by one wheel notch, 1/1.25 to zoom out).  This overload always
+    /// applies the raw factor regardless of <see cref="WheelZoomPresets"/> — use
+    /// it in tests that need deterministic pivot-point math.</para>
     /// </summary>
     public void SimulateWheelZoom(float vpX, float vpY, float factor)
     {
         float scrollOffX = _scrollViewer is not null ? _scrollTargetX : 0f;
         float scrollOffY = _scrollViewer is not null ? _scrollTargetY : 0f;
         ZoomToward(vpX + scrollOffX, vpY + scrollOffY, factor);
+    }
+
+    /// <summary>
+    /// Test-only: simulates a single mouse-wheel zoom event toward the given
+    /// <b>viewport-space</b> point, using preset stepping when <see cref="WheelZoomPresets"/>
+    /// is set.  Mirrors <see cref="OnPointerWheelChanged"/> exactly.
+    /// </summary>
+    public void SimulateWheelZoom(float vpX, float vpY, bool zoomIn)
+    {
+        float scrollOffX = _scrollViewer is not null ? _scrollTargetX : 0f;
+        float scrollOffY = _scrollViewer is not null ? _scrollTargetY : 0f;
+        ZoomToward(vpX + scrollOffX, vpY + scrollOffY, ComputeWheelFactor(zoomIn));
     }
 
     /// <summary>Exposed for tests: the synchronous scroll-target maintained by ZoomToward.</summary>
@@ -1377,7 +1401,7 @@ public class WireframeControl : Control
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
-        float factor = e.Delta.Y > 0 ? 1.25f : 1f / 1.25f;
+        float factor = ComputeWheelFactor(e.Delta.Y > 0);
         // e.GetPosition(this) returns content-space coords inside a ScrollViewer
         // (viewport position + scroll offset).  Using the ScrollViewer as the reference
         // gives stable viewport-space coords that are independent of the current offset.
@@ -1387,6 +1411,17 @@ public class WireframeControl : Control
         float scrollOffY = _scrollViewer is not null ? _scrollTargetY : 0f;
         ZoomToward((float)pivotVp.X + scrollOffX, (float)pivotVp.Y + scrollOffY, factor);
         e.Handled = true;
+    }
+
+    /// <summary>Computes the zoom factor for one wheel notch, using preset stepping when available.</summary>
+    private float ComputeWheelFactor(bool zoomIn)
+    {
+        if (WheelZoomPresets is { Length: > 0 } presets)
+        {
+            int newPct = ZoomPresetStepper.StepToNextPreset(_zoom * 100f, presets, zoomIn ? +1 : -1);
+            return newPct / 100f / _zoom;
+        }
+        return zoomIn ? 1.25f : 1f / 1.25f;
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/ZoomPresetStepper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/ZoomPresetStepper.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace AnimationEditor.App.Controls;
+
+
+/// <summary>
+/// Pure helper that steps a zoom percentage to the next or previous entry in a
+/// preset list.  Shared by <see cref="WireframeControl"/>, <see cref="PreviewControl"/>,
+/// and <see cref="MainWindow"/> so all three use identical stepping logic.
+/// </summary>
+internal static class ZoomPresetStepper
+{
+    /// <summary>Tolerance used when snapping <paramref name="currentPct"/> to a preset value.</summary>
+    private const float Epsilon = 0.01f;
+
+    /// <summary>
+    /// Returns the next preset above (<paramref name="direction"/> &gt; 0) or below
+    /// (<paramref name="direction"/> &lt; 0) <paramref name="currentPct"/>.
+    /// <para>
+    /// Float drift is handled by snapping <paramref name="currentPct"/> to the nearest
+    /// preset when they are within <c>0.01</c> of each other, so that zooming in while
+    /// standing exactly on a preset always advances to the next one.
+    /// </para>
+    /// </summary>
+    /// <param name="currentPct">Current zoom as a percentage (e.g. 100 for 100 %).</param>
+    /// <param name="presets">Sorted ascending array of preset percentages.  Must not be empty.</param>
+    /// <param name="direction">+1 for zoom-in (step up), −1 for zoom-out (step down).</param>
+    internal static int StepToNextPreset(float currentPct, int[] presets, int direction)
+    {
+        // Snap float drift: if currentPct is within epsilon of a preset, treat it as exact.
+        foreach (var p in presets)
+        {
+            if (MathF.Abs(currentPct - p) <= Epsilon)
+            {
+                currentPct = p;
+                break;
+            }
+        }
+
+        if (direction > 0)
+        {
+            for (int i = 0; i < presets.Length; i++)
+                if (presets[i] > currentPct) return presets[i];
+            return presets[^1];
+        }
+        else
+        {
+            for (int i = presets.Length - 1; i >= 0; i--)
+                if (presets[i] < currentPct) return presets[i];
+            return presets[0];
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -169,6 +169,7 @@ public partial class MainWindow : Window
         ZoomCombo.SelectionChanged += OnZoomComboSelectionChanged;
         ZoomPlusBtn.Click  += (_, _) => StepZoomPreset(WireframeCtrl.Zoom * 100f, _zoomPresets, +1, p => WireframeCtrl.SetZoomPercent(p));
         ZoomMinusBtn.Click += (_, _) => StepZoomPreset(WireframeCtrl.Zoom * 100f, _zoomPresets, -1, p => WireframeCtrl.SetZoomPercent(p));
+        WireframeCtrl.WheelZoomPresets = _zoomPresets;
 
         // Apply initial grid state
         WireframeCtrl.SetGrid(false, 16);
@@ -257,7 +258,7 @@ public partial class MainWindow : Window
     // writes Text back into the control.
 
     private static readonly int[] _zoomPresets =
-        { 10, 25, 50, 100, 200, 400, 800 };
+        { 5, 10, 16, 25, 33, 50, 66, 75, 100, 150, 200, 300, 400, 800, 1600, 3200 };
     private static readonly string[] _zoomPresetTexts =
         _zoomPresets.Select(p => $"{p}%").ToArray();
 
@@ -726,6 +727,7 @@ public partial class MainWindow : Window
         PreviewZoomCombo.SelectionChanged += OnPreviewZoomComboSelectionChanged;
         PreviewZoomPlusBtn.Click  += (_, _) => StepZoomPreset(PreviewCtrl.Zoom * 100f, _previewZoomPresets, +1, p => PreviewCtrl.SetZoomPercent(p));
         PreviewZoomMinusBtn.Click += (_, _) => StepZoomPreset(PreviewCtrl.Zoom * 100f, _previewZoomPresets, -1, p => PreviewCtrl.SetZoomPercent(p));
+        PreviewCtrl.WheelZoomPresets = _previewZoomPresets;
 
         PreviewCtrl.ZoomChanged += SyncPreviewZoomCombo;
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
@@ -766,13 +768,10 @@ public partial class MainWindow : Window
 
     // ── Editable preview-zoom combo (bottom preview) ─────────────────────────
     //
-    // Same editable-AutoCompleteBox pattern as ZoomCombo above. The bottom
-    // preview's wheel zoom uses a 1.25 / 0.8 multiplier so it almost always
-    // lands on a non-preset value — making the preset-snap display from the
-    // pre-fix code straight-up wrong.
+    // Same editable-AutoCompleteBox pattern as ZoomCombo above.
 
     private static readonly int[] _previewZoomPresets =
-        { 10, 25, 50, 100, 200, 400 };
+        { 5, 10, 16, 25, 33, 50, 66, 75, 100, 150, 200, 300, 400, 800, 1600, 3200 };
     private static readonly string[] _previewZoomPresetTexts =
         _previewZoomPresets.Select(p => $"{p}%").ToArray();
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewZoomComboSyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewZoomComboSyncTests.cs
@@ -69,13 +69,12 @@ public class PreviewZoomComboSyncTests
         var preview = FindCtrl<PreviewControl>(window, "PreviewCtrl");
         var combo   = FindCtrl<AutoCompleteBox>(window, "PreviewZoomCombo");
 
-        // One wheel-in notch from 100 % lands at 125 % — explicitly NOT in the
-        // preset list { 10, 25, 50, 100, 200, 400 }. The combo must display
-        // the live value, not snap to "100%".
+        // One wheel-in notch from 100 % steps to the next preset (150 %).
+        // The combo must display the live value exactly.
         preview.SimulateWheelZoom(100, 100, zoomIn: true);
         Dispatcher.UIThread.RunJobs();
 
-        Assert.Equal("125%", combo.Text);
+        Assert.Equal("150%", combo.Text);
 
         window.Close();
     }
@@ -92,10 +91,10 @@ public class PreviewZoomComboSyncTests
         var combo   = FindCtrl<AutoCompleteBox>(window, "PreviewZoomCombo");
         var plusBtn = FindCtrl<Button>(window, "PreviewZoomPlusBtn");
 
-        // 100 → 125 (between 100 and 200). + must jump to 200, not back to 100.
+        // 100 → 150 (next preset above 100). + must jump to 200, not back to 100.
         preview.SimulateWheelZoom(100, 100, zoomIn: true);
         Dispatcher.UIThread.RunJobs();
-        Assert.Equal("125%", combo.Text);
+        Assert.Equal("150%", combo.Text);
 
         // Buttons are wired via the Click event; raise it directly to drive the handler.
         plusBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
@@ -119,12 +118,12 @@ public class PreviewZoomComboSyncTests
 
         preview.SimulateWheelZoom(100, 100, zoomIn: true);
         Dispatcher.UIThread.RunJobs();
-        Assert.Equal("125%", combo.Text);
+        Assert.Equal("150%", combo.Text);
 
         minusBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
         Dispatcher.UIThread.RunJobs();
 
-        // 125 → previous preset strictly less = 100.
+        // 150 → previous preset strictly less = 100.
         Assert.Equal("100%", combo.Text);
         window.Close();
     }
@@ -147,8 +146,8 @@ public class PreviewZoomComboSyncTests
         plusBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
         Dispatcher.UIThread.RunJobs();
 
-        // From exactly 100 (a preset), + must jump to the strictly-greater one (200), not stay at 100.
-        Assert.Equal("200%", combo.Text);
+        // From exactly 100 (a preset), + must jump to the strictly-greater one (150), not stay at 100.
+        Assert.Equal("150%", combo.Text);
         window.Close();
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WheelZoomPresetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WheelZoomPresetTests.cs
@@ -1,0 +1,252 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #213 — mouse-wheel zoom now steps through the same preset list used by
+/// the +/− buttons, so it always lands on a round-number zoom level.
+///
+/// Covers:
+///  • <see cref="ZoomPresetStepper"/> unit tests (float precision, edge cases)
+///  • WireframeControl and PreviewControl wheel-zoom integration via MainWindow
+/// </summary>
+public class WheelZoomPresetTests
+{
+    // ── ZoomPresetStepper unit tests ──────────────────────────────────────────
+
+    private static readonly int[] _samplePresets = { 50, 75, 100, 150, 200 };
+
+    [Fact]
+    public void StepToNextPreset_ZoomIn_FromExactPreset_GoesToNextPreset()
+    {
+        Assert.Equal(150, ZoomPresetStepper.StepToNextPreset(100f, _samplePresets, +1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomOut_FromExactPreset_GoesToPreviousPreset()
+    {
+        Assert.Equal(75, ZoomPresetStepper.StepToNextPreset(100f, _samplePresets, -1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomIn_FromBetweenPresets_GoesToNextAbove()
+    {
+        Assert.Equal(150, ZoomPresetStepper.StepToNextPreset(125f, _samplePresets, +1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomOut_FromBetweenPresets_GoesToNextBelow()
+    {
+        Assert.Equal(100, ZoomPresetStepper.StepToNextPreset(125f, _samplePresets, -1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomIn_AtMaxPreset_ClampsToMax()
+    {
+        Assert.Equal(200, ZoomPresetStepper.StepToNextPreset(200f, _samplePresets, +1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomOut_AtMinPreset_ClampsToMin()
+    {
+        Assert.Equal(50, ZoomPresetStepper.StepToNextPreset(50f, _samplePresets, -1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomIn_FloatDriftBelowPreset_AdvancesNotStalls()
+    {
+        // 99.99998 is below 100 by less than epsilon; must snap to 100 and advance to 150.
+        Assert.Equal(150, ZoomPresetStepper.StepToNextPreset(99.99998f, _samplePresets, +1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomOut_FloatDriftAbovePreset_AdvancesNotStalls()
+    {
+        // 100.00002 is above 100 by less than epsilon; must snap to 100 and step back to 75.
+        Assert.Equal(75, ZoomPresetStepper.StepToNextPreset(100.00002f, _samplePresets, -1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomIn_FloatDrift_NonRoundPreset()
+    {
+        // 33% and 66% are tricky (not exactly representable as float).
+        // 32.9999 is near 33 — must snap and advance to 50.
+        var presets = new[] { 33, 50, 66, 75 };
+        Assert.Equal(50, ZoomPresetStepper.StepToNextPreset(32.9999f, presets, +1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_ZoomOut_FloatDrift_NonRoundPreset()
+    {
+        var presets = new[] { 33, 50, 66, 75 };
+        Assert.Equal(50, ZoomPresetStepper.StepToNextPreset(66.00001f, presets, -1));
+    }
+
+    [Fact]
+    public void StepToNextPreset_SingleElement_ClampsInBothDirections()
+    {
+        // The guard is at the call site (WheelZoomPresets is { Length: > 0 }), but
+        // test the stepper itself with a single-element array for completeness.
+        var single = new[] { 100 };
+        Assert.Equal(100, ZoomPresetStepper.StepToNextPreset(100f, single, +1));
+        Assert.Equal(100, ZoomPresetStepper.StepToNextPreset(100f, single, -1));
+    }
+
+    // ── Integration tests via MainWindow ─────────────────────────────────────
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static T FindCtrl<T>(MainWindow w, string name) where T : Control
+        => w.FindControl<T>(name)
+           ?? throw new InvalidOperationException($"Control '{name}' not found");
+
+    [AvaloniaFact]
+    public void WireframeWheel_ZoomIn_FromPreset_LandsOnNextPreset()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var ctrl  = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+        var combo = FindCtrl<AutoCompleteBox>(window, "ZoomCombo");
+
+        ctrl.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+
+        ctrl.SimulateWheelZoom(50f, 50f, zoomIn: true);
+        Dispatcher.UIThread.RunJobs();
+
+        // Next preset above 100 is 150.
+        Assert.Equal("150%", combo.Text);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void WireframeWheel_ZoomOut_FromPreset_LandsOnPreviousPreset()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var ctrl  = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+        var combo = FindCtrl<AutoCompleteBox>(window, "ZoomCombo");
+
+        ctrl.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+
+        ctrl.SimulateWheelZoom(50f, 50f, zoomIn: false);
+        Dispatcher.UIThread.RunJobs();
+
+        // Previous preset below 100 is 75.
+        Assert.Equal("75%", combo.Text);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void WireframeWheel_MultipleStepsIn_PassThroughPresets()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var ctrl  = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+        var combo = FindCtrl<AutoCompleteBox>(window, "ZoomCombo");
+
+        ctrl.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+
+        // 100 → 150 → 200 (two notches always land on presets).
+        ctrl.SimulateWheelZoom(50f, 50f, zoomIn: true);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("150%", combo.Text);
+
+        ctrl.SimulateWheelZoom(50f, 50f, zoomIn: true);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("200%", combo.Text);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PreviewWheel_ZoomIn_FromPreset_LandsOnNextPreset()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var preview = FindCtrl<PreviewControl>(window, "PreviewCtrl");
+        var combo   = FindCtrl<AutoCompleteBox>(window, "PreviewZoomCombo");
+
+        preview.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+
+        preview.SimulateWheelZoom(100, 100, zoomIn: true);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("150%", combo.Text);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PreviewWheel_ZoomOut_FromPreset_LandsOnPreviousPreset()
+    {
+        var ctx    = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var preview = FindCtrl<PreviewControl>(window, "PreviewCtrl");
+        var combo   = FindCtrl<AutoCompleteBox>(window, "PreviewZoomCombo");
+
+        preview.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+
+        preview.SimulateWheelZoom(100, 100, zoomIn: false);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("75%", combo.Text);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void WireframeWheel_StandaloneControl_NoPresets_UsesMultiplier()
+    {
+        // A WireframeControl created without MainWindow has WheelZoomPresets = null,
+        // so it falls back to the 1.25× multiplier (legacy behaviour).
+        var ctx  = ResetSingletons();
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.Measure(new Size(400, 300));
+        ctrl.Arrange(new Rect(0, 0, 400, 300));
+
+        float? lastPct = null;
+        ctrl.ZoomChanged += pct => lastPct = pct;
+
+        ctrl.SimulateWheelZoom(50f, 50f, factor: 1.25f);
+
+        Assert.NotNull(lastPct);
+        Assert.Equal(125f, lastPct!.Value, precision: 2);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #213 — mouse-wheel zoom on both the Wireframe and Preview panels now always lands on a round-number preset (same list as the +/- buttons), instead of the raw ×1.25/×0.8 multiplier that could leave the zoom at values like 125%, 156%, etc.

## Changes

- **ZoomPresetStepper.cs** (new) — pure static helper that steps a zoom percentage to the next/previous entry in a preset list, with epsilon-based float snapping to prevent drift-induced stalling when already on a preset.

- **WireframeControl** — added WheelZoomPresets property; OnPointerWheelChanged now calls ComputeWheelFactor(bool) → ZoomToward. Added SimulateWheelZoom(bool zoomIn) overload for testing; original loat factor overload retained for precision pan/zoom regression tests.

- **PreviewControl** — added WheelZoomPresets property; ApplyWheelZoom updated to ool zoomIn. Falls back to ×1.25/×0.8 when WheelZoomPresets is null (standalone control, no MainWindow).

- **MainWindow** — expanded preset list from { 10, 25, 50, 100, 200, 400 } to { 5, 10, 16, 25, 33, 50, 66, 75, 100, 150, 200, 300, 400, 800, 1600, 3200 }; wires WheelZoomPresets on both controls during startup.

- **WheelZoomPresetTests.cs** (new) — ZoomPresetStepper unit tests (float drift, edge cases, clamping) + MainWindow integration tests for both panels.

- **PreviewZoomComboSyncTests.cs** — updated 4 assertions that expected old 125% wheel result; now correctly expect 150% (next preset above 100%).

Closes #213