### PR TITLE
Fix timeline thumbnail not reflecting frame flip state

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -126,12 +126,24 @@ public sealed class ThumbnailService
         using var canvas = new SKCanvas(thumb);
         canvas.Clear(SKColors.Transparent);
         using var paint  = new SKPaint { Color = SKColors.White };
+
+        bool anyFlip = frame.FlipHorizontal || frame.FlipVertical;
+        if (anyFlip)
+        {
+            canvas.Save();
+            float flipScaleX = frame.FlipHorizontal ? -1f : 1f;
+            float flipScaleY = frame.FlipVertical   ? -1f : 1f;
+            canvas.Scale(flipScaleX, flipScaleY, finalW / 2f, finalH / 2f);
+        }
+
         // Nearest-neighbour ("point") sampling: keeps sprite-sheet art crisp/pixellated
         // instead of the blurry smear linear filtering produces on game art.
         canvas.DrawImage(region,
             SKRect.Create(0, 0, finalW, finalH),
             new SKSamplingOptions(SKFilterMode.Nearest),
             paint);
+
+        if (anyFlip) canvas.Restore();
         return thumb;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
@@ -6,15 +6,17 @@ namespace AnimationEditor.Core.ViewModels;
 /// Value signature of the visual a chain's first-frame thumbnail is rendered from.
 /// Two equal <see cref="ThumbnailSource"/> values produce an identical thumbnail, so the
 /// animation tree only regenerates a chain icon when this changes — which happens on a
-/// frame reorder, a first-frame texture swap, a first-frame region edit, or a first-frame
-/// delete.
+/// frame reorder, a first-frame texture swap, a first-frame region edit, a first-frame
+/// flip toggle, or a first-frame delete.
 /// </summary>
 public readonly record struct ThumbnailSource(
     string? TextureName,
     float Left,
     float Right,
     float Top,
-    float Bottom)
+    float Bottom,
+    bool FlipHorizontal,
+    bool FlipVertical)
 {
     /// <summary>
     /// Returns the signature of <paramref name="chain"/>'s first frame, or <c>null</c>
@@ -31,6 +33,8 @@ public readonly record struct ThumbnailSource(
             frame.LeftCoordinate,
             frame.RightCoordinate,
             frame.TopCoordinate,
-            frame.BottomCoordinate);
+            frame.BottomCoordinate,
+            frame.FlipHorizontal,
+            frame.FlipVertical);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -19,11 +19,13 @@ namespace AnimationEditor.App.Tests;
 public class ThumbnailServiceTests
 {
     /// <summary>A frame whose UV region is the given rectangle of the source (defaults to the whole sheet).</summary>
-    private static AnimationFrameSave Frame(float left = 0f, float top = 0f, float right = 1f, float bottom = 1f)
+    private static AnimationFrameSave Frame(float left = 0f, float top = 0f, float right = 1f, float bottom = 1f,
+        bool flipH = false, bool flipV = false)
         => new()
         {
             LeftCoordinate  = left,  TopCoordinate    = top,
             RightCoordinate = right, BottomCoordinate = bottom,
+            FlipHorizontal  = flipH, FlipVertical     = flipV,
         };
 
     /// <summary>A sprite sheet whose left half is <paramref name="left"/> and right half <paramref name="right"/>.</summary>
@@ -92,5 +94,50 @@ public class ThumbnailServiceTests
                 Assert.True(pureRed || pureBlue,
                     $"Pixel ({x},{y}) = {p} — point sampling should leave a hard seam, not a blended pixel.");
             }
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_FlipHorizontal_MirrorsImageHorizontally()
+    {
+        // Left half red, right half blue. With FlipHorizontal=true the right side of the
+        // thumbnail must be red and the left side blue — opposite of the unflipped crop.
+        using var source = SplitSheet(16, 8, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(
+            source, Frame(flipH: true), 16, 8);
+
+        Assert.NotNull(thumb);
+        // Leftmost pixel should be blue (was originally on the right).
+        var leftPx = thumb!.GetPixel(0, 4);
+        Assert.True(leftPx.Blue > leftPx.Red,
+            $"Left edge pixel {leftPx} should be blue after horizontal flip.");
+        // Rightmost pixel should be red (was originally on the left).
+        var rightPx = thumb.GetPixel(thumb.Width - 1, 4);
+        Assert.True(rightPx.Red > rightPx.Blue,
+            $"Right edge pixel {rightPx} should be red after horizontal flip.");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_FlipVertical_MirrorsImageVertically()
+    {
+        // Top half red, bottom half blue. With FlipVertical=true the bottom must be red and
+        // the top must be blue.
+        using var source = new SKBitmap(8, 16);
+        for (int y = 0; y < 16; y++)
+            for (int x = 0; x < 8; x++)
+                source.SetPixel(x, y, y < 8 ? SKColors.Red : SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(
+            source, Frame(flipV: true), 8, 16);
+
+        Assert.NotNull(thumb);
+        // Top pixel should be blue (was originally at the bottom).
+        var topPx = thumb!.GetPixel(4, 0);
+        Assert.True(topPx.Blue > topPx.Red,
+            $"Top edge pixel {topPx} should be blue after vertical flip.");
+        // Bottom pixel should be red (was originally at the top).
+        var bottomPx = thumb.GetPixel(4, thumb.Height - 1);
+        Assert.True(bottomPx.Red > bottomPx.Blue,
+            $"Bottom edge pixel {bottomPx} should be red after vertical flip.");
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
@@ -31,7 +31,7 @@ public class ThumbnailSourceTests
 
         var source = ThumbnailSource.FromChain(chain);
 
-        Assert.Equal(new ThumbnailSource("sheet.png", 0f, 0.5f, 0f, 1f), source);
+        Assert.Equal(new ThumbnailSource("sheet.png", 0f, 0.5f, 0f, 1f, false, false), source);
     }
 
     [Fact]
@@ -62,5 +62,41 @@ public class ThumbnailSourceTests
         });
 
         Assert.NotEqual(ThumbnailSource.FromChain(leftHalf), ThumbnailSource.FromChain(rightHalf));
+    }
+
+    [Fact]
+    public void FromChain_FlipHorizontalChange_ProducesUnequalSignature()
+    {
+        // A flip toggle on the first frame must invalidate the cached chain icon.
+        var normal = new AnimationChainSave { Name = "Normal" };
+        normal.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f, FlipHorizontal = false,
+        });
+        var flipped = new AnimationChainSave { Name = "Flipped" };
+        flipped.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f, FlipHorizontal = true,
+        });
+
+        Assert.NotEqual(ThumbnailSource.FromChain(normal), ThumbnailSource.FromChain(flipped));
+    }
+
+    [Fact]
+    public void FromChain_FlipVerticalChange_ProducesUnequalSignature()
+    {
+        // A vertical flip toggle on the first frame must also invalidate the cached chain icon.
+        var normal = new AnimationChainSave { Name = "Normal" };
+        normal.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f, FlipVertical = false,
+        });
+        var flipped = new AnimationChainSave { Name = "Flipped" };
+        flipped.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f, FlipVertical = true,
+        });
+
+        Assert.NotEqual(ThumbnailSource.FromChain(normal), ThumbnailSource.FromChain(flipped));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #282

When a frame has FlipHorizontal or FlipVertical set, the timeline thumbnail (and the chain tree icon) now correctly renders the mirrored image.

## Root cause

Two separate gaps:

1. **ThumbnailSource** — the change-detection value type used to decide whether to regenerate a chain's tree icon did not include the flip flags, so toggling a flip was invisible to the cache invalidation check.

2. **ThumbnailService.RenderFrameThumbnail** — the Skia render path cropped and scaled the frame region but never applied any canvas transform for FlipHorizontal/FlipVertical, so the bitmap was always unflipped regardless of the frame data.

## Changes

- ThumbnailSource: added FlipHorizontal and FlipVertical positional members; updated FromChain to capture them from the first frame.
- ThumbnailService.RenderFrameThumbnail: added a canvas.Save/Scale/Restore block mirroring the pattern already used by PreviewControl.DrawFrame (FlipScaleCalculator).
- Two new tests in ThumbnailServiceTests verify the horizontal and vertical flip render paths.
- Two new tests in ThumbnailSourceTests verify that a flip toggle on the first frame produces an unequal ThumbnailSource signature.
- Updated the existing ThumbnailSourceTests.FromChain_CapturesFirstFrameTextureAndRegion assertion to use the new 7-argument constructor.