### PR TITLE
Squash history ListBox item height

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1062,6 +1062,12 @@
                              BorderThickness="1,0,0,0"
                              Padding="0"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListBox.Styles>
+                            <Style Selector="ListBoxItem">
+                                <Setter Property="MinHeight" Value="0" />
+                                <Setter Property="Padding" Value="0" />
+                            </Style>
+                        </ListBox.Styles>
                         <ListBox.ItemTemplate>
                             <DataTemplate x:DataType="appModels:HistoryEntryVm">
                                 <TextBlock Text="{Binding Description}"


### PR DESCRIPTION
The Fluent theme sets a default \MinHeight\ of 32px on every \ListBoxItem\, which made the history pane items tall and wasteful despite the small 11px font.

**Fix:** add \ListBox.Styles\ targeting \ListBoxItem\ to set \MinHeight=0\ and \Padding=0\, letting the \TextBlock\'s own \Padding=8,3\ drive the row height. Rows are now approximately half the previous height, matching the established pattern used elsewhere in the editor (e.g. the zoom combo box styles).

No logic was changed — this is a pure layout/styling fix.

Closes #314