### PR TITLE
Fix #269: assign unique Frame N name on frame paste

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2301,6 +2301,7 @@ public partial class MainWindow : Window
             foreach (var pasted in frames)
                 pasted.ShapesSave ??= new ShapesSave();
 
+            FramePasteLogic.AssignUniqueNames(targetChain.Frames, frames);
             _appCommands.PasteFrames(targetChain, frames);
             _selectedState.SelectedFrame = frames[^1];
             _appCommands.RefreshWireframe();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FramePasteLogic.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FramePasteLogic.cs
@@ -1,0 +1,45 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Assigns unique "Frame N" names to pasted frames so no two frames in a chain share a label.
+/// Kept separate from clipboard serialization so the naming rule is unit-testable.
+/// </summary>
+public static class FramePasteLogic
+{
+    /// <summary>
+    /// Assigns the next free "Frame N" name to each frame in <paramref name="pastedFrames"/>,
+    /// using <paramref name="existingFrames"/> as the already-occupied name set.
+    /// Always picks next-free "Frame N" regardless of the pasted frame's current name
+    /// (even custom names fall back to "Frame N" — keeps it simple and consistent).
+    /// </summary>
+    public static void AssignUniqueNames(
+        IList<AnimationFrameSave> existingFrames,
+        IReadOnlyList<AnimationFrameSave> pastedFrames)
+    {
+        var taken = new HashSet<string>();
+        foreach (var f in existingFrames)
+            if (!string.IsNullOrEmpty(f.Name))
+                taken.Add(f.Name);
+
+        foreach (var frame in pastedFrames)
+        {
+            var name = NextFreeFrameName(taken);
+            frame.Name = name;
+            taken.Add(name);
+        }
+    }
+
+    private static string NextFreeFrameName(HashSet<string> taken)
+    {
+        int i = 1;
+        while (true)
+        {
+            var candidate = $"Frame {i}";
+            if (!taken.Contains(candidate)) return candidate;
+            i++;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FramePasteLogicTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FramePasteLogicTests.cs
@@ -1,0 +1,79 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class FramePasteLogicTests
+{
+    static AnimationFrameSave Frame(string name) => new AnimationFrameSave { Name = name };
+
+    [Fact]
+    public void AssignUniqueNames_CollidingName_RenamesWithNextFreeFrameN()
+    {
+        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
+        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 2", pasted[0].Name);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_CustomName_FallsBackToNextFreeFrameN()
+    {
+        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
+        var pasted   = new List<AnimationFrameSave> { Frame("Jump") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 2", pasted[0].Name);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_FrameAlreadyFreeWithSameName_KeepsName()
+    {
+        // "Frame 3" is free (Frame 1 and Frame 2 are taken), so NextFreeFrameName returns "Frame 3".
+        var existing = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 2") };
+        var pasted   = new List<AnimationFrameSave> { Frame("Frame 3") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 3", pasted[0].Name);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_GapInSequence_FillsGap()
+    {
+        var existing = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 3") };
+        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 2", pasted[0].Name);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_MultipleFramesPasted_AllGetUniqueNames()
+    {
+        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
+        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 1") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 2", pasted[0].Name);
+        Assert.Equal("Frame 3", pasted[1].Name);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_NoExistingFrames_StartsAtFrame1()
+    {
+        var existing = new List<AnimationFrameSave>();
+        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal("Frame 1", pasted[0].Name);
+    }
+}


### PR DESCRIPTION
Closes #269

## Problem
Copy/pasting a frame produced a copy with the same name as the source, creating two identically-named entries in the tree.

## Solution
- New FramePasteLogic.AssignUniqueNames (Core layer, fully testable) — for each pasted frame, picks the next free \Frame N\ slot from the target chain, regardless of the pasted frame's current name (custom names also fall back to \Frame N\, keeping it simple and consistent).
- MainWindow.axaml.cs paste-frames branch calls \AssignUniqueNames\ before \PasteFrames\.

## Tests
6 new unit tests in \FramePasteLogicTests\ covering: name collision, custom name fallback, multiple frames pasted at once, empty chain, gap-fill, and free-name preservation. All 952 Core tests pass.