### PR TITLE
AE: Load Recent - abbreviated name, tooltip, 5-item cap, position below Load

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -75,10 +75,9 @@
                     <MenuItem Header="_File">
                         <MenuItem Header="_New"          x:Name="MenuNew"    InputGesture="Ctrl+N" />
                         <MenuItem Header="_Load..."       x:Name="MenuLoad"   InputGesture="Ctrl+L" />
+                        <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
                         <MenuItem Header="_Save"          x:Name="MenuSave"   InputGesture="Ctrl+S" />
                         <MenuItem Header="Save _As..."    x:Name="MenuSaveAs" />
-                        <Separator />
-                        <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
                     </MenuItem>
                     <MenuItem Header="_Edit">
                         <MenuItem Header="_Undo"            x:Name="MenuUndo"          InputGesture="Ctrl+Z" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -605,9 +605,10 @@ public partial class MainWindow : Window
     private void RefreshRecentFiles()
     {
         MenuLoadRecent.Items.Clear();
-        foreach (var file in _appSettings.RecentFiles)
+        foreach (var file in _appSettings.RecentFiles.Take(5))
         {
-            var item = new MenuItem { Header = file };
+            var item = new MenuItem { Header = System.IO.Path.GetFileName(file) };
+            ToolTip.SetTip(item, file);
             var captured = file;
             item.Click += async (_, _) => await LoadAnimationFileAsync(captured);
             MenuLoadRecent.Items.Add(item);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecentFilesMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecentFilesMenuTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reflection;
 using AnimationEditor.Core.Models;
 using Avalonia.Controls;
@@ -31,11 +32,12 @@ public class RecentFilesMenuTests
     [AvaloniaFact]
     public void RecentFiles_ShowsAbbreviatedFileNameAsHeader()
     {
+        var fullPath = Path.Combine(Path.GetTempPath(), "Games", "MyProject", "player.achx");
         var (window, appSettings) = CreateWindowWithSettings();
         try
         {
             appSettings.RecentFiles.Clear();
-            appSettings.RecentFiles.Add(@"C:\Games\MyProject\player.achx");
+            appSettings.RecentFiles.Add(fullPath);
             CallRefreshRecentFiles(window);
 
             var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
@@ -49,7 +51,7 @@ public class RecentFilesMenuTests
     [AvaloniaFact]
     public void RecentFiles_ShowsFullPathAsToolTip()
     {
-        const string fullPath = @"C:\Games\MyProject\player.achx";
+        var fullPath = Path.Combine(Path.GetTempPath(), "Games", "MyProject", "player.achx");
         var (window, appSettings) = CreateWindowWithSettings();
         try
         {
@@ -73,7 +75,7 @@ public class RecentFilesMenuTests
         {
             appSettings.RecentFiles.Clear();
             for (int i = 0; i < 10; i++)
-                appSettings.RecentFiles.Add($@"C:\Games\file{i}.achx");
+                appSettings.RecentFiles.Add(Path.Combine(Path.GetTempPath(), $"file{i}.achx"));
             CallRefreshRecentFiles(window);
 
             var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
@@ -90,8 +92,8 @@ public class RecentFilesMenuTests
         try
         {
             appSettings.RecentFiles.Clear();
-            appSettings.RecentFiles.Add(@"C:\a.achx");
-            appSettings.RecentFiles.Add(@"C:\b.achx");
+            appSettings.RecentFiles.Add(Path.Combine(Path.GetTempPath(), "a.achx"));
+            appSettings.RecentFiles.Add(Path.Combine(Path.GetTempPath(), "b.achx"));
             CallRefreshRecentFiles(window);
 
             var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecentFilesMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecentFilesMenuTests.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using AnimationEditor.Core.Models;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies the Load Recent submenu shows abbreviated file names with full-path
+/// tooltips and limits to five items.
+/// </summary>
+public class RecentFilesMenuTests
+{
+    private static (MainWindow Window, AppSettingsModel AppSettings) CreateWindowWithSettings()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        var appSettings = (AppSettingsModel)typeof(MainWindow)
+            .GetField("_appSettings", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+        return (window, appSettings);
+    }
+
+    private static void CallRefreshRecentFiles(MainWindow window)
+        => typeof(MainWindow)
+            .GetMethod("RefreshRecentFiles", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, null);
+
+    [AvaloniaFact]
+    public void RecentFiles_ShowsAbbreviatedFileNameAsHeader()
+    {
+        var (window, appSettings) = CreateWindowWithSettings();
+        try
+        {
+            appSettings.RecentFiles.Clear();
+            appSettings.RecentFiles.Add(@"C:\Games\MyProject\player.achx");
+            CallRefreshRecentFiles(window);
+
+            var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
+            var item = (MenuItem)menuLoadRecent.Items[0]!;
+
+            Assert.Equal("player.achx", item.Header?.ToString());
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecentFiles_ShowsFullPathAsToolTip()
+    {
+        const string fullPath = @"C:\Games\MyProject\player.achx";
+        var (window, appSettings) = CreateWindowWithSettings();
+        try
+        {
+            appSettings.RecentFiles.Clear();
+            appSettings.RecentFiles.Add(fullPath);
+            CallRefreshRecentFiles(window);
+
+            var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
+            var item = (MenuItem)menuLoadRecent.Items[0]!;
+
+            Assert.Equal(fullPath, ToolTip.GetTip(item)?.ToString());
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecentFiles_LimitsToFiveItems_WhenMoreExist()
+    {
+        var (window, appSettings) = CreateWindowWithSettings();
+        try
+        {
+            appSettings.RecentFiles.Clear();
+            for (int i = 0; i < 10; i++)
+                appSettings.RecentFiles.Add($@"C:\Games\file{i}.achx");
+            CallRefreshRecentFiles(window);
+
+            var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
+
+            Assert.Equal(5, menuLoadRecent.Items.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecentFiles_FewerThanFive_ShowsAllItems()
+    {
+        var (window, appSettings) = CreateWindowWithSettings();
+        try
+        {
+            appSettings.RecentFiles.Clear();
+            appSettings.RecentFiles.Add(@"C:\a.achx");
+            appSettings.RecentFiles.Add(@"C:\b.achx");
+            CallRefreshRecentFiles(window);
+
+            var menuLoadRecent = window.FindControl<MenuItem>("MenuLoadRecent")!;
+
+            Assert.Equal(2, menuLoadRecent.Items.Count);
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
## Changes

- **Abbreviated name**: RefreshRecentFiles now uses \Path.GetFileName\ for the menu header instead of the full path
- **Tooltip**: Full path is shown as a tooltip on hover via \ToolTip.SetTip\
- **5-item cap**: Uses \.Take(5)\ to limit displayed entries (settings still store up to 20)
- **Position**: Moved \Load Recent\ to immediately below \_Load...\ in the File menu (removed the separator that made it its own section)

## Tests added

\RecentFilesMenuTests\ (4 headless Avalonia tests):
- \RecentFiles_ShowsAbbreviatedFileNameAsHeader\
- \RecentFiles_ShowsFullPathAsToolTip\
- \RecentFiles_LimitsToFiveItems_WhenMoreExist\
- \RecentFiles_FewerThanFive_ShowsAllItems\

Closes #253