### PR TITLE
test(animation-editor): HistoryUndoButton/RedoButton enable/disable coverage (#313)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
@@ -138,6 +138,10 @@
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="Padding" Value="0"/>
         </Style>
+        <!-- Disabled buttons: dim so the user can tell they are unavailable -->
+        <Style Selector="Button:disabled">
+            <Setter Property="Opacity" Value="0.35" />
+        </Style>
         <!-- Icon-based +/- buttons: render SVG from file so path data lives in one place only -->
         <Style Selector="Button.plus">
             <Setter Property="ContentTemplate">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1066,6 +1066,8 @@
                             <Style Selector="ListBoxItem">
                                 <Setter Property="MinHeight" Value="0" />
                                 <Setter Property="Padding" Value="0" />
+                                <!-- Selection tracks current undo position; user clicks must not change it -->
+                                <Setter Property="IsHitTestVisible" Value="False" />
                             </Style>
                         </ListBox.Styles>
                         <ListBox.ItemTemplate>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1054,32 +1054,27 @@
                         </Grid>
                     </Border>
 
-                    <!-- ── History list ── -->
-                    <ListBox x:Name="HistoryList"
-                             Grid.Row="1"
-                             Background="{StaticResource BgPanel}"
-                             BorderBrush="{StaticResource LineBrush}"
-                             BorderThickness="1,0,0,0"
-                             Padding="0"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                        <ListBox.Styles>
-                            <Style Selector="ListBoxItem">
-                                <Setter Property="MinHeight" Value="0" />
-                                <Setter Property="Padding" Value="0" />
-                                <!-- Selection tracks current undo position; user clicks must not change it -->
-                                <Setter Property="IsHitTestVisible" Value="False" />
-                            </Style>
-                        </ListBox.Styles>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="appModels:HistoryEntryVm">
-                                <TextBlock Text="{Binding Description}"
-                                           FontSize="11"
-                                           Foreground="{Binding Foreground}"
-                                           Padding="8,3"
-                                           TextTrimming="CharacterEllipsis" />
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <!-- ── History list (read-only — no user selection) ── -->
+                    <ScrollViewer x:Name="HistoryScrollViewer"
+                                  Grid.Row="1"
+                                  Background="{StaticResource BgPanel}"
+                                  BorderBrush="{StaticResource LineBrush}"
+                                  BorderThickness="1,0,0,0"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl x:Name="HistoryList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="appModels:HistoryEntryVm">
+                                    <Border Background="{Binding Background}">
+                                        <TextBlock Text="{Binding Description}"
+                                                   FontSize="11"
+                                                   Foreground="{Binding Foreground}"
+                                                   Padding="8,3"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
 
                 </Grid>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -487,16 +487,20 @@ public partial class MainWindow : Window
         var undoHistory = _undoManager.UndoHistory;
         var redoHistory = _undoManager.RedoHistory;
         var items = new List<Models.HistoryEntryVm>();
-        // Newest undo item at the top, oldest at the bottom
-        foreach (var cmd in undoHistory.Reverse())
-            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec"));
+        // Redo items at the top (dimmed) — they keep their position when undone
         foreach (var cmd in redoHistory)
             items.Add(new Models.HistoryEntryVm(cmd.Description, "#6a6e76"));
+        // Undo items below, newest first, bright
+        foreach (var cmd in undoHistory.Reverse())
+            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec"));
         HistoryList.ItemsSource = items;
 
-        // Current step is always row 0 (most recent action)
-        HistoryList.SelectedIndex = undoHistory.Count > 0 ? 0 : -1;
-        if (items.Count > 0)
+        // Select the most recent applied command (first undo item)
+        int selectedIndex = undoHistory.Count > 0 ? redoHistory.Count : -1;
+        HistoryList.SelectedIndex = selectedIndex;
+        if (selectedIndex >= 0)
+            HistoryList.ScrollIntoView(items[selectedIndex]);
+        else if (items.Count > 0)
             HistoryList.ScrollIntoView(items[0]);
 
         HistoryUndoButton.IsEnabled = _undoManager.CanUndo;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -487,21 +487,18 @@ public partial class MainWindow : Window
         var undoHistory = _undoManager.UndoHistory;
         var redoHistory = _undoManager.RedoHistory;
         var items = new List<Models.HistoryEntryVm>();
-        // Redo items at the top (dimmed) — they keep their position when undone
-        foreach (var cmd in redoHistory)
+        // Redo items reversed so newest-recorded sits at top — positions never move on undo/redo
+        foreach (var cmd in redoHistory.Reverse())
             items.Add(new Models.HistoryEntryVm(cmd.Description, "#6a6e76"));
-        // Undo items below, newest first, bright
+        // Undo items newest-first; first entry is the current "you are here" position
+        bool firstUndo = true;
         foreach (var cmd in undoHistory.Reverse())
-            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec"));
+        {
+            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec", firstUndo));
+            firstUndo = false;
+        }
         HistoryList.ItemsSource = items;
-
-        // Select the most recent applied command (first undo item)
-        int selectedIndex = undoHistory.Count > 0 ? redoHistory.Count : -1;
-        HistoryList.SelectedIndex = selectedIndex;
-        if (selectedIndex >= 0)
-            HistoryList.ScrollIntoView(items[selectedIndex]);
-        else if (items.Count > 0)
-            HistoryList.ScrollIntoView(items[0]);
+        HistoryScrollViewer.Offset = new Avalonia.Vector(0, 0);
 
         HistoryUndoButton.IsEnabled = _undoManager.CanUndo;
         HistoryRedoButton.IsEnabled = _undoManager.CanRedo;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HistoryEntryVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HistoryEntryVm.cs
@@ -1,6 +1,13 @@
+using Avalonia.Media;
+
 namespace AnimationEditor.App.Models;
 
 /// <summary>View model for a single row in the History panel.</summary>
 /// <param name="Description">Human-readable description of the command.</param>
 /// <param name="Foreground">Hex colour for the text (muted for redo items).</param>
-internal sealed record HistoryEntryVm(string Description, string Foreground);
+/// <param name="IsCurrent">True for the most-recent undo entry (the "you are here" marker).</param>
+internal sealed record HistoryEntryVm(string Description, string Foreground, bool IsCurrent = false)
+{
+    /// <summary>Accent background for the current position; transparent for all other rows.</summary>
+    public IBrush Background => IsCurrent ? new SolidColorBrush(Color.Parse("#d83a3a")) : Brushes.Transparent;
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryEntryVmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryEntryVmTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.App.Models;
+using Avalonia.Media;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class HistoryEntryVmTests
+{
+    [Fact]
+    public void Background_WhenIsCurrent_IsNonTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec", IsCurrent: true);
+        var brush = Assert.IsType<SolidColorBrush>(vm.Background);
+        Assert.NotEqual(Colors.Transparent, brush.Color);
+    }
+
+    [Fact]
+    public void Background_WhenNotCurrent_IsTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec", IsCurrent: false);
+        Assert.Same(Brushes.Transparent, vm.Background);
+    }
+
+    [Fact]
+    public void Background_DefaultIsCurrent_IsTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec");
+        Assert.Same(Brushes.Transparent, vm.Background);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.App.Models;
 using FlatRedBall2.Animation.Content;
 using Xunit;
 
@@ -151,11 +154,42 @@ public class HistoryPanelButtonStateTests
         finally { window.Close(); }
     }
 
+    // ── History list ordering ─────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void HistoryList_UndoneItemStaysAtTop_NotMovedToBottom()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd("A"));
+            ctx.UndoManager.Record(new StubCmd("B"));
+            ctx.UndoManager.Undo(); // B → redo stack
+            Dispatcher.UIThread.RunJobs();
+
+            var list = window.FindControl<ListBox>("HistoryList")!;
+            var items = ((IEnumerable<HistoryEntryVm>)list.ItemsSource!).ToList();
+
+            // B was undone; it must appear at row 0 (top), not at the bottom
+            Assert.Equal(2, items.Count);
+            Assert.Equal("B", items[0].Description);
+            Assert.Equal("A", items[1].Description);
+
+            // B is dimmed (redo item), A is bright (applied item)
+            Assert.Equal("#6a6e76", items[0].Foreground);
+            Assert.Equal("#e6e8ec", items[1].Foreground);
+
+            // Selection sits on A (the most recently applied command)
+            Assert.Equal(1, list.SelectedIndex);
+        }
+        finally { window.Close(); }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private sealed class StubCmd : IUndoableCommand
+    private sealed class StubCmd(string description = "Stub") : IUndoableCommand
     {
-        public string Description => "Stub";
+        public string Description => description;
         public bool Do() => true;
         public void Undo() { }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
@@ -1,0 +1,162 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies that HistoryUndoButton and HistoryRedoButton enable/disable
+/// to reflect the current undo/redo availability.
+/// </summary>
+public class HistoryPanelButtonStateTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    // ── Initial state ─────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void HistoryUndoButton_DisabledInitially()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var btn = window.FindControl<Button>("HistoryUndoButton")!;
+            Assert.False(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void HistoryRedoButton_DisabledInitially()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var btn = window.FindControl<Button>("HistoryRedoButton")!;
+            Assert.False(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── After recording a command ─────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void HistoryUndoButton_EnabledAfterCommandRecorded()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryUndoButton")!;
+            Assert.True(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void HistoryRedoButton_StillDisabledAfterCommandRecorded()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryRedoButton")!;
+            Assert.False(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── After undoing ─────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void HistoryRedoButton_EnabledAfterUndo()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            ctx.UndoManager.Undo();
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryRedoButton")!;
+            Assert.True(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void HistoryUndoButton_DisabledAfterAllCommandsUndone()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            ctx.UndoManager.Undo();
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryUndoButton")!;
+            Assert.False(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── After redoing ─────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void HistoryRedoButton_DisabledAfterRedo()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            ctx.UndoManager.Undo();
+            ctx.UndoManager.Redo();
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryRedoButton")!;
+            Assert.False(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void HistoryUndoButton_ReEnabledAfterRedo()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd());
+            ctx.UndoManager.Undo();
+            ctx.UndoManager.Redo();
+            Dispatcher.UIThread.RunJobs();
+
+            var btn = window.FindControl<Button>("HistoryUndoButton")!;
+            Assert.True(btn.IsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private sealed class StubCmd : IUndoableCommand
+    {
+        public string Description => "Stub";
+        public bool Do() => true;
+        public void Undo() { }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
@@ -167,7 +167,7 @@ public class HistoryPanelButtonStateTests
             ctx.UndoManager.Undo(); // B → redo stack
             Dispatcher.UIThread.RunJobs();
 
-            var list = window.FindControl<ListBox>("HistoryList")!;
+            var list = window.FindControl<ItemsControl>("HistoryList")!;
             var items = ((IEnumerable<HistoryEntryVm>)list.ItemsSource!).ToList();
 
             // B was undone; it must appear at row 0 (top), not at the bottom
@@ -179,8 +179,9 @@ public class HistoryPanelButtonStateTests
             Assert.Equal("#6a6e76", items[0].Foreground);
             Assert.Equal("#e6e8ec", items[1].Foreground);
 
-            // Selection sits on A (the most recently applied command)
-            Assert.Equal(1, list.SelectedIndex);
+            // A is the current "you are here" entry
+            Assert.False(items[0].IsCurrent);
+            Assert.True(items[1].IsCurrent);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
Closes #313
Closes #315

## What

Fixes both #313 (Undo/Redo buttons should grey out) and #315 (history list should not be user-selectable).

## Changes

### Button enable/disable (#313)
`HistoryUndoButton` and `HistoryRedoButton` are already wired to `RefreshHistoryPanel()` — tests added to lock in the behavior.

### Disabled buttons visually grey out
Added `Button:disabled { Opacity: 0.35 }` in `App.axaml` so SVG icon buttons dim when `IsEnabled=false`.

### Read-only history list (#315)
Replaced `ListBox` with `ItemsControl`+`ScrollViewer` — no selection concept, no keyboard navigation, clicks do nothing.

### Stable item ordering
Items never move position on undo/redo: redo items (dimmed `#6a6e76`) sit at the top in recorded order, undo items (bright) below. `redoHistory.Reverse()` ensures correct top-to-bottom order.

### "You are here" marker
`HistoryEntryVm.IsCurrent` adds a red-accent background row to the most recently applied command.

## Tests
- `HistoryPanelButtonStateTests` — 9 `[AvaloniaFact]` tests for button state + ordering
- `HistoryEntryVmTests` — 3 `[Fact]` tests for `IsCurrent`/`Background`

All 414 tests pass.