### PR TITLE
fix(AE): clear selection when deleting frames or chains (#284)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
@@ -1,6 +1,7 @@
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
 {
@@ -51,12 +52,12 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             foreach (var (chain, _) in _removed)
                 _acls.AnimationChains.Remove(chain);
 
+            ClearSelectionForRemovedChains();
             _commands.RefreshTreeView();
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.RefreshWireframe();
             _commands.SaveCurrentAnimationChainList();
-            _selectedState.SelectedChain = null;
             return true;
         }
 
@@ -80,12 +81,37 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         {
             foreach (var (chain, _) in _removed)
                 _acls.AnimationChains.Remove(chain);
+            ClearSelectionForRemovedChains();
             _commands.RefreshTreeView();
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.RefreshWireframe();
             _commands.SaveCurrentAnimationChainList();
-            _selectedState.SelectedChain = null;
+        }
+
+        /// <summary>
+        /// Drops every just-removed chain from the selection. Without this the
+        /// preview keeps rendering an orphaned chain's frames, because
+        /// <see cref="ISelectedState.SelectedChain"/> still points at a chain that
+        /// is no longer in the project. See issue #284.
+        /// </summary>
+        private void ClearSelectionForRemovedChains()
+        {
+            var removedChains = _removed.Select(r => r.Chain).ToHashSet();
+
+            // Drop deleted chains from the multi-selection bag.
+            var nodes = _selectedState.SelectedNodes;
+            if (nodes.Any(n => n is AnimationChainSave c && removedChains.Contains(c)))
+            {
+                _selectedState.SelectedNodes = nodes
+                    .Where(n => n is not AnimationChainSave c || !removedChains.Contains(c))
+                    .ToList();
+            }
+
+            // Clear the primary selection if it pointed at a deleted chain. Setting
+            // SelectedChain = null also clears any frame/rectangle/circle under it.
+            if (_selectedState.SelectedChain is { } selected && removedChains.Contains(selected))
+                _selectedState.SelectedChain = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
@@ -1,6 +1,7 @@
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
 {
@@ -49,11 +50,11 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             foreach (var (frame, _) in _removed)
                 _chain.Frames.Remove(frame);
 
+            ClearSelectionForRemovedFrames();
             _commands.RefreshTreeNode(_chain);
             _commands.RefreshWireframe();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
-            _selectedState.SelectedFrame = null;
             return true;
         }
 
@@ -75,11 +76,36 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         {
             foreach (var (frame, _) in _removed)
                 _chain.Frames.Remove(frame);
+            ClearSelectionForRemovedFrames();
             _commands.RefreshTreeNode(_chain);
             _commands.RefreshWireframe();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
-            _selectedState.SelectedFrame = null;
+        }
+
+        /// <summary>
+        /// Drops every just-removed frame from the selection. Without this the
+        /// preview keeps rendering an orphaned frame's sprite and shapes, because
+        /// <see cref="ISelectedState.SelectedFrame"/> still points at a frame that
+        /// is no longer in the chain. See issue #284.
+        /// </summary>
+        private void ClearSelectionForRemovedFrames()
+        {
+            var removedFrames = _removed.Select(r => r.Frame).ToHashSet();
+
+            // Drop deleted frames from the multi-selection bag.
+            var nodes = _selectedState.SelectedNodes;
+            if (nodes.Any(n => n is AnimationFrameSave f && removedFrames.Contains(f)))
+            {
+                _selectedState.SelectedNodes = nodes
+                    .Where(n => n is not AnimationFrameSave f || !removedFrames.Contains(f))
+                    .ToList();
+            }
+
+            // Clear the primary selection if it pointed at a deleted frame. Setting
+            // SelectedFrame = null also clears any rectangle/circle selected on it.
+            if (_selectedState.SelectedFrame is { } selected && removedFrames.Contains(selected))
+                _selectedState.SelectedFrame = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteChainsSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteChainsSelectionTests.cs
@@ -1,0 +1,69 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Deleting a chain must drop that chain from the selection. A stale
+/// <see cref="ISelectedState.SelectedChain"/> pointing at an orphaned chain keeps
+/// the preview rendering its frames. Same selection-clearing gap as issue #284.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class DeleteChainsSelectionTests
+{
+    [Fact]
+    public async Task DeleteChains_ClearsSelectedChain_WhenSelectedChainIsDeleted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        ctx.SelectedState.SelectedChain = chain;
+
+        await ctx.AppCommands.AskToDeleteAnimationChains(new List<AnimationChainSave> { chain });
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public async Task DeleteChains_KeepsSelectedChain_WhenADifferentChainIsDeleted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var first = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var keep  = TestHelpers.MakeChain(ctx.Acls, "Run");
+        ctx.SelectedState.SelectedChain = keep;
+
+        await ctx.AppCommands.AskToDeleteAnimationChains(new List<AnimationChainSave> { first });
+
+        Assert.Same(keep, ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public async Task DeleteChains_RemovesDeletedChainsFromMultiSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var a = TestHelpers.MakeChain(ctx.Acls, "A");
+        var b = TestHelpers.MakeChain(ctx.Acls, "B");
+        ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+
+        await ctx.AppCommands.AskToDeleteAnimationChains(new List<AnimationChainSave> { a, b });
+
+        Assert.Empty(ctx.SelectedState.SelectedNodes);
+    }
+
+    [Fact]
+    public async Task DeleteChains_Redo_ClearsSelectionAgain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        ctx.SelectedState.SelectedChain = chain;
+
+        await ctx.AppCommands.AskToDeleteAnimationChains(new List<AnimationChainSave> { chain });
+        ctx.UndoManager.Undo();
+
+        // User re-selects the restored chain, then redoes the delete.
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteFramesSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DeleteFramesSelectionTests.cs
@@ -1,0 +1,91 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Deleting a frame must drop that frame from the selection. A stale
+/// <see cref="ISelectedState.SelectedFrame"/> pointing at an orphaned frame keeps
+/// the preview rendering its sprite and shapes. See issue #284.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class DeleteFramesSelectionTests
+{
+    [Fact]
+    public void DeleteFrames_ClearsSelectedFrame_WhenSelectedFrameIsDeleted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 3);
+        var middle = chain.Frames[1];
+        ctx.SelectedState.SelectedFrame = middle;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { middle });
+
+        Assert.Null(ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void DeleteFrames_KeepsSelectedFrame_WhenADifferentFrameIsDeleted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 3);
+        var first = chain.Frames[0];
+        var last  = chain.Frames[2];
+        ctx.SelectedState.SelectedFrame = last;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { first });
+
+        Assert.Same(last, ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void DeleteFrames_ClearsSelectedShape_WhenSelectedFrameWithShapeIsDeleted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        frame.ShapesSave!.Shapes.Add(rect);
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+
+        Assert.Null(ctx.SelectedState.SelectedFrame);
+        Assert.Null(ctx.SelectedState.SelectedRectangle);
+    }
+
+    [Fact]
+    public void DeleteFrames_RemovesDeletedFramesFromMultiSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", frameCount: 4);
+        ctx.SelectedState.SelectedChain = chain;
+        var f0 = chain.Frames[0];
+        var f2 = chain.Frames[2];
+        ctx.SelectedState.SelectedNodes = new List<object> { f0, f2 };
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { f0, f2 });
+
+        Assert.Empty(ctx.SelectedState.SelectedNodes);
+    }
+
+    [Fact]
+    public void DeleteFrames_Redo_ClearsSelectionAgain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var first = chain.Frames[0];
+        ctx.SelectedState.SelectedFrame = first;
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { first });
+        ctx.UndoManager.Undo();
+
+        // User re-selects the restored frame, then redoes the delete.
+        ctx.SelectedState.SelectedFrame = first;
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedFrame);
+    }
+}


### PR DESCRIPTION
## Problem

Deleting the selected frame from the tree view left `ISelectedState.SelectedFrame` pointing at the now-orphaned frame. `PreviewControl.Render` and `BuildShapeInfos` both read `SelectedFrame` directly, so the deleted frame's sprite **and** collision shapes kept rendering in the bottom preview.

The issue's "research direction" notes correctly identified this as a *shared* selection-clearing gap: `DeleteChainsCommand` had the identical bug — deleting the selected chain left `SelectedChain` stale, so the deleted chain's frames kept playing in the preview. (Per scope confirmation with the maintainer, this PR covers both.)

The fix belongs in the **delete handlers**, not a preview-side empty-selection clear: the selection after a delete isn't *empty*, it's *stale* — it points at a live object that's no longer in the project.

## Fix

`DeleteFramesCommand` and `DeleteChainsCommand` now drop every just-removed item from the selection, in both `Do()` and `Redo()`:
- the primary selection (`SelectedFrame` / `SelectedChain`) is set to `null` if it pointed at a deleted item;
- deleted items are removed from the `SelectedNodes` multi-select bag.

Clearing `SelectedFrame` / `SelectedChain` cascades through the existing `SelectedState` setters to also clear any rectangle/circle selected beneath it. `Undo()` is intentionally left unchanged — none of the delete commands restore selection on undo, and matching that keeps the change tight.

## Tests

TDD — failing tests written first, then the fix:
- `DeleteFramesSelectionTests` (5 tests): selected frame cleared on delete; unrelated selected frame survives; selected shape cascade-cleared; multi-select bag pruned; redo re-clears.
- `DeleteChainsSelectionTests` (4 tests): same coverage for chains.

Full suite green: **955** Core + **379** App tests pass.

Closes #284