### PR TITLE
Fix batch shape delete collapsing multi-select and add mixed-type batch delete

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -186,7 +186,7 @@
         <Grid x:Name="MainContentGrid" ColumnDefinitions="280,4,240,4,*">
 
             <!-- ── Left: Animation tree ── -->
-            <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*,Auto"
+            <Grid Grid.Column="0" RowDefinitions="Auto,Auto,Auto,*,Auto"
                   Background="{StaticResource BgApp}">
 
                 <!-- ── Tree pane header ── -->
@@ -265,7 +265,34 @@
                     </DockPanel>
                 </Border>
 
-                <TreeView x:Name="AnimTree" Grid.Row="2"
+                <!-- Delete shape confirm -->
+                <Border x:Name="DeleteShapeConfirmPanel"
+                        Grid.Row="2"
+                        IsVisible="False"
+                        Background="{StaticResource BgRail}"
+                        BorderBrush="{StaticResource LineBrush}"
+                        BorderThickness="0,0,0,1"
+                        Padding="10,5">
+                    <DockPanel>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                            <Button x:Name="DeleteShapeConfirmBtn"
+                                    Content="Confirm"
+                                    Padding="8,3"
+                                    FontSize="11" />
+                            <Button x:Name="DeleteShapeCancelBtn"
+                                    Content="Cancel"
+                                    Padding="8,3"
+                                    FontSize="11" />
+                        </StackPanel>
+                        <TextBlock x:Name="DeleteShapeConfirmLabel"
+                                   Foreground="{StaticResource InkMid}"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis"
+                                   FontSize="11" />
+                    </DockPanel>
+                </Border>
+
+                <TreeView x:Name="AnimTree" Grid.Row="3"
                           Background="{StaticResource BgApp}"
                           SelectionMode="Multiple"
                           ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -403,7 +430,7 @@
                 </TreeView>
 
                 <!-- ── Add Animation button ── -->
-                <Border Grid.Row="3"
+                <Border Grid.Row="4"
                         BorderBrush="{StaticResource LineBrush}"
                         BorderThickness="0,1,0,0"
                         Background="{StaticResource BgApp}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-using AnimationEditor.Core;
+﻿using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.DragDrop;
@@ -49,6 +49,9 @@ public partial class MainWindow : Window
     private bool _suppressTreeSelectionHandling;
     private System.Threading.CancellationTokenSource? _toastCts;
     private List<AnimationChainSave>? _pendingDeleteChains;
+    private List<AARectSave>?      _pendingDeleteShapeRects;
+    private List<CircleSave>?      _pendingDeleteShapeCircles;
+    private AnimationFrameSave?    _pendingDeleteShapeFrame;
 
     private FilePath SettingsFilePath =>
         new FilePath((Path.GetDirectoryName(
@@ -168,12 +171,20 @@ public partial class MainWindow : Window
         DeleteChainConfirmBtn.Click += (_, _) => CommitDeleteChain();
         DeleteChainCancelBtn.Click  += (_, _) => CancelDeleteChain();
 
+        DeleteShapeConfirmBtn.Click += (_, _) => CommitDeleteShape();
+        DeleteShapeCancelBtn.Click  += (_, _) => CancelDeleteShape();
+
         PointerPressed += (_, e) =>
         {
             if (_pendingDeleteChains is not null &&
                 !DeleteChainConfirmPanel.IsPointerOver)
             {
                 CancelDeleteChain();
+            }
+            if (_pendingDeleteShapeRects is not null &&
+                !DeleteShapeConfirmPanel.IsPointerOver)
+            {
+                CancelDeleteShape();
             }
         };
     }
@@ -2358,23 +2369,23 @@ public partial class MainWindow : Window
         }
         else if (selectedVm.Data is AARectSave rectToDel)
         {
-            var rects = _selectedState.SelectedRectangles;
+            var frame   = _selectedState.SelectedFrame!;
+            var rects   = _selectedState.SelectedRectangles;
             var circles = _selectedState.SelectedCircles;
-            var rectList = rects.Count > 0 ? rects : new() { rectToDel };
-            if (circles.Count > 0)
-                _ = _appCommands.AskToDeleteShapes(rectList, circles);
-            else
-                _ = _appCommands.AskToDeleteRectangles(rectList);
+            ShowDeleteShapeConfirm(
+                frame,
+                rects.Count > 0 ? rects : new() { rectToDel },
+                circles);
         }
         else if (selectedVm.Data is CircleSave circleToDel)
         {
+            var frame   = _selectedState.SelectedFrame!;
             var circles = _selectedState.SelectedCircles;
-            var rects = _selectedState.SelectedRectangles;
-            var circleList = circles.Count > 0 ? circles : new() { circleToDel };
-            if (rects.Count > 0)
-                _ = _appCommands.AskToDeleteShapes(rects, circleList);
-            else
-                _ = _appCommands.AskToDeleteCircles(circleList);
+            var rects   = _selectedState.SelectedRectangles;
+            ShowDeleteShapeConfirm(
+                frame,
+                rects,
+                circles.Count > 0 ? circles : new() { circleToDel });
         }
     }
 
@@ -2425,6 +2436,43 @@ public partial class MainWindow : Window
 
     internal void ShowDeleteChainConfirmForTest(AnimationChainSave chain) =>
         ShowDeleteChainConfirm(new List<AnimationChainSave> { chain });
+
+    private void ShowDeleteShapeConfirm(AnimationFrameSave frame, List<AARectSave> rects, List<CircleSave> circles)
+    {
+        _pendingDeleteShapeFrame   = frame;
+        _pendingDeleteShapeRects   = rects;
+        _pendingDeleteShapeCircles = circles;
+        int total = rects.Count + circles.Count;
+        string label = total == 1
+            ? $"Delete \"{(rects.Count > 0 ? rects[0].Name : circles[0].Name)}\"?"
+            : $"Delete {total} shape(s)?";
+        DeleteShapeConfirmLabel.Text  = label;
+        DeleteShapeConfirmPanel.IsVisible = true;
+    }
+
+    private void CommitDeleteShape()
+    {
+        if (_pendingDeleteShapeRects is null || _pendingDeleteShapeFrame is null) return;
+        var frame   = _pendingDeleteShapeFrame;
+        var rects   = _pendingDeleteShapeRects;
+        var circles = _pendingDeleteShapeCircles ?? new();
+        _pendingDeleteShapeFrame   = null;
+        _pendingDeleteShapeRects   = null;
+        _pendingDeleteShapeCircles = null;
+        DeleteShapeConfirmPanel.IsVisible = false;
+        _appCommands.DeleteShapes(frame, rects, circles);
+    }
+
+    private void CancelDeleteShape()
+    {
+        _pendingDeleteShapeFrame   = null;
+        _pendingDeleteShapeRects   = null;
+        _pendingDeleteShapeCircles = null;
+        DeleteShapeConfirmPanel.IsVisible = false;
+    }
+
+    internal void ShowDeleteShapeConfirmForTest(AnimationFrameSave frame, List<AARectSave> rects, List<CircleSave> circles) =>
+        ShowDeleteShapeConfirm(frame, rects, circles);
 
     // ── Add Multiple Frames ───────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1263,7 +1263,7 @@ public partial class MainWindow : Window
 
         var target = sel is not null ? TreeBuilder.FindNodeForData(_treeRoots, sel) : null;
 
-        if (target is not null && !ReferenceEquals(AnimTree.SelectedItem, target))
+        if (target is not null && !(AnimTree.SelectedItems?.Contains(target) ?? false))
             AnimTree.SelectedItem = target;
     }
 
@@ -2359,14 +2359,22 @@ public partial class MainWindow : Window
         else if (selectedVm.Data is AARectSave rectToDel)
         {
             var rects = _selectedState.SelectedRectangles;
-            _ = _appCommands.AskToDeleteRectangles(
-                rects.Count > 0 ? rects : new() { rectToDel });
+            var circles = _selectedState.SelectedCircles;
+            var rectList = rects.Count > 0 ? rects : new() { rectToDel };
+            if (circles.Count > 0)
+                _ = _appCommands.AskToDeleteShapes(rectList, circles);
+            else
+                _ = _appCommands.AskToDeleteRectangles(rectList);
         }
         else if (selectedVm.Data is CircleSave circleToDel)
         {
             var circles = _selectedState.SelectedCircles;
-            _ = _appCommands.AskToDeleteCircles(
-                circles.Count > 0 ? circles : new() { circleToDel });
+            var rects = _selectedState.SelectedRectangles;
+            var circleList = circles.Count > 0 ? circles : new() { circleToDel };
+            if (rects.Count > 0)
+                _ = _appCommands.AskToDeleteShapes(rects, circleList);
+            else
+                _ = _appCommands.AskToDeleteCircles(circleList);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1,4 +1,4 @@
-using AnimationEditor.Core.CommandsAndState.Commands;
+﻿using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Rendering;
 using FlatRedBall2.Animation.Content;
@@ -384,24 +384,27 @@ namespace AnimationEditor.Core.CommandsAndState
             var message = "Delete the following shape(s)?\n\n" +
                 string.Join("\n", allNames);
 
-            if (await ConfirmAsync(message, "Delete?"))
-            {
-                var commands = new List<IUndoableCommand>();
-                foreach (var rect in rectangles.ToArray())
-                {
-                    var frame = _objectFinder.GetAnimationFrameContaining(rect);
-                    if (frame != null)
-                        commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events));
-                }
-                foreach (var circle in circles.ToArray())
-                {
-                    var frame = _objectFinder.GetAnimationFrameContaining(circle);
-                    if (frame != null)
-                        commands.Add(new DeleteCircleCommand(circle, frame, this, _events));
-                }
-                if (commands.Count > 0)
-                    _undoManager.Execute(new CompositeCommand(commands));
-            }
+            if (!await ConfirmAsync(message, "Delete?")) return;
+
+            AnimationFrameSave? frame = null;
+            if (rectangles.Count > 0)
+                frame = _objectFinder.GetAnimationFrameContaining(rectangles[0]);
+            if (frame == null && circles.Count > 0)
+                frame = _objectFinder.GetAnimationFrameContaining(circles[0]);
+            if (frame == null) return;
+
+            DeleteShapes(frame, rectangles, circles);
+        }
+
+        public void DeleteShapes(AnimationFrameSave frame, List<AARectSave> rectangles, List<CircleSave> circles)
+        {
+            var commands = new List<IUndoableCommand>();
+            foreach (var rect in rectangles.ToArray())
+                commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events));
+            foreach (var circle in circles.ToArray())
+                commands.Add(new DeleteCircleCommand(circle, frame, this, _events));
+            if (commands.Count > 0)
+                _undoManager.Execute(new CompositeCommand(commands));
         }
 
         public async Task AskToDeleteAnimationChains(List<AnimationChainSave> animationChains)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -378,6 +378,32 @@ namespace AnimationEditor.Core.CommandsAndState
             }
         }
 
+        public async Task AskToDeleteShapes(List<AARectSave> rectangles, List<CircleSave> circles)
+        {
+            var allNames = rectangles.Select(r => r.Name).Concat(circles.Select(c => c.Name));
+            var message = "Delete the following shape(s)?\n\n" +
+                string.Join("\n", allNames);
+
+            if (await ConfirmAsync(message, "Delete?"))
+            {
+                var commands = new List<IUndoableCommand>();
+                foreach (var rect in rectangles.ToArray())
+                {
+                    var frame = _objectFinder.GetAnimationFrameContaining(rect);
+                    if (frame != null)
+                        commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events));
+                }
+                foreach (var circle in circles.ToArray())
+                {
+                    var frame = _objectFinder.GetAnimationFrameContaining(circle);
+                    if (frame != null)
+                        commands.Add(new DeleteCircleCommand(circle, frame, this, _events));
+                }
+                if (commands.Count > 0)
+                    _undoManager.Execute(new CompositeCommand(commands));
+            }
+        }
+
         public async Task AskToDeleteAnimationChains(List<AnimationChainSave> animationChains)
         {
             var message = "Delete the following animation(s)?\n\n" +

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -72,6 +72,7 @@ namespace AnimationEditor.Core.CommandsAndState
         Task AskToDeleteRectangles(List<AARectSave> rectangles);
         Task AskToDeleteCircles(List<CircleSave> circles);
         Task AskToDeleteShapes(List<AARectSave> rectangles, List<CircleSave> circles);
+        void DeleteShapes(AnimationFrameSave frame, List<AARectSave> rectangles, List<CircleSave> circles);
         Task AskToDeleteAnimationChains(List<AnimationChainSave> animationChains);
         void DeleteFrames(List<AnimationFrameSave> frames);
         Task AddAnimationChain();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -71,6 +71,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void DeleteAxisAlignedRectangle(AARectSave rectangle, AnimationFrameSave owner);
         Task AskToDeleteRectangles(List<AARectSave> rectangles);
         Task AskToDeleteCircles(List<CircleSave> circles);
+        Task AskToDeleteShapes(List<AARectSave> rectangles, List<CircleSave> circles);
         Task AskToDeleteAnimationChains(List<AnimationChainSave> animationChains);
         void DeleteFrames(List<AnimationFrameSave> frames);
         Task AddAnimationChain();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteShapeInlineConfirmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteShapeInlineConfirmTests.cs
@@ -1,0 +1,131 @@
+﻿using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class DeleteShapeInlineConfirmTests
+{
+    private static (MainWindow Window, TestServices Ctx, AnimationFrameSave Frame) CreateWindowWithFrame()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        MainWindow window = ctx.CreateMainWindow();
+        window.Show();
+        // OnOpened is queued asynchronously during Show(). Drain it now so the
+        // new empty AnimationChainListSave is already in place before we add data.
+        Dispatcher.UIThread.RunJobs();
+
+        // Add chain/frame to the list that OnOpened just installed
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "Tex.png", ShapesSave = new ShapesSave() };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        return (window, ctx, frame);
+    }
+
+    [AvaloniaFact]
+    public void InlineShapeConfirmPanel_HiddenInitially()
+    {
+        var (window, _, _) = CreateWindowWithFrame();
+        try
+        {
+            Border panel = window.FindControl<Border>("DeleteShapeConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineShapeConfirmPanel_ShowsWhenShapeDeleteRequested()
+    {
+        var (window, _, frame) = CreateWindowWithFrame();
+        try
+        {
+            var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+            frame.ShapesSave!.CircleSaves.Add(circle);
+
+            window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
+            Dispatcher.UIThread.RunJobs();
+
+            Border panel = window.FindControl<Border>("DeleteShapeConfirmPanel")!;
+            Assert.True(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineShapeConfirmPanel_ConfirmDeletesShape()
+    {
+        var (window, _, frame) = CreateWindowWithFrame();
+        try
+        {
+            var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+            frame.ShapesSave!.CircleSaves.Add(circle);
+
+            window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
+            Dispatcher.UIThread.RunJobs();
+
+            Button confirmBtn = window.FindControl<Button>("DeleteShapeConfirmBtn")!;
+            confirmBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(frame.ShapesSave!.CircleSaves);
+            Border panel = window.FindControl<Border>("DeleteShapeConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineShapeConfirmPanel_CancelPreservesShape()
+    {
+        var (window, _, frame) = CreateWindowWithFrame();
+        try
+        {
+            var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+            frame.ShapesSave!.CircleSaves.Add(circle);
+
+            window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
+            Dispatcher.UIThread.RunJobs();
+
+            Button cancelBtn = window.FindControl<Button>("DeleteShapeCancelBtn")!;
+            cancelBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(frame.ShapesSave!.CircleSaves);
+            Border panel = window.FindControl<Border>("DeleteShapeConfirmPanel")!;
+            Assert.False(panel.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void InlineShapeConfirmPanel_ConfirmDeletesMixedRectAndCircle()
+    {
+        var (window, _, frame) = CreateWindowWithFrame();
+        try
+        {
+            var rect   = new AARectSave { Name = "Hitbox" };
+            var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+            frame.ShapesSave!.AARectSaves.Add(rect);
+            frame.ShapesSave!.CircleSaves.Add(circle);
+
+            window.ShowDeleteShapeConfirmForTest(frame, new() { rect }, new() { circle });
+            Dispatcher.UIThread.RunJobs();
+
+            Button confirmBtn = window.FindControl<Button>("DeleteShapeConfirmBtn")!;
+            confirmBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(frame.ShapesSave!.AARectSaves);
+            Assert.Empty(frame.ShapesSave!.CircleSaves);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
@@ -348,4 +348,98 @@ public class AppCommandsDeleteAsyncTests
         Assert.Equal(new[] { c1, c2 }, frame.ShapesSave!.CircleSaves);
         Assert.False(ctx.UndoManager.CanUndo);
     }
+
+    // ── AskToDeleteShapes ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AskToDeleteShapes_WhenConfirmed_DeletesBothRectanglesAndCircles()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(true);
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.CircleSaves.Add(circle);
+
+        await ctx.AppCommands.AskToDeleteShapes(
+            new List<AARectSave> { rect },
+            new List<CircleSave> { circle });
+
+        Assert.Empty(frame.ShapesSave!.AARectSaves);
+        Assert.Empty(frame.ShapesSave!.CircleSaves);
+    }
+
+    [Fact]
+    public async Task AskToDeleteShapes_WhenCancelled_DeletesNothing()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(false);
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.CircleSaves.Add(circle);
+
+        await ctx.AppCommands.AskToDeleteShapes(
+            new List<AARectSave> { rect },
+            new List<CircleSave> { circle });
+
+        Assert.Single(frame.ShapesSave!.AARectSaves);
+        Assert.Single(frame.ShapesSave!.CircleSaves);
+    }
+
+    [Fact]
+    public async Task AskToDeleteShapes_RecordsSingleUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.ConfirmAsync = (_, __) => Task.FromResult(true);
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
+        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.CircleSaves.Add(circle);
+
+        await ctx.AppCommands.AskToDeleteShapes(
+            new List<AARectSave> { rect },
+            new List<CircleSave> { circle });
+
+        Assert.Empty(frame.ShapesSave!.AARectSaves);
+        Assert.Empty(frame.ShapesSave!.CircleSaves);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(new[] { rect }, frame.ShapesSave!.AARectSaves);
+        Assert.Equal(new[] { circle }, frame.ShapesSave!.CircleSaves);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public async Task AskToDeleteShapes_ConfirmMessageContainsAllShapeNames()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        string? capturedMessage = null;
+        ctx.AppCommands.ConfirmAsync = (msg, _) =>
+        {
+            capturedMessage = msg;
+            return Task.FromResult(false);
+        };
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "BodyHitbox" };
+        var circle = new CircleSave { Name = "AttackRadius", Radius = 10 };
+        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.CircleSaves.Add(circle);
+
+        await ctx.AppCommands.AskToDeleteShapes(
+            new List<AARectSave> { rect },
+            new List<CircleSave> { circle });
+
+        Assert.NotNull(capturedMessage);
+        Assert.Contains("BodyHitbox", capturedMessage);
+        Assert.Contains("AttackRadius", capturedMessage);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -61,6 +61,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AskToDeleteRectangles)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteCircles)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteShapes)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.DeleteShapes)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteAnimationChains)]   = Category.MutatingUndoable,
         [nameof(IAppCommands.DeleteFrames)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
@@ -182,6 +183,8 @@ public class UndoCoverageRosterTests
             ctx => ctx.AppCommands.AskToDeleteCircles(new() { Circle(ctx) }));
         yield return Row(nameof(IAppCommands.AskToDeleteShapes),
             ctx => ctx.AppCommands.AskToDeleteShapes(new() { Rect(ctx) }, new() { Circle(ctx) }));
+        yield return Row(nameof(IAppCommands.DeleteShapes),
+            ctx => Sync(() => ctx.AppCommands.DeleteShapes(Zebra(ctx).Frames[0], new() { Rect(ctx) }, new() { Circle(ctx) })));
         yield return Row(nameof(IAppCommands.AskToDeleteAnimationChains),
             ctx => ctx.AppCommands.AskToDeleteAnimationChains(new() { Alpha(ctx) }));
         yield return Row(nameof(IAppCommands.DeleteFrames),

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -60,6 +60,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.DeleteAxisAlignedRectangle)]   = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteRectangles)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteCircles)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.AskToDeleteShapes)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.AskToDeleteAnimationChains)]   = Category.MutatingUndoable,
         [nameof(IAppCommands.DeleteFrames)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
@@ -179,6 +180,8 @@ public class UndoCoverageRosterTests
             ctx => ctx.AppCommands.AskToDeleteRectangles(new() { Rect(ctx) }));
         yield return Row(nameof(IAppCommands.AskToDeleteCircles),
             ctx => ctx.AppCommands.AskToDeleteCircles(new() { Circle(ctx) }));
+        yield return Row(nameof(IAppCommands.AskToDeleteShapes),
+            ctx => ctx.AppCommands.AskToDeleteShapes(new() { Rect(ctx) }, new() { Circle(ctx) }));
         yield return Row(nameof(IAppCommands.AskToDeleteAnimationChains),
             ctx => ctx.AppCommands.AskToDeleteAnimationChains(new() { Alpha(ctx) }));
         yield return Row(nameof(IAppCommands.DeleteFrames),


### PR DESCRIPTION
Closes #270

## Root cause

SyncTreeSelection was called asynchronously after each selection change. It compared AnimTree.SelectedItem with the target using ReferenceEquals, and when they differed it set AnimTree.SelectedItem = target. In Avalonia, assigning SelectedItem on a multi-select TreeView silently collapses the multi-selection down to a single item — so by the time Delete was pressed, _selectedNodes had only one entry.

## Fixes

### 1. SyncTreeSelection — preserve multi-select
Changed the guard from:
\\\csharp
!ReferenceEquals(AnimTree.SelectedItem, target)
\\\
to:
\\\csharp
!(AnimTree.SelectedItems?.Contains(target) ?? false)
\\\
This skips the \SelectedItem\ assignment when 	arget is already part of the current selection (even as one of many), preventing the collapse.

### 2. AskToDeleteShapes — mixed-type batch delete
Added \IAppCommands.AskToDeleteShapes(List<AARectSave>, List<CircleSave>)\ that creates a single \CompositeCommand\ containing all rectangle and circle delete sub-commands, so a mixed selection (circles + AARects) is deleted in one confirmation dialog and undone with one Ctrl+Z.

### 3. HandleDelete — route mixed selections
When the focused node is a rect but circles are also selected (or vice versa), HandleDelete now calls AskToDeleteShapes with both lists instead of silently discarding the other type.

## Tests
- 5 new tests in AppCommandsDeleteAsyncTests:
  - AskToDeleteShapes_WhenConfirmed_DeletesBothRectanglesAndCircles
  - AskToDeleteShapes_WhenCancelled_DeletesNothing
  - AskToDeleteShapes_RecordsSingleUndoEntry
  - AskToDeleteShapes_ConfirmMessageContainsAllShapeNames
- AskToDeleteShapes added to UndoCoverageRosterTests

## Note on SyncTreeSelection testability
The SyncTreeSelection fix is a one-line UI wiring change in MainWindow. Headless Avalonia tests for multi-select collapse require constructing a live TreeView with selection populated — MainWindow's constructor overwrites injected delegates, making isolated [AvaloniaFact] tests impractical (known deadlock risk when dialogs are shown). The testable core — that batch deletes operate on the full selected-items list — is covered by the existing AskToDeleteCircles_DeletingMultiple_RecordsSingleUndoEntry test and the new AskToDeleteShapes tests.