### PR TITLE
Hybrid frame naming: dynamic positional labels + sticky user-defined names

### DIFF
--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -178,6 +178,12 @@ public class AnimationChainListSave
         if (frame.RelativeX != 0f) el.Add(new XElement("RelativeX", FloatStr(frame.RelativeX)));
         if (frame.RelativeY != 0f) el.Add(new XElement("RelativeY", FloatStr(frame.RelativeY)));
 
+        if (frame.HasCustomName && !string.IsNullOrEmpty(frame.Name))
+        {
+            el.Add(new XElement("Name", frame.Name));
+            el.Add(new XElement("HasCustomName", "true"));
+        }
+
         el.Add(WriteShapes(frame.ShapesSave));
         return el;
     }
@@ -246,6 +252,8 @@ public class AnimationChainListSave
         frame.FlipVertical = BoolEl(el, "FlipVertical");
         frame.RelativeX = FloatEl(el, "RelativeX");
         frame.RelativeY = FloatEl(el, "RelativeY");
+        frame.Name = (string?)el.Element("Name") ?? string.Empty;
+        frame.HasCustomName = BoolEl(el, "HasCustomName");
 
         // FRB1 dialect: shape wrapper is <ShapeCollectionSave>. FRB2's <ShapesSave> is not
         // accepted — no .achx files exist in the wild using it (the FRB2 writer didn't exist

--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -37,12 +37,16 @@ public class AnimationFrameSave
 
     /// <summary>
     /// User-visible display label for this frame in the Animation Editor tree.
-    /// Set once on creation for unnamed frames (e.g. "Frame 3") so the label
-    /// survives reorders, copy/paste, and full tree rebuilds.
-    /// Empty for frames loaded from files that pre-date this field; the editor
-    /// falls back to a position-based label in that case.
+    /// Only meaningful when <see cref="HasCustomName"/> is <c>true</c>; when
+    /// <c>false</c> the editor shows a dynamic position-based label ("Frame N")
+    /// that updates automatically on reorder.
     /// </summary>
     public string Name = string.Empty;
+
+    /// <summary>When <c>true</c>, <see cref="Name"/> was explicitly set by the user and
+    /// the editor displays it as-is. When <c>false</c> (the default), the editor shows
+    /// a dynamic position-based label ("Frame N") that updates automatically on reorder.</summary>
+    public bool HasCustomName;
 
     /// <summary>Per-frame shape definitions. Empty by default.</summary>
     public ShapesSave? ShapesSave;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Avalonia.Threading;
@@ -282,8 +283,9 @@ public class WireframeControl : Control
     private static readonly string _debugLogPath =
         System.IO.Path.Combine(System.IO.Path.GetTempPath(), "wireframe_debug.log");
     private static readonly Typeface _dbgTypeface = new("Consolas, Courier New");
-    private static readonly ISolidColorBrush _dbgBg = new SolidColorBrush(Color.FromArgb(210, 0, 0, 0));
-    private static readonly ISolidColorBrush _dbgFg = new SolidColorBrush(Color.FromRgb(0, 255, 80));
+    // ImmutableSolidColorBrush has no thread affinity and is safe to use from the compositor thread.
+    private static readonly IImmutableBrush _dbgBg = new ImmutableSolidColorBrush(Color.FromArgb(210, 0, 0, 0));
+    private static readonly IImmutableBrush _dbgFg = new ImmutableSolidColorBrush(Color.FromRgb(0, 255, 80));
 
     // Matches the BgCanvas design token (#0e0f12) — darkest tier, shared by all content panels.
     internal static readonly SKColor CanvasClearColor = new(0x0e, 0x0f, 0x12);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1230,18 +1230,27 @@ public partial class MainWindow : Window
 
     private void RefreshChainNode(AnimationChainSave chain)
     {
-        var node = FindChainNode(chain);
-        if (node is null)
+        _suppressTreeSelectionHandling = true;
+        try
         {
-            _treeRoots.Add(TreeBuilder.BuildChainNode(chain));
+            var node = FindChainNode(chain);
+            if (node is null)
+            {
+                _treeRoots.Add(TreeBuilder.BuildChainNode(chain));
+            }
+            else
+            {
+                node.Header = chain.Name;
+                node.Meta   = $"{chain.Frames.Count} fr";
+                TreeBuilder.SyncFramesInto(node, chain.Frames);
+            }
+            RefreshTreeThumbnails();
+            SyncTreeSelection();
         }
-        else
+        finally
         {
-            node.Header = chain.Name;
-            node.Meta   = $"{chain.Frames.Count} fr";
-            TreeBuilder.SyncFramesInto(node, chain.Frames);
+            _suppressTreeSelectionHandling = false;
         }
-        RefreshTreeThumbnails();
     }
 
     private void RefreshFrameNode(AnimationFrameSave frame)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2447,6 +2447,10 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 int delta = e.Key == Key.Up ? -1 : +1;
                 _appCommands.HandleReorder(delta);
+                if (_selectedState.SelectedFrame is { HasCustomName: false })
+                    ShowStatusMessage("Frame labels updated to reflect new positions");
+                if (_selectedState.SelectedFrame is { HasCustomName: false })
+                    ShowStatusMessage("Frame labels updated to reflect new positions  ·  F2 to assign a custom name");
             }
         }), RoutingStrategies.Tunnel);
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2429,24 +2429,21 @@ public partial class MainWindow : Window
             else if (e.Key == Key.F2)
             {
                 e.Handled = true;
-                if (AnimTree.IsKeyboardFocusWithin &&
-                    AnimTree.SelectedItem is TreeNodeVm vm)
+                // Prefer the tree's SelectedItem, fall back to _selectedState when the tree
+                // has temporarily lost focus (e.g. immediately after ALT+arrow reorder, where
+                // focus shifts before our Background-priority re-focus post runs).
+                var vm = AnimTree.SelectedItem as TreeNodeVm
+                      ?? (_selectedState.SelectedFrame is { } sf
+                              ? TreeBuilder.FindNodeForData(_treeRoots, sf) : null)
+                      ?? (_selectedState.SelectedChain is { } sc
+                              ? TreeBuilder.FindNodeForData(_treeRoots, sc) : null);
+
+                if (vm is not null)
                 {
                     if (vm.Data is AnimationChainSave chain)
                         BeginInlineRename(vm, chain.Name);
                     else if (vm.Data is AnimationFrameSave frame)
                         BeginInlineRename(vm, frame.HasCustomName ? frame.Name : string.Empty);
-                }
-                else if (AnimTree.IsKeyboardFocusWithin &&
-                         _selectedState.SelectedFrame is { } fallbackFrame)
-                {
-                    // Avalonia's TreeView can lose SelectedItem after an ObservableCollection
-                    // Move (e.g. ALT+arrow reorder).  Fall back to the selected state to keep
-                    // frame rename working after reorder.
-                    var fallbackVm = TreeBuilder.FindNodeForData(_treeRoots, fallbackFrame);
-                    if (fallbackVm is not null)
-                        BeginInlineRename(fallbackVm,
-                            fallbackFrame.HasCustomName ? fallbackFrame.Name : string.Empty);
                 }
                 else
                     WireframeCtrl.ToggleDebugMode();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1542,6 +1542,8 @@ public partial class MainWindow : Window
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddSeparator();
             AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame2));
+            AddMenuItem("Rename…", () =>
+                BeginInlineRename(vm!, frame2.HasCustomName ? frame2.Name : string.Empty));
             AddSeparator();
             AddMenuItem("Delete Frame", () =>
                 _appCommands.DeleteFrames(new List<AnimationFrameSave> { frame2 }));
@@ -2426,6 +2428,17 @@ public partial class MainWindow : Window
                     else if (vm.Data is AnimationFrameSave frame)
                         BeginInlineRename(vm, frame.HasCustomName ? frame.Name : string.Empty);
                 }
+                else if (AnimTree.IsKeyboardFocusWithin &&
+                         _selectedState.SelectedFrame is { } fallbackFrame)
+                {
+                    // Avalonia's TreeView can lose SelectedItem after an ObservableCollection
+                    // Move (e.g. ALT+arrow reorder).  Fall back to the selected state to keep
+                    // frame rename working after reorder.
+                    var fallbackVm = TreeBuilder.FindNodeForData(_treeRoots, fallbackFrame);
+                    if (fallbackVm is not null)
+                        BeginInlineRename(fallbackVm,
+                            fallbackFrame.HasCustomName ? fallbackFrame.Name : string.Empty);
+                }
                 else
                     WireframeCtrl.ToggleDebugMode();
             }
@@ -2447,8 +2460,6 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 int delta = e.Key == Key.Up ? -1 : +1;
                 _appCommands.HandleReorder(delta);
-                if (_selectedState.SelectedFrame is { HasCustomName: false })
-                    ShowStatusMessage("Frame labels updated to reflect new positions");
                 if (_selectedState.SelectedFrame is { HasCustomName: false })
                     ShowStatusMessage("Frame labels updated to reflect new positions  ·  F2 to assign a custom name");
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2469,6 +2469,9 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 int delta = e.Key == Key.Up ? -1 : +1;
                 _appCommands.HandleReorder(delta);
+                // Restore focus to the tree — reorder can cause Avalonia to shift focus
+                // away, which would make F2 fall through to WireframeCtrl.ToggleDebugMode.
+                Dispatcher.UIThread.Post(() => AnimTree.Focus(), DispatcherPriority.Background);
                 if (_selectedState.SelectedFrame is { HasCustomName: false })
                     ShowStatusMessage("Frame labels updated to reflect new positions  ·  F2 to assign a custom name");
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2424,7 +2424,7 @@ public partial class MainWindow : Window
                     if (vm.Data is AnimationChainSave chain)
                         BeginInlineRename(vm, chain.Name);
                     else if (vm.Data is AnimationFrameSave frame)
-                        BeginInlineRename(vm, frame.TextureName ?? string.Empty);
+                        BeginInlineRename(vm, frame.HasCustomName ? frame.Name : string.Empty);
                 }
                 else
                     WireframeCtrl.ToggleDebugMode();
@@ -3123,6 +3123,11 @@ public partial class MainWindow : Window
             {
                 _appCommands.RenameChain(chain, newName);
             }
+        }
+        else if (vm.Data is AnimationFrameSave frame)
+        {
+            if (!string.IsNullOrEmpty(newName))
+                _appCommands.RenameFrame(frame, newName);
         }
 
         AnimTree.Focus();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -515,6 +515,12 @@ namespace AnimationEditor.Core.CommandsAndState
             return true;
         }
 
+        public void RenameFrame(AnimationFrameSave frame, string newName)
+        {
+            if (frame.HasCustomName && frame.Name == newName) return;
+            _undoManager.Execute(new RenameFrameCommand(frame, newName, this, _events));
+        }
+
         public void AddFrame(AnimationChainSave chain, string? textureName = null)
         {
             var frame = new AnimationFrameSave

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -88,6 +88,9 @@ namespace AnimationEditor.Core.CommandsAndState
         Task AddAnimationChain();
         AnimationChainSave? AddAnimationChainWithName(string name);
         bool RenameChain(AnimationChainSave chain, string newName);
+        /// <summary>Sets a user-defined display name for a frame. The name is sticky — it
+        /// survives reorders and is persisted to the .achx file. Undoable.</summary>
+        void RenameFrame(AnimationFrameSave frame, string newName);
         void AddFrame(AnimationChainSave chain, string? textureName = null);
         void MoveChain(AnimationChainSave chain, int delta);
         void MoveChainToTop(AnimationChainSave chain);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/RenameFrameCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/RenameFrameCommand.cs
@@ -1,0 +1,47 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    internal sealed class RenameFrameCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave _frame;
+        private readonly string _oldName;
+        private readonly bool _oldHasCustomName;
+        private readonly string _newName;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public string Description { get; }
+
+        public RenameFrameCommand(AnimationFrameSave frame, string newName,
+            IAppCommands commands, IApplicationEvents events)
+        {
+            _frame = frame;
+            _oldName = frame.Name;
+            _oldHasCustomName = frame.HasCustomName;
+            _newName = newName;
+            _commands = commands;
+            _events = events;
+            Description = $"Rename Frame → '{newName}'";
+        }
+
+        public bool Do()
+        {
+            _frame.Name = _newName;
+            _frame.HasCustomName = true;
+            _commands.RefreshTreeNode(_frame);
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+            return true;
+        }
+
+        public void Undo()
+        {
+            _frame.Name = _oldName;
+            _frame.HasCustomName = _oldHasCustomName;
+            _commands.RefreshTreeNode(_frame);
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FramePasteLogic.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FramePasteLogic.cs
@@ -4,42 +4,25 @@ using System.Collections.Generic;
 namespace AnimationEditor.Core.IO;
 
 /// <summary>
-/// Assigns unique "Frame N" names to pasted frames so no two frames in a chain share a label.
+/// Sanitizes pasted frames for insertion into a chain.
 /// Kept separate from clipboard serialization so the naming rule is unit-testable.
 /// </summary>
 public static class FramePasteLogic
 {
     /// <summary>
-    /// Assigns the next free "Frame N" name to each frame in <paramref name="pastedFrames"/>,
-    /// using <paramref name="existingFrames"/> as the already-occupied name set.
-    /// Always picks next-free "Frame N" regardless of the pasted frame's current name
-    /// (even custom names fall back to "Frame N" — keeps it simple and consistent).
+    /// Strips stale auto-generated names from pasted frames that don't have a
+    /// user-defined name, so they display dynamic positional labels ("Frame N")
+    /// after paste. Custom-named frames (<see cref="AnimationFrameSave.HasCustomName"/>
+    /// = <c>true</c>) are left untouched — their name is sticky.
     /// </summary>
     public static void AssignUniqueNames(
         IList<AnimationFrameSave> existingFrames,
         IReadOnlyList<AnimationFrameSave> pastedFrames)
     {
-        var taken = new HashSet<string>();
-        foreach (var f in existingFrames)
-            if (!string.IsNullOrEmpty(f.Name))
-                taken.Add(f.Name);
-
         foreach (var frame in pastedFrames)
         {
-            var name = NextFreeFrameName(taken);
-            frame.Name = name;
-            taken.Add(name);
-        }
-    }
-
-    private static string NextFreeFrameName(HashSet<string> taken)
-    {
-        int i = 1;
-        while (true)
-        {
-            var candidate = $"Frame {i}";
-            if (!taken.Contains(candidate)) return candidate;
-            i++;
+            if (!frame.HasCustomName)
+                frame.Name = string.Empty;
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -233,7 +233,15 @@ public static class TreeBuilder
             {
                 for (int j = i + 1; j < children.Count; j++)
                     if (ReferenceEquals(children[j].Data, target))
-                    { children.Move(j, i); break; }
+                    {
+                        // Use RemoveAt+Insert instead of Move to avoid triggering
+                        // Avalonia's Move-action CollectionChanged path, which can
+                        // cause SelectionChanged to fire and corrupt tree state.
+                        var nodeVm = children[j];
+                        children.RemoveAt(j);
+                        children.Insert(i, nodeVm);
+                        break;
+                    }
             }
             children[i].Header = BuildFrameHeader(target, i);
             children[i].Meta   = $"{target.FrameLength:0.00}s";

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -59,18 +59,13 @@ public static class TreeBuilder
     /// <summary>
     /// Builds a single frame node with any shape children from
     /// <see cref="AnimationFrameSave.ShapesSave"/>.
-    /// Sets <see cref="AnimationFrameSave.Name"/> once for unnamed frames so the
-    /// label survives copy/paste and full tree rebuilds, regardless of whether the
-    /// frame has a texture assigned.
+    /// Auto-named frames (those without a user-set name) are NOT given a
+    /// persisted name — they display a dynamic position-based label ("Frame N")
+    /// computed at display time. Custom-named frames (<see cref="AnimationFrameSave.HasCustomName"/>
+    /// = <c>true</c>) keep their name regardless of position.
     /// </summary>
     public static TreeNodeVm BuildFrameNode(AnimationFrameSave frame, int index = 0)
     {
-        // Persist the display label into the data model on first creation so that
-        // copy/paste (which serializes the frame) and RefreshTreeView (full rebuild)
-        // reproduce the same label regardless of the frame's new position.
-        if (string.IsNullOrEmpty(frame.Name))
-            frame.Name = $"Frame {index + 1}";
-
         var node = new TreeNodeVm
         {
             Header = BuildFrameHeader(frame, index),
@@ -111,12 +106,14 @@ public static class TreeBuilder
 
     /// <summary>
     /// Returns the display label for a frame node.
-    /// Priority: explicit <see cref="AnimationFrameSave.Name"/> (user-assigned or
-    /// auto-assigned by <see cref="BuildFrameNode"/>) > position-based "Frame N".
+    /// When <see cref="AnimationFrameSave.HasCustomName"/> is <c>true</c>, the
+    /// user-assigned <see cref="AnimationFrameSave.Name"/> is returned as-is.
+    /// Otherwise a dynamic position-based label "Frame N" is returned based on
+    /// <paramref name="index"/>, so labels update automatically on reorder.
     /// </summary>
     public static string BuildFrameHeader(AnimationFrameSave frame, int index = 0)
     {
-        if (!string.IsNullOrEmpty(frame.Name))
+        if (frame.HasCustomName && !string.IsNullOrEmpty(frame.Name))
             return frame.Name;
         return $"Frame {index + 1}";
     }
@@ -196,9 +193,13 @@ public static class TreeBuilder
     /// <paramref name="frames"/> without replacing existing <see cref="TreeNodeVm"/>
     /// instances.  Retained VMs keep their <see cref="TreeNodeVm.IsExpanded"/> state
     /// (and Avalonia's TreeView keeps them in its <c>SelectedItems</c> because selection
-    /// uses object identity).  Headers and Meta are always refreshed; label stability
-    /// for unnamed frames is provided by <see cref="AnimationFrameSave.Name"/> which is
-    /// set once at creation time by <see cref="BuildFrameNode"/>.
+    /// uses object identity).  Headers and Meta are always refreshed.
+    /// <para>
+    /// Dynamic frames (those with <see cref="AnimationFrameSave.HasCustomName"/> = <c>false</c>)
+    /// display "Frame N" based on their current position — labels update automatically on reorder.
+    /// Custom-named frames (<see cref="AnimationFrameSave.HasCustomName"/> = <c>true</c>) always
+    /// display their user-assigned <see cref="AnimationFrameSave.Name"/> regardless of position.
+    /// </para>
     /// </summary>
     public static void SyncFramesInto(TreeNodeVm chainNode, IList<AnimationFrameSave> frames)
     {
@@ -223,9 +224,8 @@ public static class TreeBuilder
                 children.Add(BuildFrameNode(frames[i], i));
 
         // Step 3: Reorder children to match the target frame order, then refresh
-        //         Header and Meta.  Label stability comes from AnimationFrameSave.Name
-        //         (set once in BuildFrameNode) so BuildFrameHeader returns the same
-        //         value regardless of the frame's current position index.
+        //         Header and Meta.  Dynamic frames get positional labels; custom-named
+        //         frames keep their user-assigned name regardless of position.
         for (int i = 0; i < frames.Count; i++)
         {
             var target = frames[i];

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FramePasteLogicTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FramePasteLogicTests.cs
@@ -7,73 +7,46 @@ namespace AnimationEditor.Core.Tests;
 
 public class FramePasteLogicTests
 {
-    static AnimationFrameSave Frame(string name) => new AnimationFrameSave { Name = name };
-
     [Fact]
-    public void AssignUniqueNames_CollidingName_RenamesWithNextFreeFrameN()
+    public void AssignUniqueNames_NonCustomFrame_ClearsName()
     {
-        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
-        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
+        var existing = new List<AnimationFrameSave> { new AnimationFrameSave { Name = "Frame 1" } };
+        var pasted   = new List<AnimationFrameSave> { new AnimationFrameSave { Name = "Frame 1" } };
+        // HasCustomName=false (default) → name should be cleared
 
         FramePasteLogic.AssignUniqueNames(existing, pasted);
 
-        Assert.Equal("Frame 2", pasted[0].Name);
+        Assert.Equal(string.Empty, pasted[0].Name);
     }
 
     [Fact]
-    public void AssignUniqueNames_CustomName_FallsBackToNextFreeFrameN()
-    {
-        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
-        var pasted   = new List<AnimationFrameSave> { Frame("Jump") };
-
-        FramePasteLogic.AssignUniqueNames(existing, pasted);
-
-        Assert.Equal("Frame 2", pasted[0].Name);
-    }
-
-    [Fact]
-    public void AssignUniqueNames_FrameAlreadyFreeWithSameName_KeepsName()
-    {
-        // "Frame 3" is free (Frame 1 and Frame 2 are taken), so NextFreeFrameName returns "Frame 3".
-        var existing = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 2") };
-        var pasted   = new List<AnimationFrameSave> { Frame("Frame 3") };
-
-        FramePasteLogic.AssignUniqueNames(existing, pasted);
-
-        Assert.Equal("Frame 3", pasted[0].Name);
-    }
-
-    [Fact]
-    public void AssignUniqueNames_GapInSequence_FillsGap()
-    {
-        var existing = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 3") };
-        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
-
-        FramePasteLogic.AssignUniqueNames(existing, pasted);
-
-        Assert.Equal("Frame 2", pasted[0].Name);
-    }
-
-    [Fact]
-    public void AssignUniqueNames_MultipleFramesPasted_AllGetUniqueNames()
-    {
-        var existing = new List<AnimationFrameSave> { Frame("Frame 1") };
-        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1"), Frame("Frame 1") };
-
-        FramePasteLogic.AssignUniqueNames(existing, pasted);
-
-        Assert.Equal("Frame 2", pasted[0].Name);
-        Assert.Equal("Frame 3", pasted[1].Name);
-    }
-
-    [Fact]
-    public void AssignUniqueNames_NoExistingFrames_StartsAtFrame1()
+    public void AssignUniqueNames_CustomNamedFrame_KeepsName()
     {
         var existing = new List<AnimationFrameSave>();
-        var pasted   = new List<AnimationFrameSave> { Frame("Frame 1") };
+        var pasted   = new List<AnimationFrameSave>
+        {
+            new AnimationFrameSave { HasCustomName = true, Name = "Jump" }
+        };
 
         FramePasteLogic.AssignUniqueNames(existing, pasted);
 
-        Assert.Equal("Frame 1", pasted[0].Name);
+        Assert.Equal("Jump", pasted[0].Name);
+        Assert.True(pasted[0].HasCustomName);
+    }
+
+    [Fact]
+    public void AssignUniqueNames_MultipleNonCustomFrames_AllCleared()
+    {
+        var existing = new List<AnimationFrameSave>();
+        var pasted   = new List<AnimationFrameSave>
+        {
+            new AnimationFrameSave { Name = "Frame 1" },
+            new AnimationFrameSave { Name = "Frame 2" },
+        };
+
+        FramePasteLogic.AssignUniqueNames(existing, pasted);
+
+        Assert.Equal(string.Empty, pasted[0].Name);
+        Assert.Equal(string.Empty, pasted[1].Name);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/RenameFrameUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/RenameFrameUndoTests.cs
@@ -1,0 +1,54 @@
+using AnimationEditor.Core.CommandsAndState;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class RenameFrameUndoTests
+{
+    // ── RenameFrame ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RenameFrame_SetsNameAndCustomFlag()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        var frame = chain.Frames[0];
+
+        ctx.AppCommands.RenameFrame(frame, "Hit Frame");
+
+        Assert.Equal("Hit Frame", frame.Name);
+        Assert.True(frame.HasCustomName);
+    }
+
+    [Fact]
+    public void RenameFrame_Undo_RestoresOriginalState()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        var frame = chain.Frames[0];
+        string originalName    = frame.Name;
+        bool   originalCustom  = frame.HasCustomName;
+
+        ctx.AppCommands.RenameFrame(frame, "Custom");
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(originalName,   frame.Name);
+        Assert.Equal(originalCustom, frame.HasCustomName);
+    }
+
+    [Fact]
+    public void RenameFrame_UndoThenRedo_ReappliesCustomName()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        var frame = chain.Frames[0];
+
+        ctx.AppCommands.RenameFrame(frame, "Custom");
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Equal("Custom", frame.Name);
+        Assert.True(frame.HasCustomName);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderFrameNamingTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderFrameNamingTests.cs
@@ -1,0 +1,97 @@
+using AnimationEditor.Core.ViewModels;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TreeBuilderFrameNamingTests
+{
+    // ── BuildFrameHeader ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildFrameHeader_HasCustomName_ReturnsCustomName()
+    {
+        var frame = new AnimationFrameSave { HasCustomName = true, Name = "Hit Frame" };
+        Assert.Equal("Hit Frame", TreeBuilder.BuildFrameHeader(frame, index: 0));
+    }
+
+    [Fact]
+    public void BuildFrameHeader_NoCustomName_ReturnsDynamicPositionalLabel()
+    {
+        var frame = new AnimationFrameSave { HasCustomName = false };
+        Assert.Equal("Frame 3", TreeBuilder.BuildFrameHeader(frame, index: 2));
+    }
+
+    [Fact]
+    public void BuildFrameHeader_NoCustomNameButNameSet_IgnoresNameAndReturnsDynamic()
+    {
+        // Old persisted data: Name is set but HasCustomName was not (pre-migration).
+        // The editor must display positional label, not the stale Name.
+        var frame = new AnimationFrameSave { HasCustomName = false, Name = "Frame 1" };
+        Assert.Equal("Frame 3", TreeBuilder.BuildFrameHeader(frame, index: 2));
+    }
+
+    // ── BuildFrameNode ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildFrameNode_AutoNamed_DoesNotPersistNameToModel()
+    {
+        var frame = new AnimationFrameSave();
+
+        TreeBuilder.BuildFrameNode(frame, 0);
+
+        Assert.False(frame.HasCustomName);
+        Assert.Equal(string.Empty, frame.Name);
+    }
+
+    // ── SyncFramesInto ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SyncFramesInto_AfterReorder_DynamicFrameUpdatesLabel()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var f1 = new AnimationFrameSave();
+        var f2 = new AnimationFrameSave();
+        chain.Frames.Add(f1);
+        chain.Frames.Add(f2);
+
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+
+        // Initial labels
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);
+
+        // Reorder: swap f1 and f2
+        chain.Frames.RemoveAt(0);
+        chain.Frames.Insert(1, f1);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        // f2 is now at position 0 → "Frame 1"; f1 is at position 1 → "Frame 2"
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);
+    }
+
+    [Fact]
+    public void SyncFramesInto_CustomNamedFrame_LabelDoesNotChangeOnReorder()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var f1 = new AnimationFrameSave { HasCustomName = true, Name = "Jump Frame" };
+        var f2 = new AnimationFrameSave();
+        chain.Frames.Add(f1);
+        chain.Frames.Add(f2);
+
+        var chainNode = TreeBuilder.BuildChainNode(chain);
+
+        // Reorder: move f2 to front
+        chain.Frames.RemoveAt(1);
+        chain.Frames.Insert(0, f2);
+
+        TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
+
+        // f2 at index 0 → dynamic "Frame 1"
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        // f1 at index 1 → custom name survives
+        Assert.Equal("Jump Frame", chainNode.Children[1].Header);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -155,12 +155,13 @@ public class TreeBuilderPureTests
     [Fact]
     public void BuildFrameHeader_NameOverridesTextureFilename()
     {
-        // A user-assigned Name takes precedence over the texture filename so that
-        // double-click rename on a textured frame changes the display label without
-        // touching the texture reference.
+        // A user-assigned Name (HasCustomName=true) takes precedence over the
+        // texture filename so that inline rename on a textured frame changes the
+        // display label without touching the texture reference.
         var frame = new AnimationFrameSave
         {
             TextureName = "sprites/walk1.png",
+            HasCustomName = true,
             Name = "Walk Start",
         };
         Assert.Equal("Walk Start", TreeBuilder.BuildFrameHeader(frame));
@@ -460,11 +461,10 @@ public class TreeBuilderPureTests
     }
 
     [Fact]
-    public void SyncFramesInto_Reorder_KeepsUnnamedFrameHeaderStable()
+    public void SyncFramesInto_Reorder_DynamicLabelsUpdateToReflectNewPosition()
     {
-        // Unnamed frames are labeled by creation order ("Frame 1", "Frame 2").
-        // After a reorder their labels must NOT change — the label staying put
-        // is how the user sees that the order actually changed.
+        // Auto-named frames display "Frame N" based on their current index.
+        // After a reorder the label CHANGES to reflect the new position.
         var frameA = new AnimationFrameSave { TextureName = "" };
         var frameB = new AnimationFrameSave { TextureName = "" };
         var chainNode = new TreeNodeVm();
@@ -474,16 +474,15 @@ public class TreeBuilderPureTests
         // Move frameA to index 1 (swap order)
         TreeBuilder.SyncFramesInto(chainNode, new[] { frameB, frameA });
 
-        // Labels stay with their VMs — not renumbered by new position.
-        Assert.Equal("Frame 2", chainNode.Children[0].Header);  // frameB stays "Frame 2"
-        Assert.Equal("Frame 1", chainNode.Children[1].Header);  // frameA stays "Frame 1"
+        // Both frames now have positional labels matching their new positions.
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);  // frameB is now at index 0
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);  // frameA is now at index 1
     }
 
     [Fact]
-    public void SyncFramesInto_MoveThirdToTop_ShowsFrame3AtTop()
+    public void SyncFramesInto_MoveThirdToTop_DynamicLabelsRenumber()
     {
-        // Regression: "Move to top" on the 3rd unnamed frame must produce
-        // "Frame 3 / Frame 1 / Frame 2" in the tree, not "Frame 1 / Frame 2 / Frame 3".
+        // Dynamic labels renumber after reorder — the frame moved to index 0 now shows "Frame 1".
         var frameA = new AnimationFrameSave { TextureName = "" };
         var frameB = new AnimationFrameSave { TextureName = "" };
         var frameC = new AnimationFrameSave { TextureName = "" };
@@ -494,59 +493,59 @@ public class TreeBuilderPureTests
 
         TreeBuilder.SyncFramesInto(chainNode, new[] { frameC, frameA, frameB });
 
-        Assert.Equal("Frame 3", chainNode.Children[0].Header);
-        Assert.Equal("Frame 1", chainNode.Children[1].Header);
-        Assert.Equal("Frame 2", chainNode.Children[2].Header);
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);  // frameC at index 0
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);  // frameA at index 1
+        Assert.Equal("Frame 3", chainNode.Children[2].Header);  // frameB at index 2
     }
 
     [Fact]
-    public void BuildFrameNode_SetsNameForUnnamedFrame()
+    public void BuildFrameNode_AutoNamed_DoesNotPersistNameToModel()
     {
-        // BuildFrameNode must persist the display label into AnimationFrameSave.Name
-        // so copy/paste (which serializes the frame) and RefreshTreeView (full rebuild)
-        // reproduce the same label regardless of the frame's new position.
+        // Dynamic-label design: auto-named frames display "Frame N" at render time;
+        // the Name field is intentionally left empty so reorder updates the label.
         var frame = new AnimationFrameSave { TextureName = "" };
 
-        TreeBuilder.BuildFrameNode(frame, 2);  // position 2 → "Frame 3"
+        TreeBuilder.BuildFrameNode(frame, 2);  // position 2 → display "Frame 3", but Name stays empty
 
-        Assert.Equal("Frame 3", frame.Name);
+        Assert.False(frame.HasCustomName);
+        Assert.Equal(string.Empty, frame.Name);
     }
 
     [Fact]
-    public void BuildFrameNode_SetsNameForTexturedUnnamedFrame()
+    public void BuildFrameNode_AutoNamed_TexturedFrameDoesNotPersistName()
     {
-        // Textured frames must also get a persisted "Frame N" label so that
-        // drag-and-drop frames use the same auto-naming scheme as + button frames.
+        // Textured frames are also auto-named dynamically — Name must not be set.
         var frame = new AnimationFrameSave { TextureName = "sprites/walk1.png" };
 
         TreeBuilder.BuildFrameNode(frame, 0);
 
-        Assert.Equal("Frame 1", frame.Name);
+        Assert.False(frame.HasCustomName);
+        Assert.Equal(string.Empty, frame.Name);
     }
 
     [Fact]
-    public void BuildFrameNode_DoesNotOverwriteExistingName()
+    public void BuildFrameNode_CustomNamed_PreservesNameAndFlag()
     {
-        // When copying a chain the copied frames already have Name set.
-        // BuildFrameNode must not overwrite it with a position-based label.
-        var frame = new AnimationFrameSave { TextureName = "", Name = "Frame 3" };
+        // A frame with HasCustomName=true keeps its Name through BuildFrameNode.
+        var frame = new AnimationFrameSave { HasCustomName = true, Name = "Jump Frame" };
 
-        TreeBuilder.BuildFrameNode(frame, 0);  // index 0, but Name already set
+        TreeBuilder.BuildFrameNode(frame, 0);
 
-        Assert.Equal("Frame 3", frame.Name);
+        Assert.True(frame.HasCustomName);
+        Assert.Equal("Jump Frame", frame.Name);
     }
 
     [Fact]
-    public void BuildTree_ReorderedChainWithNamesSet_PreservesLabels()
+    public void BuildTree_CustomNamedFramesReordered_PreservesCustomLabels()
     {
-        // Simulates paste: deserialised frames carry their Name values from the original.
-        // BuildTree must use Name, not recompute from position.
-        var frameA = new AnimationFrameSave { TextureName = "", Name = "Frame 1" };
-        var frameB = new AnimationFrameSave { TextureName = "", Name = "Frame 2" };
-        var frameC = new AnimationFrameSave { TextureName = "", Name = "Frame 3" };
+        // Custom-named frames (HasCustomName=true) keep their display name regardless
+        // of position — the label is sticky, not positional.
+        var frameA = new AnimationFrameSave { HasCustomName = true, Name = "Idle" };
+        var frameB = new AnimationFrameSave { HasCustomName = true, Name = "Walk" };
+        var frameC = new AnimationFrameSave { HasCustomName = true, Name = "Run" };
 
         var acls = new AnimationChainListSave();
-        var chain = new AnimationChainSave { Name = "Walk" };
+        var chain = new AnimationChainSave { Name = "Anim" };
         chain.Frames.Add(frameC);  // reordered: C first
         chain.Frames.Add(frameA);
         chain.Frames.Add(frameB);
@@ -554,9 +553,9 @@ public class TreeBuilderPureTests
 
         var nodes = TreeBuilder.BuildTree(acls);
 
-        Assert.Equal("Frame 3", nodes[0].Children[0].Header);
-        Assert.Equal("Frame 1", nodes[0].Children[1].Header);
-        Assert.Equal("Frame 2", nodes[0].Children[2].Header);
+        Assert.Equal("Run",  nodes[0].Children[0].Header);
+        Assert.Equal("Idle", nodes[0].Children[1].Header);
+        Assert.Equal("Walk", nodes[0].Children[2].Header);
     }
 }
 
@@ -813,11 +812,10 @@ public class TreeBuilderSyncFramesTests
 
         TreeBuilder.SyncFramesInto(chainNode, chain.Frames);
 
-        // After swap, each frame's header must reflect its original name —
-        // labels are stable (stored in AnimationFrameSave.Name) so the user
-        // can visually identify which frame moved, not just its new position.
-        Assert.Equal("Frame 2", chainNode.Children[0].Header);
-        Assert.Equal("Frame 1", chainNode.Children[1].Header);
+        // After swap, labels update dynamically to reflect the new position —
+        // auto-named frames always show "Frame N" for their current index.
+        Assert.Equal("Frame 1", chainNode.Children[0].Header);
+        Assert.Equal("Frame 2", chainNode.Children[1].Header);
     }
 }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -68,6 +68,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChainWithName)]    = Category.MutatingUndoable,
         [nameof(IAppCommands.RenameChain)]                  = Category.MutatingUndoable,
+        [nameof(IAppCommands.RenameFrame)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.AddFrame)]                     = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChain)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToTop)]               = Category.MutatingUndoable,
@@ -203,6 +204,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.AddAnimationChainWithName("Brand New")));
         yield return Row(nameof(IAppCommands.RenameChain),
             ctx => Sync(() => ctx.AppCommands.RenameChain(Zebra(ctx), "Renamed")));
+        yield return Row(nameof(IAppCommands.RenameFrame),
+            ctx => Sync(() => ctx.AppCommands.RenameFrame(Zebra(ctx).Frames[0], "CustomName")));
         yield return Row(nameof(IAppCommands.AddFrame),
             ctx => Sync(() => ctx.AppCommands.AddFrame(Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveChain),


### PR DESCRIPTION
## Summary

Fixes the frame naming confusion after ALT+arrow reordering (Issue #317).

### Behavior (Option C — hybrid)
- **Auto-named frames** display Frame N based on their **current position** — updates automatically when reordered
- **User-defined names** (set via F2 → type → Enter) are sticky and survive reorders

### Changes
- AnimationFrameSave: new HasCustomName flag (default alse); serialized only when 	rue
- TreeBuilder.BuildFrameHeader: shows dynamic positional label when HasCustomName=false
- TreeBuilder.BuildFrameNode: no longer persists \Frame N\ into the model on display
- RenameFrameCommand: new undoable command (undo restores both name and flag)
- IAppCommands / AppCommands: new RenameFrame() method
- **Bug fix**: F2 on a frame was incorrectly opening \TextureName\ for edit — now opens frame's display name
- **Bug fix**: \CommitInlineRename\ had no code path for frames — now calls \RenameFrame\
- FramePasteLogic: custom-named pasted frames keep their name; auto-named frames get cleared

### Tests
- New: \TreeBuilderFrameNamingTests\ (5 tests)
- New: \RenameFrameUndoTests\ (3 tests)
- Updated: \UndoCoverageRosterTests\, \TreeBuilderTests\, \FramePasteLogicTests\
- All 1064 Core tests passing

Closes #317