### PR TITLE
fix(#340): History list — Photoshop order (oldest top, newest bottom)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -470,18 +470,17 @@ public partial class MainWindow : Window
         var undoHistory = _undoManager.UndoHistory;
         var redoHistory = _undoManager.RedoHistory;
         var items = new List<Models.HistoryEntryVm>();
-        // Redo items reversed so newest-recorded sits at top — positions never move on undo/redo
-        foreach (var cmd in redoHistory.Reverse())
+        // Photoshop order: oldest applied at top, newest applied at bottom, redo items below.
+        foreach (var cmd in undoHistory)
+            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec"));
+        // Mark the most recently applied command as "you are here".
+        if (items.Count > 0)
+            items[^1] = items[^1] with { IsCurrent = true };
+        // Redo items follow: next-to-redo first, furthest future last.
+        foreach (var cmd in redoHistory)
             items.Add(new Models.HistoryEntryVm(cmd.Description, "#6a6e76"));
-        // Undo items newest-first; first entry is the current "you are here" position
-        bool firstUndo = true;
-        foreach (var cmd in undoHistory.Reverse())
-        {
-            items.Add(new Models.HistoryEntryVm(cmd.Description, "#e6e8ec", firstUndo));
-            firstUndo = false;
-        }
         HistoryList.ItemsSource = items;
-        int currentIndex = redoHistory.Count;
+        int currentIndex = undoHistory.Count - 1;
         ScrollHistoryToCurrent(currentIndex, items.Count);
 
         HistoryUndoButton.IsEnabled = _undoManager.CanUndo;
@@ -490,7 +489,7 @@ public partial class MainWindow : Window
 
     private void ScrollHistoryToCurrent(int currentIndex, int totalCount)
     {
-        if (totalCount == 0) return;
+        if (totalCount == 0 || currentIndex < 0) return;
         Dispatcher.UIThread.Post(() =>
         {
             double extent   = HistoryScrollViewer.Extent.Height;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HistoryPanelButtonStateTests.cs
@@ -156,8 +156,13 @@ public class HistoryPanelButtonStateTests
 
     // ── History list ordering ─────────────────────────────────────────────────
 
+    /// <summary>
+    /// Photoshop order: applied (undo) items sit above redo items.
+    /// Oldest applied entry is at the top; newest applied is the "you are here" row;
+    /// redo items appear below, with the next-to-redo item immediately under the cursor.
+    /// </summary>
     [AvaloniaFact]
-    public void HistoryList_UndoneItemStaysAtTop_NotMovedToBottom()
+    public void HistoryList_AppliedItemsAboveRedoItems_PhotoshopOrder()
     {
         var (window, ctx) = CreateWindow();
         try
@@ -170,18 +175,45 @@ public class HistoryPanelButtonStateTests
             var list = window.FindControl<ItemsControl>("HistoryList")!;
             var items = ((IEnumerable<HistoryEntryVm>)list.ItemsSource!).ToList();
 
-            // B was undone; it must appear at row 0 (top), not at the bottom
+            // Applied history at top, redo items below
             Assert.Equal(2, items.Count);
-            Assert.Equal("B", items[0].Description);
-            Assert.Equal("A", items[1].Description);
+            Assert.Equal("A", items[0].Description); // oldest applied at top
+            Assert.Equal("B", items[1].Description); // redo item at bottom
 
-            // B is dimmed (redo item), A is bright (applied item)
-            Assert.Equal("#6a6e76", items[0].Foreground);
-            Assert.Equal("#e6e8ec", items[1].Foreground);
+            // A is bright (applied), B is dimmed (redo)
+            Assert.Equal("#e6e8ec", items[0].Foreground);
+            Assert.Equal("#6a6e76", items[1].Foreground);
 
             // A is the current "you are here" entry
+            Assert.True(items[0].IsCurrent);
+            Assert.False(items[1].IsCurrent);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void HistoryList_MultipleAppliedCommands_OldestAtTopNewestAtBottom()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.UndoManager.Record(new StubCmd("A"));
+            ctx.UndoManager.Record(new StubCmd("B"));
+            ctx.UndoManager.Record(new StubCmd("C"));
+            Dispatcher.UIThread.RunJobs();
+
+            var list = window.FindControl<ItemsControl>("HistoryList")!;
+            var items = ((IEnumerable<HistoryEntryVm>)list.ItemsSource!).ToList();
+
+            Assert.Equal(3, items.Count);
+            Assert.Equal("A", items[0].Description);
+            Assert.Equal("B", items[1].Description);
+            Assert.Equal("C", items[2].Description);
+
+            // C is the most recently applied — "you are here"
             Assert.False(items[0].IsCurrent);
-            Assert.True(items[1].IsCurrent);
+            Assert.False(items[1].IsCurrent);
+            Assert.True(items[2].IsCurrent);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
## Summary

Flips the History panel list to the Photoshop mental model as described in #340.

**Before:** redo items at the top (reversed), then undo items newest-first — the list was inverted.
**After:** undo items oldest-first (top → bottom), with the most recently applied row marked as 'you are here', and redo items below in first-to-redo order.

## Changes

- \RefreshHistoryPanel()\ — rewritten to emit items in Photoshop order
- \ScrollHistoryToCurrent()\ — guards against \currentIndex == -1\ (pure redo state with nothing applied)
- \HistoryPanelButtonStateTests\ — old ordering test replaced with two new tests covering the Photoshop ordering

All 1,515 tests pass.

Closes #340