### PR TITLE
Fix: exclude Button visual children from chain double-tap gesture

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -352,7 +352,8 @@
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
                                         ToolTip.Tip="Add Frame"
-                                        Click="OnAddFrameBtnClick" />
+                                        Click="OnAddFrameBtnClick"
+                                        DoubleTapped="OnAddFrameBtnDoubleTapped" />
                             </Grid>
                         </TreeDataTemplate>
                     </TreeView.ItemTemplate>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -889,6 +889,10 @@ public partial class MainWindow : Window
         e.Handled = true;
     }
 
+    // DoubleTapped on the + button must not reach OnAnimTreeDoubleTapped.
+    // Marking handled here mirrors how the header TextBlock suppresses the fallback handler.
+    private void OnAddFrameBtnDoubleTapped(object? _, TappedEventArgs e) => e.Handled = true;
+
     private void OnTreeDragOver(object? sender, DragEventArgs e)
     {
         // Use TryGetFiles() — the correct Avalonia 12 API for OS file drops
@@ -2611,14 +2615,14 @@ public partial class MainWindow : Window
     private void OnAnimTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
         // If the TextBlock's DoubleTapped handler already handled the event (inline rename),
-        // skip. Belt-and-suspenders: also bail if source is a TextBlock in case Avalonia
-        // gesture routing raises a fresh event instance per subscriber.
+        // or if the + button's DoubleTapped handler consumed it, skip.
         if (e.Handled) return;
         if (e.Source is not Control src) return;
         if (src is TextBlock) return;
-        // Exclude clicks that originated from inside a Button (e.g. the Add Frame + button).
-        // The event source is often a visual child of the button (ContentPresenter, SVG icon,
-        // etc.), not the Button itself, so a simple `is Button` check is insufficient.
+        // Belt-and-suspenders: exclude clicks that originated from inside a Button even if
+        // the Button's DoubleTapped handler didn't fire (e.g. focus or routing edge cases).
+        // The event source is often a visual child (ContentPresenter, SVG icon, etc.),
+        // not the Button itself, so a simple `is Button` check is insufficient.
         if (src.FindAncestorOfType<Button>(includeSelf: true) is not null) return;
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (tvi?.DataContext is not TreeNodeVm vm) return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2611,12 +2611,15 @@ public partial class MainWindow : Window
     private void OnAnimTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
         // If the TextBlock's DoubleTapped handler already handled the event (inline rename),
-        // skip expand/collapse. Belt-and-suspenders: also bail if source is a TextBlock in
-        // case Avalonia gesture routing raises a fresh event instance per subscriber.
+        // skip. Belt-and-suspenders: also bail if source is a TextBlock in case Avalonia
+        // gesture routing raises a fresh event instance per subscriber.
         if (e.Handled) return;
-        if (e.Source is TextBlock) return;
-        if (e.Source is Button) return;
         if (e.Source is not Control src) return;
+        if (src is TextBlock) return;
+        // Exclude clicks that originated from inside a Button (e.g. the Add Frame + button).
+        // The event source is often a visual child of the button (ContentPresenter, SVG icon,
+        // etc.), not the Button itself, so a simple `is Button` check is insufficient.
+        if (src.FindAncestorOfType<Button>(includeSelf: true) is not null) return;
         var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (tvi?.DataContext is not TreeNodeVm vm) return;
         if (!HandleAnimTreeNodeDoubleTap(vm)) return;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -1094,6 +1094,42 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
+    public void AddFrameBtnDoubleTapped_MarksEventHandled()
+    {
+            // Regression (#218): the + button has DoubleTapped="OnAddFrameBtnDoubleTapped" which
+            // marks e.Handled=true so that OnAnimTreeDoubleTapped (registered with handledEventsToo=false)
+            // never fires when the double-tap originates from the + button area.
+            var (window, ctx) = CreateWindow();
+            try
+            {
+                var chain = new AnimationChainSave { Name = "Walk" };
+                ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+                TriggerRefreshTreeView(window);
+                Dispatcher.UIThread.RunJobs();
+
+                var tree = GetTree(window);
+                var chainNode = GetRoots(tree)[0];
+                chainNode.IsExpanded = true;
+                Dispatcher.UIThread.RunJobs();
+
+                var fakeArgs = (TappedEventArgs)System.Runtime.CompilerServices.RuntimeHelpers
+                    .GetUninitializedObject(typeof(TappedEventArgs));
+
+                var handler = typeof(MainWindow).GetMethod(
+                    "OnAddFrameBtnDoubleTapped",
+                    BindingFlags.NonPublic | BindingFlags.Instance)
+                    ?? throw new InvalidOperationException("OnAddFrameBtnDoubleTapped not found");
+                handler.Invoke(window, [null, fakeArgs]);
+
+                Assert.True(fakeArgs.Handled,
+                    "OnAddFrameBtnDoubleTapped must set e.Handled=true to block the chain rename.");
+                Assert.False(chainNode.IsEditing,
+                    "The chain node must not enter rename mode after + button double-tap.");
+            }
+            finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void PressEnterToConfirmRename_DoesNotCollapseChainNode()
     {
             // Regression: Avalonia 12.x TreeViewItem.OnKeyDown handles Key.Enter by toggling

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -1035,6 +1035,65 @@ public class HeadlessTreeViewTests
     }
 
     [AvaloniaFact]
+    public void DoubleTapOnPlusButtonDescendant_DoesNotTriggerChainRename()
+    {
+        // Regression (#218): rapid double-clicks on the Add Frame (+) button were misinterpreted
+        // as a double-click on the chain row. The button uses a ContentTemplate (SVG icon), so
+        // the DoubleTapped event source is the SVG — a visual child of the Button, not the
+        // Button itself — meaning `if (e.Source is Button) return;` did not filter it out.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree = GetTree(window);
+            var chainNode = GetRoots(tree)[0];
+            chainNode.IsExpanded = true;
+            Dispatcher.UIThread.RunJobs();
+
+            // Find the Add Frame (+) button inside the chain row.
+            var addBtn = tree.GetVisualDescendants()
+                .OfType<Button>()
+                .FirstOrDefault(b => b.Classes.Contains("add-frame-btn"));
+            Assert.NotNull(addBtn);
+
+            // Use the button's first visual descendant (ContentPresenter / SVG) as the
+            // event source. If the template hasn't been applied, fall back to the button
+            // itself — FindAncestorOfType with includeSelf: true still catches it.
+            Control innerControl = addBtn.GetVisualDescendants().OfType<Control>().FirstOrDefault()
+                ?? addBtn;
+
+            // Preconditions: innerControl really is under the Button and the chain's TreeViewItem.
+            Assert.Same(addBtn, innerControl.FindAncestorOfType<Button>(includeSelf: true));
+            var tvi = innerControl.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+            Assert.NotNull(tvi);
+            Assert.Same(chainNode, tvi.DataContext);
+
+            // Construct TappedEventArgs without calling the constructor (which requires a live
+            // PointerEventArgs). The handler only reads e.Handled and e.Source.
+            var fakeArgs = (TappedEventArgs)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(TappedEventArgs));
+            fakeArgs.Source = innerControl;
+
+            var handler = typeof(MainWindow).GetMethod(
+                "OnAnimTreeDoubleTapped",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("OnAnimTreeDoubleTapped not found");
+            handler.Invoke(window, [null, fakeArgs]);
+            Dispatcher.UIThread.RunJobs();
+
+            // The chain must NOT have been put into inline-rename mode.
+            Assert.False(chainNode.IsEditing,
+                "Double-tap from inside the Add Frame + button must not start an inline rename.");
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void PressEnterToConfirmRename_DoesNotCollapseChainNode()
     {
             // Regression: Avalonia 12.x TreeViewItem.OnKeyDown handles Key.Enter by toggling


### PR DESCRIPTION
## Summary

Fixes #218

Rapid double-clicks on the Add Frame (+) button were misinterpreted as a double-click on the chain row, triggering an inline rename (or in previous behavior, collapse) of the chain.

## Root Cause

The + button uses a ContentTemplate with an SVG icon. When clicked, Avalonia reports the SVG (a visual *child* of the button) as .Source on the DoubleTapped event — not the Button itself. The guard if (e.Source is Button) return; therefore had no effect.

## Fix

Replace the direct type check with FindAncestorOfType<Button>(includeSelf: true) in OnAnimTreeDoubleTapped, so any double-tap event whose source is anywhere inside a Button's visual subtree is suppressed:

\\\csharp
// Before
if (e.Source is Button) return;

// After  
if (src.FindAncestorOfType<Button>(includeSelf: true) is not null) return;
\\\

## Test

Added DoubleTapOnPlusButtonDescendant_DoesNotTriggerChainRename in HeadlessTreeViewTests. The test:
1. Finds the live + button in the headless visual tree
2. Simulates OnAnimTreeDoubleTapped with the button's inner control as the source
3. Includes precondition assertions verifying the inner control is genuinely inside both the Button and the chain's TreeViewItem
4. Asserts chainNode.IsEditing stays alse

Closes #218