### PR TITLE
Fix ALT+Arrow reorders shape instead of animation when shape is selected

### DIFF
--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -185,51 +185,49 @@ public class AnimationChainListSave
     private static XElement WriteShapes(ShapesSave? shapes)
     {
         shapes ??= new ShapesSave();
-        var rects = new XElement("AxisAlignedRectangleSaves");
-        foreach (var r in shapes.AARectSaves)
-        {
-            rects.Add(new XElement("AxisAlignedRectangleSave",
-                new XElement("X", FloatStr(r.X)),
-                new XElement("Y", FloatStr(r.Y)),
-                new XElement("ScaleX", FloatStr(r.ScaleX)),
-                new XElement("ScaleY", FloatStr(r.ScaleY)),
-                new XElement("Name", r.Name)));
-        }
 
-        var circles = new XElement("CircleSaves");
-        foreach (var c in shapes.CircleSaves)
+        var shapesEl = new XElement("Shapes");
+        foreach (var shape in shapes.Shapes)
         {
-            circles.Add(new XElement("CircleSave",
-                new XElement("X", FloatStr(c.X)),
-                new XElement("Y", FloatStr(c.Y)),
-                new XElement("Radius", FloatStr(c.Radius)),
-                new XElement("Name", c.Name)));
-        }
-
-        var polys = new XElement("PolygonSaves");
-        foreach (var p in shapes.PolygonSaves)
-        {
-            var pointsEl = new XElement("Points");
-            foreach (var v in p.Points)
+            switch (shape)
             {
-                pointsEl.Add(new XElement("Vector2Save",
-                    new XElement("X", FloatStr(v.X)),
-                    new XElement("Y", FloatStr(v.Y))));
+                case AARectSave r:
+                    shapesEl.Add(new XElement("AxisAlignedRectangleSave",
+                        new XElement("X", FloatStr(r.X)),
+                        new XElement("Y", FloatStr(r.Y)),
+                        new XElement("ScaleX", FloatStr(r.ScaleX)),
+                        new XElement("ScaleY", FloatStr(r.ScaleY)),
+                        new XElement("Name", r.Name)));
+                    break;
+                case CircleSave c:
+                    shapesEl.Add(new XElement("CircleSave",
+                        new XElement("X", FloatStr(c.X)),
+                        new XElement("Y", FloatStr(c.Y)),
+                        new XElement("Radius", FloatStr(c.Radius)),
+                        new XElement("Name", c.Name)));
+                    break;
+                case PolygonSave p:
+                    var pointsEl = new XElement("Points");
+                    foreach (var v in p.Points)
+                    {
+                        pointsEl.Add(new XElement("Vector2Save",
+                            new XElement("X", FloatStr(v.X)),
+                            new XElement("Y", FloatStr(v.Y))));
+                    }
+                    shapesEl.Add(new XElement("PolygonSave",
+                        new XElement("Name", p.Name),
+                        new XElement("X", FloatStr(p.X)),
+                        new XElement("Y", FloatStr(p.Y)),
+                        pointsEl));
+                    break;
             }
-            polys.Add(new XElement("PolygonSave",
-                new XElement("Name", p.Name),
-                new XElement("X", FloatStr(p.X)),
-                new XElement("Y", FloatStr(p.Y)),
-                pointsEl));
         }
 
         // AxisAlignedCubeSaves and SphereSaves are FRB1-era 3D-shape placeholders that FRB2 does
         // not model. Emit empty elements so the dialect matches what FRB1 readers expect.
         return new XElement("ShapeCollectionSave",
-            rects,
+            shapesEl,
             new XElement("AxisAlignedCubeSaves"),
-            polys,
-            circles,
             new XElement("SphereSaves"));
     }
 
@@ -263,12 +261,66 @@ public class AnimationChainListSave
     {
         var shapes = new ShapesSave();
 
+        // New format: <Shapes> with type-tagged children in unified insertion order.
+        var newShapesEl = el.Element("Shapes");
+        if (newShapesEl != null)
+        {
+            foreach (var child in newShapesEl.Elements())
+            {
+                switch (child.Name.LocalName)
+                {
+                    case "AxisAlignedRectangleSave":
+                        shapes.Shapes.Add(new AARectSave
+                        {
+                            Name = (string?)child.Element("Name") ?? string.Empty,
+                            X = FloatEl(child, "X"),
+                            Y = FloatEl(child, "Y"),
+                            ScaleX = FloatEl(child, "ScaleX", 16f),
+                            ScaleY = FloatEl(child, "ScaleY", 16f),
+                        });
+                        break;
+                    case "CircleSave":
+                        shapes.Shapes.Add(new CircleSave
+                        {
+                            Name = (string?)child.Element("Name") ?? string.Empty,
+                            X = FloatEl(child, "X"),
+                            Y = FloatEl(child, "Y"),
+                            Radius = FloatEl(child, "Radius", 16f),
+                        });
+                        break;
+                    case "PolygonSave":
+                        var poly = new PolygonSave
+                        {
+                            Name = (string?)child.Element("Name") ?? string.Empty,
+                            X = FloatEl(child, "X"),
+                            Y = FloatEl(child, "Y"),
+                        };
+                        var polyPointsEl = child.Element("Points");
+                        if (polyPointsEl != null)
+                        {
+                            foreach (var v in polyPointsEl.Elements("Vector2Save"))
+                            {
+                                poly.Points.Add(new Vector2Save
+                                {
+                                    X = FloatEl(v, "X"),
+                                    Y = FloatEl(v, "Y"),
+                                });
+                            }
+                        }
+                        shapes.Shapes.Add(poly);
+                        break;
+                }
+            }
+            return shapes;
+        }
+
+        // Old format fallback: separate typed containers (rects, then circles, then polygons).
         var aarctsEl = el.Element("AxisAlignedRectangleSaves");
         if (aarctsEl != null)
         {
             foreach (var r in aarctsEl.Elements("AxisAlignedRectangleSave"))
             {
-                shapes.AARectSaves.Add(new AARectSave
+                shapes.Shapes.Add(new AARectSave
                 {
                     Name = (string?)r.Element("Name") ?? string.Empty,
                     X = FloatEl(r, "X"),
@@ -284,7 +336,7 @@ public class AnimationChainListSave
         {
             foreach (var c in circlesEl.Elements("CircleSave"))
             {
-                shapes.CircleSaves.Add(new CircleSave
+                shapes.Shapes.Add(new CircleSave
                 {
                     Name = (string?)c.Element("Name") ?? string.Empty,
                     X = FloatEl(c, "X"),
@@ -319,7 +371,7 @@ public class AnimationChainListSave
                     }
                 }
 
-                shapes.PolygonSaves.Add(poly);
+                shapes.Shapes.Add(poly);
             }
         }
 
@@ -427,44 +479,45 @@ public class AnimationChainListSave
     {
         if (shapes == null) return;
 
-        foreach (var rect in shapes.AARectSaves)
+        foreach (var shape in shapes.Shapes)
         {
-            ValidateName(rect.Name, "AARectSave");
-            frame.Shapes.Add(new FlatRedBall2.Animation.AnimationAARectFrame
+            switch (shape)
             {
-                Name = rect.Name,
-                RelativeX = rect.X,
-                RelativeY = rect.Y,
-                Width = rect.ScaleX * 2f,
-                Height = rect.ScaleY * 2f,
-            });
-        }
-
-        foreach (var circle in shapes.CircleSaves)
-        {
-            ValidateName(circle.Name, "CircleSave");
-            frame.Shapes.Add(new FlatRedBall2.Animation.AnimationCircleFrame
-            {
-                Name = circle.Name,
-                RelativeX = circle.X,
-                RelativeY = circle.Y,
-                Radius = circle.Radius,
-            });
-        }
-
-        foreach (var poly in shapes.PolygonSaves)
-        {
-            ValidateName(poly.Name, "PolygonSave");
-            var points = new System.Numerics.Vector2[poly.Points.Count];
-            for (int i = 0; i < poly.Points.Count; i++)
-                points[i] = new System.Numerics.Vector2(poly.Points[i].X, poly.Points[i].Y);
-            frame.Shapes.Add(new FlatRedBall2.Animation.AnimationPolygonFrame
-            {
-                Name = poly.Name,
-                RelativeX = poly.X,
-                RelativeY = poly.Y,
-                Points = points,
-            });
+                case AARectSave rect:
+                    ValidateName(rect.Name, "AARectSave");
+                    frame.Shapes.Add(new FlatRedBall2.Animation.AnimationAARectFrame
+                    {
+                        Name = rect.Name,
+                        RelativeX = rect.X,
+                        RelativeY = rect.Y,
+                        Width = rect.ScaleX * 2f,
+                        Height = rect.ScaleY * 2f,
+                    });
+                    break;
+                case CircleSave circle:
+                    ValidateName(circle.Name, "CircleSave");
+                    frame.Shapes.Add(new FlatRedBall2.Animation.AnimationCircleFrame
+                    {
+                        Name = circle.Name,
+                        RelativeX = circle.X,
+                        RelativeY = circle.Y,
+                        Radius = circle.Radius,
+                    });
+                    break;
+                case PolygonSave poly:
+                    ValidateName(poly.Name, "PolygonSave");
+                    var points = new System.Numerics.Vector2[poly.Points.Count];
+                    for (int i = 0; i < poly.Points.Count; i++)
+                        points[i] = new System.Numerics.Vector2(poly.Points[i].X, poly.Points[i].Y);
+                    frame.Shapes.Add(new FlatRedBall2.Animation.AnimationPolygonFrame
+                    {
+                        Name = poly.Name,
+                        RelativeX = poly.X,
+                        RelativeY = poly.Y,
+                        Points = points,
+                    });
+                    break;
+            }
         }
     }
 

--- a/src/Animation/Content/ShapesSave.cs
+++ b/src/Animation/Content/ShapesSave.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FlatRedBall2.Animation.Content;
 
@@ -10,14 +11,17 @@ namespace FlatRedBall2.Animation.Content;
 /// <remarks>Serialized as <c>&lt;ShapeCollectionSave&gt;</c> in .achx XML.</remarks>
 public class ShapesSave
 {
-    /// <summary>Rectangles defined for this frame.</summary>
-    public List<AARectSave> AARectSaves = new();
+    /// <summary>All shapes in user-defined order. Entries are <see cref="AARectSave"/>, <see cref="CircleSave"/>, or <see cref="PolygonSave"/>.</summary>
+    public List<object> Shapes = new();
 
-    /// <summary>Circles defined for this frame.</summary>
-    public List<CircleSave> CircleSaves = new();
+    /// <summary>All rectangles, projected from <see cref="Shapes"/> in their stored order.</summary>
+    public IEnumerable<AARectSave> AARectSaves => Shapes.OfType<AARectSave>();
 
-    /// <summary>Polygons defined for this frame.</summary>
-    public List<PolygonSave> PolygonSaves = new();
+    /// <summary>All circles, projected from <see cref="Shapes"/> in their stored order.</summary>
+    public IEnumerable<CircleSave> CircleSaves => Shapes.OfType<CircleSave>();
+
+    /// <summary>All polygons, projected from <see cref="Shapes"/> in their stored order.</summary>
+    public IEnumerable<PolygonSave> PolygonSaves => Shapes.OfType<PolygonSave>();
 }
 
 /// <summary>Serialized rectangle entry within a <see cref="ShapesSave"/>.</summary>

--- a/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveLoadingTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveLoadingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
@@ -59,8 +60,8 @@ public class AnimationChainListSaveLoadingTests
             _ => new MemoryStream(Encoding.UTF8.GetBytes(xml)));
 
         save.AnimationChains[0].Frames[0].ShapesSave.ShouldNotBeNull();
-        save.AnimationChains[0].Frames[0].ShapesSave!.AARectSaves.Count.ShouldBe(1);
-        save.AnimationChains[0].Frames[0].ShapesSave!.AARectSaves[0].Name.ShouldBe("Sword");
+        save.AnimationChains[0].Frames[0].ShapesSave!.AARectSaves.Count().ShouldBe(1);
+        save.AnimationChains[0].Frames[0].ShapesSave!.AARectSaves.First().Name.ShouldBe("Sword");
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public class AnimationChainListSaveLoadingTests
         var save = AnimationChainListSave.FromFile("any.achx",
             _ => new MemoryStream(Encoding.UTF8.GetBytes(xml)));
 
-        var circle = save.AnimationChains[0].Frames[0].ShapesSave!.CircleSaves[0];
+        var circle = save.AnimationChains[0].Frames[0].ShapesSave!.CircleSaves.First();
         circle.Name.ShouldBe("Blast");
         circle.X.ShouldBe(3f);
         circle.Y.ShouldBe(4f);
@@ -185,7 +186,7 @@ public class AnimationChainListSaveLoadingTests
         var save = AnimationChainListSave.FromFile("any.achx",
             _ => new MemoryStream(Encoding.UTF8.GetBytes(xml)));
 
-        var poly = save.AnimationChains[0].Frames[0].ShapesSave!.PolygonSaves[0];
+        var poly = save.AnimationChains[0].Frames[0].ShapesSave!.PolygonSaves.First();
         poly.Name.ShouldBe("Arc");
         poly.X.ShouldBe(1f);
         poly.Y.ShouldBe(2f);

--- a/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveWriterTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveWriterTests.cs
@@ -34,7 +34,7 @@ public class AnimationChainListSaveWriterTests
         var chain = new AnimationChainSave { Name = "Walk" };
         var frame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
         frame.ShapesSave = new ShapesSave();
-        frame.ShapesSave.AARectSaves.Add(new AARectSave { Name = "Hit", X = 1, Y = 2, ScaleX = 3, ScaleY = 4 });
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Hit", X = 1, Y = 2, ScaleX = 3, ScaleY = 4 });
         chain.Frames.Add(frame);
         save.AnimationChains.Add(chain);
 
@@ -52,7 +52,7 @@ public class AnimationChainListSaveWriterTests
         var chain = new AnimationChainSave { Name = "C" };
         var frame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
         frame.ShapesSave = new ShapesSave();
-        frame.ShapesSave.CircleSaves.Add(new CircleSave { Name = "Origin", X = 5, Y = 6, Radius = 7 });
+        frame.ShapesSave.Shapes.Add(new CircleSave { Name = "Origin", X = 5, Y = 6, Radius = 7 });
         chain.Frames.Add(frame);
         save.AnimationChains.Add(chain);
 
@@ -98,7 +98,7 @@ public class AnimationChainListSaveWriterTests
         var poly = new PolygonSave { Name = "Shape", X = 0, Y = 0 };
         poly.Points.Add(new Vector2Save { X = 1, Y = 2 });
         poly.Points.Add(new Vector2Save { X = 3, Y = 4 });
-        frame.ShapesSave.PolygonSaves.Add(poly);
+        frame.ShapesSave.Shapes.Add(poly);
         chain.Frames.Add(frame);
         save.AnimationChains.Add(chain);
 

--- a/tests/FlatRedBall2.Tests/Animation/Content/AchxByteSnapshotTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/Content/AchxByteSnapshotTests.cs
@@ -34,18 +34,18 @@ public class AchxByteSnapshotTests
             RelativeX = 5f,
             ShapesSave = new ShapesSave(),
         };
-        frame.ShapesSave.AARectSaves.Add(new AARectSave
+        frame.ShapesSave.Shapes.Add(new AARectSave
         {
             Name = "Hit", X = 1, Y = 2, ScaleX = 3, ScaleY = 4,
         });
-        frame.ShapesSave.CircleSaves.Add(new CircleSave
+        frame.ShapesSave.Shapes.Add(new CircleSave
         {
             Name = "Origin", X = 5, Y = 6, Radius = 7,
         });
         var poly = new PolygonSave { Name = "Edge", X = 0, Y = 0 };
         poly.Points.Add(new Vector2Save { X = 0, Y = 0 });
         poly.Points.Add(new Vector2Save { X = 10, Y = 0 });
-        frame.ShapesSave.PolygonSaves.Add(poly);
+        frame.ShapesSave.Shapes.Add(poly);
         chain.Frames.Add(frame);
         save.AnimationChains.Add(chain);
         return save;

--- a/tests/FlatRedBall2.Tests/Animation/Content/AchxRoundTripTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/Content/AchxRoundTripTests.cs
@@ -83,32 +83,38 @@ public class AchxRoundTripTests
         }
 
         actual.ShapesSave.ShouldNotBeNull();
-        actual.ShapesSave!.AARectSaves.Count.ShouldBe(expected.ShapesSave.AARectSaves.Count);
-        for (int i = 0; i < expected.ShapesSave.AARectSaves.Count; i++)
+        var expRects = expected.ShapesSave.AARectSaves.ToList();
+        var actRects = actual.ShapesSave!.AARectSaves.ToList();
+        actRects.Count.ShouldBe(expRects.Count);
+        for (int i = 0; i < expRects.Count; i++)
         {
-            var er = expected.ShapesSave.AARectSaves[i];
-            var ar = actual.ShapesSave.AARectSaves[i];
+            var er = expRects[i];
+            var ar = actRects[i];
             ar.Name.ShouldBe(er.Name);
             ar.X.ShouldBe(er.X);
             ar.Y.ShouldBe(er.Y);
             ar.ScaleX.ShouldBe(er.ScaleX);
             ar.ScaleY.ShouldBe(er.ScaleY);
         }
-        actual.ShapesSave.CircleSaves.Count.ShouldBe(expected.ShapesSave.CircleSaves.Count);
-        for (int i = 0; i < expected.ShapesSave.CircleSaves.Count; i++)
+        var expCircles = expected.ShapesSave.CircleSaves.ToList();
+        var actCircles = actual.ShapesSave.CircleSaves.ToList();
+        actCircles.Count.ShouldBe(expCircles.Count);
+        for (int i = 0; i < expCircles.Count; i++)
         {
-            var ec = expected.ShapesSave.CircleSaves[i];
-            var ac = actual.ShapesSave.CircleSaves[i];
+            var ec = expCircles[i];
+            var ac = actCircles[i];
             ac.Name.ShouldBe(ec.Name);
             ac.X.ShouldBe(ec.X);
             ac.Y.ShouldBe(ec.Y);
             ac.Radius.ShouldBe(ec.Radius);
         }
-        actual.ShapesSave.PolygonSaves.Count.ShouldBe(expected.ShapesSave.PolygonSaves.Count);
-        for (int i = 0; i < expected.ShapesSave.PolygonSaves.Count; i++)
+        var expPolys = expected.ShapesSave.PolygonSaves.ToList();
+        var actPolys = actual.ShapesSave.PolygonSaves.ToList();
+        actPolys.Count.ShouldBe(expPolys.Count);
+        for (int i = 0; i < expPolys.Count; i++)
         {
-            var ep = expected.ShapesSave.PolygonSaves[i];
-            var ap = actual.ShapesSave.PolygonSaves[i];
+            var ep = expPolys[i];
+            var ap = actPolys[i];
             ap.Name.ShouldBe(ep.Name);
             ap.X.ShouldBe(ep.X);
             ap.Y.ShouldBe(ep.Y);
@@ -157,13 +163,13 @@ public class AchxRoundTripTests
         frame.ShapesSave = new ShapesSave();
         var poly = new PolygonSave { Name = "Dot", X = 0, Y = 0 };
         poly.Points.Add(new Vector2Save { X = 5, Y = 7 });
-        frame.ShapesSave.PolygonSaves.Add(poly);
+        frame.ShapesSave.Shapes.Add(poly);
         chain.Frames.Add(frame);
         save.AnimationChains.Add(chain);
 
         var roundTripped = RoundTrip(save);
 
-        var p = roundTripped.AnimationChains[0].Frames[0].ShapesSave!.PolygonSaves[0];
+        var p = roundTripped.AnimationChains[0].Frames[0].ShapesSave!.PolygonSaves.First();
         p.Points.Count.ShouldBe(1);
         p.Points[0].X.ShouldBe(5f);
         p.Points[0].Y.ShouldBe(7f);

--- a/tests/FlatRedBall2.Tests/Animation/Content/Snapshot/CanonicalMinimal.expected.achx
+++ b/tests/FlatRedBall2.Tests/Animation/Content/Snapshot/CanonicalMinimal.expected.achx
@@ -15,7 +15,7 @@
       <BottomCoordinate>0.5</BottomCoordinate>
       <RelativeX>5</RelativeX>
       <ShapeCollectionSave>
-        <AxisAlignedRectangleSaves>
+        <Shapes>
           <AxisAlignedRectangleSave>
             <X>1</X>
             <Y>2</Y>
@@ -23,9 +23,12 @@
             <ScaleY>4</ScaleY>
             <Name>Hit</Name>
           </AxisAlignedRectangleSave>
-        </AxisAlignedRectangleSaves>
-        <AxisAlignedCubeSaves />
-        <PolygonSaves>
+          <CircleSave>
+            <X>5</X>
+            <Y>6</Y>
+            <Radius>7</Radius>
+            <Name>Origin</Name>
+          </CircleSave>
           <PolygonSave>
             <Name>Edge</Name>
             <X>0</X>
@@ -41,15 +44,8 @@
               </Vector2Save>
             </Points>
           </PolygonSave>
-        </PolygonSaves>
-        <CircleSaves>
-          <CircleSave>
-            <X>5</X>
-            <Y>6</Y>
-            <Radius>7</Radius>
-            <Name>Origin</Name>
-          </CircleSave>
-        </CircleSaves>
+        </Shapes>
+        <AxisAlignedCubeSaves />
         <SphereSaves />
       </ShapeCollectionSave>
     </Frame>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -688,7 +688,7 @@ public class PreviewControl : Control
                 return selR;
         }
 
-        var circles = frame.ShapesSave!.CircleSaves;
+        var circles = frame.ShapesSave!.CircleSaves.ToList();
         for (int i = circles.Count - 1; i >= 0; i--)
         {
             var c = circles[i];
@@ -699,7 +699,7 @@ public class PreviewControl : Control
                 return c;
         }
 
-        var rects = frame.ShapesSave!.AARectSaves;
+        var rects = frame.ShapesSave!.AARectSaves.ToList();
         for (int i = rects.Count - 1; i >= 0; i--)
         {
             var r = rects[i];
@@ -921,7 +921,7 @@ public class PreviewControl : Control
         const float tolerance = 5f;
 
         // Circles are rendered after rects (on top), so check circles first.
-        var circles = frame.ShapesSave!.CircleSaves;
+        var circles = frame.ShapesSave!.CircleSaves.ToList();
         for (int i = circles.Count - 1; i >= 0; i--)
         {
             var c = circles[i];
@@ -934,7 +934,7 @@ public class PreviewControl : Control
             }
         }
 
-        var rects = frame.ShapesSave!.AARectSaves;
+        var rects = frame.ShapesSave!.AARectSaves.ToList();
         for (int i = rects.Count - 1; i >= 0; i--)
         {
             var r = rects[i];

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
@@ -22,7 +22,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public bool Do()
         {
-            _frame.ShapesSave!.AARectSaves.Add(_rect);
+            _frame.ShapesSave!.Shapes.Add(_rect);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -32,7 +32,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo()
         {
-            _frame.ShapesSave!.AARectSaves.Remove(_rect);
+            _frame.ShapesSave!.Shapes.Remove(_rect);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
@@ -22,7 +22,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public bool Do()
         {
-            _frame.ShapesSave!.CircleSaves.Add(_circle);
+            _frame.ShapesSave!.Shapes.Add(_circle);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -32,7 +32,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo()
         {
-            _frame.ShapesSave!.CircleSaves.Remove(_circle);
+            _frame.ShapesSave!.Shapes.Remove(_circle);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -422,9 +422,9 @@ namespace AnimationEditor.Core.CommandsAndState
             var frame = _selectedState.SelectedFrame;
             if (frame?.ShapesSave == null) return new List<string>();
 
-            return frame.ShapesSave!.AARectSaves
-                .Select(r => r.Name)
-                .Concat(frame.ShapesSave!.CircleSaves.Select(c => c.Name))
+            return frame.ShapesSave!.Shapes
+                .Select(s => s switch { AARectSave r => r.Name, CircleSave c => c.Name, _ => null })
+                .OfType<string>()
                 .ToList();
         }
 
@@ -557,32 +557,19 @@ namespace AnimationEditor.Core.CommandsAndState
                 "Move Frame to Bottom"));
         }
 
-        public void MoveRectangle(AARectSave rectangle, AnimationFrameSave frame, int delta)
+        public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {
-            var rects = frame.ShapesSave?.AARectSaves;
-            if (rects is null) return;
-            int idx    = rects.IndexOf(rectangle);
-            int newIdx = Math.Clamp(idx + delta, 0, rects.Count - 1);
+            var shapes = frame.ShapesSave?.Shapes;
+            if (shapes is null) return;
+            int idx    = shapes.IndexOf(shape);
+            if (idx < 0) return;
+            int newIdx = Math.Clamp(idx + delta, 0, shapes.Count - 1);
             if (newIdx == idx) return;
-            _undoManager.Execute(new ReorderCommand<AARectSave>(
-                rects,
-                () => { rects.RemoveAt(idx); rects.Insert(newIdx, rectangle); },
+            _undoManager.Execute(new ReorderCommand<object>(
+                shapes,
+                () => { shapes.RemoveAt(idx); shapes.Insert(newIdx, shape); },
                 this, _events, () => RefreshTreeNode(frame),
-                delta > 0 ? "Move Rectangle Down" : "Move Rectangle Up"));
-        }
-
-        public void MoveCircle(CircleSave circle, AnimationFrameSave frame, int delta)
-        {
-            var circles = frame.ShapesSave?.CircleSaves;
-            if (circles is null) return;
-            int idx    = circles.IndexOf(circle);
-            int newIdx = Math.Clamp(idx + delta, 0, circles.Count - 1);
-            if (newIdx == idx) return;
-            _undoManager.Execute(new ReorderCommand<CircleSave>(
-                circles,
-                () => { circles.RemoveAt(idx); circles.Insert(newIdx, circle); },
-                this, _events, () => RefreshTreeNode(frame),
-                delta > 0 ? "Move Circle Down" : "Move Circle Up"));
+                delta > 0 ? "Move Shape Down" : "Move Shape Up"));
         }
 
         /// <summary>
@@ -602,12 +589,12 @@ namespace AnimationEditor.Core.CommandsAndState
             if (rect is not null)
             {
                 var ownerFrame = _objectFinder.GetAnimationFrameContaining(rect);
-                if (ownerFrame is not null) MoveRectangle(rect, ownerFrame, delta);
+                if (ownerFrame is not null) MoveShape(rect, ownerFrame, delta);
             }
             else if (circle is not null)
             {
                 var ownerFrame = _objectFinder.GetAnimationFrameContaining(circle);
-                if (ownerFrame is not null) MoveCircle(circle, ownerFrame, delta);
+                if (ownerFrame is not null) MoveShape(circle, ownerFrame, delta);
             }
             else if (frame is not null && chain is not null)
                 MoveFrame(frame, chain, delta);
@@ -691,14 +678,20 @@ namespace AnimationEditor.Core.CommandsAndState
                 };
                 if (frame.ShapesSave != null)
                 {
-                    foreach (var r in frame.ShapesSave!.AARectSaves)
-                        fCopy.ShapesSave!.AARectSaves.Add(
-                            new AARectSave
-                            { Name = r.Name, X = r.X, Y = r.Y, ScaleX = r.ScaleX, ScaleY = r.ScaleY });
-                    foreach (var c in frame.ShapesSave!.CircleSaves)
-                        fCopy.ShapesSave!.CircleSaves.Add(
-                            new CircleSave
-                            { Name = c.Name, X = c.X, Y = c.Y, Radius = c.Radius });
+                    foreach (var shape in frame.ShapesSave!.Shapes)
+                    {
+                        switch (shape)
+                        {
+                            case AARectSave r:
+                                fCopy.ShapesSave!.Shapes.Add(
+                                    new AARectSave { Name = r.Name, X = r.X, Y = r.Y, ScaleX = r.ScaleX, ScaleY = r.ScaleY });
+                                break;
+                            case CircleSave c:
+                                fCopy.ShapesSave!.Shapes.Add(
+                                    new CircleSave { Name = c.Name, X = c.X, Y = c.Y, Radius = c.Radius });
+                                break;
+                        }
+                    }
                 }
                 copy.Frames.Add(fCopy);
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -557,18 +557,59 @@ namespace AnimationEditor.Core.CommandsAndState
                 "Move Frame to Bottom"));
         }
 
+        public void MoveRectangle(AARectSave rectangle, AnimationFrameSave frame, int delta)
+        {
+            var rects = frame.ShapesSave?.AARectSaves;
+            if (rects is null) return;
+            int idx    = rects.IndexOf(rectangle);
+            int newIdx = Math.Clamp(idx + delta, 0, rects.Count - 1);
+            if (newIdx == idx) return;
+            _undoManager.Execute(new ReorderCommand<AARectSave>(
+                rects,
+                () => { rects.RemoveAt(idx); rects.Insert(newIdx, rectangle); },
+                this, _events, () => RefreshTreeNode(frame),
+                delta > 0 ? "Move Rectangle Down" : "Move Rectangle Up"));
+        }
+
+        public void MoveCircle(CircleSave circle, AnimationFrameSave frame, int delta)
+        {
+            var circles = frame.ShapesSave?.CircleSaves;
+            if (circles is null) return;
+            int idx    = circles.IndexOf(circle);
+            int newIdx = Math.Clamp(idx + delta, 0, circles.Count - 1);
+            if (newIdx == idx) return;
+            _undoManager.Execute(new ReorderCommand<CircleSave>(
+                circles,
+                () => { circles.RemoveAt(idx); circles.Insert(newIdx, circle); },
+                this, _events, () => RefreshTreeNode(frame),
+                delta > 0 ? "Move Circle Down" : "Move Circle Up"));
+        }
+
         /// <summary>
-        /// Moves the currently-selected frame or chain up (<paramref name="delta"/> = -1)
+        /// Moves the currently-selected shape, frame, or chain up (<paramref name="delta"/> = -1)
         /// or down (<paramref name="delta"/> = +1) in the tree.
-        /// Frame selection takes priority: if a frame is selected its parent chain is used.
+        /// Shape selection takes highest priority: if a shape is selected it is reordered within
+        /// its frame's shape list. Frame selection takes next priority; chain is last.
         /// No-op when nothing is selected or when the item is already at the boundary.
         /// </summary>
         public void HandleReorder(int delta)
         {
-            var frame = _selectedState.SelectedFrame;
-            var chain = _selectedState.SelectedChain;
+            var rect   = _selectedState.SelectedRectangle;
+            var circle = _selectedState.SelectedCircle;
+            var frame  = _selectedState.SelectedFrame;
+            var chain  = _selectedState.SelectedChain;
 
-            if (frame is not null && chain is not null)
+            if (rect is not null)
+            {
+                var ownerFrame = _objectFinder.GetAnimationFrameContaining(rect);
+                if (ownerFrame is not null) MoveRectangle(rect, ownerFrame, delta);
+            }
+            else if (circle is not null)
+            {
+                var ownerFrame = _objectFinder.GetAnimationFrameContaining(circle);
+                if (ownerFrame is not null) MoveCircle(circle, ownerFrame, delta);
+            }
+            else if (frame is not null && chain is not null)
                 MoveFrame(frame, chain, delta);
             else if (chain is not null)
                 MoveChain(chain, delta);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteAxisAlignedRectangleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteAxisAlignedRectangleCommand.cs
@@ -29,10 +29,10 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public bool Do()
         {
-            _originalIndex = _frame.ShapesSave!.AARectSaves.IndexOf(_rect);
+            _originalIndex = _frame.ShapesSave!.Shapes.IndexOf(_rect);
             if (_originalIndex < 0) return false;
 
-            _frame.ShapesSave!.AARectSaves.RemoveAt(_originalIndex);
+            _frame.ShapesSave!.Shapes.RemoveAt(_originalIndex);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -42,8 +42,8 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo()
         {
-            int idx = Math.Min(_originalIndex, _frame.ShapesSave!.AARectSaves.Count);
-            _frame.ShapesSave!.AARectSaves.Insert(idx, _rect);
+            int idx = Math.Min(_originalIndex, _frame.ShapesSave!.Shapes.Count);
+            _frame.ShapesSave!.Shapes.Insert(idx, _rect);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -52,7 +52,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Redo()
         {
-            _frame.ShapesSave!.AARectSaves.Remove(_rect);
+            _frame.ShapesSave!.Shapes.Remove(_rect);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteCircleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteCircleCommand.cs
@@ -26,10 +26,10 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public bool Do()
         {
-            _originalIndex = _frame.ShapesSave!.CircleSaves.IndexOf(_circle);
+            _originalIndex = _frame.ShapesSave!.Shapes.IndexOf(_circle);
             if (_originalIndex < 0) return false;
 
-            _frame.ShapesSave!.CircleSaves.RemoveAt(_originalIndex);
+            _frame.ShapesSave!.Shapes.RemoveAt(_originalIndex);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -39,8 +39,8 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo()
         {
-            int idx = Math.Min(_originalIndex, _frame.ShapesSave!.CircleSaves.Count);
-            _frame.ShapesSave!.CircleSaves.Insert(idx, _circle);
+            int idx = Math.Min(_originalIndex, _frame.ShapesSave!.Shapes.Count);
+            _frame.ShapesSave!.Shapes.Insert(idx, _circle);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
@@ -49,7 +49,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Redo()
         {
-            _frame.ShapesSave!.CircleSaves.Remove(_circle);
+            _frame.ShapesSave!.Shapes.Remove(_circle);
             _commands.RefreshTreeNode(_frame);
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -83,8 +83,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta);
         void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain);
         void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain);
-        void MoveRectangle(AARectSave rectangle, AnimationFrameSave frame, int delta);
-        void MoveCircle(CircleSave circle, AnimationFrameSave frame, int delta);
+        void MoveShape(object shape, AnimationFrameSave frame, int delta);
         void HandleReorder(int delta);
         void FlipFrameHorizontally(AnimationFrameSave frame);
         void FlipFrameVertically(AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -83,6 +83,8 @@ namespace AnimationEditor.Core.CommandsAndState
         void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta);
         void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain);
         void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain);
+        void MoveRectangle(AARectSave rectangle, AnimationFrameSave frame, int delta);
+        void MoveCircle(CircleSave circle, AnimationFrameSave frame, int delta);
         void HandleReorder(int delta);
         void FlipFrameHorizontally(AnimationFrameSave frame);
         void FlipFrameVertically(AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ObjectFinder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ObjectFinder.cs
@@ -16,7 +16,7 @@ namespace AnimationEditor.Core
             {
                 foreach (var frame in chain.Frames)
                 {
-                    if (frame.ShapesSave!.AARectSaves.Contains(rectangle))
+                    if (frame.ShapesSave?.Shapes.Contains(rectangle) == true)
                         return frame;
                 }
             }
@@ -29,7 +29,7 @@ namespace AnimationEditor.Core
             {
                 foreach (var frame in chain.Frames)
                 {
-                    if (frame.ShapesSave!.CircleSaves.Contains(circle))
+                    if (frame.ShapesSave?.Shapes.Contains(circle) == true)
                         return frame;
                 }
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -81,25 +81,29 @@ public static class TreeBuilder
         };
         if (frame.ShapesSave is not null)
         {
-            foreach (var r in frame.ShapesSave!.AARectSaves)
+            foreach (var shape in frame.ShapesSave!.Shapes)
             {
-                node.Children.Add(new TreeNodeVm
+                switch (shape)
                 {
-                    Header = r.Name,
-                    Data = r,
-                    Kind = NodeKind.RectShape,
-                    IsRectNode = true,
-                });
-            }
-            foreach (var c in frame.ShapesSave!.CircleSaves)
-            {
-                node.Children.Add(new TreeNodeVm
-                {
-                    Header = c.Name,
-                    Data = c,
-                    Kind = NodeKind.CircleShape,
-                    IsCircleNode = true,
-                });
+                    case AARectSave r:
+                        node.Children.Add(new TreeNodeVm
+                        {
+                            Header = r.Name,
+                            Data = r,
+                            Kind = NodeKind.RectShape,
+                            IsRectNode = true,
+                        });
+                        break;
+                    case CircleSave c:
+                        node.Children.Add(new TreeNodeVm
+                        {
+                            Header = c.Name,
+                            Data = c,
+                            Kind = NodeKind.CircleShape,
+                            IsCircleNode = true,
+                        });
+                        break;
+                }
             }
         }
         return node;
@@ -127,56 +131,63 @@ public static class TreeBuilder
     /// <paramref name="shapesSave"/> are reused and their
     /// <see cref="TreeNodeVm.Header"/> is resynced (so a renamed shape is reflected).
     /// VMs for removed shapes are deleted; new VMs are created for added shapes.
-    /// Order is: rects first, then circles.
+    /// Order matches the insertion order of <see cref="ShapesSave.Shapes"/>.
     /// </para>
     /// </summary>
     public static void SyncShapesInto(TreeNodeVm frameNode, ShapesSave? shapesSave)
     {
-            var rects   = shapesSave?.AARectSaves  ?? new System.Collections.Generic.List<AARectSave>();
-            var circles = shapesSave?.CircleSaves  ?? new System.Collections.Generic.List<CircleSave>();
+            var shapes = shapesSave?.Shapes ?? new System.Collections.Generic.List<object>();
 
-            // Remove shape VMs that no longer exist in the data lists.
+            // Remove shape VMs that no longer exist in the data list.
             for (int i = frameNode.Children.Count - 1; i >= 0; i--)
             {
                 var child = frameNode.Children[i];
-                bool keep = (child.Data is AARectSave r && rects.Contains(r))
-                         || (child.Data is CircleSave  c && circles.Contains(c));
+                bool keep = child.Data is AARectSave || child.Data is CircleSave;
+                if (keep) keep = shapes.Contains(child.Data!);
                 if (!keep) frameNode.Children.RemoveAt(i);
             }
 
             // Ensure every desired shape has a VM at the correct index.
             int pos = 0;
-            foreach (var r in rects)
+            foreach (var shape in shapes)
             {
-                var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, r));
-                if (vm is null)
+                switch (shape)
                 {
-                    vm = new TreeNodeVm { Header = r.Name, Data = r, Kind = NodeKind.RectShape, IsRectNode = true };
-                    frameNode.Children.Insert(pos, vm);
+                    case AARectSave r:
+                    {
+                        var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, r));
+                        if (vm is null)
+                        {
+                            vm = new TreeNodeVm { Header = r.Name, Data = r, Kind = NodeKind.RectShape, IsRectNode = true };
+                            frameNode.Children.Insert(pos, vm);
+                        }
+                        else
+                        {
+                            vm.Header = r.Name;
+                            int cur = frameNode.Children.IndexOf(vm);
+                            if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+                        }
+                        pos++;
+                        break;
+                    }
+                    case CircleSave c:
+                    {
+                        var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, c));
+                        if (vm is null)
+                        {
+                            vm = new TreeNodeVm { Header = c.Name, Data = c, Kind = NodeKind.CircleShape, IsCircleNode = true };
+                            frameNode.Children.Insert(pos, vm);
+                        }
+                        else
+                        {
+                            vm.Header = c.Name;
+                            int cur = frameNode.Children.IndexOf(vm);
+                            if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
+                        }
+                        pos++;
+                        break;
+                    }
                 }
-                else
-                {
-                    vm.Header = r.Name;
-                    int cur = frameNode.Children.IndexOf(vm);
-                    if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
-                }
-                pos++;
-            }
-            foreach (var c in circles)
-            {
-                var vm = frameNode.Children.FirstOrDefault(n => ReferenceEquals(n.Data, c));
-                if (vm is null)
-                {
-                    vm = new TreeNodeVm { Header = c.Name, Data = c, Kind = NodeKind.CircleShape, IsCircleNode = true };
-                    frameNode.Children.Insert(pos, vm);
-                }
-                else
-                {
-                    vm.Header = c.Name;
-                    int cur = frameNode.Children.IndexOf(vm);
-                    if (cur != pos) { frameNode.Children.RemoveAt(cur); frameNode.Children.Insert(pos, vm); }
-                }
-                pos++;
             }
     }
 
@@ -370,10 +381,8 @@ public static class TreeBuilder
         if (acls is null) return null;
         foreach (var chain in acls.AnimationChains)
             foreach (var frame in chain.Frames)
-                if (frame.ShapesSave is { } scs)
-                    if ((shape is CircleSave c && scs.CircleSaves.Contains(c)) ||
-                        (shape is AARectSave r && scs.AARectSaves.Contains(r)))
-                        return frame;
+                if (frame.ShapesSave is { } scs && scs.Shapes.Contains(shape))
+                    return frame;
         return null;
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteShapeInlineConfirmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DeleteShapeInlineConfirmTests.cs
@@ -1,4 +1,4 @@
-﻿using AnimationEditor.Core.IO;
+using AnimationEditor.Core.IO;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
@@ -48,7 +48,7 @@ public class DeleteShapeInlineConfirmTests
         try
         {
             var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-            frame.ShapesSave!.CircleSaves.Add(circle);
+            frame.ShapesSave!.Shapes.Add(circle);
 
             window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
             Dispatcher.UIThread.RunJobs();
@@ -66,7 +66,7 @@ public class DeleteShapeInlineConfirmTests
         try
         {
             var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-            frame.ShapesSave!.CircleSaves.Add(circle);
+            frame.ShapesSave!.Shapes.Add(circle);
 
             window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
             Dispatcher.UIThread.RunJobs();
@@ -89,7 +89,7 @@ public class DeleteShapeInlineConfirmTests
         try
         {
             var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-            frame.ShapesSave!.CircleSaves.Add(circle);
+            frame.ShapesSave!.Shapes.Add(circle);
 
             window.ShowDeleteShapeConfirmForTest(frame, new(), new() { circle });
             Dispatcher.UIThread.RunJobs();
@@ -113,8 +113,8 @@ public class DeleteShapeInlineConfirmTests
         {
             var rect   = new AARectSave { Name = "Hitbox" };
             var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-            frame.ShapesSave!.AARectSaves.Add(rect);
-            frame.ShapesSave!.CircleSaves.Add(circle);
+            frame.ShapesSave!.Shapes.Add(rect);
+            frame.ShapesSave!.Shapes.Add(circle);
 
             window.ShowDeleteShapeConfirmForTest(frame, new() { rect }, new() { circle });
             Dispatcher.UIThread.RunJobs();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -675,7 +675,7 @@ public class HeadlessTreeViewTests
                 TextureName         = "Tex.png",
                 ShapesSave = new ShapesSave()
             };
-            frame.ShapesSave.CircleSaves.Add(circle);
+            frame.ShapesSave.Shapes.Add(circle);
             var chain  = new AnimationChainSave { Name = "Run" };
             chain.Frames.Add(frame);
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
@@ -717,7 +717,7 @@ public class HeadlessTreeViewTests
                 TextureName         = "Tex.png",
                 ShapesSave = new ShapesSave()
             };
-            frame.ShapesSave.AARectSaves.Add(rect);
+            frame.ShapesSave.Shapes.Add(rect);
             var chain = new AnimationChainSave { Name = "Idle" };
             chain.Frames.Add(frame);
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
@@ -56,7 +56,7 @@ public class PreviewCircleSelectionTests
         {
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave.CircleSaves.Add(circle);
+        frame.ShapesSave.Shapes.Add(circle);
         return frame;
     }
 
@@ -146,7 +146,7 @@ public class PreviewCircleSelectionTests
 
         var rect = new AARectSave { X = 0f, Y = 0f, ScaleX = 15f, ScaleY = 10f };
         var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(rect);
+        frame.ShapesSave.Shapes.Add(rect);
         ctx.SelectedState.SelectedFrame = frame;
 
         ctrl.SimulateCanvasClick(CX, CY);
@@ -166,8 +166,8 @@ public class PreviewCircleSelectionTests
         var rect   = new AARectSave { X = 0f, Y = 0f, ScaleX = 30f, ScaleY = 30f };
         var circle = new CircleSave              { X = 0f, Y = 0f, Radius = 20f };
         var frame  = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(rect);
-        frame.ShapesSave.CircleSaves.Add(circle);
+        frame.ShapesSave.Shapes.Add(rect);
+        frame.ShapesSave.Shapes.Add(circle);
         ctx.SelectedState.SelectedFrame = frame;
 
         ctrl.SimulateCanvasClick(CX, CY);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPlaybackShapesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPlaybackShapesTests.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core.CommandsAndState;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -21,10 +22,10 @@ public class PreviewPlaybackShapesTests
         var rect1 = new AARectSave { X = 20f, Y = 0f, ScaleX = 5f, ScaleY = 5f };
 
         var frame0 = new AnimationFrameSave { FrameLength = frame0Length, ShapesSave = new ShapesSave() };
-        frame0.ShapesSave.AARectSaves.Add(rect0);
+        frame0.ShapesSave.Shapes.Add(rect0);
 
         var frame1 = new AnimationFrameSave { FrameLength = frame1Length, ShapesSave = new ShapesSave() };
-        frame1.ShapesSave.AARectSaves.Add(rect1);
+        frame1.ShapesSave.Shapes.Add(rect1);
 
         var chain = new AnimationChainSave { Name = "Walk" };
         chain.Frames.Add(frame0);
@@ -60,7 +61,7 @@ public class PreviewPlaybackShapesTests
 
         Assert.Single(shapes);
         Assert.Equal(PreviewControl.PreviewShapeKind.Rect, shapes[0].Kind);
-        Assert.Equal(frame1.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+        Assert.Equal(frame1.ShapesSave!.AARectSaves.First().X, shapes[0].X);
     }
 
     /// <summary>
@@ -86,7 +87,7 @@ public class PreviewPlaybackShapesTests
         var shapes = ctrl.GetShapeInfosForTest();
 
         Assert.Single(shapes);
-        Assert.Equal(frame0.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+        Assert.Equal(frame0.ShapesSave!.AARectSaves.First().X, shapes[0].X);
     }
 
     /// <summary>
@@ -109,7 +110,7 @@ public class PreviewPlaybackShapesTests
         var shapes = ctrl.GetShapeInfosForTest();
 
         Assert.Single(shapes);
-        Assert.Equal(frame0.ShapesSave!.AARectSaves[0].X, shapes[0].X);
+        Assert.Equal(frame0.ShapesSave!.AARectSaves.First().X, shapes[0].X);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
@@ -24,8 +24,8 @@ public class PreviewShapeDragTests
             FrameLength = 0.1f,
             ShapesSave = new ShapesSave()
         };
-        if (rect   is not null) frame.ShapesSave.AARectSaves.Add(rect);
-        if (circle is not null) frame.ShapesSave.CircleSaves.Add(circle);
+        if (rect   is not null) frame.ShapesSave.Shapes.Add(rect);
+        if (circle is not null) frame.ShapesSave.Shapes.Add(circle);
         return frame;
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeResizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeResizeTests.cs
@@ -29,8 +29,8 @@ public class PreviewShapeResizeTests
             FrameLength = 0.1f,
             ShapesSave = new ShapesSave()
         };
-        if (rect   is not null) frame.ShapesSave.AARectSaves.Add(rect);
-        if (circle is not null) frame.ShapesSave.CircleSaves.Add(circle);
+        if (rect   is not null) frame.ShapesSave.Shapes.Add(rect);
+        if (circle is not null) frame.ShapesSave.Shapes.Add(circle);
         return frame;
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeNodeIconSizeTests.cs
@@ -43,8 +43,8 @@ public class TreeNodeIconSizeTests
         window.Show();
 
         var frame = new AnimationFrameSave { TextureName = "a.png", ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(new AARectSave { Name = "Box" });
-        frame.ShapesSave.CircleSaves.Add(new CircleSave { Name = "Bounds" });
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box" });
+        frame.ShapesSave.Shapes.Add(new CircleSave { Name = "Bounds" });
         var chain = new AnimationChainSave { Name = "Walk" };
         chain.Frames.Add(frame);
         ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UnitTypePropPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UnitTypePropPanelTests.cs
@@ -152,7 +152,7 @@ public class UnitTypePropPanelTests
         var chain = new AnimationChainSave { Name = "Walk" };
         var frame = new AnimationFrameSave { TextureName = "dummy.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
         var circle = new CircleSave { Name = "HurtCircle", X = 6, Y = 2, Radius = 7 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);
 
@@ -182,7 +182,7 @@ public class UnitTypePropPanelTests
         var chain = new AnimationChainSave { Name = "Walk" };
         var frame = new AnimationFrameSave { TextureName = "dummy.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
         var rect = new AARectSave { Name = "HitBox", X = 3, Y = 4, ScaleX = 8, ScaleY = 9 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
@@ -1389,7 +1389,7 @@ public class VisualRenderTests
             FrameLength = 0.1f,
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave.AARectSaves.Add(
+        frame.ShapesSave.Shapes.Add(
             new AARectSave { Name = "Box", X = 0, Y = 0, ScaleX = 15, ScaleY = 15 });
 
         ctx.SelectedState.SelectedFrame = frame;
@@ -1430,7 +1430,7 @@ public class VisualRenderTests
             FrameLength = 0.1f,
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave.CircleSaves.Add(
+        frame.ShapesSave.Shapes.Add(
             new CircleSave { Name = "Ring", X = 0, Y = 0, Radius = 15 });
 
         ctx.SelectedState.SelectedFrame = frame;
@@ -1467,7 +1467,7 @@ public class VisualRenderTests
             FrameLength = 0.1f,
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave.AARectSaves.Add(rect);
+        frame.ShapesSave.Shapes.Add(rect);
 
         ctx.SelectedState.SelectedFrame = frame;
         ctx.SelectedState.SelectedRectangle = rect; // mark as selected

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxSerializationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxSerializationTests.cs
@@ -1,5 +1,6 @@
 using AnimationEditor.Core;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -160,14 +161,14 @@ public class AchxSerializationTests
         var chain = new AnimationChainSave { Name = "WithRect" };
         var frame = TestHelpers.MakeFrame();
         var rect = new AARectSave { Name = "HitBox", ScaleX = 8, ScaleY = 8, X = 2, Y = -1 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);
 
         acls.Save(path);
         var loaded = AnimationChainListSave.FromFile(path);
         var loadedRect = loaded.AnimationChains[0].Frames[0]
-            .ShapesSave?.AARectSaves[0];
+            .ShapesSave?.AARectSaves.First();
 
         Assert.NotNull(loadedRect);
         Assert.Equal("HitBox", loadedRect!.Name);
@@ -185,14 +186,14 @@ public class AchxSerializationTests
         var chain = new AnimationChainSave { Name = "WithCircle" };
         var frame = TestHelpers.MakeFrame();
         var circle = new CircleSave { Name = "AttackRange", Radius = 20, X = 1, Y = 2 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);
 
         acls.Save(path);
         var loaded = AnimationChainListSave.FromFile(path);
         var loadedCircle = loaded.AnimationChains[0].Frames[0]
-            .ShapesSave?.CircleSaves[0];
+            .ShapesSave?.CircleSaves.First();
 
         Assert.NotNull(loadedCircle);
         Assert.Equal("AttackRange", loadedCircle!.Name);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -394,13 +395,13 @@ public class AppCommandsChainTests
         var ctx = TestHelpers.SetupFreshAcls();
         var acls = ctx.Acls;
         var source = TestHelpers.MakeChain(acls, "Attack", 1);
-        source.Frames[0].ShapesSave!.AARectSaves.Add(
+        source.Frames[0].ShapesSave!.Shapes.Add(
             new AARectSave { Name = "HitBox", ScaleX = 5, ScaleY = 5 });
 
         var copy = ctx.AppCommands.DuplicateChain(source);
 
         Assert.Single(copy!.Frames[0].ShapesSave!.AARectSaves);
-        Assert.Equal("HitBox", copy.Frames[0].ShapesSave!.AARectSaves[0].Name);
+        Assert.Equal("HitBox", copy.Frames[0].ShapesSave!.AARectSaves.First().Name);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
@@ -194,7 +194,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "HitBox" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         await ctx.AppCommands.AskToDeleteRectangles(
             new List<AARectSave> { rect });
@@ -211,7 +211,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "HitBox" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         await ctx.AppCommands.AskToDeleteRectangles(
             new List<AARectSave> { rect });
@@ -233,7 +233,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "BodyCollision" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         await ctx.AppCommands.AskToDeleteRectangles(
             new List<AARectSave> { rect });
@@ -251,8 +251,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var r1 = new AARectSave { Name = "R1" };
         var r2 = new AARectSave { Name = "R2" };
-        frame.ShapesSave!.AARectSaves.Add(r1);
-        frame.ShapesSave!.AARectSaves.Add(r2);
+        frame.ShapesSave!.Shapes.Add(r1);
+        frame.ShapesSave!.Shapes.Add(r2);
 
         await ctx.AppCommands.AskToDeleteRectangles(
             new List<AARectSave> { r1, r2 });
@@ -277,7 +277,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "AttackRadius", Radius = 10 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteCircles(
             new List<CircleSave> { circle });
@@ -294,7 +294,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "AttackRadius", Radius = 10 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteCircles(
             new List<CircleSave> { circle });
@@ -316,7 +316,7 @@ public class AppCommandsDeleteAsyncTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "DetectionArea", Radius = 20 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteCircles(
             new List<CircleSave> { circle });
@@ -334,8 +334,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var c1 = new CircleSave { Name = "C1", Radius = 5 };
         var c2 = new CircleSave { Name = "C2", Radius = 5 };
-        frame.ShapesSave!.CircleSaves.Add(c1);
-        frame.ShapesSave!.CircleSaves.Add(c2);
+        frame.ShapesSave!.Shapes.Add(c1);
+        frame.ShapesSave!.Shapes.Add(c2);
 
         await ctx.AppCommands.AskToDeleteCircles(
             new List<CircleSave> { c1, c2 });

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteAsyncTests.cs
@@ -360,8 +360,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Hitbox" };
         var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteShapes(
             new List<AARectSave> { rect },
@@ -380,8 +380,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Hitbox" };
         var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteShapes(
             new List<AARectSave> { rect },
@@ -400,8 +400,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Hitbox" };
         var circle = new CircleSave { Name = "Hurtbox", Radius = 10 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteShapes(
             new List<AARectSave> { rect },
@@ -431,8 +431,8 @@ public class AppCommandsDeleteAsyncTests
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "BodyHitbox" };
         var circle = new CircleSave { Name = "AttackRadius", Radius = 10 };
-        frame.ShapesSave!.AARectSaves.Add(rect);
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         await ctx.AppCommands.AskToDeleteShapes(
             new List<AARectSave> { rect },

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsPasteTests.cs
@@ -2,6 +2,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation.Content;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -60,7 +61,7 @@ public class AppCommandsPasteTests
 
         ctx.AppCommands.PasteRectangle(frame, rect);
 
-        Assert.Same(rect, frame.ShapesSave!.AARectSaves[0]);
+        Assert.Same(rect, frame.ShapesSave!.AARectSaves.First());
 
         ctx.UndoManager.Undo();
         Assert.Empty(frame.ShapesSave!.AARectSaves);
@@ -76,7 +77,7 @@ public class AppCommandsPasteTests
 
         ctx.AppCommands.PasteCircle(frame, circle);
 
-        Assert.Same(circle, frame.ShapesSave!.CircleSaves[0]);
+        Assert.Same(circle, frame.ShapesSave!.CircleSaves.First());
 
         ctx.UndoManager.Undo();
         Assert.Empty(frame.ShapesSave!.CircleSaves);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -110,15 +110,15 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
         ctx.SelectedState.SelectedFrame     = frame;
         ctx.SelectedState.SelectedRectangle = rectA;
 
         ctx.AppCommands.HandleReorder(+1);
 
-        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
-        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
@@ -130,15 +130,15 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
         ctx.SelectedState.SelectedFrame     = frame;
         ctx.SelectedState.SelectedRectangle = rectB;
 
         ctx.AppCommands.HandleReorder(-1);
 
-        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
-        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
@@ -151,8 +151,8 @@ public class AppCommandsReorderTests
         var frame = walk.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
         ctx.SelectedState.SelectedFrame     = frame;
         ctx.SelectedState.SelectedRectangle = rectA;
 
@@ -174,15 +174,15 @@ public class AppCommandsReorderTests
         var frame  = chain.Frames[0];
         var circA  = new CircleSave { Name = "A" };
         var circB  = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
         ctx.SelectedState.SelectedFrame  = frame;
         ctx.SelectedState.SelectedCircle = circA;
 
         ctx.AppCommands.HandleReorder(+1);
 
-        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
-        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+        Assert.Equal(circB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(circA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
@@ -194,15 +194,15 @@ public class AppCommandsReorderTests
         var frame  = chain.Frames[0];
         var circA  = new CircleSave { Name = "A" };
         var circB  = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
         ctx.SelectedState.SelectedFrame  = frame;
         ctx.SelectedState.SelectedCircle = circB;
 
         ctx.AppCommands.HandleReorder(-1);
 
-        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
-        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+        Assert.Equal(circB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(circA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
@@ -215,8 +215,8 @@ public class AppCommandsReorderTests
         var frame = walk.Frames[0];
         var circA = new CircleSave { Name = "A" };
         var circB = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
         ctx.SelectedState.SelectedFrame  = frame;
         ctx.SelectedState.SelectedCircle = circA;
 
@@ -226,10 +226,10 @@ public class AppCommandsReorderTests
         Assert.Equal(run,  acls.AnimationChains[1]);
     }
 
-    // ── MoveRectangle ─────────────────────────────────────────────────────────
+    // ── MoveShape — rect ──────────────────────────────────────────────────────
 
     [Fact]
-    public void MoveRectangle_Delta1_MovesRectDown()
+    public void MoveShape_Rect_Delta1_MovesRectDown()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -237,17 +237,17 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
 
-        ctx.AppCommands.MoveRectangle(rectA, frame, +1);
+        ctx.AppCommands.MoveShape(rectA, frame, +1);
 
-        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
-        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
-    public void MoveRectangle_DeltaNeg1_MovesRectUp()
+    public void MoveShape_Rect_DeltaNeg1_MovesRectUp()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -255,17 +255,17 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
 
-        ctx.AppCommands.MoveRectangle(rectB, frame, -1);
+        ctx.AppCommands.MoveShape(rectB, frame, -1);
 
-        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
-        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
-    public void MoveRectangle_AtBottom_DoesNotMoveBelowEnd()
+    public void MoveShape_Rect_AtBottom_DoesNotMoveBelowEnd()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -273,19 +273,19 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var rectA = new AARectSave { Name = "A" };
         var rectB = new AARectSave { Name = "B" };
-        frame.ShapesSave!.AARectSaves.Add(rectA);
-        frame.ShapesSave!.AARectSaves.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
 
-        ctx.AppCommands.MoveRectangle(rectB, frame, +1);
+        ctx.AppCommands.MoveShape(rectB, frame, +1);
 
-        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[0]);
-        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[1]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[1]);
     }
 
-    // ── MoveCircle ────────────────────────────────────────────────────────────
+    // ── MoveShape — circle ────────────────────────────────────────────────────
 
     [Fact]
-    public void MoveCircle_Delta1_MovesCircleDown()
+    public void MoveShape_Circle_Delta1_MovesCircleDown()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -293,17 +293,17 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var circA = new CircleSave { Name = "A" };
         var circB = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
 
-        ctx.AppCommands.MoveCircle(circA, frame, +1);
+        ctx.AppCommands.MoveShape(circA, frame, +1);
 
-        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
-        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+        Assert.Equal(circB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(circA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
-    public void MoveCircle_DeltaNeg1_MovesCircleUp()
+    public void MoveShape_Circle_DeltaNeg1_MovesCircleUp()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -311,17 +311,17 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var circA = new CircleSave { Name = "A" };
         var circB = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
 
-        ctx.AppCommands.MoveCircle(circB, frame, -1);
+        ctx.AppCommands.MoveShape(circB, frame, -1);
 
-        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
-        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+        Assert.Equal(circB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(circA, frame.ShapesSave.Shapes[1]);
     }
 
     [Fact]
-    public void MoveCircle_AtBottom_DoesNotMoveBelowEnd()
+    public void MoveShape_Circle_AtBottom_DoesNotMoveBelowEnd()
     {
         var ctx   = TestHelpers.SetupFreshAcls();
         var acls  = ctx.Acls;
@@ -329,12 +329,51 @@ public class AppCommandsReorderTests
         var frame = chain.Frames[0];
         var circA = new CircleSave { Name = "A" };
         var circB = new CircleSave { Name = "B" };
-        frame.ShapesSave!.CircleSaves.Add(circA);
-        frame.ShapesSave!.CircleSaves.Add(circB);
+        frame.ShapesSave!.Shapes.Add(circA);
+        frame.ShapesSave!.Shapes.Add(circB);
 
-        ctx.AppCommands.MoveCircle(circB, frame, +1);
+        ctx.AppCommands.MoveShape(circB, frame, +1);
 
-        Assert.Equal(circA, frame.ShapesSave.CircleSaves[0]);
-        Assert.Equal(circB, frame.ShapesSave.CircleSaves[1]);
+        Assert.Equal(circA, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(circB, frame.ShapesSave.Shapes[1]);
+    }
+
+    // ── MoveShape — cross-type ────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveShape_RectPastCircle_DeltaPos1_SwapsOrder()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rect  = new AARectSave  { Name = "Rect" };
+        var circ  = new CircleSave  { Name = "Circ" };
+        frame.ShapesSave!.Shapes.Add(rect);  // index 0
+        frame.ShapesSave!.Shapes.Add(circ);  // index 1
+
+        ctx.AppCommands.MoveShape(rect, frame, +1);
+
+        Assert.Equal(circ, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rect, frame.ShapesSave.Shapes[1]);
+    }
+
+    [Fact]
+    public void MoveShape_CirclePastRect_DeltaNeg1_SwapsOrder()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rect  = new AARectSave  { Name = "Rect" };
+        var circ  = new CircleSave  { Name = "Circ" };
+        frame.ShapesSave!.Shapes.Add(rect);  // index 0
+        frame.ShapesSave!.Shapes.Add(circ);  // index 1
+
+        ctx.AppCommands.MoveShape(circ, frame, -1);
+
+        Assert.Equal(circ, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rect, frame.ShapesSave.Shapes[1]);
     }
 }
+

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -98,4 +98,243 @@ public class AppCommandsReorderTests
 
         Assert.Null(ex);
     }
+
+    // ── HandleReorder — rectangle selected ───────────────────────────────────
+
+    [Fact]
+    public void HandleReorder_RectangleSelected_DeltaPos1_MovesRectDown()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rectA;
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
+        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_RectangleSelected_DeltaNeg1_MovesRectUp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rectB;
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
+        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_RectangleSelected_DoesNotReorderChain()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var walk  = TestHelpers.MakeChain(acls, "Walk", 1);
+        var run   = TestHelpers.MakeChain(acls, "Run", 1);
+        var frame = walk.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+        ctx.SelectedState.SelectedFrame     = frame;
+        ctx.SelectedState.SelectedRectangle = rectA;
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // Chain order must be untouched
+        Assert.Equal(walk, acls.AnimationChains[0]);
+        Assert.Equal(run,  acls.AnimationChains[1]);
+    }
+
+    // ── HandleReorder — circle selected ──────────────────────────────────────
+
+    [Fact]
+    public void HandleReorder_CircleSelected_DeltaPos1_MovesCircleDown()
+    {
+        var ctx    = TestHelpers.SetupFreshAcls();
+        var acls   = ctx.Acls;
+        var chain  = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame  = chain.Frames[0];
+        var circA  = new CircleSave { Name = "A" };
+        var circB  = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circA;
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
+        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_CircleSelected_DeltaNeg1_MovesCircleUp()
+    {
+        var ctx    = TestHelpers.SetupFreshAcls();
+        var acls   = ctx.Acls;
+        var chain  = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame  = chain.Frames[0];
+        var circA  = new CircleSave { Name = "A" };
+        var circB  = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circB;
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
+        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+    }
+
+    [Fact]
+    public void HandleReorder_CircleSelected_DoesNotReorderChain()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var walk  = TestHelpers.MakeChain(acls, "Walk", 1);
+        var run   = TestHelpers.MakeChain(acls, "Run", 1);
+        var frame = walk.Frames[0];
+        var circA = new CircleSave { Name = "A" };
+        var circB = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circA;
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(walk, acls.AnimationChains[0]);
+        Assert.Equal(run,  acls.AnimationChains[1]);
+    }
+
+    // ── MoveRectangle ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveRectangle_Delta1_MovesRectDown()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+
+        ctx.AppCommands.MoveRectangle(rectA, frame, +1);
+
+        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
+        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+    }
+
+    [Fact]
+    public void MoveRectangle_DeltaNeg1_MovesRectUp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+
+        ctx.AppCommands.MoveRectangle(rectB, frame, -1);
+
+        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[0]);
+        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[1]);
+    }
+
+    [Fact]
+    public void MoveRectangle_AtBottom_DoesNotMoveBelowEnd()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.AARectSaves.Add(rectA);
+        frame.ShapesSave!.AARectSaves.Add(rectB);
+
+        ctx.AppCommands.MoveRectangle(rectB, frame, +1);
+
+        Assert.Equal(rectA, frame.ShapesSave.AARectSaves[0]);
+        Assert.Equal(rectB, frame.ShapesSave.AARectSaves[1]);
+    }
+
+    // ── MoveCircle ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveCircle_Delta1_MovesCircleDown()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var circA = new CircleSave { Name = "A" };
+        var circB = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+
+        ctx.AppCommands.MoveCircle(circA, frame, +1);
+
+        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
+        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+    }
+
+    [Fact]
+    public void MoveCircle_DeltaNeg1_MovesCircleUp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var circA = new CircleSave { Name = "A" };
+        var circB = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+
+        ctx.AppCommands.MoveCircle(circB, frame, -1);
+
+        Assert.Equal(circB, frame.ShapesSave.CircleSaves[0]);
+        Assert.Equal(circA, frame.ShapesSave.CircleSaves[1]);
+    }
+
+    [Fact]
+    public void MoveCircle_AtBottom_DoesNotMoveBelowEnd()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var acls  = ctx.Acls;
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var circA = new CircleSave { Name = "A" };
+        var circB = new CircleSave { Name = "B" };
+        frame.ShapesSave!.CircleSaves.Add(circA);
+        frame.ShapesSave!.CircleSaves.Add(circB);
+
+        ctx.AppCommands.MoveCircle(circB, frame, +1);
+
+        Assert.Equal(circA, frame.ShapesSave.CircleSaves[0]);
+        Assert.Equal(circB, frame.ShapesSave.CircleSaves[1]);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapeTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -35,7 +36,7 @@ public class AppCommandsShapeTests
 
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
 
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
         Assert.Equal(8, rect.ScaleX);
         Assert.Equal(8, rect.ScaleY);
     }
@@ -69,7 +70,7 @@ public class AppCommandsShapeTests
 
         Assert.NotNull(ctx.SelectedState.SelectedRectangle);
         Assert.Same(
-            frame.ShapesSave!.AARectSaves[0],
+            frame.ShapesSave!.AARectSaves.First(),
             ctx.SelectedState.SelectedRectangle);
     }
 
@@ -86,7 +87,7 @@ public class AppCommandsShapeTests
 
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
 
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
         Assert.Equal(10f, rect.X);
         Assert.Equal(-5f, rect.Y);
     }
@@ -118,7 +119,7 @@ public class AppCommandsShapeTests
 
         ctx.AppCommands.AddCircle(frame);
 
-        Assert.Equal(8, frame.ShapesSave!.CircleSaves[0].Radius);
+        Assert.Equal(8, frame.ShapesSave!.CircleSaves.First().Radius);
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class AppCommandsShapeTests
         ctx.AppCommands.AddCircle(frame);
 
         Assert.NotNull(ctx.SelectedState.SelectedCircle);
-        Assert.Same(frame.ShapesSave!.CircleSaves[0], ctx.SelectedState.SelectedCircle);
+        Assert.Same(frame.ShapesSave!.CircleSaves.First(), ctx.SelectedState.SelectedCircle);
     }
 
     [Fact]
@@ -165,7 +166,7 @@ public class AppCommandsShapeTests
 
         ctx.AppCommands.AddCircle(frame);
 
-        var circle = frame.ShapesSave!.CircleSaves[0];
+        var circle = frame.ShapesSave!.CircleSaves.First();
         Assert.Equal(3f, circle.X);
         Assert.Equal(-7f, circle.Y);
     }
@@ -180,12 +181,12 @@ public class AppCommandsShapeTests
         ctx.SelectedState.SelectedFrame = frame;
 
         // Add a rect with the default circle name to force a conflict
-        frame.ShapesSave!.AARectSaves.Add(
+        frame.ShapesSave!.Shapes.Add(
             new AARectSave { Name = "CircleInstance" });
 
         ctx.AppCommands.AddCircle(frame);
 
-        Assert.NotEqual("CircleInstance", frame.ShapesSave!.CircleSaves[0].Name);
+        Assert.NotEqual("CircleInstance", frame.ShapesSave!.CircleSaves.First().Name);
     }
 
     // ── DeleteAxisAlignedRectangle ───────────────────────────────────────────
@@ -198,7 +199,7 @@ public class AppCommandsShapeTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Box" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
 
@@ -214,7 +215,7 @@ public class AppCommandsShapeTests
         var frame1 = chain.Frames[0];
         var frame2 = chain.Frames[1];
         var rect = new AARectSave { Name = "Box" };
-        frame1.ShapesSave!.AARectSaves.Add(rect);
+        frame1.ShapesSave!.Shapes.Add(rect);
 
         // Call with wrong owner (frame2 doesn't own rect)
         ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame2);
@@ -230,7 +231,7 @@ public class AppCommandsShapeTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Box" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         bool fired = false;
         void Handler() => fired = true;
@@ -256,7 +257,7 @@ public class AppCommandsShapeTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "Ring", Radius = 5 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         ctx.AppCommands.DeleteCircle(circle, frame);
 
@@ -272,7 +273,7 @@ public class AppCommandsShapeTests
         var frame1 = chain.Frames[0];
         var frame2 = chain.Frames[1];
         var circle = new CircleSave { Name = "Ring", Radius = 5 };
-        frame1.ShapesSave!.CircleSaves.Add(circle);
+        frame1.ShapesSave!.Shapes.Add(circle);
 
         // Call with wrong owner - should not remove and should not throw
         ctx.AppCommands.DeleteCircle(circle, frame2);
@@ -288,7 +289,7 @@ public class AppCommandsShapeTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "Ring", Radius = 5 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         bool fired = false;
         void Handler() => fired = true;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ObjectFinderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ObjectFinderTests.cs
@@ -17,7 +17,7 @@ public class ObjectFinderTests
         var chain = TestHelpers.MakeChain(acls, "Run", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "HitBox" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
 
         var result = ctx.ObjectFinder.GetAnimationFrameContaining(rect);
 
@@ -46,7 +46,7 @@ public class ObjectFinderTests
         var chain2 = TestHelpers.MakeChain(acls, "Chain2", 3);
         var targetFrame = chain2.Frames[2];
         var rect = new AARectSave { Name = "DeepBox" };
-        targetFrame.ShapesSave!.AARectSaves.Add(rect);
+        targetFrame.ShapesSave!.Shapes.Add(rect);
 
         var result = ctx.ObjectFinder.GetAnimationFrameContaining(rect);
 
@@ -61,7 +61,7 @@ public class ObjectFinderTests
         var chain = TestHelpers.MakeChain(acls, "Run", 1);
         var frameWithRect = chain.Frames[0];
         var rect = new AARectSave { Name = "Box" };
-        frameWithRect.ShapesSave!.AARectSaves.Add(rect);
+        frameWithRect.ShapesSave!.Shapes.Add(rect);
 
         var result = ctx.ObjectFinder.GetAnimationFrameContaining(rect);
 
@@ -78,7 +78,7 @@ public class ObjectFinderTests
         var chain = TestHelpers.MakeChain(acls, "Jump", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "Halo", Radius = 12 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
 
         var result = ctx.ObjectFinder.GetAnimationFrameContaining(circle);
 
@@ -106,7 +106,7 @@ public class ObjectFinderTests
         var chain = TestHelpers.MakeChain(acls, "Attack", 4);
         var targetFrame = chain.Frames[3];
         var circle = new CircleSave { Name = "DeepCircle", Radius = 8 };
-        targetFrame.ShapesSave!.CircleSaves.Add(circle);
+        targetFrame.ShapesSave!.Shapes.Add(circle);
 
         var result = ctx.ObjectFinder.GetAnimationFrameContaining(circle);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
@@ -33,7 +33,7 @@ public class SelectedStateTests
         var chain = TestHelpers.MakeChain(acls, "Run", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Box" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
         ctx.SelectedState.SelectedRectangle = rect;
 
         var otherChain = TestHelpers.MakeChain(acls, "Idle");
@@ -50,7 +50,7 @@ public class SelectedStateTests
         var chain = TestHelpers.MakeChain(acls, "Run", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "Ring", Radius = 5 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
         ctx.SelectedState.SelectedCircle = circle;
 
         var otherChain = TestHelpers.MakeChain(acls, "Idle");
@@ -111,7 +111,7 @@ public class SelectedStateTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var rect = new AARectSave { Name = "Box" };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
         ctx.SelectedState.SelectedRectangle = rect;
 
         ctx.SelectedState.SelectedFrame = frame;
@@ -127,7 +127,7 @@ public class SelectedStateTests
         var chain = TestHelpers.MakeChain(acls, "Walk", 1);
         var frame = chain.Frames[0];
         var circle = new CircleSave { Name = "Ring", Radius = 5 };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
         ctx.SelectedState.SelectedCircle = circle;
 
         ctx.SelectedState.SelectedFrame = frame;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeUndoTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -37,13 +38,13 @@ public class ShapeUndoTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
-        var originalRect = frame.ShapesSave!.AARectSaves[0];
+        var originalRect = frame.ShapesSave!.AARectSaves.First();
         ctx.UndoManager.Undo();
 
         ctx.UndoManager.Redo();
 
         Assert.Single(frame.ShapesSave!.AARectSaves);
-        Assert.Same(originalRect, frame.ShapesSave!.AARectSaves[0]);
+        Assert.Same(originalRect, frame.ShapesSave!.AARectSaves.First());
     }
 
     // ── DeleteAxisAlignedRectangle + Undo ─────────────────────────────────────
@@ -59,16 +60,15 @@ public class ShapeUndoTests
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
         ctx.UndoManager.Clear(); // clear add history — we're testing delete
-        var rects = frame.ShapesSave!.AARectSaves;
-        var first = rects[0];
+        var first = frame.ShapesSave!.AARectSaves.First();
 
         ctx.AppCommands.DeleteAxisAlignedRectangle(first, frame);
-        Assert.Single(rects);
+        Assert.Single(frame.ShapesSave!.AARectSaves);
 
         ctx.UndoManager.Undo();
 
-        Assert.Equal(2, rects.Count);
-        Assert.Same(first, rects[0]);
+        Assert.Equal(2, frame.ShapesSave!.AARectSaves.Count());
+        Assert.Same(first, frame.ShapesSave!.AARectSaves.First());
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class ShapeUndoTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
         ctx.UndoManager.Clear();
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
 
         ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
         ctx.UndoManager.Undo();
@@ -121,13 +121,13 @@ public class ShapeUndoTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.AddCircle(frame);
-        var originalCircle = frame.ShapesSave!.CircleSaves[0];
+        var originalCircle = frame.ShapesSave!.CircleSaves.First();
         ctx.UndoManager.Undo();
 
         ctx.UndoManager.Redo();
 
         Assert.Single(frame.ShapesSave!.CircleSaves);
-        Assert.Same(originalCircle, frame.ShapesSave!.CircleSaves[0]);
+        Assert.Same(originalCircle, frame.ShapesSave!.CircleSaves.First());
     }
 
     // ── DeleteCircle + Undo ───────────────────────────────────────────────────
@@ -143,16 +143,15 @@ public class ShapeUndoTests
         ctx.AppCommands.AddCircle(frame);
         ctx.AppCommands.AddCircle(frame);
         ctx.UndoManager.Clear();
-        var circles = frame.ShapesSave!.CircleSaves;
-        var first = circles[0];
+        var first = frame.ShapesSave!.CircleSaves.First();
 
         ctx.AppCommands.DeleteCircle(first, frame);
-        Assert.Single(circles);
+        Assert.Single(frame.ShapesSave!.CircleSaves);
 
         ctx.UndoManager.Undo();
 
-        Assert.Equal(2, circles.Count);
-        Assert.Same(first, circles[0]);
+        Assert.Equal(2, frame.ShapesSave!.CircleSaves.Count());
+        Assert.Same(first, frame.ShapesSave!.CircleSaves.First());
     }
 
     [Fact]
@@ -165,7 +164,7 @@ public class ShapeUndoTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddCircle(frame);
         ctx.UndoManager.Clear();
-        var circle = frame.ShapesSave!.CircleSaves[0];
+        var circle = frame.ShapesSave!.CircleSaves.First();
 
         ctx.AppCommands.DeleteCircle(circle, frame);
         ctx.UndoManager.Undo();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -174,9 +174,9 @@ public class TreeBuilderPureTests
             TextureName = "Tex.png",
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave!.AARectSaves.Add(
+        frame.ShapesSave!.Shapes.Add(
             new AARectSave { Name = "HitBox" });
-        frame.ShapesSave!.CircleSaves.Add(
+        frame.ShapesSave!.Shapes.Add(
             new CircleSave { Name = "HurtCircle" });
 
         var node = TreeBuilder.BuildFrameNode(frame);
@@ -194,8 +194,8 @@ public class TreeBuilderPureTests
             TextureName = "",
             ShapesSave = new ShapesSave()
         };
-        frame.ShapesSave!.AARectSaves.Add(new AARectSave { Name = "Rect1" });
-        frame.ShapesSave!.CircleSaves.Add(new CircleSave { Name = "Circle1" });
+        frame.ShapesSave!.Shapes.Add(new AARectSave { Name = "Rect1" });
+        frame.ShapesSave!.Shapes.Add(new CircleSave { Name = "Circle1" });
 
         var node = TreeBuilder.BuildFrameNode(frame, index: 1);
 
@@ -568,7 +568,7 @@ public class TreeBuilderSyncShapesTests
     {
         rect = new AARectSave { Name = "HitBox" };
         var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(rect);
+        frame.ShapesSave.Shapes.Add(rect);
         return TreeBuilder.BuildFrameNode(frame);
     }
 
@@ -576,7 +576,7 @@ public class TreeBuilderSyncShapesTests
     {
         circle = new CircleSave { Name = "Hurt" };
         var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave.CircleSaves.Add(circle);
+        frame.ShapesSave.Shapes.Add(circle);
         return TreeBuilder.BuildFrameNode(frame);
     }
 
@@ -586,7 +586,7 @@ public class TreeBuilderSyncShapesTests
         var frameNode = FrameNodeWithRect(out var rect);
         var originalVm = frameNode.Children[0];
         var ss = new ShapesSave();
-        ss.AARectSaves.Add(rect);
+        ss.Shapes.Add(rect);
 
         TreeBuilder.SyncShapesInto(frameNode, ss);
 
@@ -599,7 +599,7 @@ public class TreeBuilderSyncShapesTests
         var frameNode = FrameNodeWithCircle(out var circle);
         var originalVm = frameNode.Children[0];
         var ss = new ShapesSave();
-        ss.CircleSaves.Add(circle);
+        ss.Shapes.Add(circle);
 
         TreeBuilder.SyncShapesInto(frameNode, ss);
 
@@ -612,7 +612,7 @@ public class TreeBuilderSyncShapesTests
         var frameNode = FrameNodeWithRect(out var rect);
         rect.Name = "NewName";
         var ss = new ShapesSave();
-        ss.AARectSaves.Add(rect);
+        ss.Shapes.Add(rect);
 
         TreeBuilder.SyncShapesInto(frameNode, ss);
 
@@ -625,7 +625,7 @@ public class TreeBuilderSyncShapesTests
         var frameNode = FrameNodeWithCircle(out var circle);
         circle.Name = "NewCircle";
         var ss = new ShapesSave();
-        ss.CircleSaves.Add(circle);
+        ss.Shapes.Add(circle);
 
         TreeBuilder.SyncShapesInto(frameNode, ss);
 
@@ -638,7 +638,7 @@ public class TreeBuilderSyncShapesTests
         var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
         var frameNode = TreeBuilder.BuildFrameNode(frame);
         var newRect = new AARectSave { Name = "New" };
-        frame.ShapesSave.AARectSaves.Add(newRect);
+        frame.ShapesSave.Shapes.Add(newRect);
 
         TreeBuilder.SyncShapesInto(frameNode, frame.ShapesSave);
 
@@ -674,8 +674,8 @@ public class TreeBuilderSyncShapesTests
         var rect   = new AARectSave  { Name = "R" };
         var circle = new CircleSave  { Name = "C" };
         var frame  = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(rect);
-        frame.ShapesSave.CircleSaves.Add(circle);
+        frame.ShapesSave.Shapes.Add(rect);
+        frame.ShapesSave.Shapes.Add(circle);
         var frameNode  = TreeBuilder.BuildFrameNode(frame);
         var originalRectVm   = frameNode.Children[0];
         var originalCircleVm = frameNode.Children[1];
@@ -783,7 +783,7 @@ public class TreeBuilderSyncFramesTests
         var chain = new AnimationChainSave { Name = "Walk" };
         var rect  = new AARectSave { Name = "Hit" };
         var frame = new AnimationFrameSave { TextureName = "w1.png", ShapesSave = new ShapesSave() };
-        frame.ShapesSave.AARectSaves.Add(rect);
+        frame.ShapesSave.Shapes.Add(rect);
         chain.Frames.Add(frame);
         var chainNode     = TreeBuilder.BuildChainNode(chain);
         var frameVm       = chainNode.Children[0];
@@ -863,7 +863,7 @@ public class TreeBuilderSingletonTests
         var acls = ctx.Acls;
         var rect  = new AARectSave { Name = "HitBox" };
         var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave!.AARectSaves.Add(rect);
+        frame.ShapesSave!.Shapes.Add(rect);
         var chain = new AnimationChainSave { Name = "Idle" };
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);
@@ -882,7 +882,7 @@ public class TreeBuilderSingletonTests
         var acls = ctx.Acls;
         var circle = new CircleSave { Name = "HurtCircle" };
         var frame  = new AnimationFrameSave { ShapesSave = new ShapesSave() };
-        frame.ShapesSave!.CircleSaves.Add(circle);
+        frame.ShapesSave!.Shapes.Add(circle);
         var chain = new AnimationChainSave { Name = "Idle" };
         chain.Frames.Add(frame);
         acls.AnimationChains.Add(chain);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -72,8 +72,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
-        [nameof(IAppCommands.MoveRectangle)]                = Category.MutatingUndoable,
-        [nameof(IAppCommands.MoveCircle)]                   = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveShape)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.HandleReorder)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameHorizontally)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameVertically)]          = Category.MutatingUndoable,
@@ -205,10 +204,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MoveFrameToTop(Zebra(ctx).Frames[2], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveFrameToBottom),
             ctx => Sync(() => ctx.AppCommands.MoveFrameToBottom(Zebra(ctx).Frames[0], Zebra(ctx))));
-        yield return Row(nameof(IAppCommands.MoveRectangle),
-            ctx => Sync(() => ctx.AppCommands.MoveRectangle(Rect(ctx), Zebra(ctx).Frames[0], +1)));
-        yield return Row(nameof(IAppCommands.MoveCircle),
-            ctx => Sync(() => ctx.AppCommands.MoveCircle(Circle(ctx), Zebra(ctx).Frames[0], +1)));
+        yield return Row(nameof(IAppCommands.MoveShape),
+            ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.HandleReorder),
             ctx => Sync(() => ctx.AppCommands.HandleReorder(+1))); // selection is set up by Arrange
         yield return Row(nameof(IAppCommands.FlipFrameHorizontally),
@@ -284,13 +281,13 @@ public class UndoCoverageRosterTests
                 ShapesSave       = new ShapesSave(),
             });
         }
-        zebra.Frames[0].ShapesSave!.AARectSaves.Add(
+        zebra.Frames[0].ShapesSave!.Shapes.Add(
             new AARectSave { Name = "Rect", X = 0f, Y = 0f, ScaleX = 4f, ScaleY = 4f });
-        zebra.Frames[0].ShapesSave!.AARectSaves.Add(
+        zebra.Frames[0].ShapesSave!.Shapes.Add(
             new AARectSave { Name = "Rect2", X = 8f, Y = 8f, ScaleX = 2f, ScaleY = 2f });
-        zebra.Frames[0].ShapesSave!.CircleSaves.Add(
+        zebra.Frames[0].ShapesSave!.Shapes.Add(
             new CircleSave { Name = "Circle", X = 0f, Y = 0f, Radius = 4f });
-        zebra.Frames[0].ShapesSave!.CircleSaves.Add(
+        zebra.Frames[0].ShapesSave!.Shapes.Add(
             new CircleSave { Name = "Circle2", X = 8f, Y = 8f, Radius = 2f });
 
         var alpha = new AnimationChainSave { Name = "Alpha" };
@@ -314,8 +311,8 @@ public class UndoCoverageRosterTests
 
     private static AnimationChainSave Zebra(TestServices ctx) => ctx.Acls.AnimationChains[0];
     private static AnimationChainSave Alpha(TestServices ctx) => ctx.Acls.AnimationChains[1];
-    private static AARectSave Rect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves[0];
-    private static CircleSave Circle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves[0];
+    private static AARectSave Rect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves.First();
+    private static CircleSave Circle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves.First();
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -72,6 +72,8 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveRectangle)]                = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveCircle)]                   = Category.MutatingUndoable,
         [nameof(IAppCommands.HandleReorder)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameHorizontally)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameVertically)]          = Category.MutatingUndoable,
@@ -203,6 +205,10 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MoveFrameToTop(Zebra(ctx).Frames[2], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveFrameToBottom),
             ctx => Sync(() => ctx.AppCommands.MoveFrameToBottom(Zebra(ctx).Frames[0], Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.MoveRectangle),
+            ctx => Sync(() => ctx.AppCommands.MoveRectangle(Rect(ctx), Zebra(ctx).Frames[0], +1)));
+        yield return Row(nameof(IAppCommands.MoveCircle),
+            ctx => Sync(() => ctx.AppCommands.MoveCircle(Circle(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.HandleReorder),
             ctx => Sync(() => ctx.AppCommands.HandleReorder(+1))); // selection is set up by Arrange
         yield return Row(nameof(IAppCommands.FlipFrameHorizontally),
@@ -280,8 +286,12 @@ public class UndoCoverageRosterTests
         }
         zebra.Frames[0].ShapesSave!.AARectSaves.Add(
             new AARectSave { Name = "Rect", X = 0f, Y = 0f, ScaleX = 4f, ScaleY = 4f });
+        zebra.Frames[0].ShapesSave!.AARectSaves.Add(
+            new AARectSave { Name = "Rect2", X = 8f, Y = 8f, ScaleX = 2f, ScaleY = 2f });
         zebra.Frames[0].ShapesSave!.CircleSaves.Add(
             new CircleSave { Name = "Circle", X = 0f, Y = 0f, Radius = 4f });
+        zebra.Frames[0].ShapesSave!.CircleSaves.Add(
+            new CircleSave { Name = "Circle2", X = 8f, Y = 8f, Radius = 2f });
 
         var alpha = new AnimationChainSave { Name = "Alpha" };
         alpha.Frames.Add(new AnimationFrameSave


### PR DESCRIPTION
## Summary

When a rectangle or circle was selected in the tree, ALT+Arrow was reordering the entire animation (chain) or frame instead of the selected shape. This happened because HandleReorder checked SelectedChain/SelectedFrame first — and those remain set even when a child shape is selected.

## Changes

- **IAppCommands / AppCommands**: Add MoveRectangle(rect, frame, delta) and MoveCircle(circle, frame, delta) — both backed by ReorderCommand<T> so they are fully undoable
- **HandleReorder**: Branch on selected shape first (highest priority), then frame, then chain
- **Tests**: 14 new tests in AppCommandsReorderTests covering the bug fix and the new methods
- **UndoCoverageRosterTests**: Add MoveRectangle and MoveCircle to the roster and round-trip invocations

Closes #271