### PR TITLE
Undo/redo preserves and restores selection

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
@@ -8,16 +8,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationFrameSave _frame;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly AARectSave? _preAddRect;
 
         public string Description => "Add Rectangle";
 
         public AddAxisAlignedRectangleCommand(AARectSave rect, AnimationFrameSave frame,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _rect = rect;
             _frame = frame;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddRect = selectedState.SelectedRectangle;
         }
 
         public bool Do()
@@ -27,6 +31,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedRectangle = _rect;
             return true;
         }
 
@@ -37,6 +42,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedRectangle = _preAddRect;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddChainCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddChainCommand.cs
@@ -8,16 +8,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationChainListSave _acls;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly AnimationChainSave? _preAddChain;
 
         public string Description { get; }
 
         public AddChainCommand(AnimationChainSave chain, AnimationChainListSave acls,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _chain = chain;
             _acls = acls;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddChain = selectedState.SelectedChain;
             Description = $"Add Animation '{chain.Name}'";
         }
 
@@ -29,6 +33,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeView();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedChain = _chain;
             return true;
         }
 
@@ -38,6 +43,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeView();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedChain = _preAddChain;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
@@ -8,16 +8,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationFrameSave _frame;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly CircleSave? _preAddCircle;
 
         public string Description => "Add Circle";
 
         public AddCircleCommand(CircleSave circle, AnimationFrameSave frame,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _circle = circle;
             _frame = frame;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddCircle = selectedState.SelectedCircle;
         }
 
         public bool Do()
@@ -27,6 +31,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedCircle = _circle;
             return true;
         }
 
@@ -37,6 +42,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedCircle = _preAddCircle;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFrameCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFrameCommand.cs
@@ -8,16 +8,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationChainSave _chain;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly AnimationFrameSave? _preAddFrame;
 
         public string Description { get; }
 
         public AddFrameCommand(AnimationFrameSave frame, AnimationChainSave chain,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _frame = frame;
             _chain = chain;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddFrame = selectedState.SelectedFrame;
             Description = $"Add Frame to '{chain.Name}'";
         }
 
@@ -27,6 +31,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeNode(_chain);
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = _frame;
             return true;
         }
 
@@ -36,6 +41,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeNode(_chain);
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = _preAddFrame;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
@@ -13,17 +13,21 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationChainSave _chain;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly AnimationFrameSave? _preAddFrame;
 
         public string Description { get; }
 
         public AddFramesCommand(
             AnimationFrameSave[] frames, AnimationChainSave chain,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _frames = frames;
             _chain = chain;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddFrame = selectedState.SelectedFrame;
             Description = frames.Length == 1
                 ? $"Add Frame to '{chain.Name}'"
                 : $"Add {frames.Length} Frames to '{chain.Name}'";
@@ -37,6 +41,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeNode(_chain);
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = _frames[^1];
             return true;
         }
 
@@ -47,6 +52,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshTreeNode(_chain);
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = _preAddFrame;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -260,7 +260,7 @@ namespace AnimationEditor.Core.CommandsAndState
             var acls = _pm.AnimationChainListSave;
             if (acls == null) return;
 
-            _undoManager.Execute(new DeleteChainsCommand(animationChains, acls, this, _events));
+            _undoManager.Execute(new DeleteChainsCommand(animationChains, acls, this, _events, _selectedState));
         }
 
         public void AddAxisAlignedRectangle(AnimationFrameSave frame)
@@ -274,8 +274,7 @@ namespace AnimationEditor.Core.CommandsAndState
             };
 
             ApplyRectangleMatch(rectangleSave, frame);
-            _undoManager.Execute(new AddAxisAlignedRectangleCommand(rectangleSave, frame, this, _events));
-            _selectedState.SelectedRectangle = rectangleSave;
+            _undoManager.Execute(new AddAxisAlignedRectangleCommand(rectangleSave, frame, this, _events, _selectedState));
         }
 
         public void AddCircle(AnimationFrameSave frame)
@@ -288,8 +287,7 @@ namespace AnimationEditor.Core.CommandsAndState
             };
 
             ApplyCircleMatch(circleSave, frame);
-            _undoManager.Execute(new AddCircleCommand(circleSave, frame, this, _events));
-            _selectedState.SelectedCircle = circleSave;
+            _undoManager.Execute(new AddCircleCommand(circleSave, frame, this, _events, _selectedState));
         }
 
         /// <summary>
@@ -330,12 +328,12 @@ namespace AnimationEditor.Core.CommandsAndState
 
         public void DeleteCircle(CircleSave circle, AnimationFrameSave owner)
         {
-            _undoManager.Execute(new DeleteCircleCommand(circle, owner, this, _events));
+            _undoManager.Execute(new DeleteCircleCommand(circle, owner, this, _events, _selectedState));
         }
 
         public void DeleteAxisAlignedRectangle(AARectSave rectangle, AnimationFrameSave owner)
         {
-            _undoManager.Execute(new DeleteAxisAlignedRectangleCommand(rectangle, owner, this, _events));
+            _undoManager.Execute(new DeleteAxisAlignedRectangleCommand(rectangle, owner, this, _events, _selectedState));
         }
 
         public async Task AskToDeleteRectangles(List<AARectSave> rectangles)
@@ -351,7 +349,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 {
                     var frame = _objectFinder.GetAnimationFrameContaining(rectangle);
                     if (frame != null)
-                        commands.Add(new DeleteAxisAlignedRectangleCommand(rectangle, frame, this, _events));
+                        commands.Add(new DeleteAxisAlignedRectangleCommand(rectangle, frame, this, _events, _selectedState));
                 }
                 if (commands.Count > 0)
                 {
@@ -376,7 +374,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 {
                     var frame = _objectFinder.GetAnimationFrameContaining(circle);
                     if (frame != null)
-                        commands.Add(new DeleteCircleCommand(circle, frame, this, _events));
+                        commands.Add(new DeleteCircleCommand(circle, frame, this, _events, _selectedState));
                 }
                 if (commands.Count > 0)
                 {
@@ -410,9 +408,9 @@ namespace AnimationEditor.Core.CommandsAndState
         {
             var commands = new List<IUndoableCommand>();
             foreach (var rect in rectangles.ToArray())
-                commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events));
+                commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events, _selectedState));
             foreach (var circle in circles.ToArray())
-                commands.Add(new DeleteCircleCommand(circle, frame, this, _events));
+                commands.Add(new DeleteCircleCommand(circle, frame, this, _events, _selectedState));
             if (commands.Count > 0)
                 _undoManager.Execute(new CompositeCommand(commands));
         }
@@ -437,7 +435,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 string label = validFrames.Count == 1
                     ? $"Frame {chain.Frames.IndexOf(validFrames[0]) + 1}"
                     : $"{validFrames.Count} frames";
-                _undoManager.Execute(new DeleteFramesCommand(frames, chain, this, _events));
+                _undoManager.Execute(new DeleteFramesCommand(frames, chain, this, _events, _selectedState));
                 if (validFrames.Count > 0)
                     FramesDeleted?.Invoke(label);
             }
@@ -482,8 +480,7 @@ namespace AnimationEditor.Core.CommandsAndState
 
             name = StringFunctions.MakeStringUnique(name, acls.AnimationChains.Select(c => c.Name).ToList());
             var chain = new AnimationChainSave { Name = name };
-            _undoManager.Execute(new AddChainCommand(chain, acls, this, _events));
-            _selectedState.SelectedChain = chain;
+            _undoManager.Execute(new AddChainCommand(chain, acls, this, _events, _selectedState));
             return chain;
         }
 
@@ -516,8 +513,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 FrameLength      = 0.1f,
                 ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave()
             };
-            _undoManager.Execute(new AddFrameCommand(frame, chain, this, _events));
-            _selectedState.SelectedFrame = frame;
+            _undoManager.Execute(new AddFrameCommand(frame, chain, this, _events, _selectedState));
         }
 
         public void MoveChain(AnimationChainSave chain, int delta)
@@ -725,8 +721,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 copy.Frames.Add(fCopy);
             }
 
-            _undoManager.Execute(new AddChainCommand(copy, acls, this, _events));
-            _selectedState.SelectedChain = copy;
+            _undoManager.Execute(new AddChainCommand(copy, acls, this, _events, _selectedState));
             return copy;
         }
 
@@ -849,8 +844,7 @@ namespace AnimationEditor.Core.CommandsAndState
             var added = result.Frames.ToArray();
             if (added.Length > 0)
             {
-                _undoManager.Execute(new AddFramesCommand(added, chain, this, _events));
-                _selectedState.SelectedFrame = added[^1];
+                _undoManager.Execute(new AddFramesCommand(added, chain, this, _events, _selectedState));
             }
 
             return result.ExceededTextureBounds;
@@ -944,8 +938,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave()
             };
 
-            _undoManager.Execute(new AddFrameCommand(frame, chain, this, _events));
-            _selectedState.SelectedFrame = frame;
+            _undoManager.Execute(new AddFrameCommand(frame, chain, this, _events, _selectedState));
         }
 
         // ── Texture assignment (WF10b — write direction) ─────────────────────────
@@ -970,19 +963,19 @@ namespace AnimationEditor.Core.CommandsAndState
         {
             var acls = _pm.AnimationChainListSave;
             if (acls is null) return;
-            _undoManager.Execute(new PasteChainsCommand(acls, chains, this, _events));
+            _undoManager.Execute(new PasteChainsCommand(acls, chains, this, _events, _selectedState));
         }
 
         /// <inheritdoc cref="IAppCommands.PasteFrames"/>
         public void PasteFrames(AnimationChainSave chain, IReadOnlyList<AnimationFrameSave> frames) =>
-            _undoManager.Execute(new AddFramesCommand(frames.ToArray(), chain, this, _events));
+            _undoManager.Execute(new AddFramesCommand(frames.ToArray(), chain, this, _events, _selectedState));
 
         /// <inheritdoc cref="IAppCommands.PasteRectangle"/>
         public void PasteRectangle(AnimationFrameSave frame, AARectSave rectangle) =>
-            _undoManager.Execute(new AddAxisAlignedRectangleCommand(rectangle, frame, this, _events));
+            _undoManager.Execute(new AddAxisAlignedRectangleCommand(rectangle, frame, this, _events, _selectedState));
 
         /// <inheritdoc cref="IAppCommands.PasteCircle"/>
         public void PasteCircle(AnimationFrameSave frame, CircleSave circle) =>
-            _undoManager.Execute(new AddCircleCommand(circle, frame, this, _events));
+            _undoManager.Execute(new AddCircleCommand(circle, frame, this, _events, _selectedState));
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteAxisAlignedRectangleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteAxisAlignedRectangleCommand.cs
@@ -9,6 +9,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationFrameSave _frame;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
 
         private int _originalIndex = -1;  // captured by Do()
 
@@ -18,12 +19,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             AARectSave rect,
             AnimationFrameSave frame,
             IAppCommands commands,
-            IApplicationEvents events)
+            IApplicationEvents events,
+            ISelectedState selectedState)
         {
             _rect = rect;
             _frame = frame;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
             Description = $"Delete Rectangle '{rect.Name}'";
         }
 
@@ -37,6 +40,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedRectangle = null;
             return true;
         }
 
@@ -48,6 +52,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedRectangle = _rect;
         }
 
         public void Redo()
@@ -57,6 +62,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedRectangle = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
@@ -10,6 +10,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationChainListSave _acls;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
 
         // Captured by Do(): the chains actually removed, paired with where they were.
         private (AnimationChainSave Chain, int OriginalIndex)[] _removed = [];
@@ -20,12 +21,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             IReadOnlyList<AnimationChainSave> chains,
             AnimationChainListSave acls,
             IAppCommands commands,
-            IApplicationEvents events)
+            IApplicationEvents events,
+            ISelectedState selectedState)
         {
             _chains = chains;
             _acls = acls;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
             Description = chains.Count == 1
                 ? $"Delete '{chains[0].Name}'"
                 : $"Delete {chains.Count} Animations";
@@ -53,6 +56,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events.RaiseAnimationChainsChanged();
             _commands.RefreshWireframe();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedChain = null;
             return true;
         }
 
@@ -69,6 +73,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events.RaiseAnimationChainsChanged();
             _commands.RefreshWireframe();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedChain = _removed[0].Chain;
         }
 
         public void Redo()
@@ -80,6 +85,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events.RaiseAnimationChainsChanged();
             _commands.RefreshWireframe();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedChain = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteCircleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteCircleCommand.cs
@@ -9,18 +9,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationFrameSave _frame;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
 
         private int _originalIndex = -1;  // captured by Do()
 
         public string Description { get; }
 
         public DeleteCircleCommand(CircleSave circle, AnimationFrameSave frame,
-            IAppCommands commands, IApplicationEvents events)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
         {
             _circle = circle;
             _frame = frame;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
             Description = $"Delete Circle '{circle.Name}'";
         }
 
@@ -34,6 +36,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedCircle = null;
             return true;
         }
 
@@ -45,6 +48,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedCircle = _circle;
         }
 
         public void Redo()
@@ -54,6 +58,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshAnimationFrameDisplay();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedCircle = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
@@ -10,6 +10,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly AnimationChainSave _chain;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
 
         // Captured by Do(): the frames actually removed, paired with where they were.
         private (AnimationFrameSave Frame, int OriginalIndex)[] _removed = [];
@@ -20,12 +21,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             IReadOnlyList<AnimationFrameSave> frames,
             AnimationChainSave chain,
             IAppCommands commands,
-            IApplicationEvents events)
+            IApplicationEvents events,
+            ISelectedState selectedState)
         {
             _frames = frames;
             _chain = chain;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
             Description = frames.Count == 1 ? "Delete Frame" : $"Delete {frames.Count} Frames";
         }
 
@@ -50,6 +53,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshWireframe();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = null;
             return true;
         }
 
@@ -64,6 +68,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshWireframe();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = _removed[0].Frame;
         }
 
         public void Redo()
@@ -74,6 +79,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands.RefreshWireframe();
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();
+            _selectedState.SelectedFrame = null;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteChainsCommand.cs
@@ -19,6 +19,8 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly IReadOnlyList<AnimationChainSave> _chains;
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly AnimationChainSave? _preAddChain;
 
         private int[] _insertedIndices = [];
 
@@ -28,12 +30,15 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             AnimationChainListSave acls,
             IReadOnlyList<AnimationChainSave> chains,
             IAppCommands commands,
-            IApplicationEvents events)
+            IApplicationEvents events,
+            ISelectedState selectedState)
         {
             _acls = acls;
             _chains = chains;
             _commands = commands;
             _events = events;
+            _selectedState = selectedState;
+            _preAddChain = selectedState.SelectedChain;
             Description = chains.Count == 1 ? "Paste Animation" : $"Paste {chains.Count} Animations";
         }
 
@@ -47,6 +52,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
                 .ToArray();
 
             RaiseSideEffects();
+            _selectedState.SelectedChain = _chains[0];
             return true;
         }
 
@@ -55,6 +61,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             foreach (var chain in _chains)
                 _acls.AnimationChains.Remove(chain);
             RaiseSideEffects();
+            _selectedState.SelectedChain = _preAddChain;
         }
 
         public void Redo()
@@ -65,6 +72,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
                 _acls.AnimationChains.Insert(idx, _chains[i]);
             }
             RaiseSideEffects();
+            _selectedState.SelectedChain = _chains[0];
         }
 
         private void RaiseSideEffects()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HistoryPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HistoryPanelTests.cs
@@ -109,7 +109,7 @@ public class HistoryPanelTests
         var acls = new AnimationChainListSave();
         var chain = new AnimationChainSave { Name = "Walk" };
         var ctx = TestHelpers.SetupFreshAcls();
-        var cmd = new AddChainCommand(chain, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents);
+        var cmd = new AddChainCommand(chain, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
 
         Assert.Contains("Walk", cmd.Description);
     }
@@ -130,7 +130,7 @@ public class HistoryPanelTests
     {
         var chain = new AnimationChainSave { Name = "Walk" };
         var ctx = TestHelpers.SetupFreshAcls();
-        var cmd = new DeleteChainsCommand(new[] { chain }, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents);
+        var cmd = new DeleteChainsCommand(new[] { chain }, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
 
         Assert.Contains("Walk", cmd.Description);
     }
@@ -144,7 +144,7 @@ public class HistoryPanelTests
             new AnimationChainSave { Name = "Run" },
         };
         var ctx = TestHelpers.SetupFreshAcls();
-        var cmd = new DeleteChainsCommand(chains, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents);
+        var cmd = new DeleteChainsCommand(chains, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
 
         Assert.Contains("2", cmd.Description);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoRedoSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoRedoSelectionTests.cs
@@ -1,0 +1,305 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class UndoRedoSelectionTests
+{
+    // ── AddChain ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddChain_Redo_SelectsAddedChain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.AddAnimationChainWithName("Walk");
+        var chain = ctx.Acls.AnimationChains[0];
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Same(chain, ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void AddChain_Undo_RestoresPreAddSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.AddAnimationChainWithName("A");
+        var chainA = ctx.Acls.AnimationChains[0];
+        ctx.SelectedState.SelectedChain = chainA;
+
+        ctx.AppCommands.AddAnimationChainWithName("B");
+        ctx.UndoManager.Undo();
+
+        Assert.Same(chainA, ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void AddChain_Undo_SelectionIsNull()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.AppCommands.AddAnimationChainWithName("Walk");
+
+        ctx.UndoManager.Undo();
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+
+    // ── AddCircle ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddCircle_Redo_SelectsCircle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.AddCircle(frame);
+        var circle = frame.ShapesSave!.CircleSaves[0];
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Same(circle, ctx.SelectedState.SelectedCircle);
+    }
+
+    [Fact]
+    public void AddCircle_Undo_ClearsCircleSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.AddCircle(frame);
+        ctx.UndoManager.Undo();
+
+        Assert.Null(ctx.SelectedState.SelectedCircle);
+    }
+
+    // ── AddFrame ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddFrame_Redo_SelectsFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+
+        ctx.AppCommands.AddFrame(chain);
+        var frame = chain.Frames[0];
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Same(frame, ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void AddFrame_Undo_ClearsFrameSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+
+        ctx.AppCommands.AddFrame(chain);
+        ctx.UndoManager.Undo();
+
+        Assert.Null(ctx.SelectedState.SelectedFrame);
+    }
+
+    // ── AddRect ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddRect_Redo_SelectsRect()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.AddAxisAlignedRectangle(frame);
+        var rect = frame.ShapesSave!.AARectSaves[0];
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Same(rect, ctx.SelectedState.SelectedRectangle);
+    }
+
+    [Fact]
+    public void AddRect_Undo_ClearsRectSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.AddAxisAlignedRectangle(frame);
+        ctx.UndoManager.Undo();
+
+        Assert.Null(ctx.SelectedState.SelectedRectangle);
+    }
+
+    // ── DeleteChain ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteChain_Redo_ClearsChainSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        ctx.AppCommands.DeleteAnimationChains(new List<AnimationChainSave> { chain });
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void DeleteChain_Undo_SelectsRestoredChain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+
+        ctx.AppCommands.DeleteAnimationChains(new List<AnimationChainSave> { chain });
+        ctx.UndoManager.Undo();
+
+        Assert.Same(chain, ctx.SelectedState.SelectedChain);
+    }
+
+    // ── DeleteCircle ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteCircle_Redo_ClearsCircleSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        ctx.AppCommands.AddCircle(frame);
+        ctx.UndoManager.Clear();
+        var circle = frame.ShapesSave!.CircleSaves[0];
+
+        ctx.AppCommands.DeleteCircle(circle, frame);
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedCircle);
+    }
+
+    [Fact]
+    public void DeleteCircle_Undo_SelectsRestoredCircle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        ctx.AppCommands.AddCircle(frame);
+        ctx.UndoManager.Clear();
+        var circle = frame.ShapesSave!.CircleSaves[0];
+
+        ctx.AppCommands.DeleteCircle(circle, frame);
+        ctx.UndoManager.Undo();
+
+        Assert.Same(circle, ctx.SelectedState.SelectedCircle);
+    }
+
+    // ── DeleteFrames ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteFrames_Redo_ClearsFrameSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        ctx.SelectedState.SelectedChain = chain;
+        var frame = chain.Frames[0];
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void DeleteFrames_Undo_SelectsRestoredFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        ctx.SelectedState.SelectedChain = chain;
+        var frame = chain.Frames[0];
+
+        ctx.AppCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
+        ctx.UndoManager.Undo();
+
+        Assert.Same(frame, ctx.SelectedState.SelectedFrame);
+    }
+
+    // ── PasteChains ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PasteChains_Undo_SelectionFallsBack()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var pastedChain = new AnimationChainSave { Name = "Pasted" };
+
+        ctx.AppCommands.PasteChains(new List<AnimationChainSave> { pastedChain });
+        ctx.UndoManager.Undo();
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void PasteChains_UndoRedo_RedoReselectsFirstPastedChain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var pastedChain = new AnimationChainSave { Name = "Pasted" };
+
+        ctx.AppCommands.PasteChains(new List<AnimationChainSave> { pastedChain });
+        var firstChain = ctx.Acls.AnimationChains[0];
+        ctx.UndoManager.Undo();
+
+        ctx.UndoManager.Redo();
+
+        Assert.Same(firstChain, ctx.SelectedState.SelectedChain);
+    }
+
+    // ── DeleteRect ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteRect_Redo_ClearsRectSelection()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        ctx.AppCommands.AddAxisAlignedRectangle(frame);
+        ctx.UndoManager.Clear();
+        var rect = frame.ShapesSave!.AARectSaves[0];
+
+        ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Null(ctx.SelectedState.SelectedRectangle);
+    }
+
+    [Fact]
+    public void DeleteRect_Undo_SelectsRestoredRect()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        ctx.AppCommands.AddAxisAlignedRectangle(frame);
+        ctx.UndoManager.Clear();
+        var rect = frame.ShapesSave!.AARectSaves[0];
+
+        ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
+        ctx.UndoManager.Undo();
+
+        Assert.Same(rect, ctx.SelectedState.SelectedRectangle);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoRedoSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoRedoSelectionTests.cs
@@ -58,7 +58,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.AddCircle(frame);
-        var circle = frame.ShapesSave!.CircleSaves[0];
+        var circle = frame.ShapesSave!.CircleSaves.First();
         ctx.UndoManager.Undo();
 
         ctx.UndoManager.Redo();
@@ -120,7 +120,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
         ctx.UndoManager.Undo();
 
         ctx.UndoManager.Redo();
@@ -180,7 +180,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddCircle(frame);
         ctx.UndoManager.Clear();
-        var circle = frame.ShapesSave!.CircleSaves[0];
+        var circle = frame.ShapesSave!.CircleSaves.First();
 
         ctx.AppCommands.DeleteCircle(circle, frame);
         ctx.UndoManager.Undo();
@@ -198,7 +198,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddCircle(frame);
         ctx.UndoManager.Clear();
-        var circle = frame.ShapesSave!.CircleSaves[0];
+        var circle = frame.ShapesSave!.CircleSaves.First();
 
         ctx.AppCommands.DeleteCircle(circle, frame);
         ctx.UndoManager.Undo();
@@ -277,7 +277,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
         ctx.UndoManager.Clear();
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
 
         ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
         ctx.UndoManager.Undo();
@@ -295,7 +295,7 @@ public class UndoRedoSelectionTests
         chain.Frames.Add(frame);
         ctx.AppCommands.AddAxisAlignedRectangle(frame);
         ctx.UndoManager.Clear();
-        var rect = frame.ShapesSave!.AARectSaves[0];
+        var rect = frame.ShapesSave!.AARectSaves.First();
 
         ctx.AppCommands.DeleteAxisAlignedRectangle(rect, frame);
         ctx.UndoManager.Undo();


### PR DESCRIPTION
Closes #279

## What changed

After undo or redo, `SelectedState` was left stale — e.g. after Add + Undo the selected item was still pointing at the just-removed object.

### Rules implemented
- **Add commands** (AddChain, AddFrame, AddFrames, AddRect, AddCircle, PasteChains): `Do`/`Redo` select the new item; `Undo` restores the pre-add selection.
- **Delete commands** (DeleteChains, DeleteFrames, DeleteRect, DeleteCircle): `Undo` selects the first restored item; `Do`/`Redo` clear selection for that item type.
- **Property-edit commands** (rename, move, resize, flip, reorder, bulk edit): no changes — selection is preserved unchanged, which was already correct.

### Implementation
Each add/delete command now receives `ISelectedState` in its constructor and captures the pre-operation selection at construction time (before `Execute` calls `Do`). Selection management lives entirely in the command, not in `AppCommands`.

The now-redundant `_selectedState.Selected* = …` lines that used to live in `AppCommands` after each `Execute` call were removed.

### Tests
17 new failing-first tests in `UndoRedoSelectionTests.cs` covering every add/delete command's undo and redo selection behaviour. All 1,380 tests (994 Core + 386 App) pass.