### PR TITLE
fix: grid toggle no longer retroactively snaps existing frame UVs

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -934,67 +934,7 @@ public class WireframeControl : Control
     {
         _showGrid = show;
         _gridSize = cellSize;
-        // Snap and write UV back when grid is enabled so existing frames immediately
-        // align to grid lines.  This is the only place that mutates frame UV data;
-        // passive RefreshFramesInternal calls (e.g. from SelectionChanged) do not.
-        ApplyGridSnap();
         RefreshFramesInternal();
-    }
-
-    /// <summary>
-    /// Snaps the UV coordinates of every currently-visible frame to the active
-    /// grid and writes them back to the <see cref="AnimationFrameSave"/> objects.
-    /// Called only from <see cref="SetGrid"/> so that passive refreshes triggered
-    /// by selection changes cannot silently corrupt animation data.
-    /// </summary>
-    private void ApplyGridSnap()
-    {
-        if (!_showGrid || _gridSize <= 0 || _bitmap is null) return;
-
-        var selectedFrame  = _selectedState?.SelectedFrame;
-        var selectedChain  = _selectedState?.SelectedChain;
-        var selectedChains = _selectedState?.SelectedChains;
-
-        string? achxFolder = string.IsNullOrEmpty(_projectManager?.FileName)
-            ? null
-            : (Path.GetDirectoryName(_projectManager!.FileName) ?? string.Empty);
-
-        IEnumerable<AnimationFrameSave> framesToSnap;
-        if (selectedFrame != null)
-            framesToSnap = new[] { selectedFrame };
-        else if (selectedChains?.Count > 0)
-            framesToSnap = selectedChains.SelectMany(c => c.Frames);
-        else if (selectedChain?.Frames != null)
-            framesToSnap = selectedChain.Frames;
-        else
-            return;
-
-        float w = _bitmap.Width;
-        float h = _bitmap.Height;
-        static float Snap(float v, int g) => MathF.Round(v / g) * g;
-
-        foreach (var frame in framesToSnap)
-        {
-            if (string.IsNullOrEmpty(frame.TextureName)) continue;
-
-            if (achxFolder != null && _loadedTexturePath != null)
-            {
-                var fp = new FilePath(Path.Combine(achxFolder, frame.TextureName));
-                if (!fp.Equals(new FilePath(_loadedTexturePath))) continue;
-            }
-
-            float pixL = Snap(frame.LeftCoordinate   * w, _gridSize);
-            float pixT = Snap(frame.TopCoordinate    * h, _gridSize);
-            float pixR = Snap(frame.RightCoordinate  * w, _gridSize);
-            float pixB = Snap(frame.BottomCoordinate * h, _gridSize);
-            if (pixR <= pixL) pixR = pixL + _gridSize;
-            if (pixB <= pixT) pixB = pixT + _gridSize;
-
-            frame.LeftCoordinate   = pixL / w;
-            frame.RightCoordinate  = pixR / w;
-            frame.TopCoordinate    = pixT / h;
-            frame.BottomCoordinate = pixB / h;
-        }
     }
 
     /// <summary>
@@ -2114,9 +2054,9 @@ public class WireframeControl : Control
 
             if (_showGrid && _gridSize > 0)
             {
-                // Snap the display coordinates to grid line intersections.
-                // UV write-back is intentionally omitted here; it is the sole
-                // responsibility of ApplyGridSnap (called from SetGrid).
+                // Snap the display coordinates to grid line intersections for
+                // visual feedback.  UV write-back is intentionally omitted —
+                // grid is a future-edit setting and must never modify existing frames.
                 static float Snap(float v, int g) => MathF.Round(v / g) * g;
                 pixL = Snap(pixL, _gridSize);
                 pixT = Snap(pixT, _gridSize);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -400,12 +400,66 @@ public class GridRenderTests
     // ── Grid-snap: boundary box alignment ─────────────────────────────────────
 
     /// <summary>
-    /// A frame whose pixel bounds are not aligned to the grid should have its
-    /// displayed bounds (and UV coordinates) snapped to the nearest grid line
-    /// when grid mode is active.
+    /// Enabling the grid must NOT modify existing frame UV coordinates.
+    /// Grid is a future-edit setting: it snaps new drags and new frame creation
+    /// but must never rewrite the positions of frames that already exist.
     /// </summary>
     [AvaloniaFact]
-    public void GridEnabled_NonAlignedFrameBounds_SnapsToNearestGridLine()
+    public void SetGrid_Enable_DoesNotModifyExistingFrameUvCoordinates()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black, 100, 100);
+
+        var chain = new AnimationChainSave { Name = "C" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = System.IO.Path.GetFileName(png),
+            // Deliberately off-grid (not divisible by 10): 13, 23, 47, 58 pixels.
+            LeftCoordinate   = 13f / 100f,
+            TopCoordinate    = 23f / 100f,
+            RightCoordinate  = 47f / 100f,
+            BottomCoordinate = 58f / 100f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);
+
+        float origLeft   = frame.LeftCoordinate;
+        float origTop    = frame.TopCoordinate;
+        float origRight  = frame.RightCoordinate;
+        float origBottom = frame.BottomCoordinate;
+
+        try
+        {
+            ctrl.SetGrid(true, 10);
+
+            Assert.Equal(origLeft,   frame.LeftCoordinate);
+            Assert.Equal(origTop,    frame.TopCoordinate);
+            Assert.Equal(origRight,  frame.RightCoordinate);
+            Assert.Equal(origBottom, frame.BottomCoordinate);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// A frame whose pixel bounds are not aligned to the grid should have its
+    /// <em>displayed</em> bounds snapped to the nearest grid line when grid mode
+    /// is active.  The underlying UV coordinates must remain unchanged — the snap
+    /// is display-only so the wireframe gives visual grid alignment feedback
+    /// without destructively modifying animation data.
+    /// </summary>
+    [AvaloniaFact]
+    public void GridEnabled_NonAlignedFrameBounds_DisplayBoundsSnapToNearestGridLine()
     {
         var ctx = ResetSingletons();
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -432,7 +486,6 @@ public class GridRenderTests
         ctx.SelectedState.SelectedFrame = frame;
 
         var ctrl = ctx.CreateWireframeControl();
-        ctrl.InitializeServices(ctx.SelectedState, ctx.AppState, ctx.AppCommands, ctx.ApplicationEvents, ctx.ProjectManager, ctx.UndoManager);
         ctrl.LoadTexture(png);
         ctrl.SetCamera(0, 0, 1);
 
@@ -444,17 +497,17 @@ public class GridRenderTests
             Assert.Single(rects);
             var bounds = rects[0].Bounds;
 
-            // Each edge should be on a 10-pixel boundary.
+            // Display bounds snapped to 10-pixel grid for visual feedback.
             Assert.Equal(0, (int)bounds.Left   % 10);
             Assert.Equal(0, (int)bounds.Top    % 10);
             Assert.Equal(0, (int)bounds.Right  % 10);
             Assert.Equal(0, (int)bounds.Bottom % 10);
 
-            // UV data on the frame itself must also be snapped.
-            Assert.Equal(0, (int)MathF.Round(frame.LeftCoordinate   * 100) % 10);
-            Assert.Equal(0, (int)MathF.Round(frame.TopCoordinate    * 100) % 10);
-            Assert.Equal(0, (int)MathF.Round(frame.RightCoordinate  * 100) % 10);
-            Assert.Equal(0, (int)MathF.Round(frame.BottomCoordinate * 100) % 10);
+            // UV data on the frame itself must NOT be snapped.
+            Assert.Equal(13f / 100f, frame.LeftCoordinate);
+            Assert.Equal(23f / 100f, frame.TopCoordinate);
+            Assert.Equal(47f / 100f, frame.RightCoordinate);
+            Assert.Equal(58f / 100f, frame.BottomCoordinate);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
@@ -510,8 +563,8 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// Toggling grid off must leave the displayed bounds unchanged (the UV data
-    /// was already snapped when grid was on, and grid-off does not re-snap).
+    /// When the grid is disabled, displayed bounds must equal the raw UV pixel
+    /// coordinates — no snapping is applied in either direction.
     /// </summary>
     [AvaloniaFact]
     public void GridDisabled_BoundsMatchRawUV()


### PR DESCRIPTION
Closes #312

## What changed

WireframeControl.SetGrid() was calling ApplyGridSnap() which mutated rame.LeftCoordinate / RightCoordinate / TopCoordinate / BottomCoordinate in place for every visible frame on the selected animation. Accidentally checking the Grid checkbox while an animation was selected would silently corrupt that animation's frame regions.

## Fix

- Removed the ApplyGridSnap() call and the entire method from SetGrid().
- SetGrid() now only updates the snap-enabled flag and cell size, then triggers a redraw via RefreshFramesInternal().
- The **display-only** snap inside RefreshFramesInternal is retained — the wireframe still shows frames snapped to grid lines for visual feedback, but the underlying UV coordinates are never modified.

## Tests

- SetGrid_Enable_DoesNotModifyExistingFrameUvCoordinates — new test, was RED before fix
- GridEnabled_NonAlignedFrameBounds_DisplayBoundsSnapToNearestGridLine — renamed from the old test that asserted the buggy UV write-back; now asserts display bounds snap + UV unchanged
- All 1,455 tests pass