### PR TITLE
Disable history panel selection (replace ListBox with ItemsControl)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1054,24 +1054,27 @@
                         </Grid>
                     </Border>
 
-                    <!-- ── History list ── -->
-                    <ListBox x:Name="HistoryList"
-                             Grid.Row="1"
-                             Background="{StaticResource BgPanel}"
-                             BorderBrush="{StaticResource LineBrush}"
-                             BorderThickness="1,0,0,0"
-                             Padding="0"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="appModels:HistoryEntryVm">
-                                <TextBlock Text="{Binding Description}"
-                                           FontSize="11"
-                                           Foreground="{Binding Foreground}"
-                                           Padding="8,3"
-                                           TextTrimming="CharacterEllipsis" />
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <!-- ── History list (read-only, no user selection) ── -->
+                    <ScrollViewer x:Name="HistoryScrollViewer"
+                                  Grid.Row="1"
+                                  Background="{StaticResource BgPanel}"
+                                  BorderBrush="{StaticResource LineBrush}"
+                                  BorderThickness="1,0,0,0"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl x:Name="HistoryList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="appModels:HistoryEntryVm">
+                                    <Border Background="{Binding Background}">
+                                        <TextBlock Text="{Binding Description}"
+                                                   FontSize="11"
+                                                   Foreground="{Binding Foreground}"
+                                                   Padding="8,3"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
 
                 </Grid>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -487,17 +487,17 @@ public partial class MainWindow : Window
         var undoHistory = _undoManager.UndoHistory;
         var redoHistory = _undoManager.RedoHistory;
         var items = new List<Models.HistoryEntryVm>();
-        // Newest undo item at the top, oldest at the bottom
+        // Newest undo item at the top, oldest at the bottom; first entry is "current position"
+        bool firstUndo = true;
         foreach (var cmd in undoHistory.Reverse())
-            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec"));
+        {
+            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec", firstUndo));
+            firstUndo = false;
+        }
         foreach (var cmd in redoHistory)
             items.Add(new Models.HistoryEntryVm(cmd.Description, "#6a6e76"));
         HistoryList.ItemsSource = items;
-
-        // Current step is always row 0 (most recent action)
-        HistoryList.SelectedIndex = undoHistory.Count > 0 ? 0 : -1;
-        if (items.Count > 0)
-            HistoryList.ScrollIntoView(items[0]);
+        HistoryScrollViewer.Offset = new Avalonia.Vector(0, 0);
 
         HistoryUndoButton.IsEnabled = _undoManager.CanUndo;
         HistoryRedoButton.IsEnabled = _undoManager.CanRedo;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HistoryEntryVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HistoryEntryVm.cs
@@ -1,6 +1,13 @@
+using Avalonia.Media;
+
 namespace AnimationEditor.App.Models;
 
 /// <summary>View model for a single row in the History panel.</summary>
 /// <param name="Description">Human-readable description of the command.</param>
 /// <param name="Foreground">Hex colour for the text (muted for redo items).</param>
-internal sealed record HistoryEntryVm(string Description, string Foreground);
+/// <param name="IsCurrent">True for the most-recent undo entry (the "you are here" marker).</param>
+internal sealed record HistoryEntryVm(string Description, string Foreground, bool IsCurrent = false)
+{
+    /// <summary>Accent background for the current position; transparent for all other rows.</summary>
+    public IBrush Background => IsCurrent ? new SolidColorBrush(Color.Parse("#d83a3a")) : Brushes.Transparent;
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryEntryVmTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryEntryVmTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.App.Models;
+using Avalonia.Media;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class HistoryEntryVmTests
+{
+    [Fact]
+    public void Background_WhenIsCurrent_IsNonTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec", IsCurrent: true);
+        var brush = Assert.IsType<SolidColorBrush>(vm.Background);
+        Assert.NotEqual(Colors.Transparent, brush.Color);
+    }
+
+    [Fact]
+    public void Background_WhenNotCurrent_IsTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec", IsCurrent: false);
+        Assert.Same(Brushes.Transparent, vm.Background);
+    }
+
+    [Fact]
+    public void Background_DefaultIsCurrent_IsTransparent()
+    {
+        var vm = new HistoryEntryVm("Test", "#e6e8ec");
+        Assert.Same(Brushes.Transparent, vm.Background);
+    }
+}


### PR DESCRIPTION
## Summary

Clicking items or pressing arrow keys in the History panel's list box had no effect, which was confusing to users.

## Change

Replace the ListBox with a ScrollViewer + ItemsControl. ItemsControl has no selection semantics, so the user can never interact with individual rows. The "you are here" marker (current undo position) is now shown via a red-accent background on the top item, driven by the new HistoryEntryVm.IsCurrent property rather than ListBox.SelectedIndex.

## Files changed

- HistoryEntryVm.cs — add IsCurrent and Background (accent brush / transparent)
- MainWindow.axaml — replace ListBox with ScrollViewer+ItemsControl; update DataTemplate to use Border background binding
- MainWindow.axaml.cs — update RefreshHistoryPanel() to mark first undo entry as current, remove SelectedIndex/ScrollIntoView calls, scroll via HistoryScrollViewer.Offset
- HistoryEntryVmTests.cs — unit tests for IsCurrent background logic

Closes #315