### PR TITLE
Fix texture name TextBox blocking paste

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -882,7 +882,7 @@
                                                    Foreground="{StaticResource InkMid}" />
                                         <Grid ColumnDefinitions="*,24">
                                             <TextBox x:Name="PropTextureName" Grid.Column="0"
-                                                     FontSize="10" IsReadOnly="True" Opacity="0.7" />
+                                                     FontSize="10" />
                                             <Button x:Name="PropTextureBrowseBtn" Grid.Column="1"
                                                     Content="…" FontSize="10"
                                                     Width="24" Height="22"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1729,7 +1729,32 @@ public partial class MainWindow : Window
         PropCircleY.ValueChanged   += (_, _) => ApplyCircleProps();
         PropCircleRadius.ValueChanged += (_, _) => ApplyCircleProps();
 
+        PropTextureName.LostFocus  += (_, _) => ApplyTextureName();
         PropTextureBrowseBtn.Click += async (_, _) => await BrowseForFrameTexture();
+    }
+
+    private void ApplyTextureName()
+    {
+        if (_suppressPropRefresh) return;
+        var frame = _selectedState.SelectedFrame;
+        if (frame is null) return;
+
+        var inputText = PropTextureName.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(inputText)) return;
+
+        var currentDisplay = TexturePathHelper.ComputeDisplayPath(frame.TextureName, _projectManager.FileName);
+        if (inputText == currentDisplay) return;
+
+        string achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
+            ? string.Empty
+            : (Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty);
+
+        string absolutePath = TexturePathHelper.ResolveDisplayPath(inputText, achxFolder);
+        string storePath    = TexturePathHelper.ComputeStorePath(absolutePath, achxFolder);
+
+        _appCommands.SetFrameTextureName(frame, storePath);
+        WireframeCtrl.LoadTexture(absolutePath);
+        RefreshPropertyPanel();
     }
 
     private async Task BrowseForFrameTexture()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TexturePathHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TexturePathHelper.cs
@@ -61,6 +61,28 @@ public static class TexturePathHelper
         return IsAbsolute(rel) ? framePath : rel;
     }
 
+    /// <summary>
+    /// Resolves a display path (which may be relative or absolute) to an absolute path
+    /// using the .achx folder as the base for relative paths. This is the inverse of
+    /// <see cref="ComputeDisplayPath"/>: a relative display path is combined with
+    /// <paramref name="achxFolder"/> and normalized via <see cref="Path.GetFullPath"/>.
+    /// </summary>
+    /// <param name="displayPath">
+    /// The path as shown in the texture name TextBox — may be relative (relative to the
+    /// .achx folder) or absolute.
+    /// </param>
+    /// <param name="achxFolder">
+    /// The directory of the .achx file. If empty, <paramref name="displayPath"/> is
+    /// returned unchanged.
+    /// </param>
+    public static string ResolveDisplayPath(string displayPath, string achxFolder)
+    {
+        if (string.IsNullOrEmpty(displayPath)) return string.Empty;
+        if (IsAbsolute(displayPath)) return displayPath;
+        if (string.IsNullOrEmpty(achxFolder)) return displayPath;
+        return Path.GetFullPath(Path.Combine(achxFolder, displayPath));
+    }
+
     private static bool IsAbsolute(string path)
         => Path.IsPathRooted(path)
            || (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':');

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using AnimationEditor.Core.IO;
 using Xunit;
 
@@ -118,5 +119,52 @@ public class TexturePathHelperTests
         string display = TexturePathHelper.ComputeDisplayPath(absolute, null);
 
         Assert.Equal(absolute, display);
+    }
+
+    // ── ResolveDisplayPath ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveDisplayPath_EmptyDisplayPath_ReturnsEmpty()
+    {
+        string resolved = TexturePathHelper.ResolveDisplayPath(string.Empty, @"C:\Project\Animations\");
+
+        Assert.Equal(string.Empty, resolved);
+    }
+
+    [Fact]
+    public void ResolveDisplayPath_AbsolutePath_ReturnedUnchanged()
+    {
+        const string absolute = @"C:\Project\Content\Hero.png";
+        string resolved = TexturePathHelper.ResolveDisplayPath(absolute, @"C:\Project\Animations\");
+
+        Assert.Equal(absolute, resolved);
+    }
+
+    [Fact]
+    public void ResolveDisplayPath_RelativePathEmptyAchxFolder_ReturnedUnchanged()
+    {
+        string resolved = TexturePathHelper.ResolveDisplayPath("Hero.png", string.Empty);
+
+        Assert.Equal("Hero.png", resolved);
+    }
+
+    [Fact]
+    public void ResolveDisplayPath_SimpleRelativePath_ResolvesToAbsolute()
+    {
+        string resolved = TexturePathHelper.ResolveDisplayPath("Hero.png", @"C:\Project\Animations\");
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(@"C:\Project\Animations\", "Hero.png")),
+            resolved);
+    }
+
+    [Fact]
+    public void ResolveDisplayPath_DotDotRelativePath_ResolvesToAbsolute()
+    {
+        string resolved = TexturePathHelper.ResolveDisplayPath("../Content/Hero.png", @"C:\Project\Animations\");
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(@"C:\Project\Animations\", "../Content/Hero.png")),
+            resolved);
     }
 }


### PR DESCRIPTION
## Summary

PropTextureName had IsReadOnly="True" which silently blocked Ctrl+V paste. The user could copy text from a frame's texture box, but couldn't paste it into another frame's texture box.

## Changes

- **MainWindow.axaml** — Remove IsReadOnly="True" and Opacity="0.7" from PropTextureName
- **MainWindow.axaml.cs** — Wire PropTextureName.LostFocus → ApplyTextureName() so pasted (or typed) text commits to the frame on focus loss
- **TexturePathHelper.cs** — Add ResolveDisplayPath(displayPath, achxFolder): the inverse of ComputeDisplayPath — converts a display path (relative or absolute) back to an absolute path
- **TexturePathHelperTests.cs** — 5 new unit tests covering all ResolveDisplayPath paths

## How to test

1. Open a project with at least two frames
2. Select a frame with a non-empty texture → highlight and Ctrl+C the texture name
3. Select a frame with no texture → click in the texture TextBox → Ctrl+V
4. Click elsewhere (focus loss) → texture should be applied

Closes #318