### PR TITLE
docs(skill): add "[AvaloniaFact] is a last resort" to animation-editor skill

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -45,7 +45,13 @@ dotnet test  tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/
 dotnet test  tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/
 ```
 
-App tests use `[AvaloniaFact]` from `Avalonia.Headless.XUnit`; they construct `MainWindow` and drive it with `Dispatcher.UIThread.RunJobs()` between actions. See `WireframePanZoomTests.cs` for the established pattern (per-test service graph via `TestHelpers.BuildServices()`, tmp-dir PNG fixture, `FindCtrl<T>` helper).
+## `[AvaloniaFact]` is a last resort
+
+`[AvaloniaFact]` (from `Avalonia.Headless.XUnit`) runs the test on a headless Avalonia UI thread. It is slow and **deadlocks** on anything that blocks the UI thread waiting for the UI — a code path reaching `Window.ShowDialog` hangs forever with nothing to close the dialog. The `MainWindow` constructor also overwrites injected delegates (`AppCommands.ConfirmAsync`, `PromptStringAsync`, `FileDialogService`), so a stub installed *before* construction is silently lost.
+
+Default to a plain `[Fact]` against `AnimationEditor.Core` (`AppCommands`, commands, `SelectedState`, `AppState`). Reach for `[AvaloniaFact]` only when the behavior under test genuinely *is* UI — layout, control templates, input routing, visual tree. Logic reachable only by reflecting into a private `MainWindow` method is a signal to move it into Core, not to write an `[AvaloniaFact]`.
+
+Tests that do need it construct `MainWindow` and drive it with `Dispatcher.UIThread.RunJobs()` between actions — see `WireframePanZoomTests.cs` for the established pattern.
 
 ## Two-panel mental model
 


### PR DESCRIPTION
## What

Adds an **`[AvaloniaFact]` is a last resort** subsection to the `animation-editor` skill.

## Why

While picking up stalled Animation Editor work, an `AnimationEditor.App` `[AvaloniaFact]` test froze CI (a ~7-minute hang → OOM-killed test host) and local runs. Root cause: the test drove a headless `MainWindow` whose code path reached `Window.ShowDialog`, which deadlocks the headless UI thread — nothing exists to close the dialog. Compounding it, the `MainWindow` constructor silently re-wires injected delegates (`ConfirmAsync`, `PromptStringAsync`, `FileDialogService`) to its own dialogs, so a stub installed *before* construction is quietly discarded.

The deeper pattern: these tests reached into a private `MainWindow` method by reflection to verify logic that was already (or could be) covered by pure `[Fact]` tests against `AnimationEditor.Core`.

## The guidance

- Default to a plain `[Fact]` against `AnimationEditor.Core`.
- Reserve `[AvaloniaFact]` for behavior that genuinely *is* UI (layout, control templates, input routing, visual tree).
- Reflecting into a private `MainWindow` method to reach logic is the signal to move that logic into Core, not to write an `[AvaloniaFact]`.

Logged in `.claude/skill_change_log.jsonl` (gitignored local audit log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)