### PR TITLE
Fix Adjust Frame Time popup sizing (#251)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1499,9 +1499,10 @@ public partial class MainWindow : Window
         void UpdateLabel()
         {
             float val = (float)(durationInput.Value ?? 0m);
-            perFrameLabel.Text = radioSetAll.IsChecked == true
-                ? $"Each frame: {val / frameCount:F3} seconds"
-                : string.Empty;
+            bool showLabel = radioSetAll.IsChecked == true;
+            perFrameLabel.IsVisible = showLabel;
+            if (showLabel)
+                perFrameLabel.Text = $"Each frame: {val / frameCount:F3} seconds";
         }
 
         durationInput.ValueChanged       += (_, _) => UpdateLabel();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1466,14 +1466,7 @@ public partial class MainWindow : Window
         float totalDuration = chain.Frames.Sum(f => f.FrameLength);
         bool  canProportional = totalDuration > 0f;
 
-        var dialog = new Window
-        {
-            Title  = "Adjust All Frame Time",
-            Width  = 360,
-            Height = 240,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
-            CanResize = false
-        };
+        var dialog = BuildAdjustFrameTimeWindow();
 
         var durationInput = new NumericUpDown
         {
@@ -2520,6 +2513,20 @@ public partial class MainWindow : Window
 
         return (grid, relXInput, relYInput);
     }
+
+    /// <summary>
+    /// Creates the shell <see cref="Window"/> for the Adjust Frame Time dialog.
+    /// The height is left unset so <see cref="SizeToContent.Height"/> can size
+    /// the window to fit whichever radio-option layout is currently shown.
+    /// </summary>
+    public static Window BuildAdjustFrameTimeWindow() => new Window
+    {
+        Title  = "Adjust All Frame Time",
+        Width  = 360,
+        SizeToContent = SizeToContent.Height,
+        WindowStartupLocation = WindowStartupLocation.CenterOwner,
+        CanResize = false
+    };
 
     // ── Resize Texture ────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AdjustFrameTimeDialogLayoutTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AdjustFrameTimeDialogLayoutTests.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Layout regression tests for the Adjust Frame Time dialog (#251).
+/// Ensures the dialog uses SizeToContent instead of a fixed height so it
+/// fits its content rather than leaving large empty regions.
+/// </summary>
+public class AdjustFrameTimeDialogLayoutTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MainWindow.BuildAdjustFrameTimeWindow"/> returns a
+    /// Window whose height is driven by content (SizeToContent.Height) rather than
+    /// a hardcoded pixel value.
+    /// </summary>
+    [AvaloniaFact]
+    public void BuildAdjustFrameTimeWindow_UsesSizeToContentHeight_NotFixedHeight()
+    {
+        var window = MainWindow.BuildAdjustFrameTimeWindow();
+
+        Assert.Equal(SizeToContent.Height, window.SizeToContent);
+        Assert.True(double.IsNaN(window.Height),
+            "Height must be unset (NaN) so the dialog sizes to its content rather than leaving empty space.");
+    }
+}


### PR DESCRIPTION
## Summary

The Adjust Frame Time dialog had a hardcoded \Height = 240\ that left large empty regions, even when displaying its largest radio-option layout.

## Changes

- Replaced \Height = 240\ with \SizeToContent = SizeToContent.Height\ so the window sizes itself to fit its content
- Extracted \BuildAdjustFrameTimeWindow()\ as a \public static\ factory method (mirrors the \BuildAdjustAllRow()\ pattern used by the Adjust Offsets dialog)
- Added \AdjustFrameTimeDialogLayoutTests\ — a layout regression test verifying the window uses \SizeToContent.Height\ and has no hardcoded height

Closes #251