### PR TITLE
Risk-scaled delete confirmation for Animation Editor

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -223,22 +223,18 @@
                     </DockPanel>
                 </Border>
 
-                <!-- Delete chain confirm — stacked: label row above buttons row -->
+                <!-- Delete chain confirm -->
                 <Border x:Name="DeleteChainConfirmPanel"
                         Grid.Row="1"
                         IsVisible="False"
                         Background="{StaticResource BgRail}"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,0,0,1"
-                        Padding="10,6">
-                    <StackPanel Spacing="5">
-                        <TextBlock x:Name="DeleteChainConfirmLabel"
-                                   Foreground="{StaticResource InkMid}"
-                                   FontSize="11"
-                                   TextWrapping="Wrap" />
-                        <StackPanel Orientation="Horizontal" Spacing="6">
+                        Padding="10,5">
+                    <DockPanel>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
                             <Button x:Name="DeleteChainConfirmBtn"
-                                    Content="Confirm ✕"
+                                    Content="Confirm"
                                     Padding="8,3"
                                     FontSize="11" />
                             <Button x:Name="DeleteChainCancelBtn"
@@ -246,7 +242,12 @@
                                     Padding="8,3"
                                     FontSize="11" />
                         </StackPanel>
-                    </StackPanel>
+                        <TextBlock x:Name="DeleteChainConfirmLabel"
+                                   Foreground="{StaticResource InkMid}"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis"
+                                   FontSize="11" />
+                    </DockPanel>
                 </Border>
 
                 <TreeView x:Name="AnimTree" Grid.Row="2"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -171,7 +171,7 @@
         <Grid x:Name="MainContentGrid" ColumnDefinitions="260,4,240,4,*">
 
             <!-- ── Left: Animation tree ── -->
-            <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*,Auto"
+            <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto"
                   Background="{StaticResource BgApp}">
 
                 <!-- ── Tree pane header ── -->
@@ -223,10 +223,12 @@
                     </DockPanel>
                 </Border>
 
-                <!-- Delete chain inline confirm -->
+                <!-- Delete chain confirm — floating overlay, sits on top of the tree -->
                 <Border x:Name="DeleteChainConfirmPanel"
-                        Grid.Row="1"
+                        Grid.Row="0" Grid.RowSpan="3"
+                        ZIndex="10"
                         IsVisible="False"
+                        VerticalAlignment="Top"
                         Background="{StaticResource BgRail}"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,0,0,1"
@@ -245,11 +247,12 @@
                         <TextBlock x:Name="DeleteChainConfirmLabel"
                                    Foreground="{StaticResource InkMid}"
                                    VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis"
                                    FontSize="11" />
                     </DockPanel>
                 </Border>
 
-                <TreeView x:Name="AnimTree" Grid.Row="2"
+                <TreeView x:Name="AnimTree" Grid.Row="1"
                           Background="{StaticResource BgApp}"
                           SelectionMode="Multiple"
                           ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -385,7 +388,7 @@
                 </TreeView>
 
                 <!-- ── Add Animation button ── -->
-                <Border Grid.Row="3"
+                <Border Grid.Row="2"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,1,0,0"
                         Background="{StaticResource BgApp}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -168,10 +168,10 @@
         </Border>
 
         <!-- ── Main content: TreeView | Property Panel | [Wireframe / Preview] ── -->
-        <Grid x:Name="MainContentGrid" ColumnDefinitions="260,4,240,4,*">
+        <Grid x:Name="MainContentGrid" ColumnDefinitions="280,4,240,4,*">
 
             <!-- ── Left: Animation tree ── -->
-            <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto"
+            <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*,Auto"
                   Background="{StaticResource BgApp}">
 
                 <!-- ── Tree pane header ── -->
@@ -223,18 +223,20 @@
                     </DockPanel>
                 </Border>
 
-                <!-- Delete chain confirm — floating overlay, sits on top of the tree -->
+                <!-- Delete chain confirm — stacked: label row above buttons row -->
                 <Border x:Name="DeleteChainConfirmPanel"
-                        Grid.Row="0" Grid.RowSpan="3"
-                        ZIndex="10"
+                        Grid.Row="1"
                         IsVisible="False"
-                        VerticalAlignment="Top"
                         Background="{StaticResource BgRail}"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,0,0,1"
-                        Padding="10,5">
-                    <DockPanel>
-                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                        Padding="10,6">
+                    <StackPanel Spacing="5">
+                        <TextBlock x:Name="DeleteChainConfirmLabel"
+                                   Foreground="{StaticResource InkMid}"
+                                   FontSize="11"
+                                   TextWrapping="Wrap" />
+                        <StackPanel Orientation="Horizontal" Spacing="6">
                             <Button x:Name="DeleteChainConfirmBtn"
                                     Content="Confirm ✕"
                                     Padding="8,3"
@@ -244,15 +246,10 @@
                                     Padding="8,3"
                                     FontSize="11" />
                         </StackPanel>
-                        <TextBlock x:Name="DeleteChainConfirmLabel"
-                                   Foreground="{StaticResource InkMid}"
-                                   VerticalAlignment="Center"
-                                   TextTrimming="CharacterEllipsis"
-                                   FontSize="11" />
-                    </DockPanel>
+                    </StackPanel>
                 </Border>
 
-                <TreeView x:Name="AnimTree" Grid.Row="1"
+                <TreeView x:Name="AnimTree" Grid.Row="2"
                           Background="{StaticResource BgApp}"
                           SelectionMode="Multiple"
                           ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -388,7 +385,7 @@
                 </TreeView>
 
                 <!-- ── Add Animation button ── -->
-                <Border Grid.Row="2"
+                <Border Grid.Row="3"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,1,0,0"
                         Background="{StaticResource BgApp}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -168,7 +168,7 @@
         </Border>
 
         <!-- ── Main content: TreeView | Property Panel | [Wireframe / Preview] ── -->
-        <Grid ColumnDefinitions="260,4,240,4,*">
+        <Grid x:Name="MainContentGrid" ColumnDefinitions="260,4,240,4,*">
 
             <!-- ── Left: Animation tree ── -->
             <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*,Auto"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -171,7 +171,7 @@
         <Grid ColumnDefinitions="260,4,240,4,*">
 
             <!-- ── Left: Animation tree ── -->
-            <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto"
+            <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*,Auto"
                   Background="{StaticResource BgApp}">
 
                 <!-- ── Tree pane header ── -->
@@ -223,7 +223,33 @@
                     </DockPanel>
                 </Border>
 
-                <TreeView x:Name="AnimTree" Grid.Row="1"
+                <!-- Delete chain inline confirm -->
+                <Border x:Name="DeleteChainConfirmPanel"
+                        Grid.Row="1"
+                        IsVisible="False"
+                        Background="{StaticResource BgRail}"
+                        BorderBrush="{StaticResource LineBrush}"
+                        BorderThickness="0,0,0,1"
+                        Padding="10,5">
+                    <DockPanel>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                            <Button x:Name="DeleteChainConfirmBtn"
+                                    Content="Confirm ✕"
+                                    Padding="8,3"
+                                    FontSize="11" />
+                            <Button x:Name="DeleteChainCancelBtn"
+                                    Content="Cancel"
+                                    Padding="8,3"
+                                    FontSize="11" />
+                        </StackPanel>
+                        <TextBlock x:Name="DeleteChainConfirmLabel"
+                                   Foreground="{StaticResource InkMid}"
+                                   VerticalAlignment="Center"
+                                   FontSize="11" />
+                    </DockPanel>
+                </Border>
+
+                <TreeView x:Name="AnimTree" Grid.Row="2"
                           Background="{StaticResource BgApp}"
                           SelectionMode="Multiple"
                           ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -359,7 +385,7 @@
                 </TreeView>
 
                 <!-- ── Add Animation button ── -->
-                <Border Grid.Row="2"
+                <Border Grid.Row="3"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,1,0,0"
                         Background="{StaticResource BgApp}"
@@ -958,6 +984,27 @@
             </Grid>
         </Grid>
     </DockPanel>
+        <!-- Frame-deleted undo toast -->
+        <Border x:Name="FrameDeletedToastPanel"
+                IsVisible="False"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Margin="0,0,0,30"
+                Background="#333"
+                CornerRadius="4"
+                Padding="12,6"
+                ZIndex="50">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <TextBlock x:Name="FrameDeletedToastLabel"
+                           Foreground="White"
+                           VerticalAlignment="Center"
+                           FontSize="12" />
+                <Button x:Name="FrameDeletedToastUndoBtn"
+                        Content="Undo"
+                        Padding="8,3"
+                        FontSize="12" />
+            </StackPanel>
+        </Border>
         <!-- Resize grips — 4px edges + 8px corners, transparent overlays -->
         <Border x:Name="GripN"  Height="4" VerticalAlignment="Top"    Background="Transparent" Cursor="TopSide"         PointerPressed="OnResizeGrip" />
         <Border x:Name="GripS"  Height="4" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomSide"      PointerPressed="OnResizeGrip" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -49,7 +49,6 @@ public partial class MainWindow : Window
     private bool _suppressTreeSelectionHandling;
     private System.Threading.CancellationTokenSource? _toastCts;
     private List<AnimationChainSave>? _pendingDeleteChains;
-    private double _savedTreeColumnWidth;
 
     private FilePath SettingsFilePath =>
         new FilePath((Path.GetDirectoryName(
@@ -2349,8 +2348,6 @@ public partial class MainWindow : Window
     private void ShowDeleteChainConfirm(AnimationChainSave chain) =>
         ShowDeleteChainConfirm(new List<AnimationChainSave> { chain });
 
-    private const double ConfirmPanelMinWidth = 360;
-
     private void ShowDeleteChainConfirm(List<AnimationChainSave> chains)
     {
         _pendingDeleteChains = chains;
@@ -2358,12 +2355,6 @@ public partial class MainWindow : Window
             ? $"Delete \"{chains[0].Name}\"?"
             : $"Delete {chains.Count} animations?";
         DeleteChainConfirmLabel.Text = label;
-
-        var col = MainContentGrid.ColumnDefinitions[0];
-        _savedTreeColumnWidth = col.Width.Value;
-        if (_savedTreeColumnWidth < ConfirmPanelMinWidth)
-            col.Width = new GridLength(ConfirmPanelMinWidth);
-
         DeleteChainConfirmPanel.IsVisible = true;
     }
 
@@ -2373,7 +2364,6 @@ public partial class MainWindow : Window
         List<AnimationChainSave> chains = _pendingDeleteChains;
         _pendingDeleteChains = null;
         DeleteChainConfirmPanel.IsVisible = false;
-        RestoreTreeColumnWidth();
         _appCommands.DeleteAnimationChains(chains);
     }
 
@@ -2381,13 +2371,6 @@ public partial class MainWindow : Window
     {
         _pendingDeleteChains = null;
         DeleteChainConfirmPanel.IsVisible = false;
-        RestoreTreeColumnWidth();
-    }
-
-    private void RestoreTreeColumnWidth()
-    {
-        if (_savedTreeColumnWidth > 0 && MainContentGrid.ColumnDefinitions[0].Width.Value > _savedTreeColumnWidth)
-            MainContentGrid.ColumnDefinitions[0].Width = new GridLength(_savedTreeColumnWidth);
     }
 
     internal void ShowDeleteChainConfirmForTest(AnimationChainSave chain) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -47,6 +47,8 @@ public partial class MainWindow : Window
     private bool _suppressZoomComboChanged;
     private bool _suppressPreviewZoomComboChanged;
     private bool _suppressTreeSelectionHandling;
+    private System.Threading.CancellationTokenSource? _toastCts;
+    private List<AnimationChainSave>? _pendingDeleteChains;
 
     private FilePath SettingsFilePath =>
         new FilePath((Path.GetDirectoryName(
@@ -151,6 +153,28 @@ public partial class MainWindow : Window
         _undoManager.StackChanged         += () => Dispatcher.UIThread.InvokeAsync(UpdateStatusBar);
         _events.AnimationChainsChanged    += HandleAnimationChainsChanged;
         _selectedState.SelectionChanged   += HandleSelectionChanged;
+
+        _appCommands.FramesDeleted += label =>
+            Dispatcher.UIThread.InvokeAsync(() => ShowFrameDeletedToast(label));
+
+        FrameDeletedToastUndoBtn.Click += (_, _) =>
+        {
+            _toastCts?.Cancel();
+            FrameDeletedToastPanel.IsVisible = false;
+            _undoManager.Undo();
+        };
+
+        DeleteChainConfirmBtn.Click += (_, _) => CommitDeleteChain();
+        DeleteChainCancelBtn.Click  += (_, _) => CancelDeleteChain();
+
+        PointerPressed += (_, e) =>
+        {
+            if (_pendingDeleteChains is not null &&
+                !DeleteChainConfirmPanel.IsPointerOver)
+            {
+                CancelDeleteChain();
+            }
+        };
     }
 
     // ── Wireframe toolbar wiring ──────────────────────────────────────────────
@@ -1392,7 +1416,7 @@ public partial class MainWindow : Window
             AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame2));
             AddSeparator();
             AddMenuItem("Delete Frame", () =>
-                _ = _appCommands.AskToDeleteFrames(new() { frame2 }));
+                _appCommands.DeleteFrames(new List<AnimationFrameSave> { frame2 }));
         }
         else if (vm?.Data is AnimationChainSave chain)
         {
@@ -1427,8 +1451,13 @@ public partial class MainWindow : Window
             AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
             AddMenuItem("Rename…",          () => BeginInlineRenameSelected(chain));
             AddSeparator();
-            AddMenuItem("Delete Animation",
-                () => _ = _appCommands.AskToDeleteAnimationChains(new() { chain }));
+            AddMenuItem("Delete Animation", () =>
+            {
+                if (chain.Frames.Count > 0)
+                    ShowDeleteChainConfirm(chain);
+                else
+                    _appCommands.DeleteAnimationChains(new List<AnimationChainSave> { chain });
+            });
         }
         else
         {
@@ -2285,16 +2314,67 @@ public partial class MainWindow : Window
         if (selectedVm.Data is AnimationChainSave chainToDel)
         {
             var chains = _selectedState.SelectedChains;
-            _ = _appCommands.AskToDeleteAnimationChains(
-                chains.Count > 0 ? chains : new() { chainToDel });
+            List<AnimationChainSave> toDelete = chains.Count > 0 ? chains : new List<AnimationChainSave> { chainToDel };
+            if (toDelete.Any(c => c.Frames.Count > 0))
+                ShowDeleteChainConfirm(toDelete);
+            else
+                _appCommands.DeleteAnimationChains(toDelete);
         }
         else if (selectedVm.Data is AnimationFrameSave frameToDel)
-            _ = _appCommands.AskToDeleteFrames(new() { frameToDel });
+            _appCommands.DeleteFrames(new List<AnimationFrameSave> { frameToDel });
         else if (selectedVm.Data is AARectSave rectToDel)
             _ = _appCommands.AskToDeleteRectangles(new() { rectToDel });
         else if (selectedVm.Data is CircleSave circleToDel)
             _ = _appCommands.AskToDeleteCircles(new() { circleToDel });
     }
+
+    private async void ShowFrameDeletedToast(string label)
+    {
+        _toastCts?.Cancel();
+        _toastCts = new System.Threading.CancellationTokenSource();
+        System.Threading.CancellationToken token = _toastCts.Token;
+
+        FrameDeletedToastLabel.Text = $"\"{label}\" deleted";
+        FrameDeletedToastPanel.IsVisible = true;
+
+        try
+        {
+            await System.Threading.Tasks.Task.Delay(4000, token);
+            FrameDeletedToastPanel.IsVisible = false;
+        }
+        catch (System.Threading.Tasks.TaskCanceledException) { }
+    }
+
+    private void ShowDeleteChainConfirm(AnimationChainSave chain) =>
+        ShowDeleteChainConfirm(new List<AnimationChainSave> { chain });
+
+    private void ShowDeleteChainConfirm(List<AnimationChainSave> chains)
+    {
+        _pendingDeleteChains = chains;
+        string label = chains.Count == 1
+            ? $"Delete \"{chains[0].Name}\"?"
+            : $"Delete {chains.Count} animations?";
+        DeleteChainConfirmLabel.Text = label;
+        DeleteChainConfirmPanel.IsVisible = true;
+    }
+
+    private void CommitDeleteChain()
+    {
+        if (_pendingDeleteChains is null) return;
+        List<AnimationChainSave> chains = _pendingDeleteChains;
+        _pendingDeleteChains = null;
+        DeleteChainConfirmPanel.IsVisible = false;
+        _appCommands.DeleteAnimationChains(chains);
+    }
+
+    private void CancelDeleteChain()
+    {
+        _pendingDeleteChains = null;
+        DeleteChainConfirmPanel.IsVisible = false;
+    }
+
+    internal void ShowDeleteChainConfirmForTest(AnimationChainSave chain) =>
+        ShowDeleteChainConfirm(new List<AnimationChainSave> { chain });
 
     // ── Add Multiple Frames ───────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -49,6 +49,7 @@ public partial class MainWindow : Window
     private bool _suppressTreeSelectionHandling;
     private System.Threading.CancellationTokenSource? _toastCts;
     private List<AnimationChainSave>? _pendingDeleteChains;
+    private double _savedTreeColumnWidth;
 
     private FilePath SettingsFilePath =>
         new FilePath((Path.GetDirectoryName(
@@ -2348,6 +2349,8 @@ public partial class MainWindow : Window
     private void ShowDeleteChainConfirm(AnimationChainSave chain) =>
         ShowDeleteChainConfirm(new List<AnimationChainSave> { chain });
 
+    private const double ConfirmPanelMinWidth = 360;
+
     private void ShowDeleteChainConfirm(List<AnimationChainSave> chains)
     {
         _pendingDeleteChains = chains;
@@ -2355,6 +2358,12 @@ public partial class MainWindow : Window
             ? $"Delete \"{chains[0].Name}\"?"
             : $"Delete {chains.Count} animations?";
         DeleteChainConfirmLabel.Text = label;
+
+        var col = MainContentGrid.ColumnDefinitions[0];
+        _savedTreeColumnWidth = col.Width.Value;
+        if (_savedTreeColumnWidth < ConfirmPanelMinWidth)
+            col.Width = new GridLength(ConfirmPanelMinWidth);
+
         DeleteChainConfirmPanel.IsVisible = true;
     }
 
@@ -2364,6 +2373,7 @@ public partial class MainWindow : Window
         List<AnimationChainSave> chains = _pendingDeleteChains;
         _pendingDeleteChains = null;
         DeleteChainConfirmPanel.IsVisible = false;
+        RestoreTreeColumnWidth();
         _appCommands.DeleteAnimationChains(chains);
     }
 
@@ -2371,6 +2381,13 @@ public partial class MainWindow : Window
     {
         _pendingDeleteChains = null;
         DeleteChainConfirmPanel.IsVisible = false;
+        RestoreTreeColumnWidth();
+    }
+
+    private void RestoreTreeColumnWidth()
+    {
+        if (_savedTreeColumnWidth > 0 && MainContentGrid.ColumnDefinitions[0].Width.Value > _savedTreeColumnWidth)
+            MainContentGrid.ColumnDefinitions[0].Width = new GridLength(_savedTreeColumnWidth);
     }
 
     internal void ShowDeleteChainConfirmForTest(AnimationChainSave chain) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -95,6 +95,8 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         public IFileDialogService FileDialogService { get; set; } = NullFileDialogService.Instance;
 
+        public event Action<string>? FramesDeleted;
+
         /// <summary>
         /// Fired after <see cref="SaveCurrentAnimationChainListAsync"/> successfully saves a file.
         /// The argument is the full path of the saved file.
@@ -437,34 +439,32 @@ namespace AnimationEditor.Core.CommandsAndState
             }
         }
 
-        public async Task AskToDeleteFrames(List<AnimationFrameSave> frames)
+        public void DeleteFrames(List<AnimationFrameSave> frames)
         {
-            var message = $"Delete the following {frames.Count} frame(s)?\n\n" +
-                string.Join("\n", frames.Select(f => $"Frame {f.TextureName}"));
-
-            if (await ConfirmAsync(message, "Delete?"))
+            var chain = _selectedState.SelectedChain;
+            if (chain != null)
             {
-                var chain = _selectedState.SelectedChain;
-                if (chain != null)
-                {
-                    // Capture original indices before removal
-                    var entries = frames
-                        .Select(f => (Frame: f, OriginalIndex: chain.Frames.IndexOf(f)))
-                        .Where(e => e.OriginalIndex >= 0)
-                        .ToArray();
+                var entries = frames
+                    .Select(f => (Frame: f, OriginalIndex: chain.Frames.IndexOf(f)))
+                    .Where(e => e.OriginalIndex >= 0)
+                    .ToArray();
 
-                    foreach (var (frame, _) in entries)
-                        chain.Frames.Remove(frame);
+                foreach (var (frame, _) in entries)
+                    chain.Frames.Remove(frame);
 
-                    if (entries.Length > 0)
-                        _undoManager.Record(new DeleteFramesCommand(entries, chain, this, _events));
+                if (entries.Length > 0)
+                    _undoManager.Record(new DeleteFramesCommand(entries, chain, this, _events));
 
-                    RefreshChainNodeRequested?.Invoke(chain);
-                }
+                RefreshChainNodeRequested?.Invoke(chain);
 
-                RefreshWireframeRequested?.Invoke();
-                _events.RaiseAnimationChainsChanged();
+                string label = entries.Length == 1
+                    ? $"Frame {entries[0].OriginalIndex + 1}"
+                    : $"{entries.Length} frames";
+                FramesDeleted?.Invoke(label);
             }
+
+            RefreshWireframeRequested?.Invoke();
+            _events.RaiseAnimationChainsChanged();
         }
 
         private List<string> GetSelectedFrameShapeNames()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -33,6 +33,7 @@ namespace AnimationEditor.Core.CommandsAndState
         event Action RefreshAnimationFrameDisplayRequested;
         event Action RefreshWireframeRequested;
         event Action<string>? SaveAsCompleted;
+        event Action<string>? FramesDeleted;
 
         /// <summary>
         /// Fired when <see cref="LoadAnimationChain"/> fails — file not found, corrupt XML,
@@ -71,7 +72,7 @@ namespace AnimationEditor.Core.CommandsAndState
         Task AskToDeleteRectangles(List<AARectSave> rectangles);
         Task AskToDeleteCircles(List<CircleSave> circles);
         Task AskToDeleteAnimationChains(List<AnimationChainSave> animationChains);
-        Task AskToDeleteFrames(List<AnimationFrameSave> frames);
+        void DeleteFrames(List<AnimationFrameSave> frames);
         Task AddAnimationChain();
         AnimationChainSave? AddAnimationChainWithName(string name);
         bool RenameChain(AnimationChainSave chain, string newName);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteChainInlineConfirmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteChainInlineConfirmTests.cs
@@ -1,0 +1,101 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class DeleteChainInlineConfirmTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        MainWindow window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    [AvaloniaFact]
+    public void InlineConfirmPanel_HiddenInitially()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            Border panel = window.FindControl<Border>("DeleteChainConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineConfirmPanel_ShowsWhenChainHasFrames()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            window.ShowDeleteChainConfirmForTest(chain);
+            Dispatcher.UIThread.RunJobs();
+
+            Border panel = window.FindControl<Border>("DeleteChainConfirmPanel")!;
+            Assert.True(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineConfirmPanel_ConfirmDeletesChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            window.ShowDeleteChainConfirmForTest(chain);
+            Dispatcher.UIThread.RunJobs();
+
+            Button confirmBtn = window.FindControl<Button>("DeleteChainConfirmBtn")!;
+            confirmBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+            Border panel = window.FindControl<Border>("DeleteChainConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineConfirmPanel_CancelPreservesChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            window.ShowDeleteChainConfirmForTest(chain);
+            Dispatcher.UIThread.RunJobs();
+
+            Button cancelBtn = window.FindControl<Button>("DeleteChainCancelBtn")!;
+            cancelBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+            Border panel = window.FindControl<Border>("DeleteChainConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDeletedToastTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDeletedToastTests.cs
@@ -1,0 +1,108 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class FrameDeletedToastTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        MainWindow window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    [AvaloniaFact]
+    public void Toast_HiddenInitially()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            Border toast = window.FindControl<Border>("FrameDeletedToastPanel")!;
+            Assert.False(toast.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Toast_ShowsAfterDeleteFrames()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "Tex.png" };
+            chain.Frames.Add(frame);
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex2.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+            Dispatcher.UIThread.RunJobs();
+
+            Border toast = window.FindControl<Border>("FrameDeletedToastPanel")!;
+            Assert.True(toast.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Toast_ShowsCorrectLabel()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "Tex.png" };
+            chain.Frames.Add(frame);
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex2.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+            Dispatcher.UIThread.RunJobs();
+
+            TextBlock label = window.FindControl<TextBlock>("FrameDeletedToastLabel")!;
+            Assert.Contains("Frame 1", label.Text);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Toast_UndoBtn_RestoresDeletedFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "Tex.png" };
+            chain.Frames.Add(frame);
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "Tex2.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+            Dispatcher.UIThread.RunJobs();
+
+            Button undoBtn = window.FindControl<Button>("FrameDeletedToastUndoBtn")!;
+            undoBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(2, chain.Frames.Count);
+            Assert.Contains(frame, chain.Frames);
+
+            Border toast = window.FindControl<Border>("FrameDeletedToastPanel")!;
+            Assert.False(toast.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
@@ -70,61 +70,42 @@ public class AppCommandsDeleteAsyncTests
         }
     }
 
-    // ── AskToDeleteFrames ─────────────────────────────────────────────────────
+    // ── DeleteFrames ──────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task AskToDeleteFrames_WhenConfirmed_DeletesFramesFromSelectedChain()
+    public void DeleteFrames_DeletesFrameFromSelectedChain()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
-        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(true);
         var chain = TestHelpers.MakeChain(acls, "Run", 3);
         ctx.SelectedState.SelectedChain = chain;
         var frameToDelete = chain.Frames[1];
 
-        await ctx.AppCommands.AskToDeleteFrames(
-            new List<AnimationFrameSave> { frameToDelete });
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frameToDelete });
 
         Assert.Equal(2, chain.Frames.Count);
         Assert.DoesNotContain(frameToDelete, chain.Frames);
     }
 
     [Fact]
-    public async Task AskToDeleteFrames_WhenCancelled_DoesNotDeleteAnyFrames()
+    public void DeleteFrames_DeletesMultipleFrames()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
-        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(false);
-        var chain = TestHelpers.MakeChain(acls, "Run", 3);
-        ctx.SelectedState.SelectedChain = chain;
-
-        await ctx.AppCommands.AskToDeleteFrames(
-            new List<AnimationFrameSave> { chain.Frames[0] });
-
-        Assert.Equal(3, chain.Frames.Count);
-    }
-
-    [Fact]
-    public async Task AskToDeleteFrames_WhenConfirmed_DeletesMultipleFrames()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var acls = ctx.Acls;
-        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(true);
         var chain = TestHelpers.MakeChain(acls, "Run", 4);
         ctx.SelectedState.SelectedChain = chain;
         var toDelete = new List<AnimationFrameSave> { chain.Frames[0], chain.Frames[2] };
 
-        await ctx.AppCommands.AskToDeleteFrames(toDelete);
+        ctx.AppCommands.DeleteFrames(toDelete);
 
         Assert.Equal(2, chain.Frames.Count);
     }
 
     [Fact]
-    public async Task AskToDeleteFrames_WhenConfirmed_FiresAnimationChainsChanged()
+    public void DeleteFrames_FiresAnimationChainsChanged()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
-        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(true);
         var chain = TestHelpers.MakeChain(acls, "Run", 2);
         ctx.SelectedState.SelectedChain = chain;
         bool fired = false;
@@ -132,14 +113,55 @@ public class AppCommandsDeleteAsyncTests
         ctx.ApplicationEvents.AnimationChainsChanged += Handler;
         try
         {
-            await ctx.AppCommands.AskToDeleteFrames(
-                new List<AnimationFrameSave> { chain.Frames[0] });
+            ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { chain.Frames[0] });
             Assert.True(fired);
         }
-        finally
-        {
-            ctx.ApplicationEvents.AnimationChainsChanged -= Handler;
-        }
+        finally { ctx.ApplicationEvents.AnimationChainsChanged -= Handler; }
+    }
+
+    [Fact]
+    public void DeleteFrames_FiresFramesDeleted_MultiFrameLabel()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Run", 4);
+        ctx.SelectedState.SelectedChain = chain;
+        string? capturedLabel = null;
+        ctx.AppCommands.FramesDeleted += label => capturedLabel = label;
+        var toDelete = new List<AnimationFrameSave> { chain.Frames[0], chain.Frames[2] };
+
+        ctx.AppCommands.DeleteFrames(toDelete);
+
+        Assert.Equal("2 frames", capturedLabel);
+    }
+
+    [Fact]
+    public void DeleteFrames_FiresFramesDeleted_SingleFrameLabel()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Run", 3);
+        ctx.SelectedState.SelectedChain = chain;
+        string? capturedLabel = null;
+        ctx.AppCommands.FramesDeleted += label => capturedLabel = label;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { chain.Frames[0] });
+
+        Assert.NotNull(capturedLabel);
+        Assert.Contains("1", capturedLabel);
+    }
+
+    [Fact]
+    public void DeleteFrames_RecordsUndoCommand()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Run", 2);
+        ctx.SelectedState.SelectedChain = chain;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { chain.Frames[0] });
+
+        Assert.True(ctx.UndoManager.CanUndo);
     }
 
     // ── AskToDeleteRectangles ─────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteFramesUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteFramesUndoTests.cs
@@ -9,10 +9,10 @@ namespace AnimationEditor.Core.Tests;
 [Collection("SequentialSingletons")]
 public class DeleteFramesUndoTests
 {
-    // ── AskToDeleteFrames + Undo ──────────────────────────────────────────────
+    // ── DeleteFrames + Undo ───────────────────────────────────────────────────
 
     [Fact]
-    public async Task DeleteFrames_Undo_RestoresFrameAtOriginalIndex()
+    public void DeleteFrames_Undo_RestoresFrameAtOriginalIndex()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
@@ -20,7 +20,7 @@ public class DeleteFramesUndoTests
         ctx.SelectedState.SelectedChain = chain;
         var middle = chain.Frames[1];
 
-        await ctx.AppCommands.AskToDeleteFrames(new List<AnimationFrameSave> { middle });
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { middle });
         Assert.Equal(2, chain.Frames.Count);
 
         ctx.UndoManager.Undo();
@@ -30,7 +30,7 @@ public class DeleteFramesUndoTests
     }
 
     [Fact]
-    public async Task DeleteFrames_UndoThenRedo_RemovesFrameAgain()
+    public void DeleteFrames_UndoThenRedo_RemovesFrameAgain()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
@@ -38,7 +38,7 @@ public class DeleteFramesUndoTests
         ctx.SelectedState.SelectedChain = chain;
         var first = chain.Frames[0];
 
-        await ctx.AppCommands.AskToDeleteFrames(new List<AnimationFrameSave> { first });
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { first });
         ctx.UndoManager.Undo();
         Assert.Equal(2, chain.Frames.Count);
 
@@ -49,7 +49,7 @@ public class DeleteFramesUndoTests
     }
 
     [Fact]
-    public async Task DeleteMultipleFrames_Undo_RestoresAllAtOriginalPositions()
+    public void DeleteMultipleFrames_Undo_RestoresAllAtOriginalPositions()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
@@ -58,7 +58,7 @@ public class DeleteFramesUndoTests
         var f0 = chain.Frames[0];
         var f2 = chain.Frames[2];
 
-        await ctx.AppCommands.AskToDeleteFrames(new List<AnimationFrameSave> { f0, f2 });
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { f0, f2 });
         Assert.Equal(2, chain.Frames.Count);
 
         ctx.UndoManager.Undo();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -61,7 +61,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AskToDeleteRectangles)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteCircles)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteAnimationChains)]   = Category.MutatingUndoable,
-        [nameof(IAppCommands.AskToDeleteFrames)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.DeleteFrames)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChainWithName)]    = Category.MutatingUndoable,
         [nameof(IAppCommands.RenameChain)]                  = Category.MutatingUndoable,
@@ -177,8 +177,8 @@ public class UndoCoverageRosterTests
             ctx => ctx.AppCommands.AskToDeleteCircles(new() { Circle(ctx) }));
         yield return Row(nameof(IAppCommands.AskToDeleteAnimationChains),
             ctx => ctx.AppCommands.AskToDeleteAnimationChains(new() { Alpha(ctx) }));
-        yield return Row(nameof(IAppCommands.AskToDeleteFrames),
-            ctx => ctx.AppCommands.AskToDeleteFrames(new() { Zebra(ctx).Frames[1] }));
+        yield return Row(nameof(IAppCommands.DeleteFrames),
+            ctx => Sync(() => ctx.AppCommands.DeleteFrames(new() { Zebra(ctx).Frames[1] })));
         yield return Row(nameof(IAppCommands.AddAnimationChain),
             ctx => ctx.AppCommands.AddAnimationChain());
         yield return Row(nameof(IAppCommands.AddAnimationChainWithName),


### PR DESCRIPTION
## Summary

Implements risk-scaled delete confirmation as described in #223:

- Single-frame delete: no dialog; deletes immediately and shows a 4-second auto-dismissing undo toast
- Chain delete with frames: inline two-step confirm panel inside the tree column (no modal popup)
- Empty chain delete: deleted immediately, no confirmation needed

## Changes

- Removed AskToDeleteFrames (async modal) from IAppCommands/AppCommands; replaced with synchronous DeleteFrames that fires FramesDeleted event
- Added FrameDeletedToastPanel overlay in root Grid (AXAML + code-behind)
- Added DeleteChainConfirmPanel inline in tree column (AXAML + code-behind)
- Updated context menu and keyboard Delete handler call sites
- All existing tests updated; new FrameDeletedToastTests and DeleteChainInlineConfirmTests added (8 new tests)
- All 1280 tests pass

Closes #223