### PR TITLE
fix: gate Ctrl+C/V/Delete on TextBox focus (#281)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2262,16 +2262,19 @@ public partial class MainWindow : Window
 
             if (e.Key == Key.C && e.KeyModifiers.HasFlag(KeyModifiers.Control))
             {
+                if (IsTextInputFocused()) return;
                 e.Handled = true;
                 _ = HandleCopyAsync();
             }
             else if (e.Key == Key.V && e.KeyModifiers.HasFlag(KeyModifiers.Control))
             {
+                if (IsTextInputFocused()) return;
                 e.Handled = true;
                 _ = HandlePasteAsync();
             }
             else if (e.Key == Key.Delete)
             {
+                if (IsTextInputFocused()) return;
                 e.Handled = true;
                 HandleDelete();
             }
@@ -2311,10 +2314,17 @@ public partial class MainWindow : Window
         }), RoutingStrategies.Tunnel);
     }
 
+    // Returns true when a text-editing control (TextBox) owns keyboard focus.
+    // Used to gate frame/shape copy-paste and Delete so those keys still reach
+    // the text control instead of being swallowed by the window-level handler.
+    private bool IsTextInputFocused()
+        => FocusManager?.GetFocusedElement() is TextBox;
+
     // ── Copy / Paste ──────────────────────────────────────────────────────────
 
     private async Task HandleCopyAsync()
     {
+        if (IsTextInputFocused()) return;
         var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
         if (clipboard is null) return;
 
@@ -2336,6 +2346,7 @@ public partial class MainWindow : Window
 
     private async Task HandlePasteAsync()
     {
+        if (IsTextInputFocused()) return;
         var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
         if (clipboard is null) return;
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
@@ -1,0 +1,156 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #281: Ctrl+C / Ctrl+V / Delete must not be
+/// swallowed by the window-level handler when a TextBox has keyboard focus.
+/// Only when a non-text-editing surface is focused should those keystrokes
+/// trigger frame/shape copy-paste or deletion.
+/// </summary>
+public class CopyPasteFocusGateTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    /// <summary>
+    /// Puts a serialized frame on the clipboard, focuses a TextBox, then presses
+    /// Ctrl+V. The frame-paste handler must not fire — the chain stays empty.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task CtrlV_TextBoxFocused_DoesNotPasteFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var xml = ClipboardPayload.Serialize(
+                new List<AnimationFrameSave> { new() { TextureName = "run.png", FrameLength = 0.1f } });
+            await window.Clipboard!.SetTextAsync(xml);
+
+            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            speedInput.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            // Verify focus is actually on a TextBox before pressing the key.
+            // If focus is not on the TextBox, the gate cannot protect against paste.
+            var focused = window.FocusManager?.GetFocusedElement();
+            Assert.IsType<TextBox>(focused);
+
+            window.KeyPress(Key.V, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(chain.Frames);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Same setup, but focus is on the AnimTree (not a TextBox). Ctrl+V should
+    /// trigger the paste handler and add the frame to the chain.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task CtrlV_NonTextBoxFocused_PastesFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var xml = ClipboardPayload.Serialize(
+                new List<AnimationFrameSave> { new() { TextureName = "run.png", FrameLength = 0.1f } });
+            await window.Clipboard!.SetTextAsync(xml);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            tree.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.V, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(chain.Frames);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Ctrl+C with a TextBox focused must not overwrite clipboard text with
+    /// frame XML (nothing in the tree is being copied from a text-editor context).
+    /// </summary>
+    [AvaloniaFact]
+    public async Task CtrlC_TextBoxFocused_DoesNotOverwriteClipboard()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // Populate tree with a chain so HandleCopyAsync has something to serialize.
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            await window.Clipboard!.SetTextAsync("plain text");
+
+            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            speedInput.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.C, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            var clipboardText = await window.Clipboard!.TryGetTextAsync();
+            Assert.Equal("plain text", clipboardText);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Delete with a TextBox focused must not trigger the frame/chain deletion
+    /// handler. The chain with one frame must survive.
+    /// </summary>
+    [AvaloniaFact]
+    public void Delete_TextBoxFocused_DoesNotDeleteSelectedFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "run.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = chain.Frames[0];
+
+            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            speedInput.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(chain.Frames);
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
## Summary

Ctrl+V, Ctrl+C, and Delete were being swallowed by the window-level tunnel handler even when a TextBox had keyboard focus, making it impossible to type in text fields or edit the speed input.

## Root cause

\WireKeyboard()\ registers a \RoutingStrategies.Tunnel\ key handler on \MainWindow\ that unconditionally intercepted those three keystrokes without checking whether a text-editing control was focused.  Avalonia's \MenuItem.InputGesture\ on the Copy/Paste menu items adds a second path that calls \HandleCopyAsync\/\HandlePasteAsync\ directly, bypassing the tunnel handler.

## Fix

- Added \IsTextInputFocused()\ helper: \FocusManager?.GetFocusedElement() is TextBox\
- Guard added in **\WireKeyboard()\** (covers Ctrl+C, Ctrl+V, Delete via keyboard)
- Guard added at the top of **\HandleCopyAsync\** and **\HandlePasteAsync\** (belt-and-suspenders: covers the MenuItem InputGesture path)

## Tests

Four new \[AvaloniaFact]\ tests in \CopyPasteFocusGateTests\:
- \CtrlV_TextBoxFocused_DoesNotPasteFrame\ — paste is blocked when SpeedInput is focused
- \CtrlV_NonTextBoxFocused_PastesFrame\ — paste fires when AnimTree is focused
- \CtrlC_TextBoxFocused_DoesNotOverwriteClipboard\ — copy is blocked when TextBox is focused
- \Delete_TextBoxFocused_DoesNotDeleteSelectedFrame\ — delete is blocked when TextBox is focused

All 1381 tests pass (991 Core + 390 App).

Closes #281