### PR TITLE
Expand frame node and select shape on add (#273)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1323,6 +1323,19 @@ public partial class MainWindow : Window
 
         var target = sel is not null ? TreeBuilder.FindNodeForData(_treeRoots, sel) : null;
 
+        // When a shape is selected, ensure its parent frame node is expanded so
+        // the shape node is visible in the tree (Avalonia does not auto-expand parents).
+        if (sel is AARectSave or CircleSave)
+        {
+            var frame = _selectedState.SelectedFrame;
+            if (frame is not null)
+            {
+                var frameNode = TreeBuilder.FindNodeForData(_treeRoots, frame);
+                if (frameNode is not null)
+                    frameNode.IsExpanded = true;
+            }
+        }
+
         if (target is not null && !(AnimTree.SelectedItems?.Contains(target) ?? false))
             AnimTree.SelectedItem = target;
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
@@ -308,6 +308,68 @@ public class MainWindowMenuFlowTests
         }
         finally { window.Close(); }
     }
+
+    // ── Expand + select after adding shape (issue #273) ───────────────────────
+
+    [AvaloniaFact]
+    public void ContextMenu_AddRect_ExpandsFrameNodeAndSelectsShape()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var frame = new AnimationFrameSave { TextureName = "Tex.png", ShapesSave = new ShapesSave() };
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var chainVm = new TreeNodeVm { Header = "Walk", Data = chain, IsChainNode = true, IsExpanded = true };
+            var frameVm = new TreeNodeVm { Header = "Frame 1", Data = frame, IsFrameNode = true };
+            chainVm.Children.Add(frameVm);
+            GetRoots(GetTree(window)).Add(chainVm);
+            GetTree(window).SelectedItem = frameVm;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            TriggerContextMenuOpening(window);
+            ClickContextMenuItem(window, "Add AxisAlignedRectangle");
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(frameVm.IsExpanded, "frame node should be expanded after adding a rectangle");
+            var selectedNode = GetTree(window).SelectedItem as TreeNodeVm;
+            Assert.NotNull(selectedNode);
+            Assert.IsType<AARectSave>(selectedNode.Data);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenu_AddCircle_ExpandsFrameNodeAndSelectsShape()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var frame = new AnimationFrameSave { TextureName = "Tex.png", ShapesSave = new ShapesSave() };
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var chainVm = new TreeNodeVm { Header = "Walk", Data = chain, IsChainNode = true, IsExpanded = true };
+            var frameVm = new TreeNodeVm { Header = "Frame 1", Data = frame, IsFrameNode = true };
+            chainVm.Children.Add(frameVm);
+            GetRoots(GetTree(window)).Add(chainVm);
+            GetTree(window).SelectedItem = frameVm;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            TriggerContextMenuOpening(window);
+            ClickContextMenuItem(window, "Add Circle");
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(frameVm.IsExpanded, "frame node should be expanded after adding a circle");
+            var selectedNode = GetTree(window).SelectedItem as TreeNodeVm;
+            Assert.NotNull(selectedNode);
+            Assert.IsType<CircleSave>(selectedNode.Data);
+        }
+        finally { window.Close(); }
+    }
 }
 
 /// <summary>Test double that returns a pre-configured path (or null) from every dialog.</summary>


### PR DESCRIPTION
When a shape (AxisAlignedRectangle or Circle) is added via the context menu, the parent frame node is now auto-expanded and the new shape is selected in the tree.

**Root cause:** SyncTreeSelection was setting AnimTree.SelectedItem to the shape's node, but Avalonia does not auto-expand parent nodes when programmatically setting selection. The frame node defaulted to IsExpanded = false, so the shape node was invisible.

**Fix:** In SyncTreeSelection, when the selection target is a shape (AARectSave or CircleSave), look up the parent frame node via TreeBuilder.FindNodeForData and set IsExpanded = true before setting SelectedItem.

**Tests:** Two new [AvaloniaFact] tests in MainWindowMenuFlowTests verify that after adding a rect/circle from the context menu, the frame node is expanded and the shape node is selected in the tree.

Closes #273