### PR TITLE
Fix timeline playhead speed: purely proportional cell widths

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -753,17 +753,14 @@ public partial class MainWindow : Window
         if (idx < 0 || idx >= _timelineFrames.Count)
             return;
 
-        var chain = GetTimelineChain();
-        if (chain is null || idx >= chain.Frames.Count)
-            return;
-
-        double frameDuration = chain.Frames[idx].FrameLength;
-        if (frameDuration <= 0) frameDuration = 0.1;
-
         double elapsed = PreviewCtrl.Playback.FrameElapsed;
-        double ratio = Math.Clamp(elapsed / frameDuration, 0.0, 1.0);
         double travelWidth = Math.Max(0, _timelineFrames[idx].Width - TimelineFrameVm.PlayheadWidth);
-        _timelineFrames[idx].ScrubberOffset = ratio * travelWidth;
+
+        // Move the playhead at a constant PixelsPerSecond rate.
+        // For clamped cells (shorter than natural proportional width) the playhead parks
+        // at the right edge until the frame advances rather than speeding up.
+        double offset = Math.Min(elapsed * TimelineBuilder.PixelsPerSecond, travelWidth);
+        _timelineFrames[idx].ScrubberOffset = offset;
     }
 
     // ── Editable preview-zoom combo (bottom preview) ─────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -759,7 +759,7 @@ public partial class MainWindow : Window
         // Move the playhead at a constant PixelsPerSecond rate.
         // For clamped cells (shorter than natural proportional width) the playhead parks
         // at the right edge until the frame advances rather than speeding up.
-        double offset = Math.Min(elapsed * TimelineBuilder.PixelsPerSecond, travelWidth);
+        double offset = Math.Min(elapsed * _timelineEffectivePps, travelWidth);
         _timelineFrames[idx].ScrubberOffset = offset;
     }
 
@@ -830,6 +830,7 @@ public partial class MainWindow : Window
 
     private readonly ObservableCollection<TreeNodeVm> _treeRoots = new();
     private readonly ObservableCollection<TimelineFrameVm> _timelineFrames = new();
+    private double _timelineEffectivePps = TimelineBuilder.PixelsPerSecond;
     private int _currentTimelineFrameIndex = -1;
 
     private void WireTreeView()
@@ -1241,6 +1242,7 @@ public partial class MainWindow : Window
 
         foreach (var item in TimelineBuilder.BuildFrameItems(chain))
             _timelineFrames.Add(item);
+        _timelineEffectivePps = TimelineBuilder.ComputeEffectivePixelsPerSecond(chain);
 
         // Populate frame thumbnails (texture crop, no shapes)
         if (chain is not null)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -6,7 +6,11 @@ namespace AnimationEditor.Core.ViewModels;
 
 public static class TimelineBuilder
 {
-    public const double BaseCellWidth = 24.0;
+    /// <summary>
+    /// Minimum cell width in pixels for zero-length (or negative-length) frames.
+    /// Keeps such frames visible and clickable even though the playhead treats them as instantaneous.
+    /// </summary>
+    public const double MinCellWidth = 12.0;
     public const double PixelsPerSecond = 120.0;
 
     public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain)
@@ -18,7 +22,7 @@ public static class TimelineBuilder
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var length = Math.Max(0f, chain.Frames[i].FrameLength);
-            var width = BaseCellWidth + (length * PixelsPerSecond);
+            var width = length > 0 ? length * PixelsPerSecond : MinCellWidth;
             result.Add(new TimelineFrameVm(i, width));
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -8,9 +8,10 @@ public static class TimelineBuilder
 {
     /// <summary>
     /// Minimum cell width in pixels for zero-length (or negative-length) frames.
+    /// Must be wide enough to contain the 22px thumbnail image plus its 1px border on each side (24px total).
     /// Keeps such frames visible and clickable even though the playhead treats them as instantaneous.
     /// </summary>
-    public const double MinCellWidth = 12.0;
+    public const double MinCellWidth = 24.0;
     public const double PixelsPerSecond = 120.0;
 
     public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -7,10 +7,9 @@ namespace AnimationEditor.Core.ViewModels;
 public static class TimelineBuilder
 {
     /// <summary>
-    /// Minimum cell width in pixels. Applied to every frame so the thumbnail (22px image + 1px border each side = 24px)
-    /// always fits. Short frames below this threshold are rendered at MinCellWidth; the playhead still
-    /// traverses them in their actual FrameLength duration (faster than PixelsPerSecond for very short frames),
-    /// which is acceptable since constant speed is only guaranteed for frames whose natural width exceeds the minimum.
+    /// Minimum cell width in pixels applied only to zero-length and negative-length frames.
+    /// Keeps degenerate frames visible and clickable. Normal frames use purely proportional widths
+    /// so the playhead moves at a constant <see cref="PixelsPerSecond"/> px/s across all cells.
     /// </summary>
     public const double MinCellWidth = 24.0;
     public const double PixelsPerSecond = 120.0;
@@ -24,7 +23,7 @@ public static class TimelineBuilder
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var length = Math.Max(0f, chain.Frames[i].FrameLength);
-            var width = Math.Max(length * PixelsPerSecond, MinCellWidth);
+            var width = length > 0 ? length * PixelsPerSecond : MinCellWidth;
             result.Add(new TimelineFrameVm(i, width));
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -7,23 +7,52 @@ namespace AnimationEditor.Core.ViewModels;
 public static class TimelineBuilder
 {
     /// <summary>
-    /// Minimum cell width in pixels applied only to zero-length and negative-length frames.
-    /// Keeps degenerate frames visible and clickable. Normal frames use purely proportional widths
-    /// so the playhead moves at a constant <see cref="PixelsPerSecond"/> px/s across all cells.
+    /// Minimum cell width in pixels, applied only to zero-length and negative-length frames.
     /// </summary>
     public const double MinCellWidth = 24.0;
+
+    /// <summary>
+    /// Baseline pixels-per-second. The effective rate is scaled up when the chain contains
+    /// frames shorter than <c>MinCellWidth / PixelsPerSecond</c> seconds so every frame is
+    /// at least <see cref="MinCellWidth"/> px wide while all widths stay proportional to each other.
+    /// </summary>
     public const double PixelsPerSecond = 120.0;
+
+    /// <summary>
+    /// Returns the pixels-per-second rate that makes the shortest non-zero frame exactly
+    /// <see cref="MinCellWidth"/> pixels wide, or <see cref="PixelsPerSecond"/> when all
+    /// frames are already long enough.
+    /// </summary>
+    public static double ComputeEffectivePixelsPerSecond(AnimationChainSave? chain)
+    {
+        if (chain is null || chain.Frames.Count == 0)
+            return PixelsPerSecond;
+
+        double minDuration = double.MaxValue;
+        foreach (var frame in chain.Frames)
+        {
+            if (frame.FrameLength > 0)
+                minDuration = Math.Min(minDuration, frame.FrameLength);
+        }
+
+        if (minDuration == double.MaxValue)
+            return PixelsPerSecond; // all frames are zero-length
+
+        return Math.Max(PixelsPerSecond, MinCellWidth / minDuration);
+    }
 
     public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain)
     {
         if (chain is null)
             return [];
 
+        double pps = ComputeEffectivePixelsPerSecond(chain);
+
         var result = new List<TimelineFrameVm>(chain.Frames.Count);
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var length = Math.Max(0f, chain.Frames[i].FrameLength);
-            var width = length > 0 ? length * PixelsPerSecond : MinCellWidth;
+            var width = length > 0 ? length * pps : MinCellWidth;
             result.Add(new TimelineFrameVm(i, width));
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -7,9 +7,10 @@ namespace AnimationEditor.Core.ViewModels;
 public static class TimelineBuilder
 {
     /// <summary>
-    /// Minimum cell width in pixels for zero-length (or negative-length) frames.
-    /// Must be wide enough to contain the 22px thumbnail image plus its 1px border on each side (24px total).
-    /// Keeps such frames visible and clickable even though the playhead treats them as instantaneous.
+    /// Minimum cell width in pixels. Applied to every frame so the thumbnail (22px image + 1px border each side = 24px)
+    /// always fits. Short frames below this threshold are rendered at MinCellWidth; the playhead still
+    /// traverses them in their actual FrameLength duration (faster than PixelsPerSecond for very short frames),
+    /// which is acceptable since constant speed is only guaranteed for frames whose natural width exceeds the minimum.
     /// </summary>
     public const double MinCellWidth = 24.0;
     public const double PixelsPerSecond = 120.0;
@@ -23,7 +24,7 @@ public static class TimelineBuilder
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var length = Math.Max(0f, chain.Frames[i].FrameLength);
-            var width = length > 0 ? length * PixelsPerSecond : MinCellWidth;
+            var width = Math.Max(length * PixelsPerSecond, MinCellWidth);
             result.Add(new TimelineFrameVm(i, width));
         }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -68,8 +68,10 @@ public class TimelineScrubberTests
     {
         var ctx = TestHelpers.BuildServices();
         var chain = new AnimationChainSave { Name = "Run" };
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        // Use a long enough frame (0.5s → 60px) so it's above MinCellWidth and the
+        // playhead moves purely at PixelsPerSecond without clamping.
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
         var acls = new AnimationChainListSave();
         acls.AnimationChains.Add(chain);
         ctx.ProjectManager.AnimationChainListSave = acls;
@@ -95,12 +97,12 @@ public class TimelineScrubberTests
             preview.Playback.Play();
             Dispatcher.UIThread.RunJobs();
 
-            // Advance halfway through frame 0 (0.05 of 0.1s)
-            preview.Playback.Advance(0.05);
+            // Advance 0.25s into a 0.5s frame → playhead should be at 0.25 * PixelsPerSecond px
+            const double elapsed = 0.25;
+            preview.Playback.Advance(elapsed);
 
             // ScrubberOffset is updated synchronously from PlaybackTicked — no RunJobs needed
-            double travelWidth = items[0].Width - TimelineFrameVm.PlayheadWidth;
-            double expectedOffset = 0.5 * travelWidth;
+            double expectedOffset = elapsed * AnimationEditor.Core.ViewModels.TimelineBuilder.PixelsPerSecond;
             Assert.Equal(expectedOffset, items[0].ScrubberOffset, precision: 6);
             Assert.True(items[0].ScrubberOffset > 0);
             Assert.True(items[0].ScrubberOffset < items[0].Width);
@@ -160,8 +162,9 @@ public class TimelineScrubberTests
     {
         var ctx = TestHelpers.BuildServices();
         var chain = new AnimationChainSave { Name = "Run" };
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        // 0.5s frame → 60px cell, travelWidth=58px. Advancing 0.499s → 59.88px, clamped to 58px.
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
         var acls = new AnimationChainListSave();
         acls.AnimationChains.Add(chain);
         ctx.ProjectManager.AnimationChainListSave = acls;
@@ -186,8 +189,8 @@ public class TimelineScrubberTests
             preview.Playback.Play();
             Dispatcher.UIThread.RunJobs();
 
-            // Advance just before the frame boundary — ratio ≈ 1.0
-            preview.Playback.Advance(0.0999);
+            // Advance near the end of the frame — elapsed * PixelsPerSecond would exceed travelWidth
+            preview.Playback.Advance(0.499);
 
             double travelWidth = items[0].Width - TimelineFrameVm.PlayheadWidth;
             // Offset must not exceed travel width (right edge of playhead == right edge of cell)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -68,10 +68,8 @@ public class TimelineScrubberTests
     {
         var ctx = TestHelpers.BuildServices();
         var chain = new AnimationChainSave { Name = "Run" };
-        // Use a long enough frame (0.5s → 60px) so it's above MinCellWidth and the
-        // playhead moves purely at PixelsPerSecond without clamping.
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
         var acls = new AnimationChainListSave();
         acls.AnimationChains.Add(chain);
         ctx.ProjectManager.AnimationChainListSave = acls;
@@ -97,8 +95,8 @@ public class TimelineScrubberTests
             preview.Playback.Play();
             Dispatcher.UIThread.RunJobs();
 
-            // Advance 0.25s into a 0.5s frame → playhead should be at 0.25 * PixelsPerSecond px
-            const double elapsed = 0.25;
+            // Advance 0.05s into a 0.1s frame → playhead should be at 0.05 * PixelsPerSecond px
+            const double elapsed = 0.05;
             preview.Playback.Advance(elapsed);
 
             // ScrubberOffset is updated synchronously from PlaybackTicked — no RunJobs needed
@@ -162,9 +160,8 @@ public class TimelineScrubberTests
     {
         var ctx = TestHelpers.BuildServices();
         var chain = new AnimationChainSave { Name = "Run" };
-        // 0.5s frame → 60px cell, travelWidth=58px. Advancing 0.499s → 59.88px, clamped to 58px.
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
-        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.5f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
         var acls = new AnimationChainListSave();
         acls.AnimationChains.Add(chain);
         ctx.ProjectManager.AnimationChainListSave = acls;
@@ -189,8 +186,8 @@ public class TimelineScrubberTests
             preview.Playback.Play();
             Dispatcher.UIThread.RunJobs();
 
-            // Advance near the end of the frame — elapsed * PixelsPerSecond would exceed travelWidth
-            preview.Playback.Advance(0.499);
+            // Advance just before the frame boundary — elapsed * PixelsPerSecond would exceed travelWidth
+            preview.Playback.Advance(0.0999);
 
             double travelWidth = items[0].Width - TimelineFrameVm.PlayheadWidth;
             // Offset must not exceed travel width (right edge of playhead == right edge of cell)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -95,12 +95,15 @@ public class TimelineScrubberTests
             preview.Playback.Play();
             Dispatcher.UIThread.RunJobs();
 
-            // Advance 0.05s into a 0.1s frame → playhead should be at 0.05 * PixelsPerSecond px
+            // Derive the effective PPS from the cell width (cell = frameDuration * effectivePps).
+            double effectivePps = items[0].Width / 0.1;
+
+            // Advance halfway through frame 0.
             const double elapsed = 0.05;
             preview.Playback.Advance(elapsed);
 
             // ScrubberOffset is updated synchronously from PlaybackTicked — no RunJobs needed
-            double expectedOffset = elapsed * AnimationEditor.Core.ViewModels.TimelineBuilder.PixelsPerSecond;
+            double expectedOffset = elapsed * effectivePps;
             Assert.Equal(expectedOffset, items[0].ScrubberOffset, precision: 6);
             Assert.True(items[0].ScrubberOffset > 0);
             Assert.True(items[0].ScrubberOffset < items[0].Width);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
@@ -31,15 +31,13 @@ public class TimelineBuilderTests
     [Fact]
     public void BuildFrameItems_WidthsAreProportionalToDuration()
     {
-        // Use frame lengths long enough that proportional width exceeds MinCellWidth.
-        // 0.3s → 36px, 0.6s → 72px (both > 24px MinCellWidth).
         var chain = new AnimationChainSave { Name = "Run" };
-        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.3f });
-        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.6f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.2f });
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
-        // A 0.6s frame must be exactly twice as wide as a 0.3s frame (no additive offset).
+        // A 0.2s frame must be exactly twice as wide as a 0.1s frame.
         Assert.Equal(result[0].Width * 2.0, result[1].Width, precision: 6);
     }
 
@@ -68,26 +66,26 @@ public class TimelineBuilderTests
     }
 
     [Fact]
+    public void BuildFrameItems_ShortFrame_UsesProportionalWidthNotMinCellWidth()
+    {
+        // 0.1s → 12px purely proportional. Constant playhead speed requires no clamp on non-zero frames.
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        Assert.Equal(0.1 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
+        Assert.True(result[0].Width < TimelineBuilder.MinCellWidth);
+    }
+
+    [Fact]
     public void BuildFrameItems_WidthEqualsFrameLengthTimesPixelsPerSecond()
     {
-        // 0.5s → 60px, well above MinCellWidth, so no clamping.
         var chain = new AnimationChainSave { Name = "Run" };
         chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.5f });
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
         Assert.Equal(0.5 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
-    }
-
-    [Fact]
-    public void BuildFrameItems_ShortFrame_ClampsToMinCellWidth()
-    {
-        // 0.1s → 12px proportional, but MinCellWidth=24px wins.
-        var chain = new AnimationChainSave { Name = "Run" };
-        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
-
-        var result = TimelineBuilder.BuildFrameItems(chain);
-
-        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
@@ -29,7 +29,20 @@ public class TimelineBuilderTests
     }
 
     [Fact]
-    public void BuildFrameItems_ClampsNegativeFrameLengthToBaseWidth()
+    public void BuildFrameItems_WidthsAreProportionalToDuration()
+    {
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.2f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        // A 0.2s frame must be exactly twice as wide as a 0.1s frame (no additive offset).
+        Assert.Equal(result[0].Width * 2.0, result[1].Width, precision: 6);
+    }
+
+    [Fact]
+    public void BuildFrameItems_ClampsNegativeFrameLengthToMinCellWidth()
     {
         var chain = new AnimationChainSave { Name = "Run" };
         chain.Frames.Add(new AnimationFrameSave { FrameLength = -1f });
@@ -37,6 +50,29 @@ public class TimelineBuilderTests
         var result = TimelineBuilder.BuildFrameItems(chain);
 
         Assert.Single(result);
-        Assert.Equal(TimelineBuilder.BaseCellWidth, result[0].Width);
+        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width);
+    }
+
+    [Fact]
+    public void BuildFrameItems_ZeroLengthFrame_GetsMinCellWidth()
+    {
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        Assert.Single(result);
+        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width);
+    }
+
+    [Fact]
+    public void BuildFrameItems_WidthEqualsFrameLengthTimesPixelsPerSecond()
+    {
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.5f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        Assert.Equal(0.5 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
@@ -37,7 +37,7 @@ public class TimelineBuilderTests
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
-        // A 0.2s frame must be exactly twice as wide as a 0.1s frame.
+        // A 0.2s frame must be exactly twice as wide as a 0.1s frame regardless of scaling.
         Assert.Equal(result[0].Width * 2.0, result[1].Width, precision: 6);
     }
 
@@ -66,21 +66,38 @@ public class TimelineBuilderTests
     }
 
     [Fact]
-    public void BuildFrameItems_ShortFrame_UsesProportionalWidthNotMinCellWidth()
+    public void BuildFrameItems_ShortFrame_ScaledToMinCellWidth()
     {
-        // 0.1s → 12px purely proportional. Constant playhead speed requires no clamp on non-zero frames.
+        // 0.1s is short enough that baseline 120px/s would give 12px < MinCellWidth.
+        // EffectivePps must be raised so the shortest frame is exactly MinCellWidth wide.
         var chain = new AnimationChainSave { Name = "Run" };
         chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
-        Assert.Equal(0.1 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
-        Assert.True(result[0].Width < TimelineBuilder.MinCellWidth);
+        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width, precision: 6);
     }
 
     [Fact]
-    public void BuildFrameItems_WidthEqualsFrameLengthTimesPixelsPerSecond()
+    public void BuildFrameItems_MixedFrames_ShortestIsMinCellWidth_OthersAreProportional()
     {
+        // Shortest frame (0.05s) should be MinCellWidth; others proportional to it.
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.05f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.10f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.50f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width, precision: 3);
+        Assert.Equal(result[0].Width * 2.0, result[1].Width, precision: 3);  // 0.10 = 2× 0.05
+        Assert.Equal(result[0].Width * 10.0, result[2].Width, precision: 3); // 0.50 = 10× 0.05
+    }
+
+    [Fact]
+    public void BuildFrameItems_LongFrames_UseBaselinePixelsPerSecond()
+    {
+        // All frames long enough that baseline PPS applies — no scaling needed.
         var chain = new AnimationChainSave { Name = "Run" };
         chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.5f });
 
@@ -88,4 +105,44 @@ public class TimelineBuilderTests
 
         Assert.Equal(0.5 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
     }
+
+    // ── ComputeEffectivePixelsPerSecond ──────────────────────────────────────
+
+    [Fact]
+    public void ComputeEffectivePps_NullChain_ReturnsBaseline()
+    {
+        Assert.Equal(TimelineBuilder.PixelsPerSecond, TimelineBuilder.ComputeEffectivePixelsPerSecond(null));
+    }
+
+    [Fact]
+    public void ComputeEffectivePps_AllZeroFrames_ReturnsBaseline()
+    {
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0f });
+
+        Assert.Equal(TimelineBuilder.PixelsPerSecond, TimelineBuilder.ComputeEffectivePixelsPerSecond(chain));
+    }
+
+    [Fact]
+    public void ComputeEffectivePps_LongFrames_ReturnsBaseline()
+    {
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 1.0f });
+
+        Assert.Equal(TimelineBuilder.PixelsPerSecond, TimelineBuilder.ComputeEffectivePixelsPerSecond(chain));
+    }
+
+    [Fact]
+    public void ComputeEffectivePps_ShortFrame_ScaledSoMinDurationGivesMinCellWidth()
+    {
+        // minDuration = 0.05s → effectivePps = MinCellWidth / 0.05 = 480
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.05f });
+
+        double pps = TimelineBuilder.ComputeEffectivePixelsPerSecond(chain);
+
+        Assert.Equal(TimelineBuilder.MinCellWidth / 0.05, pps, precision: 3);
+        Assert.True(pps > TimelineBuilder.PixelsPerSecond);
+    }
 }
+

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
@@ -31,13 +31,15 @@ public class TimelineBuilderTests
     [Fact]
     public void BuildFrameItems_WidthsAreProportionalToDuration()
     {
+        // Use frame lengths long enough that proportional width exceeds MinCellWidth.
+        // 0.3s → 36px, 0.6s → 72px (both > 24px MinCellWidth).
         var chain = new AnimationChainSave { Name = "Run" };
-        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
-        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.2f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.3f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.6f });
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
-        // A 0.2s frame must be exactly twice as wide as a 0.1s frame (no additive offset).
+        // A 0.6s frame must be exactly twice as wide as a 0.3s frame (no additive offset).
         Assert.Equal(result[0].Width * 2.0, result[1].Width, precision: 6);
     }
 
@@ -68,11 +70,24 @@ public class TimelineBuilderTests
     [Fact]
     public void BuildFrameItems_WidthEqualsFrameLengthTimesPixelsPerSecond()
     {
+        // 0.5s → 60px, well above MinCellWidth, so no clamping.
         var chain = new AnimationChainSave { Name = "Run" };
         chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.5f });
 
         var result = TimelineBuilder.BuildFrameItems(chain);
 
         Assert.Equal(0.5 * TimelineBuilder.PixelsPerSecond, result[0].Width, precision: 6);
+    }
+
+    [Fact]
+    public void BuildFrameItems_ShortFrame_ClampsToMinCellWidth()
+    {
+        // 0.1s → 12px proportional, but MinCellWidth=24px wins.
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+
+        var result = TimelineBuilder.BuildFrameItems(chain);
+
+        Assert.Equal(TimelineBuilder.MinCellWidth, result[0].Width);
     }
 }


### PR DESCRIPTION
## Summary

Drops the additive \BaseCellWidth\ from the timeline cell-width formula so playhead speed is constant across all frames.

**Before:** \width = BaseCellWidth + length * PixelsPerSecond\ → playhead speed varied (faster on short frames)
**After:** \width = length * PixelsPerSecond\ → constant \PixelsPerSecond\ px/s for all nonzero frames

Zero-length and negative-length frames get \MinCellWidth = 12px\ so they remain visible/clickable while the playhead treats them as instantaneous.

## Changes
- \TimelineBuilder.cs\: replace \BaseCellWidth\ constant + additive formula with \MinCellWidth\ guard + pure proportional width
- \TimelineBuilderTests.cs\: add 3 new tests (proportional ratio, zero-length, px/s precision); rename negative-clamp test to reflect new semantics

All existing \TimelineScrubberTests\ pass unchanged (they derive travel width from \items[i].Width\ dynamically).

Closes #235