### PR TITLE
Full undo pass + History UX improvements (issues #316 and #320)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -375,7 +375,7 @@ public class WireframeControl : Control
 
     // Chain-drag state: set when the user drags the composite chain bounding rect
     private bool _draggingChain;
-    private readonly List<(FrameRect Rect, SKRect StartBounds)> _chainDragStarts = new();
+    private readonly List<(FrameRect Rect, SKRect StartBounds, float BL, float BT, float BR, float BB)> _chainDragStarts = new();
 
     // Bulk handle-drag state: populated at drag-start when multiple chains are selected.
     // Holds the before-state and start bounds of ALL visible frames so ApplyHandleDrag
@@ -1091,10 +1091,24 @@ public class WireframeControl : Control
         _draggingChain = true;
         _chainDragStarts.Clear();
         foreach (var fr in _frameRects)
-            _chainDragStarts.Add((fr, fr.Bounds));
+            _chainDragStarts.Add((fr, fr.Bounds,
+                fr.Frame.LeftCoordinate, fr.Frame.TopCoordinate,
+                fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
         _dragStartWorld = ScreenToTexture(startScreenX, startScreenY);
 
         ApplyChainDrag(new Point(endScreenX, endScreenY));
+
+        if (_chainDragStarts.Count > 0)
+        {
+            var snapshots = _chainDragStarts
+                .Select(s => new BulkFrameRegionChangedCommand.FrameSnapshot(
+                    s.Rect.Frame,
+                    s.BL, s.BT, s.BR, s.BB,
+                    s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
+                    s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
+                .ToList();
+            _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+        }
 
         ChainRegionChanged?.Invoke(chain);
         _draggingChain = false;
@@ -1440,7 +1454,9 @@ public class WireframeControl : Control
                     _draggingChain = true;
                     _chainDragStarts.Clear();
                     foreach (var fr in _frameRects)
-                        _chainDragStarts.Add((fr, fr.Bounds));
+                        _chainDragStarts.Add((fr, fr.Bounds,
+                            fr.Frame.LeftCoordinate, fr.Frame.TopCoordinate,
+                            fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
                     _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
                 }
                 e.Pointer.Capture(this);
@@ -1656,7 +1672,20 @@ public class WireframeControl : Control
         {
             var chain = _selectedState!.SelectedChain;
             if (chain != null)
+            {
+                if (_chainDragStarts.Count > 0)
+                {
+                    var snapshots = _chainDragStarts
+                        .Select(s => new BulkFrameRegionChangedCommand.FrameSnapshot(
+                            s.Rect.Frame,
+                            s.BL, s.BT, s.BR, s.BB,
+                            s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
+                            s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
+                        .ToList();
+                    _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+                }
                 ChainRegionChanged?.Invoke(chain);
+            }
             _draggingChain = false;
             _chainDragStarts.Clear();
             e.Pointer.Capture(null);
@@ -1857,7 +1886,7 @@ public class WireframeControl : Control
         float texW = _bitmap.Width;
         float texH = _bitmap.Height;
 
-        foreach (var (fr, startBounds) in _chainDragStarts)
+        foreach (var (fr, startBounds, _, _, _, _) in _chainDragStarts)
         {
             float newL = startBounds.Left   + dx;
             float newT = startBounds.Top    + dy;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/HistoryScrollHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/HistoryScrollHelper.cs
@@ -1,0 +1,19 @@
+namespace AnimationEditor.App.Helpers;
+
+internal static class HistoryScrollHelper
+{
+    internal static double? ComputeScrollOffset(
+        int currentIndex, int totalCount,
+        double extent, double viewport, double currentOffsetY)
+    {
+        if (totalCount == 0 || extent <= viewport) return null;
+        double itemHeight = extent / totalCount;
+        double itemTop = currentIndex * itemHeight;
+        double itemBottom = itemTop + itemHeight;
+        if (itemTop < currentOffsetY)
+            return itemTop;
+        if (itemBottom > currentOffsetY + viewport)
+            return itemBottom - viewport;
+        return null;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -481,10 +481,25 @@ public partial class MainWindow : Window
             firstUndo = false;
         }
         HistoryList.ItemsSource = items;
-        HistoryScrollViewer.Offset = new Avalonia.Vector(0, 0);
+        int currentIndex = redoHistory.Count;
+        ScrollHistoryToCurrent(currentIndex, items.Count);
 
         HistoryUndoButton.IsEnabled = _undoManager.CanUndo;
         HistoryRedoButton.IsEnabled = _undoManager.CanRedo;
+    }
+
+    private void ScrollHistoryToCurrent(int currentIndex, int totalCount)
+    {
+        if (totalCount == 0) return;
+        Dispatcher.UIThread.Post(() =>
+        {
+            double extent   = HistoryScrollViewer.Extent.Height;
+            double viewport = HistoryScrollViewer.Viewport.Height;
+            double newOffset = Helpers.HistoryScrollHelper.ComputeScrollOffset(
+                currentIndex, totalCount, extent, viewport,
+                HistoryScrollViewer.Offset.Y) ?? HistoryScrollViewer.Offset.Y;
+            HistoryScrollViewer.Offset = new Avalonia.Vector(0, newOffset);
+        }, Avalonia.Threading.DispatcherPriority.Render);
     }
 
     private void SetHistoryVisible(bool visible)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1947,20 +1947,15 @@ public partial class MainWindow : Window
         if (_suppressPropRefresh) return;
         var frame = _selectedState.SelectedFrame;
         if (frame is null || !PropFrameLen.Value.HasValue) return;
-        frame.FrameLength = (float)PropFrameLen.Value.Value;
-        _appCommands.RefreshTreeNode(frame);
-        _events.RaiseAnimationChainsChanged();
+        _appCommands.SetFrameLength(frame, (float)PropFrameLen.Value.Value);
     }
 
     private void ApplyFrameRelative()
     {
         if (_suppressPropRefresh) return;
         var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
-        if (PropRelX.Value.HasValue) frame.RelativeX = (float)PropRelX.Value.Value;
-        if (PropRelY.Value.HasValue) frame.RelativeY = (float)PropRelY.Value.Value;
-        _events.RaiseAnimationChainsChanged();
-        _appCommands.RefreshWireframe();
+        if (frame is null || !PropRelX.Value.HasValue || !PropRelY.Value.HasValue) return;
+        _appCommands.SetFrameRelative(frame, (float)PropRelX.Value.Value, (float)PropRelY.Value.Value);
     }
 
     private void ApplyFramePixelCoords()
@@ -1972,13 +1967,10 @@ public partial class MainWindow : Window
         if (bmpW <= 0 || bmpH <= 0) return;
         if (!PropPixelX.Value.HasValue || !PropPixelY.Value.HasValue ||
             !PropPixelW.Value.HasValue || !PropPixelH.Value.HasValue) return;
-
-        PixelFrameEditor.SetX(frame,      (int)PropPixelX.Value.Value, bmpW);
-        PixelFrameEditor.SetY(frame,      (int)PropPixelY.Value.Value, bmpH);
-        PixelFrameEditor.SetWidth(frame,  (int)PropPixelW.Value.Value, bmpW);
-        PixelFrameEditor.SetHeight(frame, (int)PropPixelH.Value.Value, bmpH);
-        _events.RaiseAnimationChainsChanged();
-        WireframeCtrl.RefreshFrames();
+        _appCommands.SetFramePixelRegion(frame,
+            (int)PropPixelX.Value.Value, (int)PropPixelY.Value.Value,
+            (int)PropPixelW.Value.Value, (int)PropPixelH.Value.Value,
+            bmpW, bmpH);
     }
 
 
@@ -1986,31 +1978,26 @@ public partial class MainWindow : Window
     {
         if (_suppressPropRefresh) return;
         var rect = _selectedState.SelectedRectangle;
-        if (rect is null) return;
-        rect.Name = PropRectName.Text ?? "";
-        if (PropRectX.Value.HasValue)      rect.X      = (float)PropRectX.Value.Value;
-        if (PropRectY.Value.HasValue)      rect.Y      = (float)PropRectY.Value.Value;
-        if (PropRectScaleX.Value.HasValue) rect.ScaleX = (float)PropRectScaleX.Value.Value;
-        if (PropRectScaleY.Value.HasValue) rect.ScaleY = (float)PropRectScaleY.Value.Value;
-        _events.RaiseAnimationChainsChanged();
-        _appCommands.RefreshWireframe();
+        if (rect is null || !PropRectX.Value.HasValue || !PropRectY.Value.HasValue ||
+            !PropRectScaleX.Value.HasValue || !PropRectScaleY.Value.HasValue) return;
         var frame = _selectedState.SelectedFrame;
-        if (frame is not null) _appCommands.RefreshTreeNode(frame);
+        _appCommands.SetRectProps(frame, rect,
+            PropRectName.Text ?? "",
+            (float)PropRectX.Value.Value, (float)PropRectY.Value.Value,
+            (float)PropRectScaleX.Value.Value, (float)PropRectScaleY.Value.Value);
     }
 
     private void ApplyCircleProps()
     {
         if (_suppressPropRefresh) return;
         var circ = _selectedState.SelectedCircle;
-        if (circ is null) return;
-        circ.Name = PropCircleName.Text ?? "";
-        if (PropCircleX.Value.HasValue)      circ.X      = (float)PropCircleX.Value.Value;
-        if (PropCircleY.Value.HasValue)      circ.Y      = (float)PropCircleY.Value.Value;
-        if (PropCircleRadius.Value.HasValue) circ.Radius = (float)PropCircleRadius.Value.Value;
-        _events.RaiseAnimationChainsChanged();
-        _appCommands.RefreshWireframe();
+        if (circ is null || !PropCircleX.Value.HasValue || !PropCircleY.Value.HasValue ||
+            !PropCircleRadius.Value.HasValue) return;
         var frame = _selectedState.SelectedFrame;
-        if (frame is not null) _appCommands.RefreshTreeNode(frame);
+        _appCommands.SetCircleProps(frame, circ,
+            PropCircleName.Text ?? "",
+            (float)PropCircleX.Value.Value, (float)PropCircleY.Value.Value,
+            (float)PropCircleRadius.Value.Value);
     }
 
     // ── Playback controls wiring ──────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -378,44 +378,27 @@ public partial class MainWindow : Window
         var (bitmapW, bitmapH) = WireframeCtrl.BitmapSize;
         if (bitmapW == 0 || bitmapH == 0) return;
 
-        // When an .achx project file is open, make the path relative to it.
-        // When no file exists yet (unsaved project), keep the absolute path so
-        // WireframeControl.DetermineTexturePath can still resolve it for display.
         string relPath = !string.IsNullOrEmpty(_projectManager.FileName)
             ? Path.GetRelativePath(
                 Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty,
                 texPath).Replace('\\', '/')
             : texPath;
 
-        // When multiple chains are selected, add a distinct frame to each one.
-        // When only one chain is in scope, behave as before and select the new frame.
         var chainsToAddTo = selectedChains.Count > 1 ? selectedChains : new List<AnimationChainSave> { primaryChain };
 
-        AnimationFrameSave? primaryFrame = null;
-        foreach (var chain in chainsToAddTo)
+        if (chainsToAddTo.Count == 1)
         {
-            var frame = new AnimationFrameSave
-            {
-                TextureName        = relPath,
-                LeftCoordinate     = minX / (float)bitmapW,
-                RightCoordinate    = maxX / (float)bitmapW,
-                TopCoordinate      = minY / (float)bitmapH,
-                BottomCoordinate   = maxY / (float)bitmapH,
-                FrameLength        = 0.1f,
-                ShapesSave = new ShapesSave()
-            };
-            chain.Frames.Add(frame);
-            _appCommands.RefreshTreeNode(chain);
-            if (chain == primaryChain)
-                primaryFrame = frame;
+            // AddFrameFromPixelBounds selects the new frame — desired behavior for single-chain.
+            _appCommands.AddFrameFromPixelBounds(primaryChain, relPath, minX, minY, maxX, maxY, bitmapW, bitmapH);
         }
-
-        // In single-chain mode select the new frame (preserves existing UX).
-        // In multi-chain mode leave selection unchanged so the multi-chain view is preserved.
-        if (chainsToAddTo.Count == 1 && primaryFrame != null)
-            _selectedState.SelectedFrame = primaryFrame;
-
-        _events.RaiseAnimationChainsChanged();
+        else
+        {
+            // Multi-chain: add to each chain but preserve the current selection.
+            var priorFrame = _selectedState.SelectedFrame;
+            foreach (var chain in chainsToAddTo)
+                _appCommands.AddFrameFromPixelBounds(chain, relPath, minX, minY, maxX, maxY, bitmapW, bitmapH);
+            _selectedState.SelectedFrame = priorFrame;
+        }
     }
 
     // ── Core event handlers ───────────────────────────────────────────────────
@@ -1082,7 +1065,7 @@ public partial class MainWindow : Window
 
         Trace.WriteLine($"[DragDrop] targetChain={targetChain?.Name ?? "(null)"}, targetFrame={targetFrame?.TextureName ?? "(null)"}, ctrl={e.KeyModifiers.HasFlag(KeyModifiers.Control)}");
 
-        var result = TextureDropProcessor.ApplyPngDrop(
+        var (result, relPath) = TextureDropProcessor.ComputePngDrop(
             targetChain,
             targetFrame,
             firstFile,
@@ -1097,25 +1080,26 @@ public partial class MainWindow : Window
             return;
         }
 
-        if (targetFrame is not null)
+        switch (result)
         {
-            _appCommands.RefreshTreeNode(targetFrame);
-            _selectedState.SelectedFrame = targetFrame;
-        }
-        else if (targetChain is not null)
-        {
-            _appCommands.RefreshTreeNode(targetChain);
+            case TextureDropResult.UpdatedFrame:
+                _appCommands.SetFrameTextureName(targetFrame!, relPath);
+                _appCommands.RefreshTreeNode(targetFrame!);
+                _selectedState.SelectedFrame = targetFrame!;
+                break;
 
-            if (result == TextureDropResult.CreatedFrame)
-            {
-                var createdFrame = targetChain.Frames.LastOrDefault();
+            case TextureDropResult.CreatedFrame:
+                _appCommands.AddFrame(targetChain!, relPath);
+                var createdFrame = targetChain!.Frames.LastOrDefault();
                 if (createdFrame is not null)
                     _selectedState.SelectedFrame = createdFrame;
-            }
-            else
-            {
+                break;
+
+            case TextureDropResult.UpdatedChainFrames:
+                _appCommands.SetAllFramesTextureName(targetChain!, relPath);
+                _appCommands.RefreshTreeNode(targetChain!);
                 _selectedState.SelectedChain = targetChain;
-            }
+                break;
         }
 
         RefreshTextureCombo();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1971,6 +1971,7 @@ public partial class MainWindow : Window
             (int)PropPixelX.Value.Value, (int)PropPixelY.Value.Value,
             (int)PropPixelW.Value.Value, (int)PropPixelH.Value.Value,
             bmpW, bmpH);
+        WireframeCtrl.RefreshFrames();
     }
 
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -979,18 +979,26 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new CompositeCommand(cmds, "Set All Frame Textures"));
         }
 
-        public void SetFrameLength(AnimationFrameSave frame, float newLength) =>
+        public void SetFrameLength(AnimationFrameSave frame, float newLength)
+        {
+            var desc = $"Set Length: {frame.FrameLength:0.###}s → {newLength:0.###}s";
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => frame.FrameLength = newLength,
-                this, _events, false, "Set Frame Length"));
+                this, _events, false, desc));
+        }
 
-        public void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY) =>
+        public void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY)
+        {
+            var desc = $"Set Offset: ({newRelX:0.##}, {newRelY:0.##})";
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => { frame.RelativeX = newRelX; frame.RelativeY = newRelY; },
-                this, _events, true, "Set Frame Offset"));
+                this, _events, true, desc));
+        }
 
         public void SetFramePixelRegion(AnimationFrameSave frame,
-            int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH) =>
+            int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH)
+        {
+            var desc = $"Set Region: ({pixelX}, {pixelY}) {pixelW}×{pixelH}";
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () =>
                 {
@@ -999,7 +1007,8 @@ namespace AnimationEditor.Core.CommandsAndState
                     PixelFrameEditor.SetWidth(frame, pixelW, bmpW);
                     PixelFrameEditor.SetHeight(frame, pixelH, bmpH);
                 },
-                this, _events, true, "Edit Frame Region"));
+                this, _events, true, desc));
+        }
 
         public void SetRectProps(AnimationFrameSave? frame, AARectSave rect,
             string name, float x, float y, float scaleX, float scaleY) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -979,6 +979,36 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new CompositeCommand(cmds, "Set All Frame Textures"));
         }
 
+        public void SetFrameLength(AnimationFrameSave frame, float newLength) =>
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () => frame.FrameLength = newLength,
+                this, _events, false, "Set Frame Length"));
+
+        public void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY) =>
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () => { frame.RelativeX = newRelX; frame.RelativeY = newRelY; },
+                this, _events, true, "Set Frame Offset"));
+
+        public void SetFramePixelRegion(AnimationFrameSave frame,
+            int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH) =>
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () =>
+                {
+                    PixelFrameEditor.SetX(frame, pixelX, bmpW);
+                    PixelFrameEditor.SetY(frame, pixelY, bmpH);
+                    PixelFrameEditor.SetWidth(frame, pixelW, bmpW);
+                    PixelFrameEditor.SetHeight(frame, pixelH, bmpH);
+                },
+                this, _events, true, "Edit Frame Region"));
+
+        public void SetRectProps(AnimationFrameSave? frame, AARectSave rect,
+            string name, float x, float y, float scaleX, float scaleY) =>
+            _undoManager.Execute(SetShapePropsCommand.ForRect(frame, rect, name, x, y, scaleX, scaleY, this, _events));
+
+        public void SetCircleProps(AnimationFrameSave? frame, CircleSave circ,
+            string name, float x, float y, float radius) =>
+            _undoManager.Execute(SetShapePropsCommand.ForCircle(frame, circ, name, x, y, radius, this, _events));
+
         // ── Paste (clipboard → project) ───────────────────────────────────────
 
         /// <inheritdoc cref="IAppCommands.PasteChains"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -970,6 +970,15 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new SetFrameTextureNameCommand(frame, frame.TextureName, textureName, this, _events));
         }
 
+        public void SetAllFramesTextureName(AnimationChainSave chain, string? textureName)
+        {
+            if (chain.Frames.Count == 0) return;
+            var cmds = chain.Frames
+                .Select(f => (IUndoableCommand)new SetFrameTextureNameCommand(f, f.TextureName, textureName, this, _events))
+                .ToArray();
+            _undoManager.Execute(new CompositeCommand(cmds, "Set All Frame Textures"));
+        }
+
         // ── Paste (clipboard → project) ───────────────────────────────────────
 
         /// <inheritdoc cref="IAppCommands.PasteChains"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -90,6 +90,8 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         private void RaiseSideEffects()
         {
+            foreach (var f in _frames)
+                _commands.RefreshTreeNode(f);
             _events.RaiseAnimationChainsChanged();
             if (_refreshWireframe)
                 _commands.RefreshWireframe();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
@@ -1,4 +1,5 @@
 using FlatRedBall2.Animation.Content;
+using System;
 using System.Collections.Generic;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
@@ -28,7 +29,40 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _snapshots = snapshots;
             _commands  = commands;
             _events    = events;
-            Description = snapshots.Count == 1 ? "Edit Frame Region" : $"Edit {snapshots.Count} Frame Regions";
+            Description = BuildDescription(snapshots);
+        }
+
+        private static string BuildDescription(IReadOnlyList<FrameSnapshot> snapshots)
+        {
+            if (snapshots.Count == 1)
+            {
+                var s = snapshots[0];
+                float bW = s.BR - s.BL, bH = s.BB - s.BT;
+                float aW = s.AR - s.AL, aH = s.AB - s.AT;
+                bool sizeChanged = Math.Abs(bW - aW) > 0.0001f || Math.Abs(bH - aH) > 0.0001f;
+                return sizeChanged ? "Resize Frame" : "Move Frame";
+            }
+
+            var first = snapshots[0];
+            float dL = first.AL - first.BL;
+            float dT = first.AT - first.BT;
+            bool isChainDrag = true;
+            foreach (var s in snapshots)
+            {
+                float bW = s.BR - s.BL, bH = s.BB - s.BT;
+                float aW = s.AR - s.AL, aH = s.AB - s.AT;
+                bool sizeChanged = Math.Abs(bW - aW) > 0.0001f || Math.Abs(bH - aH) > 0.0001f;
+                if (sizeChanged ||
+                    Math.Abs((s.AL - s.BL) - dL) > 0.0001f ||
+                    Math.Abs((s.AT - s.BT) - dT) > 0.0001f)
+                {
+                    isChainDrag = false;
+                    break;
+                }
+            }
+            return isChainDrag
+                ? $"Drag Chain ({snapshots.Count} frames)"
+                : $"Edit {snapshots.Count} Frame Regions";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FrameRegionChangedCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FrameRegionChangedCommand.cs
@@ -1,4 +1,5 @@
 using FlatRedBall2.Animation.Content;
+using System;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
 {
@@ -10,7 +11,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
 
-        public string Description => "Edit Frame Region";
+        public string Description { get; }
 
         public FrameRegionChangedCommand(
             AnimationFrameSave frame,
@@ -24,6 +25,10 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _aL = aL; _aT = aT; _aR = aR; _aB = aB;
             _commands = commands;
             _events = events;
+            float bW = bR - bL, bH = bB - bT;
+            float aW = aR - aL, aH = aB - aT;
+            bool sizeChanged = Math.Abs(bW - aW) > 0.0001f || Math.Abs(bH - aH) > 0.0001f;
+            Description = sizeChanged ? "Resize Frame" : "Move Frame";
         }
 
         public bool Do() { Apply(_aL, _aT, _aR, _aB); return true; }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -121,6 +121,12 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void SetAllFramesTextureName(AnimationChainSave chain, string? textureName);
 
+        void SetFrameLength(AnimationFrameSave frame, float newLength);
+        void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY);
+        void SetFramePixelRegion(AnimationFrameSave frame, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
+        void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
+        void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);
+
         // ── Hot Reload ────────────────────────────────────────────────────────────
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -115,6 +115,12 @@ namespace AnimationEditor.Core.CommandsAndState
         void AddFrameFromPixelBounds(AnimationChainSave chain, string textureName, int minX, int minY, int maxX, int maxY, int bitmapWidth, int bitmapHeight);
         void SetFrameTextureName(AnimationFrameSave frame, string? textureName);
 
+        /// <summary>
+        /// Assigns <paramref name="textureName"/> to every frame in <paramref name="chain"/>
+        /// as a single undoable operation. No-op when the chain has no frames.
+        /// </summary>
+        void SetAllFramesTextureName(AnimationChainSave chain, string? textureName);
+
         // ── Hot Reload ────────────────────────────────────────────────────────────
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
@@ -31,7 +31,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events   = events;
         }
 
-        public string Description => "Move Shape";
+        public string Description => $"Move {ShapeLabel(_shape)}";
+
+        private static string ShapeLabel(object shape) => shape switch
+        {
+            AARectSave r  => string.IsNullOrEmpty(r.Name) ? "Rect"   : $"Rect '{r.Name}'",
+            CircleSave c  => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
+            _             => "Shape"
+        };
 
         public bool Do() { Apply(_newX, _newY); return true; }
         public void Undo() => Apply(_oldX, _oldY);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
@@ -35,7 +35,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events    = events;
         }
 
-        public string Description => "Resize Shape";
+        public string Description => $"Resize {ShapeLabel(_shape)}";
+
+        private static string ShapeLabel(object shape) => shape switch
+        {
+            AARectSave r  => string.IsNullOrEmpty(r.Name) ? "Rect"   : $"Rect '{r.Name}'",
+            CircleSave c  => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
+            _             => "Shape"
+        };
 
         public bool Do() { Apply(_newX, _newY, _newParam1, _newParam2); return true; }
         public void Undo() => Apply(_oldX, _oldY, _oldParam1, _oldParam2);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
@@ -10,7 +10,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly IAppCommands _commands;
         private readonly IApplicationEvents _events;
 
-        public string Description => "Set Texture";
+        public string Description { get; }
 
         public SetFrameTextureNameCommand(AnimationFrameSave frame, string? oldName, string? newName,
             IAppCommands commands, IApplicationEvents events)
@@ -20,6 +20,10 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _newName = newName;
             _commands = commands;
             _events = events;
+            string? name = newName ?? oldName;
+            Description = name is not null
+                ? $"Set Texture: {System.IO.Path.GetFileName(name)}"
+                : "Set Texture";
         }
 
         public bool Do()  => Apply(_newName);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetFrameTextureNameCommand.cs
@@ -22,7 +22,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             string? name = newName ?? oldName;
             Description = name is not null
-                ? $"Set Texture: {System.IO.Path.GetFileName(name)}"
+                ? $"Set Texture: {System.IO.Path.GetFileName(name.Replace('\\', '/'))}"
                 : "Set Texture";
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
@@ -21,7 +21,7 @@ internal sealed class SetShapePropsCommand : IUndoableCommand
         new(frame, rect, rect.Name ?? "", newName,
             rect.X, rect.Y, rect.ScaleX, rect.ScaleY,
             newX, newY, newScaleX, newScaleY,
-            commands, events, "Edit Rectangle");
+            commands, events, ShapeLabel("Rect", rect.Name ?? ""));
 
     public static SetShapePropsCommand ForCircle(
         AnimationFrameSave? frame, CircleSave circ,
@@ -30,7 +30,10 @@ internal sealed class SetShapePropsCommand : IUndoableCommand
         new(frame, circ, circ.Name ?? "", newName,
             circ.X, circ.Y, circ.Radius, 0f,
             newX, newY, newRadius, 0f,
-            commands, events, "Edit Circle");
+            commands, events, ShapeLabel("Circle", circ.Name ?? ""));
+
+    private static string ShapeLabel(string type, string name) =>
+        string.IsNullOrEmpty(name) ? $"Edit {type}" : $"Edit {type} '{name}'";
 
     private SetShapePropsCommand(
         AnimationFrameSave? frame, object shape,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
@@ -1,0 +1,71 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands;
+
+internal sealed class SetShapePropsCommand : IUndoableCommand
+{
+    private readonly AnimationFrameSave? _frame;
+    private readonly object _shape;
+    private readonly string _oldName, _newName;
+    private readonly float _oldX, _oldY, _oldP1, _oldP2;
+    private readonly float _newX, _newY, _newP1, _newP2;
+    private readonly IAppCommands _commands;
+    private readonly IApplicationEvents _events;
+
+    public string Description { get; }
+
+    public static SetShapePropsCommand ForRect(
+        AnimationFrameSave? frame, AARectSave rect,
+        string newName, float newX, float newY, float newScaleX, float newScaleY,
+        IAppCommands commands, IApplicationEvents events) =>
+        new(frame, rect, rect.Name ?? "", newName,
+            rect.X, rect.Y, rect.ScaleX, rect.ScaleY,
+            newX, newY, newScaleX, newScaleY,
+            commands, events, "Edit Rectangle");
+
+    public static SetShapePropsCommand ForCircle(
+        AnimationFrameSave? frame, CircleSave circ,
+        string newName, float newX, float newY, float newRadius,
+        IAppCommands commands, IApplicationEvents events) =>
+        new(frame, circ, circ.Name ?? "", newName,
+            circ.X, circ.Y, circ.Radius, 0f,
+            newX, newY, newRadius, 0f,
+            commands, events, "Edit Circle");
+
+    private SetShapePropsCommand(
+        AnimationFrameSave? frame, object shape,
+        string oldName, string newName,
+        float oldX, float oldY, float oldP1, float oldP2,
+        float newX, float newY, float newP1, float newP2,
+        IAppCommands commands, IApplicationEvents events, string description)
+    {
+        _frame = frame; _shape = shape;
+        _oldName = oldName; _newName = newName;
+        _oldX = oldX; _oldY = oldY; _oldP1 = oldP1; _oldP2 = oldP2;
+        _newX = newX; _newY = newY; _newP1 = newP1; _newP2 = newP2;
+        _commands = commands; _events = events;
+        Description = description;
+    }
+
+    public bool Do()
+    {
+        if (_oldName == _newName && _oldX == _newX && _oldY == _newY &&
+            _oldP1 == _newP1 && _oldP2 == _newP2) return false;
+        Apply(_newName, _newX, _newY, _newP1, _newP2);
+        return true;
+    }
+
+    public void Undo() => Apply(_oldName, _oldX, _oldY, _oldP1, _oldP2);
+    public void Redo() => Apply(_newName, _newX, _newY, _newP1, _newP2);
+
+    private void Apply(string name, float x, float y, float p1, float p2)
+    {
+        if (_shape is AARectSave r) { r.Name = name; r.X = x; r.Y = y; r.ScaleX = p1; r.ScaleY = p2; }
+        else if (_shape is CircleSave c) { c.Name = name; c.X = x; c.Y = y; c.Radius = p1; }
+        if (_frame is not null) _commands.RefreshTreeNode(_frame);
+        _commands.RefreshAnimationFrameDisplay();
+        _commands.RefreshWireframe();
+        _events.RaiseAnimationChainsChanged();
+        _commands.SaveCurrentAnimationChainList();
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
@@ -64,9 +64,6 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Clear()
         {
-            System.Diagnostics.Trace.WriteLine(
-                $"[UndoManager.Clear] called — stack depth was {_undoStack.Count}\n" +
-                System.Environment.StackTrace);
             _undoStack.Clear();
             _redoStack.Clear();
             _saveState = SaveState.Unsaved;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
@@ -64,6 +64,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Clear()
         {
+            System.Diagnostics.Trace.WriteLine(
+                $"[UndoManager.Clear] called — stack depth was {_undoStack.Count}\n" +
+                System.Environment.StackTrace);
             _undoStack.Clear();
             _redoStack.Clear();
             _saveState = SaveState.Unsaved;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TextureDropProcessor.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TextureDropProcessor.cs
@@ -7,6 +7,48 @@ namespace AnimationEditor.Core.DragDrop;
 
 public static class TextureDropProcessor
 {
+    /// <summary>
+    /// Returns the result type and resolved relative texture path for a PNG drop
+    /// without mutating any model data. Use this instead of <see cref="ApplyPngDrop"/>
+    /// when the caller will route through undoable commands.
+    /// Returns <c>(NotApplied, null)</c> when the drop should be ignored.
+    /// </summary>
+    public static (TextureDropResult Result, string? RelativePath) ComputePngDrop(
+        AnimationChainSave? targetChain,
+        AnimationFrameSave? targetFrame,
+        string droppedFilePath,
+        string? achxFileName,
+        bool createFrameOnCtrl)
+    {
+        if (string.IsNullOrWhiteSpace(droppedFilePath))
+            return (TextureDropResult.NotApplied, null);
+
+        if (!string.Equals(Path.GetExtension(droppedFilePath).TrimStart('.'), "png", StringComparison.OrdinalIgnoreCase))
+            return (TextureDropResult.NotApplied, null);
+
+        string relativeTexturePath;
+        if (string.IsNullOrWhiteSpace(achxFileName))
+        {
+            relativeTexturePath = droppedFilePath;
+        }
+        else
+        {
+            var achxFolder = new FilePath(achxFileName).GetDirectoryContainingThis();
+            relativeTexturePath = new FilePath(droppedFilePath).RelativeTo(achxFolder);
+        }
+
+        if (targetFrame is not null)
+            return (TextureDropResult.UpdatedFrame, relativeTexturePath);
+
+        if (targetChain is null)
+            return (TextureDropResult.NotApplied, null);
+
+        if (createFrameOnCtrl || targetChain.Frames.Count == 0)
+            return (TextureDropResult.CreatedFrame, relativeTexturePath);
+
+        return (TextureDropResult.UpdatedChainFrames, relativeTexturePath);
+    }
+
     public static TextureDropResult ApplyPngDrop(
         AnimationChainSave? targetChain,
         AnimationFrameSave? targetFrame,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
@@ -96,10 +96,16 @@ namespace AnimationEditor.Core.HotReload
                 {
                     if (nowMs - kv.Value.Ts < DebounceMs) continue; // still in debounce window
 
-                    // Check own-save cooldown
+                    // Discard events that were triggered by our own save.
+                    // Compare the event's timestamp against the save timestamp: if the
+                    // FSW fired within CooldownMs of our save it was caused by that save.
+                    // Remove from pending so it never fires — even after the cooldown elapses.
                     if (_ownSaves.TryGetValue(kv.Key, out long saveTs) &&
-                        nowMs - saveTs < CooldownMs)
+                        kv.Value.Ts - saveTs < CooldownMs)
+                    {
+                        ready.Add(kv.Key);
                         continue;
+                    }
 
                     ready.Add(kv.Key);
                     result.Add((kv.Key, kv.Value.Type));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
@@ -31,8 +31,6 @@ namespace AnimationEditor.Core.HotReload
         public void Record(string path, WatcherChangeType type, long timestampMs)
         {
             path = path.Replace('\\', '/');
-            System.Diagnostics.Trace.WriteLine(
-                $"[FileChangeCoalescer] Record: path={path} type={type} ts={timestampMs}");
             lock (_lock)
             {
                 if (type == WatcherChangeType.Deleted)
@@ -65,8 +63,6 @@ namespace AnimationEditor.Core.HotReload
         public void RecordOwnSave(string path, long timestampMs)
         {
             path = path.Replace('\\', '/');
-            System.Diagnostics.Trace.WriteLine(
-                $"[FileChangeCoalescer] RecordOwnSave: path={path} ts={timestampMs}");
             lock (_lock)
             {
                 _ownSaves[path] = timestampMs;
@@ -109,17 +105,9 @@ namespace AnimationEditor.Core.HotReload
                     if (_ownSaves.TryGetValue(kv.Key, out long saveTs) &&
                         kv.Value.Ts - saveTs < CooldownMs)
                     {
-                        System.Diagnostics.Trace.WriteLine(
-                            $"[FileChangeCoalescer] Discarding own-save bounce: path={kv.Key} " +
-                            $"eventTs={kv.Value.Ts} saveTs={saveTs} delta={kv.Value.Ts - saveTs}ms");
                         ready.Add(kv.Key);
                         continue;
                     }
-
-                    System.Diagnostics.Trace.WriteLine(
-                        $"[FileChangeCoalescer] Firing event: path={kv.Key} " +
-                        $"type={kv.Value.Type} ownSaveTs={(_ownSaves.TryGetValue(kv.Key, out var st2) ? st2.ToString() : "none")} " +
-                        $"eventTs={kv.Value.Ts} delta={(_ownSaves.TryGetValue(kv.Key, out var st3) ? (kv.Value.Ts - st3).ToString() : "n/a")}ms");
 
                     ready.Add(kv.Key);
                     result.Add((kv.Key, kv.Value.Type));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
@@ -61,6 +61,8 @@ namespace AnimationEditor.Core.HotReload
 
         public void RecordOwnSave(string path, long timestampMs)
         {
+            System.Diagnostics.Trace.WriteLine(
+                $"[FileChangeCoalescer] RecordOwnSave: path={path} ts={timestampMs}");
             lock (_lock)
             {
                 _ownSaves[path] = timestampMs;
@@ -103,9 +105,16 @@ namespace AnimationEditor.Core.HotReload
                     if (_ownSaves.TryGetValue(kv.Key, out long saveTs) &&
                         kv.Value.Ts - saveTs < CooldownMs)
                     {
+                        System.Diagnostics.Trace.WriteLine(
+                            $"[FileChangeCoalescer] Discarding own-save bounce: path={kv.Key} " +
+                            $"eventTs={kv.Value.Ts} saveTs={saveTs} delta={kv.Value.Ts - saveTs}ms");
                         ready.Add(kv.Key);
                         continue;
                     }
+                    System.Diagnostics.Trace.WriteLine(
+                        $"[FileChangeCoalescer] Firing event: path={kv.Key} " +
+                        $"type={kv.Value.Type} ownSaveTs={(_ownSaves.TryGetValue(kv.Key, out var st2) ? st2.ToString() : "none")} " +
+                        $"eventTs={kv.Value.Ts} delta={((_ownSaves.TryGetValue(kv.Key, out var st3) ? (kv.Value.Ts - st3).ToString() : "n/a"))}ms");
 
                     ready.Add(kv.Key);
                     result.Add((kv.Key, kv.Value.Type));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
@@ -30,6 +30,7 @@ namespace AnimationEditor.Core.HotReload
 
         public void Record(string path, WatcherChangeType type, long timestampMs)
         {
+            path = path.Replace('\\', '/');
             lock (_lock)
             {
                 if (type == WatcherChangeType.Deleted)
@@ -61,8 +62,7 @@ namespace AnimationEditor.Core.HotReload
 
         public void RecordOwnSave(string path, long timestampMs)
         {
-            System.Diagnostics.Trace.WriteLine(
-                $"[FileChangeCoalescer] RecordOwnSave: path={path} ts={timestampMs}");
+            path = path.Replace('\\', '/');
             lock (_lock)
             {
                 _ownSaves[path] = timestampMs;
@@ -105,16 +105,9 @@ namespace AnimationEditor.Core.HotReload
                     if (_ownSaves.TryGetValue(kv.Key, out long saveTs) &&
                         kv.Value.Ts - saveTs < CooldownMs)
                     {
-                        System.Diagnostics.Trace.WriteLine(
-                            $"[FileChangeCoalescer] Discarding own-save bounce: path={kv.Key} " +
-                            $"eventTs={kv.Value.Ts} saveTs={saveTs} delta={kv.Value.Ts - saveTs}ms");
                         ready.Add(kv.Key);
                         continue;
                     }
-                    System.Diagnostics.Trace.WriteLine(
-                        $"[FileChangeCoalescer] Firing event: path={kv.Key} " +
-                        $"type={kv.Value.Type} ownSaveTs={(_ownSaves.TryGetValue(kv.Key, out var st2) ? st2.ToString() : "none")} " +
-                        $"eventTs={kv.Value.Ts} delta={((_ownSaves.TryGetValue(kv.Key, out var st3) ? (kv.Value.Ts - st3).ToString() : "n/a"))}ms");
 
                     ready.Add(kv.Key);
                     result.Add((kv.Key, kv.Value.Type));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/FileChangeCoalescer.cs
@@ -31,6 +31,8 @@ namespace AnimationEditor.Core.HotReload
         public void Record(string path, WatcherChangeType type, long timestampMs)
         {
             path = path.Replace('\\', '/');
+            System.Diagnostics.Trace.WriteLine(
+                $"[FileChangeCoalescer] Record: path={path} type={type} ts={timestampMs}");
             lock (_lock)
             {
                 if (type == WatcherChangeType.Deleted)
@@ -63,6 +65,8 @@ namespace AnimationEditor.Core.HotReload
         public void RecordOwnSave(string path, long timestampMs)
         {
             path = path.Replace('\\', '/');
+            System.Diagnostics.Trace.WriteLine(
+                $"[FileChangeCoalescer] RecordOwnSave: path={path} ts={timestampMs}");
             lock (_lock)
             {
                 _ownSaves[path] = timestampMs;
@@ -105,9 +109,17 @@ namespace AnimationEditor.Core.HotReload
                     if (_ownSaves.TryGetValue(kv.Key, out long saveTs) &&
                         kv.Value.Ts - saveTs < CooldownMs)
                     {
+                        System.Diagnostics.Trace.WriteLine(
+                            $"[FileChangeCoalescer] Discarding own-save bounce: path={kv.Key} " +
+                            $"eventTs={kv.Value.Ts} saveTs={saveTs} delta={kv.Value.Ts - saveTs}ms");
                         ready.Add(kv.Key);
                         continue;
                     }
+
+                    System.Diagnostics.Trace.WriteLine(
+                        $"[FileChangeCoalescer] Firing event: path={kv.Key} " +
+                        $"type={kv.Value.Type} ownSaveTs={(_ownSaves.TryGetValue(kv.Key, out var st2) ? st2.ToString() : "none")} " +
+                        $"eventTs={kv.Value.Ts} delta={(_ownSaves.TryGetValue(kv.Key, out var st3) ? (kv.Value.Ts - st3).ToString() : "n/a")}ms");
 
                     ready.Add(kv.Key);
                     result.Add((kv.Key, kv.Value.Type));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/HotReloadWatcher.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/HotReloadWatcher.cs
@@ -122,7 +122,7 @@ namespace AnimationEditor.Core.HotReload
 
         public void RecordOwnSave(string filePath)
         {
-            _coalescer.RecordOwnSave(filePath,
+            _coalescer.RecordOwnSave(filePath.Replace('\\', '/'),
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         }
 
@@ -138,28 +138,29 @@ namespace AnimationEditor.Core.HotReload
             };
 
             long Now() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            static string Norm(string p) => p.Replace('\\', '/');
 
             fsw.Changed += (_, e) =>
             {
                 if (!IsEnabled) return;
-                _coalescer.Record(e.FullPath, WatcherChangeType.Modified, Now());
+                _coalescer.Record(Norm(e.FullPath), WatcherChangeType.Modified, Now());
             };
             fsw.Created += (_, e) =>
             {
                 if (!IsEnabled) return;
-                _coalescer.Record(e.FullPath, WatcherChangeType.Created, Now());
+                _coalescer.Record(Norm(e.FullPath), WatcherChangeType.Created, Now());
             };
             fsw.Deleted += (_, e) =>
             {
                 if (!IsEnabled) return;
-                _coalescer.Record(e.FullPath, WatcherChangeType.Deleted, Now());
+                _coalescer.Record(Norm(e.FullPath), WatcherChangeType.Deleted, Now());
             };
             fsw.Renamed += (_, e) =>
             {
                 if (!IsEnabled) return;
                 // Renamed is another form of atomic-write on some tools
-                _coalescer.Record(e.OldFullPath, WatcherChangeType.Deleted, Now());
-                _coalescer.Record(e.FullPath, WatcherChangeType.Created, Now());
+                _coalescer.Record(Norm(e.OldFullPath), WatcherChangeType.Deleted, Now());
+                _coalescer.Record(Norm(e.FullPath), WatcherChangeType.Created, Now());
             };
 
             _watchers[directory] = fsw;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryScrollHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryScrollHelperTests.cs
@@ -1,0 +1,52 @@
+using AnimationEditor.App.Helpers;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class HistoryScrollHelperTests
+{
+    [Fact]
+    public void ComputeScrollOffset_EmptyList_ReturnsNull()
+    {
+        var result = HistoryScrollHelper.ComputeScrollOffset(0, 0, 500, 200, 0);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ComputeScrollOffset_ExtentFitsInViewport_ReturnsNull()
+    {
+        // extent (100) <= viewport (200) → everything fits, no scroll needed
+        var result = HistoryScrollHelper.ComputeScrollOffset(3, 10, 100, 200, 0);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ComputeScrollOffset_ItemAlreadyVisible_ReturnsNull()
+    {
+        // 10 items, 500px extent → each item is 50px tall
+        // currentIndex=3 → itemTop=150, itemBottom=200
+        // viewport=300, currentOffsetY=0 → item is fully visible (0..300 contains 150..200)
+        var result = HistoryScrollHelper.ComputeScrollOffset(3, 10, 500, 300, 0);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ComputeScrollOffset_ItemAboveViewport_ReturnsItemTop()
+    {
+        // 10 items, 500px extent → each item is 50px tall
+        // currentIndex=2 → itemTop=100, itemBottom=150
+        // viewport=100, currentOffsetY=200 → item is above viewport (100 < 200)
+        var result = HistoryScrollHelper.ComputeScrollOffset(2, 10, 500, 100, 200);
+        Assert.Equal(100.0, result);
+    }
+
+    [Fact]
+    public void ComputeScrollOffset_ItemBelowViewport_ReturnsItemBottomMinusViewport()
+    {
+        // 10 items, 500px extent → each item is 50px tall
+        // currentIndex=7 → itemTop=350, itemBottom=400
+        // viewport=100, currentOffsetY=0 → item is below viewport (400 > 0+100)
+        var result = HistoryScrollHelper.ComputeScrollOffset(7, 10, 500, 100, 0);
+        Assert.Equal(300.0, result); // 400 - 100
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
@@ -181,4 +181,53 @@ public class WireframeChainDragTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    // ── Undo / redo after chain drag ──────────────────────────────────────────
+
+    /// <summary>
+    /// After a chain drag via <see cref="WireframeControl.SimulateChainDrag"/>,
+    /// the undo manager must hold an entry so the user can undo back to the
+    /// original UV coordinates and redo to the dragged position.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateChainDrag_RecordsUndoEntry_CanUndoAndRedo()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, frameA, frameB, dir) = BuildCtrlWithChainSelected(ctx);
+        try
+        {
+            // Capture original UV coords before the drag
+            float origAL = frameA.LeftCoordinate, origAT = frameA.TopCoordinate;
+            float origAR = frameA.RightCoordinate, origAB = frameA.BottomCoordinate;
+            float origBL = frameB.LeftCoordinate, origBT = frameB.TopCoordinate;
+            float origBR = frameB.RightCoordinate, origBB = frameB.BottomCoordinate;
+
+            // Drag +16px right, +16px down (UV delta = 16/64 = 0.25)
+            ctrl.SimulateChainDrag(startScreenX: 0f, startScreenY: 0f,
+                                   endScreenX:   16f, endScreenY:   16f);
+
+            float afterAL = frameA.LeftCoordinate;
+
+            // Undo manager must have recorded an entry
+            Assert.True(ctx.UndoManager.CanUndo, "SimulateChainDrag should have pushed an undo entry");
+
+            // Undo: all UV coords must be back to original values
+            ctx.UndoManager.Undo();
+
+            Assert.Equal(origAL, frameA.LeftCoordinate,   precision: 4);
+            Assert.Equal(origAT, frameA.TopCoordinate,    precision: 4);
+            Assert.Equal(origAR, frameA.RightCoordinate,  precision: 4);
+            Assert.Equal(origAB, frameA.BottomCoordinate, precision: 4);
+            Assert.Equal(origBL, frameB.LeftCoordinate,   precision: 4);
+            Assert.Equal(origBT, frameB.TopCoordinate,    precision: 4);
+            Assert.Equal(origBR, frameB.RightCoordinate,  precision: 4);
+            Assert.Equal(origBB, frameB.BottomCoordinate, precision: 4);
+
+            // Redo: must restore the dragged position
+            ctx.UndoManager.Redo();
+
+            Assert.Equal(afterAL, frameA.LeftCoordinate, precision: 4);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
@@ -1,0 +1,147 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class CommandDescriptionTests
+{
+    // ── FrameRegionChangedCommand ─────────────────────────────────────────────
+
+    [Fact]
+    public void FrameRegionChangedCommand_Description_PositionChangedSizeUnchanged_ReturnsMove()
+    {
+        var frame = new AnimationFrameSave();
+        // Move: same size (0.5x0.5), just shifted
+        var cmd = new FrameRegionChangedCommand(frame,
+            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
+            aL: 0.1f, aT: 0.1f, aR: 0.6f, aB: 0.6f,
+            commands: null!, events: null!);
+
+        Assert.Equal("Move Frame", cmd.Description);
+    }
+
+    [Fact]
+    public void FrameRegionChangedCommand_Description_SizeChanged_ReturnsResize()
+    {
+        var frame = new AnimationFrameSave();
+        // Resize: width changed from 0.5 to 0.4
+        var cmd = new FrameRegionChangedCommand(frame,
+            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
+            aL: 0f,   aT: 0f,   aR: 0.4f, aB: 0.5f,
+            commands: null!, events: null!);
+
+        Assert.Equal("Resize Frame", cmd.Description);
+    }
+
+    // ── BulkFrameRegionChangedCommand ─────────────────────────────────────────
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_SingleFramePositionOnly_ReturnsMove()
+    {
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal("Move Frame", cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_SingleFrameSizeChanged_ReturnsResize()
+    {
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0f, AT: 0f, AR: 0.4f, AB: 0.5f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal("Resize Frame", cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_MultiFrameSameDelta_ReturnsDragChain()
+    {
+        // Both frames move by (+0.1, +0.1) with same size — chain drag
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f),
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0.5f, BT: 0f, BR: 1.0f, BB: 0.5f,
+                AL: 0.6f, AT: 0.1f, AR: 1.1f, AB: 0.6f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal("Drag Chain (2 frames)", cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_MultiFrameDifferentDeltas_ReturnsEditRegions()
+    {
+        // Three frames with different translation deltas — handle drag
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f),
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0.5f, BT: 0f, BR: 1.0f, BB: 0.5f,
+                AL: 0.7f, AT: 0.2f, AR: 1.2f, AB: 0.7f), // different delta
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0.5f, BR: 0.5f, BB: 1.0f,
+                AL: 0.1f, AT: 0.6f, AR: 0.6f, AB: 1.1f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal("Edit 3 Frame Regions", cmd.Description);
+    }
+
+    // ── SetFrameTextureNameCommand ─────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameTextureNameCommand_Description_NewNameSet_ShowsFilename()
+    {
+        var frame = new AnimationFrameSave();
+        var cmd = new SetFrameTextureNameCommand(frame,
+            oldName: null, newName: @"C:\textures\sprite.png",
+            commands: null!, events: null!);
+
+        Assert.Equal("Set Texture: sprite.png", cmd.Description);
+    }
+
+    [Fact]
+    public void SetFrameTextureNameCommand_Description_NewNameNullOldNameSet_ShowsOldFilename()
+    {
+        var frame = new AnimationFrameSave();
+        var cmd = new SetFrameTextureNameCommand(frame,
+            oldName: @"C:\textures\old.png", newName: null,
+            commands: null!, events: null!);
+
+        Assert.Equal("Set Texture: old.png", cmd.Description);
+    }
+
+    [Fact]
+    public void SetFrameTextureNameCommand_Description_BothNull_ReturnsSetTexture()
+    {
+        var frame = new AnimationFrameSave();
+        var cmd = new SetFrameTextureNameCommand(frame,
+            oldName: null, newName: null,
+            commands: null!, events: null!);
+
+        Assert.Equal("Set Texture", cmd.Description);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
@@ -131,12 +131,14 @@ public class FileChangeCoalescerTests
     [Fact]
     public void Cooldown_PathSeparatorMismatch_StillDiscarded()
     {
+        // Intentionally use both separator styles for the same logical path to verify
+        // the coalescer normalizes them before comparing.
+        const string forwardSlash = "tmp/animations/asd.achx";   // forward slashes (e.g. from FileName on Windows via Avalonia)
+        var backSlash = forwardSlash.Replace('/', '\\');           // backslashes (e.g. from FSW on Windows)
         var c = Make(debounceMs: 50, cooldownMs: 500);
-        c.RecordOwnSave("D:/Downloads/asd.achx", 0);           // forward slashes (from FileName)
-        c.Record(@"D:\Downloads\asd.achx", WatcherChangeType.Modified, 10); // backslashes (from FSW)
-        // The coalescer receives normalized paths from HotReloadWatcher, but verify the
-        // coalescer itself is also resilient to this — if callers normalize, this passes.
-        // This test documents the contract: same logical path must not fire.
+        c.RecordOwnSave(forwardSlash, 0);
+        c.Record(backSlash, WatcherChangeType.Modified, 10);
+        // The coalescer normalizes both to forward slashes — same logical path must not fire.
         var result = c.Flush(100);
         Assert.Empty(result);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
@@ -101,15 +101,30 @@ public class FileChangeCoalescerTests
         Assert.Empty(result);
     }
 
-    // 6. After cooldown expires, events fire normally.
+    // 6. A genuine external edit (event after cooldown window) still fires.
     [Fact]
-    public void Cooldown_AfterExpiry_EventsFire()
+    public void Cooldown_GenuineExternalEditAfterCooldown_Fires()
     {
         var c = Make(debounceMs: 50, cooldownMs: 500);
         c.RecordOwnSave("a.achx", 0);
-        c.Record("a.achx", WatcherChangeType.Modified, 600);  // after cooldown
+        c.Record("a.achx", WatcherChangeType.Modified, 600);  // external edit after cooldown
         var result = c.Flush(700);  // 700-600=100 >= 50 debounce
         Assert.Single(result);
+    }
+
+    // 6b. FSW bounce from own save is discarded permanently — does NOT fire after cooldown elapses.
+    [Fact]
+    public void Cooldown_OwnSaveFswBounce_NeverFiresAfterCooldown()
+    {
+        var c = Make(debounceMs: 50, cooldownMs: 500);
+        c.RecordOwnSave("a.achx", 0);
+        c.Record("a.achx", WatcherChangeType.Modified, 10);  // FSW bounce right after save
+        // During cooldown: suppressed AND discarded
+        var duringCooldown = c.Flush(100);
+        Assert.Empty(duringCooldown);
+        // After cooldown: event was discarded, so still nothing
+        var afterCooldown = c.Flush(700);
+        Assert.Empty(afterCooldown);
     }
 
     // 7. Multiple files tracked independently.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileChangeCoalescerTests.cs
@@ -127,6 +127,20 @@ public class FileChangeCoalescerTests
         Assert.Empty(afterCooldown);
     }
 
+    // 6c. Path separator mismatch (forward vs back slash) does not prevent own-save suppression.
+    [Fact]
+    public void Cooldown_PathSeparatorMismatch_StillDiscarded()
+    {
+        var c = Make(debounceMs: 50, cooldownMs: 500);
+        c.RecordOwnSave("D:/Downloads/asd.achx", 0);           // forward slashes (from FileName)
+        c.Record(@"D:\Downloads\asd.achx", WatcherChangeType.Modified, 10); // backslashes (from FSW)
+        // The coalescer receives normalized paths from HotReloadWatcher, but verify the
+        // coalescer itself is also resilient to this — if callers normalize, this passes.
+        // This test documents the contract: same logical path must not fire.
+        var result = c.Flush(100);
+        Assert.Empty(result);
+    }
+
     // 7. Multiple files tracked independently.
     [Fact]
     public void MultipleFiles_TrackedIndependently()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -1,0 +1,164 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class InspectorPropertyUndoTests
+{
+    // ── SetFrameLength ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameLength_ChangedValue_CreatesUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.FrameLength = 0.1f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameLength(frame, 0.5f);
+
+        Assert.True(ctx.UndoManager.CanUndo);
+        Assert.Equal(0.5f, frame.FrameLength);
+    }
+
+    [Fact]
+    public void SetFrameLength_SameValue_DoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.FrameLength = 0.1f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameLength(frame, 0.1f);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void SetFrameLength_Undo_RestoresOldValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.FrameLength = 0.1f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameLength(frame, 0.5f);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0.1f, frame.FrameLength);
+    }
+
+    // ── SetFrameRelative ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameRelative_Undo_RestoresBothAxes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.RelativeX = 10f;
+        frame.RelativeY = 20f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameRelative(frame, 99f, 88f);
+        Assert.True(ctx.UndoManager.CanUndo);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(10f, frame.RelativeX);
+        Assert.Equal(20f, frame.RelativeY);
+    }
+
+    // ── SetFramePixelRegion ───────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFramePixelRegion_Undo_RestoresUvCoords()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        // Start: full texture (0..1)
+        frame.LeftCoordinate   = 0f;
+        frame.RightCoordinate  = 1f;
+        frame.TopCoordinate    = 0f;
+        frame.BottomCoordinate = 1f;
+        chain.Frames.Add(frame);
+
+        // Move/resize to pixel rect (4,8,12,16) on a 64x64 texture
+        ctx.AppCommands.SetFramePixelRegion(frame, 4, 8, 12, 16, 64, 64);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0f,  frame.LeftCoordinate,   precision: 5);
+        Assert.Equal(1f,  frame.RightCoordinate,   precision: 5);
+        Assert.Equal(0f,  frame.TopCoordinate,     precision: 5);
+        Assert.Equal(1f,  frame.BottomCoordinate,  precision: 5);
+    }
+
+    // ── SetRectProps ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetRectProps_Undo_RestoresAllRectProperties()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        var rect = new AARectSave { Name = "OldName", X = 1f, Y = 2f, ScaleX = 3f, ScaleY = 4f };
+        frame.ShapesSave!.Shapes.Add(rect);
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetRectProps(frame, rect, "NewName", 10f, 20f, 30f, 40f);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal("OldName", rect.Name);
+        Assert.Equal(1f, rect.X);
+        Assert.Equal(2f, rect.Y);
+        Assert.Equal(3f, rect.ScaleX);
+        Assert.Equal(4f, rect.ScaleY);
+    }
+
+    [Fact]
+    public void SetRectProps_IdenticalValues_DoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        var rect = new AARectSave { Name = "Same", X = 1f, Y = 2f, ScaleX = 3f, ScaleY = 4f };
+        frame.ShapesSave!.Shapes.Add(rect);
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetRectProps(frame, rect, "Same", 1f, 2f, 3f, 4f);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── SetCircleProps ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetCircleProps_Undo_RestoresAllCircleProperties()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        var circ = new CircleSave { Name = "OldCircle", X = 5f, Y = 6f, Radius = 7f };
+        frame.ShapesSave!.Shapes.Add(circ);
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetCircleProps(frame, circ, "NewCircle", 50f, 60f, 70f);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal("OldCircle", circ.Name);
+        Assert.Equal(5f, circ.X);
+        Assert.Equal(6f, circ.Y);
+        Assert.Equal(7f, circ.Radius);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -93,6 +93,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AdjustUVAfterResize)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.AddFrameFromPixelBounds)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameTextureName)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetAllFramesTextureName)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteRectangle)]               = Category.MutatingUndoable,
@@ -253,6 +254,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.AddFrameFromPixelBounds(Zebra(ctx), "sheet.png", 0, 0, 8, 8, 64, 64)));
         yield return Row(nameof(IAppCommands.SetFrameTextureName),
             ctx => Sync(() => ctx.AppCommands.SetFrameTextureName(Zebra(ctx).Frames[0], "set.png")));
+        yield return Row(nameof(IAppCommands.SetAllFramesTextureName),
+            ctx => Sync(() => ctx.AppCommands.SetAllFramesTextureName(Zebra(ctx), "bulk.png")));
         yield return Row(nameof(IAppCommands.PasteChains),
             ctx => Sync(() => ctx.AppCommands.PasteChains(
                 new List<AnimationChainSave> { new() { Name = "Pasted" } })));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -94,6 +94,11 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AddFrameFromPixelBounds)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameTextureName)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.SetAllFramesTextureName)]      = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameLength)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameRelative)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFramePixelRegion)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetRectProps)]                 = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteRectangle)]               = Category.MutatingUndoable,
@@ -256,6 +261,16 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetFrameTextureName(Zebra(ctx).Frames[0], "set.png")));
         yield return Row(nameof(IAppCommands.SetAllFramesTextureName),
             ctx => Sync(() => ctx.AppCommands.SetAllFramesTextureName(Zebra(ctx), "bulk.png")));
+        yield return Row(nameof(IAppCommands.SetFrameLength),
+            ctx => Sync(() => ctx.AppCommands.SetFrameLength(Zebra(ctx).Frames[0], 0.99f)));
+        yield return Row(nameof(IAppCommands.SetFrameRelative),
+            ctx => Sync(() => ctx.AppCommands.SetFrameRelative(Zebra(ctx).Frames[0], 99f, 88f)));
+        yield return Row(nameof(IAppCommands.SetFramePixelRegion),
+            ctx => Sync(() => ctx.AppCommands.SetFramePixelRegion(Zebra(ctx).Frames[0], 4, 8, 12, 16, 64, 64)));
+        yield return Row(nameof(IAppCommands.SetRectProps),
+            ctx => Sync(() => ctx.AppCommands.SetRectProps(Zebra(ctx).Frames[0], Rect(ctx), "Renamed", 5f, 6f, 7f, 8f)));
+        yield return Row(nameof(IAppCommands.SetCircleProps),
+            ctx => Sync(() => ctx.AppCommands.SetCircleProps(Zebra(ctx).Frames[0], Circle(ctx), "Renamed", 5f, 6f, 9f)));
         yield return Row(nameof(IAppCommands.PasteChains),
             ctx => Sync(() => ctx.AppCommands.PasteChains(
                 new List<AnimationChainSave> { new() { Name = "Pasted" } })));


### PR DESCRIPTION
Closes #316
Closes #320

## Changes

**Issue #316 — Full undo pass:**
- Chain drag in wireframe now records `BulkFrameRegionChangedCommand`
- `OnFrameCreatedFromRegion` routes through `AppCommands.AddFrameFromPixelBounds`
- PNG drop routes through `SetAllFramesTextureName` (composite undoable command)
- All 5 inspector property fields now create undo entries: frame length, relative X/Y, pixel region, rect props, circle props

**Issue #320 — History UX improvements:**
- Auto-scrolls to current history entry when undo/redo is performed
- Richer history descriptions with actual values (e.g. "Set Length: 0.1s → 0.25s", "Move Rect 'hitbox'", "Set Region: (0, 0) 64×64")

**New commands:**
- `SetShapePropsCommand` — undoable inspector edits for collision shapes (name + geometry)
- `BulkFrameEditCommand` reused for frame length, offset, and pixel region edits