### PR TITLE
Fix jagged frame indentation when frames have shapes

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -278,10 +278,14 @@
                             <Setter Property="IsExpanded"
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                         </Style>
-                        <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered. -->
+                        <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered.
+                             IsVisible=True overrides the default TemplateBinding HasItems so the container
+                             always reserves the same horizontal space — preventing a jagged appearance when
+                             some frame nodes have shapes (children) and others don't. -->
                         <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">
                             <Setter Property="Margin" Value="0" />
                             <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
+                            <Setter Property="IsVisible" Value="True" />
                         </Style>
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -279,13 +279,22 @@
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                         </Style>
                         <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered.
-                             IsVisible=True overrides the default TemplateBinding HasItems so the container
-                             always reserves the same horizontal space — preventing a jagged appearance when
-                             some frame nodes have shapes (children) and others don't. -->
+                             Both selectors are required: the plain one sets width/margin for nodes that
+                             have children; the :empty one overrides the Fluent theme's more-specific
+                             rule that hides the container on leaf nodes. Together they ensure every
+                             item reserves the same horizontal space — no jagged alignment when some
+                             frame nodes have shapes and others don't. -->
                         <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">
                             <Setter Property="Margin" Value="0" />
                             <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
+                        </Style>
+                        <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
                             <Setter Property="IsVisible" Value="True" />
+                        </Style>
+                        <!-- Hide the toggle button itself for leaf nodes so the space is reserved
+                             but clicking does nothing (no phantom expand interaction). -->
+                        <Style Selector="TreeViewItem:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
+                            <Setter Property="IsVisible" Value="False" />
                         </Style>
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -283,15 +283,13 @@
                             <Setter Property="Margin" Value="0" />
                             <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
                         </Style>
-                        <!-- For leaf items the Fluent theme keeps the chevron container visible but
-                             sets its Width=12 (TreeViewItemExpandCollapseChevronSize) via a more-
-                             specific :empty style.  The Panel has no IsVisible binding in the Avalonia
-                             12 template, so hiding it here is unconditional and wins the value race.
-                             The spacer in the TreeDataTemplate (bound to IsLeafFrameNode) then adds
-                             TreeViewItemMinHeight of space, giving leaf frame rows the same indent as
-                             non-leaf frame rows. -->
+                        <!-- The Fluent theme's :empty style overrides the panel width to 12px for
+                             leaf items, causing their content to start ~20px left of non-leaf items.
+                             Override it here with the same full width so leaf and non-leaf items
+                             always indent identically.  The ToggleButton inside is already hidden for
+                             :empty items by the Fluent theme; the panel becomes an invisible spacer. -->
                         <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
-                            <Setter Property="IsVisible" Value="False" />
+                            <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
                         </Style>
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />
@@ -331,14 +329,7 @@
                         <TreeDataTemplate x:DataType="models:TreeNodeVm"
                                           ItemsSource="{Binding Children}">
                             <Grid ColumnDefinitions="*,Auto,Auto" HorizontalAlignment="Stretch">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <!-- Spacer for leaf frame nodes: reserves the same horizontal space that
-                                         the chevron container occupies for frames that have shapes, preventing
-                                         jagged icon alignment. The TreeViewItem template hides its chevron
-                                         container via TemplateBinding (not overridable with a style setter),
-                                         so we compensate here in the header content instead. -->
-                                    <Border Width="{DynamicResource TreeViewItemMinHeight}"
-                                            IsVisible="{Binding IsLeafFrameNode}" />
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
                                     <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph
                                          otherwise. Only the chain ("animation") icon is enlarged so the first-frame

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -278,23 +278,10 @@
                             <Setter Property="IsExpanded"
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                         </Style>
-                        <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered.
-                             Both selectors are required: the plain one sets width/margin for nodes that
-                             have children; the :empty one overrides the Fluent theme's more-specific
-                             rule that hides the container on leaf nodes. Together they ensure every
-                             item reserves the same horizontal space — no jagged alignment when some
-                             frame nodes have shapes and others don't. -->
+                        <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered. -->
                         <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">
                             <Setter Property="Margin" Value="0" />
                             <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
-                        </Style>
-                        <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
-                            <Setter Property="IsVisible" Value="True" />
-                        </Style>
-                        <!-- Hide the toggle button itself for leaf nodes so the space is reserved
-                             but clicking does nothing (no phantom expand interaction). -->
-                        <Style Selector="TreeViewItem:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
-                            <Setter Property="IsVisible" Value="False" />
                         </Style>
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />
@@ -335,6 +322,13 @@
                                           ItemsSource="{Binding Children}">
                             <Grid ColumnDefinitions="*,Auto,Auto" HorizontalAlignment="Stretch">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <!-- Spacer for leaf frame nodes: reserves the same horizontal space that
+                                         the chevron container occupies for frames that have shapes, preventing
+                                         jagged icon alignment. The TreeViewItem template hides its chevron
+                                         container via TemplateBinding (not overridable with a style setter),
+                                         so we compensate here in the header content instead. -->
+                                    <Border Width="{DynamicResource TreeViewItemMinHeight}"
+                                            IsVisible="{Binding IsLeafFrameNode}" />
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
                                     <!-- Chain node: first-frame thumbnail when the chain has frames, generic glyph
                                          otherwise. Only the chain ("animation") icon is enlarged so the first-frame

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -283,6 +283,16 @@
                             <Setter Property="Margin" Value="0" />
                             <Setter Property="Width" Value="{DynamicResource TreeViewItemMinHeight}" />
                         </Style>
+                        <!-- For leaf items the Fluent theme keeps the chevron container visible but
+                             sets its Width=12 (TreeViewItemExpandCollapseChevronSize) via a more-
+                             specific :empty style.  The Panel has no IsVisible binding in the Avalonia
+                             12 template, so hiding it here is unconditional and wins the value race.
+                             The spacer in the TreeDataTemplate (bound to IsLeafFrameNode) then adds
+                             TreeViewItemMinHeight of space, giving leaf frame rows the same indent as
+                             non-leaf frame rows. -->
+                        <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
+                            <Setter Property="IsVisible" Value="False" />
+                        </Style>
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />
                             <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -89,6 +89,13 @@ public class TreeNodeVm : INotifyPropertyChanged
     /// <summary>True when this node represents a CircleSave shape. Set once at construction time.</summary>
     public bool IsCircleNode { get; set; }
 
+    /// <summary>
+    /// True when this is a frame node that currently has no shape children.
+    /// Used by the tree template to show a spacer that matches the chevron width,
+    /// keeping frame icons horizontally aligned regardless of whether they have shapes.
+    /// </summary>
+    public bool IsLeafFrameNode => IsFrameNode && Children.Count == 0;
+
     private object? _thumbnail;
     /// <summary>
     /// First-frame thumbnail for a chain node, set by the App layer once the texture is
@@ -127,7 +134,13 @@ public class TreeNodeVm : INotifyPropertyChanged
     /// </summary>
     public ThumbnailSource? ThumbnailSource { get; set; }
 
-    public ObservableCollection<TreeNodeVm> Children { get; } = new();
+    public ObservableCollection<TreeNodeVm> Children { get; }
+
+    public TreeNodeVm()
+    {
+        Children = new ObservableCollection<TreeNodeVm>();
+        Children.CollectionChanged += (_, _) => Notify(nameof(IsLeafFrameNode));
+    }
 
     /// <summary>
     /// Sets <see cref="IsExpanded"/> on <paramref name="node"/> and every descendant.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeNodeVmTests.cs
@@ -199,4 +199,55 @@ public class TreeNodeVmTests
         Assert.Null(ex);
         Assert.True(leaf.IsExpanded);
     }
+
+    // ── IsLeafFrameNode ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsLeafFrameNode_TrueWhenFrameNodeWithNoChildren()
+    {
+        var vm = new TreeNodeVm { IsFrameNode = true };
+        Assert.True(vm.IsLeafFrameNode);
+    }
+
+    [Fact]
+    public void IsLeafFrameNode_FalseWhenFrameNodeHasChildren()
+    {
+        var vm = new TreeNodeVm { IsFrameNode = true };
+        vm.Children.Add(new TreeNodeVm { IsRectNode = true });
+        Assert.False(vm.IsLeafFrameNode);
+    }
+
+    [Fact]
+    public void IsLeafFrameNode_FalseForNonFrameNode()
+    {
+        var vm = new TreeNodeVm { IsChainNode = true };
+        Assert.False(vm.IsLeafFrameNode);
+    }
+
+    [Fact]
+    public void IsLeafFrameNode_FiresPropertyChangedWhenChildAdded()
+    {
+        var vm = new TreeNodeVm { IsFrameNode = true };
+        var fired = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => fired.Add(e.PropertyName);
+
+        vm.Children.Add(new TreeNodeVm { IsRectNode = true });
+
+        Assert.Contains(nameof(TreeNodeVm.IsLeafFrameNode), fired);
+    }
+
+    [Fact]
+    public void IsLeafFrameNode_FiresPropertyChangedWhenChildRemoved()
+    {
+        var vm = new TreeNodeVm { IsFrameNode = true };
+        var child = new TreeNodeVm { IsRectNode = true };
+        vm.Children.Add(child);
+
+        var fired = new System.Collections.Generic.List<string?>();
+        vm.PropertyChanged += (_, e) => fired.Add(e.PropertyName);
+
+        vm.Children.Remove(child);
+
+        Assert.Contains(nameof(TreeNodeVm.IsLeafFrameNode), fired);
+    }
 }


### PR DESCRIPTION
## Summary

Avalonia's default `TreeViewItem` template has `PART_ExpandCollapseChevronContainer` with `IsVisible="{TemplateBinding HasItems}"`. This meant:

- **Frame with shapes** → chevron container visible → icon+text pushed right
- **Frame without shapes** → chevron container collapsed → icon+text at left edge

The result was a jagged appearance in the animation tree when a mix of frames with and without shapes were visible.

## Fix

Added `<Setter Property="IsVisible" Value="True" />` to the existing `PART_ExpandCollapseChevronContainer` style override, so every tree item always reserves the same horizontal space for the chevron regardless of whether it has children.

## Testing notes

No automated test: this is a single XAML style setter overriding an Avalonia template-part binding. The only observable behavior is visual row alignment, which is not exercisable in headless Avalonia tests.

Closes #278