### PR TITLE
fix: stop preview jitter when dragging pixel-snapped frames on non-pow2 textures

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1455,15 +1455,28 @@ public class PreviewControl : Control
             ? ((int)MathF.Round(worldValue)).ToString()
             : worldValue.ToString("0.###");
 
+    /// <summary>
+    /// Converts the UV coordinates of <paramref name="frame"/> to a pixel source rect for a
+    /// texture of size (<paramref name="texW"/>, <paramref name="texH"/>).
+    /// Uses <see cref="FrameDisplayValues"/> (Math.Round) instead of plain <c>(int)</c>
+    /// truncation so that the returned dimensions are stable across drag positions on
+    /// non-power-of-2 textures (fixes preview jitter — issue #260).
+    /// </summary>
+    internal static (int sx, int sy, int sw, int sh) ComputeSourceRect(
+        AnimationFrameSave frame, int texW, int texH)
+    {
+        int sx = FrameDisplayValues.GetPixelX(frame, texW);
+        int sy = FrameDisplayValues.GetPixelY(frame, texH);
+        int sw = FrameDisplayValues.GetPixelWidth(frame, texW);
+        int sh = FrameDisplayValues.GetPixelHeight(frame, texH);
+        return (sx, sy, sw, sh);
+    }
+
     private static void DrawFrameCore(
         SKCanvas canvas, AnimationFrameSave frame, SKBitmap bm,
         float cx, float cy, float zoom, float alpha)
     {
-        int tw = bm.Width, th = bm.Height;
-        int sx = (int)(frame.LeftCoordinate   * tw);
-        int sy = (int)(frame.TopCoordinate    * th);
-        int sw = (int)Math.Max(1, (frame.RightCoordinate  - frame.LeftCoordinate)  * tw);
-        int sh = (int)Math.Max(1, (frame.BottomCoordinate - frame.TopCoordinate)   * th);
+        var (sx, sy, sw, sh) = ComputeSourceRect(frame, bm.Width, bm.Height);
 
         var src = SKRectI.Create(sx, sy, sw, sh);
         float dw = sw * zoom;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSourceRectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSourceRectTests.cs
@@ -1,0 +1,108 @@
+using AnimationEditor.App.Controls;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreviewControl.ComputeSourceRect"/> — the pixel source-rect
+/// calculation that feeds <c>DrawFrameCore</c>.
+///
+/// Root cause of issue #260: the old inline code used <c>(int)</c> truncation on
+/// UV-coordinate arithmetic. For non-power-of-2 textures, floating-point rounding
+/// means <c>(RightUV - LeftUV) * texWidth</c> can be slightly below the integer
+/// (e.g. 79.9999… instead of 80), causing sw to truncate to 79. That one-pixel
+/// jitter in sw makes <c>dw = sw * zoom</c> jitter, which shifts the centred
+/// destination rect by 0.5 px every time the region moves.
+///
+/// The fix: use <c>FrameDisplayValues</c> (Math.Round) for all four components
+/// and derive sw/sh from rounded endpoints so width is always stable.
+/// </summary>
+public class PreviewSourceRectTests
+{
+    private static AnimationFrameSave Frame(float left, float right, float top, float bottom)
+        => new()
+        {
+            LeftCoordinate   = left,
+            RightCoordinate  = right,
+            TopCoordinate    = top,
+            BottomCoordinate = bottom,
+        };
+
+    // ── sx/sy — rounding, not truncation ─────────────────────────────────────
+
+    [Fact]
+    public void ComputeSourceRect_OriginFrame_SxSyAreZero()
+    {
+        var frame = Frame(0f, 0.5f, 0f, 0.5f);
+        var (sx, sy, _, _) = PreviewControl.ComputeSourceRect(frame, 256, 256);
+        Assert.Equal(0, sx);
+        Assert.Equal(0, sy);
+    }
+
+    [Fact]
+    public void ComputeSourceRect_Sx_RoundsNotTruncates()
+    {
+        // 0.1f * 100 = 10.0000001... → rounds to 10, not truncates to 10 (coincidentally fine)
+        // More illustrative: a UV that is slightly below its integer on a 100px texture.
+        // Left = 11/100 = 0.11f → float ≈ 0.10999999940... → * 100 ≈ 10.999...
+        // (int) truncation → sx = 10  (WRONG)
+        // Math.Round         → sx = 11 (correct)
+        var frame = Frame(11f / 100f, 91f / 100f, 0f, 1f);
+        var (sx, _, _, _) = PreviewControl.ComputeSourceRect(frame, 100, 100);
+        Assert.Equal(11, sx);
+    }
+
+    // ── sw/sh — stable width across positions (the jitter bug) ───────────────
+
+    [Fact]
+    public void ComputeSourceRect_NonPowerOfTwoTexture_SwStableAcrossPositions()
+    {
+        // 80-pixel wide region on a 100-pixel wide texture at five positions.
+        // With old (int) truncation: (0.9f - 0.1f) * 100 = 79.9999... → sw = 79 (jitter).
+        // With Math.Round (correct): sw = 80 at every position.
+        int[] lefts = { 0, 5, 10, 15, 20 };
+        foreach (int left in lefts)
+        {
+            var frame = Frame(left / 100f, (left + 80) / 100f, 0f, 1f);
+            var (_, _, sw, _) = PreviewControl.ComputeSourceRect(frame, 100, 100);
+            Assert.True(sw == 80, $"sw should be 80 for left={left} but got {sw}");
+        }
+    }
+
+    [Fact]
+    public void ComputeSourceRect_NonPowerOfTwoTexture_ShStableAcrossPositions()
+    {
+        // Same test for height dimension.
+        int[] tops = { 0, 3, 7, 12, 20 };
+        foreach (int top in tops)
+        {
+            var frame = Frame(0f, 1f, top / 100f, (top + 60) / 100f);
+            var (_, _, _, sh) = PreviewControl.ComputeSourceRect(frame, 100, 100);
+            Assert.True(sh == 60, $"sh should be 60 for top={top} but got {sh}");
+        }
+    }
+
+    [Fact]
+    public void ComputeSourceRect_ZeroSizeRegion_ClampsToOne()
+    {
+        var frame = Frame(0.5f, 0.5f, 0.5f, 0.5f);
+        var (_, _, sw, sh) = PreviewControl.ComputeSourceRect(frame, 256, 256);
+        Assert.Equal(1, sw);
+        Assert.Equal(1, sh);
+    }
+
+    // ── full round-trip on a power-of-2 texture ───────────────────────────────
+
+    [Fact]
+    public void ComputeSourceRect_PowerOfTwoTexture_ExactValues()
+    {
+        // 32×32 frame starting at (64, 48) on a 256×256 texture
+        var frame = Frame(64f / 256f, 96f / 256f, 48f / 256f, 80f / 256f);
+        var (sx, sy, sw, sh) = PreviewControl.ComputeSourceRect(frame, 256, 256);
+        Assert.Equal(64, sx);
+        Assert.Equal(48, sy);
+        Assert.Equal(32, sw);
+        Assert.Equal(32, sh);
+    }
+}


### PR DESCRIPTION
## Problem

When dragging a pixel-snapped frame region in the wireframe, the bottom preview panel jitters/shifts horizontally by ~1px on every drag step. This is most visible at high zoom (~502%) on non-power-of-2 textures (e.g. a 100×100px sprite sheet).

## Root cause

\DrawFrameCore\ in \PreviewControl.cs\ computed the source rect with plain \(int)\ truncation:

\\\csharp
// Before (buggy):
int sw = (int)Math.Max(1, (frame.RightCoordinate - frame.LeftCoordinate) * tw);
\\\

For a 100px-wide texture, \(0.9f - 0.1f) * 100\ evaluates to \79.9999…\ due to IEEE 754 float precision. Truncation gives \sw = 79\ at some drag positions and \80\ at others. This makes \dw = sw * zoom\ oscillate, which shifts the centred destination rect (\dx = cx - dw/2\) by 0.5px.

## Fix

Extracted \internal static ComputeSourceRect\ that delegates to the existing \FrameDisplayValues\ helpers, which already use \Math.Round\ for exactly this conversion. \DrawFrameCore\ now calls \ComputeSourceRect\ instead of the inline truncation.

## Tests

Added \PreviewSourceRectTests\ (7 plain \[Fact]\ tests, no Avalonia headless required):
- Stable \sw\/\sh\ across 5 drag positions on a 100px non-power-of-2 texture
- Correct rounding of \sx\/\sy\
- Zero-size region clamped to 1
- Round-trip correctness on a power-of-2 texture

All 1325 tests pass.

Closes #260