### PR TITLE
Replace hardcoded Windows paths in AnimationEditor test files

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/DEVELOPMENT.md
+++ b/tools/AnimationEditorAvalonia/docs/DEVELOPMENT.md
@@ -48,3 +48,27 @@ The AnimationEditor app is still running. MSBuild cannot replace the executable 
    ```
 
 Once the process is gone, re-run `dotnet build` / `dotnet test` and it will succeed immediately.
+
+---
+
+## Writing Tests: Cross-Platform Absolute Paths
+
+**Never use hardcoded Windows paths** (`@"C:\..."`, `@"D:\..."`, etc.) in test files. Tests run on both Windows and Linux CI runners; Windows paths cause `FileNotFoundException` or path-comparison failures on Linux.
+
+Use the `TestPaths` helper class instead:
+
+```csharp
+// Good — resolves to C:\TestRoot\... on Windows, /TestRoot/... on Linux
+TestPaths.Abs("textures", "sprite.png")
+
+// For paths that need a distinct drive/root from Abs()
+TestPaths.AltAbs("Downloads", "capybara.png")
+
+// For a directory path (appends trailing separator)
+TestPaths.AbsDir("project", "textures")
+
+// For paths that must not be writable (write-failure tests)
+TestPaths.InvalidPath("recovery.achx")
+```
+
+`TestPaths` is defined in each test project's root (e.g., `AnimationEditor.Core.Tests/TestPaths.cs`). Add `AbsDir` / `InvalidPath` to `AnimationEditor.App.Tests/TestPaths.cs` if needed there too.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestPaths.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestPaths.cs
@@ -1,0 +1,39 @@
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Platform-agnostic fake absolute paths for tests that exercise path logic but never
+/// touch the real filesystem.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Abs"/> instead of hardcoded <c>@"C:\..."</c> literals so tests pass on
+/// both Windows (where <c>Path.IsPathRooted(@"C:\foo")</c> is true) and Linux/macOS
+/// (where it is false and <c>Path.GetFullPath</c> would produce garbage).
+/// <para>
+/// Two roots are provided so tests can represent paths on distinct drives or volumes:
+/// <list type="bullet">
+///   <item><c>Abs()</c> — primary root, e.g. "project" files</item>
+///   <item><c>AltAbs()</c> — secondary root, e.g. "external" files outside the project</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal static class TestPaths
+{
+    private static readonly string Root    = OperatingSystem.IsWindows() ? @"C:\TestRoot" : "/TestRoot";
+    private static readonly string AltRoot = OperatingSystem.IsWindows() ? @"D:\AltRoot"  : "/AltRoot";
+
+    /// <summary>
+    /// Returns a platform-valid absolute path under the primary test root.
+    /// E.g. <c>Abs("Project", "Animations", "Hero.achx")</c> →
+    ///   <c>"C:\TestRoot\Project\Animations\Hero.achx"</c> on Windows,
+    ///   <c>"/TestRoot/Project/Animations/Hero.achx"</c> on Linux/macOS.
+    /// </summary>
+    public static string Abs(params string[] segments) =>
+        Path.Combine(new[] { Root }.Concat(segments).ToArray());
+
+    /// <summary>
+    /// Returns a platform-valid absolute path under a secondary test root (distinct from
+    /// <see cref="Abs"/>). Use for paths that must be outside the primary root.
+    /// </summary>
+    public static string AltAbs(params string[] segments) =>
+        Path.Combine(new[] { AltRoot }.Concat(segments).ToArray());
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -131,11 +131,12 @@ public class ThumbnailServiceTests
     public void InvalidatePath_BackslashPath_EvictsForwardSlashCacheKey()
     {
         var svc = MakeSvc();
-        svc.BitmapCache["D:/Downloads/capybara.png"] = null;
+        var fwdKey = TestPaths.AltAbs("Downloads", "capybara.png").Replace('\\', '/');
+        svc.BitmapCache[fwdKey] = null;
 
-        svc.InvalidatePath(@"D:\Downloads\capybara.png");
+        svc.InvalidatePath(TestPaths.AltAbs("Downloads", "capybara.png"));
 
-        Assert.False(svc.BitmapCache.ContainsKey("D:/Downloads/capybara.png"),
+        Assert.False(svc.BitmapCache.ContainsKey(fwdKey),
             "InvalidatePath with backslash path must evict the forward-slash cache key.");
     }
 
@@ -143,22 +144,24 @@ public class ThumbnailServiceTests
     public void InvalidatePath_ForwardSlashPath_EvictsForwardSlashCacheKey()
     {
         var svc = MakeSvc();
-        svc.BitmapCache["D:/Downloads/capybara.png"] = null;
+        var fwdKey = TestPaths.AltAbs("Downloads", "capybara.png").Replace('\\', '/');
+        svc.BitmapCache[fwdKey] = null;
 
-        svc.InvalidatePath("D:/Downloads/capybara.png");
+        svc.InvalidatePath(fwdKey);
 
-        Assert.False(svc.BitmapCache.ContainsKey("D:/Downloads/capybara.png"));
+        Assert.False(svc.BitmapCache.ContainsKey(fwdKey));
     }
 
     [Fact]
     public void InvalidatePath_MixedCase_EvictsCacheKeyRegardlessOfCase()
     {
         var svc = MakeSvc();
-        svc.BitmapCache["d:/downloads/capybara.png"] = null;
+        var lowerKey = TestPaths.AltAbs("Downloads", "capybara.png").Replace('\\', '/').ToLowerInvariant();
+        svc.BitmapCache[lowerKey] = null;
 
-        svc.InvalidatePath(@"D:\Downloads\Capybara.png");
+        svc.InvalidatePath(TestPaths.AltAbs("Downloads", "Capybara.png"));
 
-        Assert.False(svc.BitmapCache.ContainsKey("d:/downloads/capybara.png"),
+        Assert.False(svc.BitmapCache.ContainsKey(lowerKey),
             "OrdinalIgnoreCase + slash normalization must handle mixed-case backslash paths.");
     }
 
@@ -179,18 +182,22 @@ public class ThumbnailServiceTests
     public void GetBitmap_BackslashPath_ThenInvalidate_EmptiesCache()
     {
         var svc = MakeSvc();
+        var absPath = TestPaths.AltAbs("Downloads", "capybara.png");
+        var fwdKey  = absPath.Replace('\\', '/');
         // Simulate GetBitmap being called with a raw Windows drag-drop path (non-existent
         // file — GetBitmap caches null for decode failures; the key format is what matters).
-        svc.GetBitmap(@"D:\Downloads\capybara.png");
+        svc.GetBitmap(absPath);
 
         // GetBitmap must have stored the entry under a forward-slash key.
-        Assert.True(svc.BitmapCache.ContainsKey("D:/Downloads/capybara.png"),
+        Assert.True(svc.BitmapCache.ContainsKey(fwdKey),
             "GetBitmap should store the cache key with forward slashes.");
-        Assert.False(svc.BitmapCache.ContainsKey(@"D:\Downloads\capybara.png"),
-            "GetBitmap must NOT store a backslash key — InvalidatePath would then miss it.");
+        // On Windows (where absPath uses backslashes), the backslash form must NOT be the key.
+        if (absPath != fwdKey)
+            Assert.False(svc.BitmapCache.ContainsKey(absPath),
+                "GetBitmap must NOT store a backslash key — InvalidatePath would then miss it.");
 
-        // Now invalidate (as OnPngChangedOnDisk does, with the raw FSW backslash path).
-        svc.InvalidatePath(@"D:\Downloads\capybara.png");
+        // Now invalidate (as OnPngChangedOnDisk does, with the raw path).
+        svc.InvalidatePath(absPath);
 
         Assert.Empty(svc.BitmapCache);
     }
@@ -198,13 +205,15 @@ public class ThumbnailServiceTests
     [Fact]
     public void GetBitmap_BackslashPath_IsRetrievableByForwardSlashKey()
     {
-        // Calling GetBitmap twice — once with backslash, once with forward slash — must
-        // hit the same cache entry (not decode twice and store under two different keys).
+        // Calling GetBitmap twice — once with backslash (Windows) or the canonical path,
+        // once with forward slash — must hit the same cache entry (not decode twice).
         var svc = MakeSvc();
-        svc.GetBitmap(@"D:\Downloads\capybara.png");
+        var absPath = TestPaths.AltAbs("Downloads", "capybara.png");
+        var fwdKey  = absPath.Replace('\\', '/');
+        svc.GetBitmap(absPath);
 
-        // Forward-slash lookup must hit the entry stored by the backslash call.
-        var _ = svc.GetBitmap("D:/Downloads/capybara.png");
+        // Forward-slash lookup must hit the entry stored by the first call.
+        var _ = svc.GetBitmap(fwdKey);
 
         Assert.Single(svc.BitmapCache);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
@@ -23,7 +23,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         Exception? capturedEx = null;
         ctx.AppCommands.LoadFailed += (path, ex) => { capturedPath = path; capturedEx = ex; };
 
-        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+        ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
         Assert.NotNull(capturedPath);
         Assert.NotNull(capturedEx);
@@ -36,7 +36,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         int fireCount = 0;
         ctx.AppCommands.LoadFailed += (_, __) => fireCount++;
 
-        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+        ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
         Assert.Equal(1, fireCount);
     }
@@ -48,7 +48,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         bool fired = false;
         ctx.AppCommands.RebuildTreeViewRequested += () => fired = true;
 
-        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+        ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
         Assert.False(fired);
     }
@@ -60,7 +60,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         bool fired = false;
         ctx.AppCommands.RefreshWireframeRequested += () => fired = true;
 
-        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+        ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
         Assert.False(fired);
     }
@@ -72,7 +72,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         var sentinel = new AnimationChainListSave();
         ctx.ProjectManager.AnimationChainListSave = sentinel;
 
-        ctx.AppCommands.LoadAnimationChain(@"C:\does\not\exist.achx");
+        ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
         Assert.Same(sentinel, ctx.ProjectManager.AnimationChainListSave);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsNewFileTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsNewFileTests.cs
@@ -26,7 +26,7 @@ public class AppCommandsNewFileTests
     [Fact]
     public void NewFile_ClearsFileName()
     {
-        ctx.ProjectManager.FileName = @"C:\some\file.achx";
+        ctx.ProjectManager.FileName = TestPaths.Abs("some", "file.achx");
 
         ctx.AppCommands.NewFile();
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
@@ -117,7 +117,7 @@ public class CommandDescriptionTests
     {
         var frame = new AnimationFrameSave();
         var cmd = new SetFrameTextureNameCommand(frame,
-            oldName: null, newName: @"C:\textures\sprite.png",
+            oldName: null, newName: TestPaths.Abs("textures", "sprite.png"),
             commands: null!, events: null!);
 
         Assert.Equal("Set Texture: sprite.png", cmd.Description);
@@ -128,7 +128,7 @@ public class CommandDescriptionTests
     {
         var frame = new AnimationFrameSave();
         var cmd = new SetFrameTextureNameCommand(frame,
-            oldName: @"C:\textures\old.png", newName: null,
+            oldName: TestPaths.Abs("textures", "old.png"), newName: null,
             commands: null!, events: null!);
 
         Assert.Equal("Set Texture: old.png", cmd.Description);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandLineArgParserTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandLineArgParserTests.cs
@@ -29,8 +29,9 @@ public class CommandLineArgParserTests
     [Fact]
     public void AchxArg_ReturnsPath()
     {
-        string? result = CommandLineArgParser.ParseFileArgument([@"C:\projects\anim.achx"]);
-        Assert.Equal(@"C:\projects\anim.achx", result);
+        var path = TestPaths.Abs("projects", "anim.achx");
+        string? result = CommandLineArgParser.ParseFileArgument([path]);
+        Assert.Equal(path, result);
     }
 
     [Fact]
@@ -43,9 +44,11 @@ public class CommandLineArgParserTests
     [Fact]
     public void MultipleArgs_ReturnsFirstAchx()
     {
+        var first  = TestPaths.Abs("first.achx");
+        var second = TestPaths.Abs("second.achx");
         string? result = CommandLineArgParser.ParseFileArgument(
-            ["--verbose", @"C:\first.achx", @"C:\second.achx"]);
-        Assert.Equal(@"C:\first.achx", result);
+            ["--verbose", first, second]);
+        Assert.Equal(first, result);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/IoManagerRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/IoManagerRecoveryTests.cs
@@ -83,7 +83,7 @@ public class IoManagerRecoveryTests : IDisposable
     [Fact]
     public void WriteRecoveryFile_WhenPathIsInvalid_DoesNotThrow()
     {
-        ctx.IoManager.RecoveryFilePath = "Z:\\NonExistentDrive\\recovery.achx";
+        ctx.IoManager.RecoveryFilePath = TestPaths.InvalidPath("recovery.achx");
         ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
 
         var ex = Record.Exception(() => ctx.IoManager.WriteRecoveryFile(ctx.ProjectManager.AnimationChainListSave));
@@ -94,7 +94,7 @@ public class IoManagerRecoveryTests : IDisposable
     [Fact]
     public void WriteRecoveryFile_WhenPathIsInvalid_FiresSaveFailed()
     {
-        ctx.IoManager.RecoveryFilePath = "Z:\\NonExistentDrive\\recovery.achx";
+        ctx.IoManager.RecoveryFilePath = TestPaths.InvalidPath("recovery.achx");
         ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
         Exception? caught = null;
         ctx.IoManager.SaveFailed += (_, e) => caught = e;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerLoadTests.cs
@@ -20,7 +20,7 @@ public class ProjectManagerLoadTests : IDisposable
         var pm = new ProjectManager();
 
         Assert.Throws<FileNotFoundException>(
-            () => pm.LoadAnimationChain(new FilePath(@"C:\does\not\exist.achx")));
+            () => pm.LoadAnimationChain(new FilePath(TestPaths.Abs("does", "not", "exist.achx"))));
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class ProjectManagerLoadTests : IDisposable
         var pm = new ProjectManager();
         pm.AnimationChainListSave = null;
 
-        try { pm.LoadAnimationChain(new FilePath(@"C:\does\not\exist.achx")); }
+        try { pm.LoadAnimationChain(new FilePath(TestPaths.Abs("does", "not", "exist.achx"))); }
         catch (FileNotFoundException) { }
 
         Assert.Null(pm.AnimationChainListSave);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestPaths.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestPaths.cs
@@ -1,0 +1,55 @@
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Platform-agnostic fake absolute paths for tests that exercise path logic but never
+/// touch the real filesystem.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Abs"/> instead of hardcoded <c>@"C:\..."</c> literals so tests pass on
+/// both Windows (where <c>Path.IsPathRooted(@"C:\foo")</c> is true) and Linux/macOS
+/// (where it is false and <c>Path.GetFullPath</c> would produce garbage).
+/// <para>
+/// Two roots are provided so tests can represent paths on distinct drives or volumes:
+/// <list type="bullet">
+///   <item><c>Abs()</c> — primary root, e.g. "project" files</item>
+///   <item><c>AltAbs()</c> — secondary root, e.g. "external" files outside the project</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal static class TestPaths
+{
+    private static readonly string Root    = OperatingSystem.IsWindows() ? @"C:\TestRoot" : "/TestRoot";
+    private static readonly string AltRoot = OperatingSystem.IsWindows() ? @"D:\AltRoot"  : "/AltRoot";
+
+    /// <summary>
+    /// Returns a platform-valid absolute path under the primary test root.
+    /// E.g. <c>Abs("Project", "Animations", "Hero.achx")</c> →
+    ///   <c>"C:\TestRoot\Project\Animations\Hero.achx"</c> on Windows,
+    ///   <c>"/TestRoot/Project/Animations/Hero.achx"</c> on Linux/macOS.
+    /// </summary>
+    public static string Abs(params string[] segments) =>
+        Path.Combine(new[] { Root }.Concat(segments).ToArray());
+
+    /// <summary>
+    /// Like <see cref="Abs"/> but appends the platform directory separator.
+    /// Use when a test needs a directory path (trailing slash).
+    /// </summary>
+    public static string AbsDir(params string[] segments) =>
+        Abs(segments) + Path.DirectorySeparatorChar;
+
+    /// <summary>
+    /// Returns a platform-valid absolute path under a secondary test root (distinct from
+    /// <see cref="Abs"/>). Use for paths that must be outside the primary root.
+    /// </summary>
+    public static string AltAbs(params string[] segments) =>
+        Path.Combine(new[] { AltRoot }.Concat(segments).ToArray());
+
+    /// <summary>
+    /// Returns an absolute path that is almost certainly unwritable on the current OS.
+    /// Use in tests that verify graceful failure when writing to an invalid location.
+    /// </summary>
+    public static string InvalidPath(string filename) =>
+        OperatingSystem.IsWindows()
+            ? Path.Combine(@"Z:\NonExistentDrive", filename)
+            : $"/nonexistent-testroot-34f9e2/{filename}";
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
@@ -5,12 +5,10 @@ namespace AnimationEditor.Core.Tests;
 
 public class TextureCopyDeciderTests
 {
-    // Use fixed Windows-style absolute paths so tests are path-separator agnostic
-    // (Path.DirectorySeparatorChar is '\' on Windows, which is what the CI runs).
-    private static readonly string Folder  = @"C:\project\Content";
-    private static readonly string Inside  = @"C:\project\Content\hero.png";
-    private static readonly string SubDir  = @"C:\project\Content\Textures\run.png";
-    private static readonly string Outside = @"C:\other\assets\enemy.png";
+    private static readonly string Folder  = TestPaths.Abs("project", "Content");
+    private static readonly string Inside  = TestPaths.Abs("project", "Content", "hero.png");
+    private static readonly string SubDir  = TestPaths.Abs("project", "Content", "Textures", "run.png");
+    private static readonly string Outside = TestPaths.Abs("other", "assets", "enemy.png");
 
     // ── Null / empty texture path ─────────────────────────────────────────────
 
@@ -44,7 +42,7 @@ public class TextureCopyDeciderTests
 
     [Fact]
     public void FolderWithTrailingSeparator_TextureInside_ReturnsFalse()
-        => Assert.False(TextureCopyDecider.ShouldPromptToCopy(Inside, Folder + @"\"));
+        => Assert.False(TextureCopyDecider.ShouldPromptToCopy(Inside, Folder + Path.DirectorySeparatorChar));
 
     // ── Texture outside project folder ────────────────────────────────────────
 
@@ -55,8 +53,8 @@ public class TextureCopyDeciderTests
     [Fact]
     public void TextureWithSamePrefix_ButNotSubPath_ReturnsTrue()
     {
-        // "C:\projectX\..." starts with "C:\project" but is NOT inside "C:\project\"
-        string notInside = @"C:\projectExtra\Content\hero.png";
+        // "...projectExtra\..." starts with "...project" but is NOT inside "...project\"
+        string notInside = TestPaths.Abs("projectExtra", "Content", "hero.png");
         Assert.True(TextureCopyDecider.ShouldPromptToCopy(notInside, Folder));
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropProcessorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropProcessorTests.cs
@@ -18,8 +18,8 @@ public class TextureDropProcessorTests
         var result = TextureDropProcessor.ApplyPngDrop(
             chain,
             frameA,
-            @"C:\Project\Content\NewTex.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "NewTex.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         Assert.Equal(TextureDropResult.UpdatedFrame, result);
@@ -37,8 +37,8 @@ public class TextureDropProcessorTests
         var result = TextureDropProcessor.ApplyPngDrop(
             chain,
             null,
-            @"C:\Project\Content\Shared.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "Shared.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         Assert.Equal(TextureDropResult.UpdatedChainFrames, result);
@@ -54,8 +54,8 @@ public class TextureDropProcessorTests
         var result = TextureDropProcessor.ApplyPngDrop(
             chain,
             null,
-            @"C:\Project\Content\NewFrameTex.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "NewFrameTex.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: true);
 
         Assert.Equal(TextureDropResult.CreatedFrame, result);
@@ -71,8 +71,8 @@ public class TextureDropProcessorTests
         var result = TextureDropProcessor.ApplyPngDrop(
             chain,
             null,
-            @"C:\Project\Content\FirstFrameTex.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "FirstFrameTex.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         Assert.Equal(TextureDropResult.CreatedFrame, result);
@@ -89,8 +89,8 @@ public class TextureDropProcessorTests
         var result = TextureDropProcessor.ApplyPngDrop(
             chain,
             null,
-            @"C:\Project\Content\NotTexture.jpg",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "NotTexture.jpg"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         Assert.Equal(TextureDropResult.NotApplied, result);
@@ -109,8 +109,8 @@ public class TextureDropProcessorTests
         TextureDropProcessor.ApplyPngDrop(
             chain,
             chain.Frames[0],
-            @"C:\Project\Tex.png",
-            @"C:\Project\Player.achx",
+            TestPaths.Abs("Project", "Tex.png"),
+            TestPaths.Abs("Project", "Player.achx"),
             createFrameOnCtrl: false);
 
         // Same folder → just the filename, no directory prefix
@@ -126,8 +126,8 @@ public class TextureDropProcessorTests
         TextureDropProcessor.ApplyPngDrop(
             chain,
             chain.Frames[0],
-            @"C:\Project\Content\Sprites\Hero.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "Sprites", "Hero.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         // FRB FileManager.MakeRelative normalises to forward slashes
@@ -143,8 +143,8 @@ public class TextureDropProcessorTests
         TextureDropProcessor.ApplyPngDrop(
             chain,
             chain.Frames[0],
-            @"C:\Project\Content\NewTex.png",
-            @"C:\Project\Animations\Player.achx",
+            TestPaths.Abs("Project", "Content", "NewTex.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
             createFrameOnCtrl: false);
 
         var tex = chain.Frames[0].TextureName;
@@ -162,7 +162,7 @@ public class TextureDropProcessorTests
         var chain = new AnimationChainSave();
 
         var result = TextureDropProcessor.ApplyPngDrop(chain, null,
-            @"D:\Downloads\sprite.png", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.png"), null, false);
 
         Assert.Equal(TextureDropResult.CreatedFrame, result);
     }
@@ -172,9 +172,9 @@ public class TextureDropProcessorTests
     {
         var chain = new AnimationChainSave();
         TextureDropProcessor.ApplyPngDrop(chain, null,
-            @"D:\Downloads\sprite.png", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.png"), null, false);
 
-        Assert.Equal(@"D:\Downloads\sprite.png", chain.Frames[0].TextureName);
+        Assert.Equal(TestPaths.AltAbs("Downloads", "sprite.png"), chain.Frames[0].TextureName);
     }
 
     [Fact]
@@ -184,10 +184,10 @@ public class TextureDropProcessorTests
         chain.Frames.Add(new AnimationFrameSave { TextureName = "old.png" });
 
         var result = TextureDropProcessor.ApplyPngDrop(chain, null,
-            @"D:\Downloads\sprite.png", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.png"), null, false);
 
         Assert.Equal(TextureDropResult.UpdatedChainFrames, result);
-        Assert.Equal(@"D:\Downloads\sprite.png", chain.Frames[0].TextureName);
+        Assert.Equal(TestPaths.AltAbs("Downloads", "sprite.png"), chain.Frames[0].TextureName);
     }
 
     [Fact]
@@ -196,10 +196,10 @@ public class TextureDropProcessorTests
         var frame = new AnimationFrameSave();
 
         var result = TextureDropProcessor.ApplyPngDrop(null, frame,
-            @"D:\Downloads\sprite.png", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.png"), null, false);
 
         Assert.Equal(TextureDropResult.UpdatedFrame, result);
-        Assert.Equal(@"D:\Downloads\sprite.png", frame.TextureName);
+        Assert.Equal(TestPaths.AltAbs("Downloads", "sprite.png"), frame.TextureName);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class TextureDropProcessorTests
         var chain = new AnimationChainSave();
 
         var result = TextureDropProcessor.ApplyPngDrop(chain, null,
-            @"D:\Downloads\sprite.jpg", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.jpg"), null, false);
 
         Assert.Equal(TextureDropResult.NotApplied, result);
     }
@@ -217,7 +217,7 @@ public class TextureDropProcessorTests
     public void ApplyPngDrop_NullAchx_NullChainAndFrame_IsIgnored()
     {
         var result = TextureDropProcessor.ApplyPngDrop(null, null,
-            @"D:\Downloads\sprite.png", null, false);
+            TestPaths.AltAbs("Downloads", "sprite.png"), null, false);
 
         Assert.Equal(TextureDropResult.NotApplied, result);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TexturePathHelperTests.cs
@@ -12,8 +12,8 @@ public class TexturePathHelperTests
     public void ComputeStorePath_TextureInAchxFolder_ReturnsSimpleRelative()
     {
         string storePath = TexturePathHelper.ComputeStorePath(
-            @"C:\Project\Animations\Hero.png",
-            @"C:\Project\Animations\");
+            TestPaths.Abs("Project", "Animations", "Hero.png"),
+            TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal("Hero.png", storePath);
     }
@@ -22,8 +22,8 @@ public class TexturePathHelperTests
     public void ComputeStorePath_TextureInSubfolder_ReturnsSubfolderRelative()
     {
         string storePath = TexturePathHelper.ComputeStorePath(
-            @"C:\Project\Animations\Sprites\Hero.png",
-            @"C:\Project\Animations\");
+            TestPaths.Abs("Project", "Animations", "Sprites", "Hero.png"),
+            TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal("Sprites/Hero.png", storePath);
     }
@@ -32,8 +32,8 @@ public class TexturePathHelperTests
     public void ComputeStorePath_TextureInSiblingFolder_ReturnsDotDotRelative()
     {
         string storePath = TexturePathHelper.ComputeStorePath(
-            @"C:\Project\Content\Hero.png",
-            @"C:\Project\Animations\");
+            TestPaths.Abs("Project", "Content", "Hero.png"),
+            TestPaths.AbsDir("Project", "Animations"));
 
         // Key fix: sibling-folder textures must be stored as "../Content/Hero.png",
         // not as the absolute path.
@@ -44,8 +44,8 @@ public class TexturePathHelperTests
     public void ComputeStorePath_TextureInGrandparentSiblingFolder_ReturnsDotDotRelative()
     {
         string storePath = TexturePathHelper.ComputeStorePath(
-            @"C:\OtherProject\Content\Hero.png",
-            @"C:\Project\Animations\");
+            TestPaths.Abs("OtherProject", "Content", "Hero.png"),
+            TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal("../../OtherProject/Content/Hero.png", storePath);
     }
@@ -53,7 +53,7 @@ public class TexturePathHelperTests
     [Fact]
     public void ComputeStorePath_EmptyAchxFolder_ReturnsAbsoluteUnchanged()
     {
-        const string absolute = @"C:\Project\Content\Hero.png";
+        var absolute = TestPaths.Abs("Project", "Content", "Hero.png");
         string storePath = TexturePathHelper.ComputeStorePath(absolute, string.Empty);
 
         Assert.Equal(absolute, storePath);
@@ -66,7 +66,7 @@ public class TexturePathHelperTests
     {
         string display = TexturePathHelper.ComputeDisplayPath(
             "../Content/Hero.png",
-            @"C:\Project\Animations\Player.achx");
+            TestPaths.Abs("Project", "Animations", "Player.achx"));
 
         Assert.Equal("../Content/Hero.png", display);
     }
@@ -75,8 +75,8 @@ public class TexturePathHelperTests
     public void ComputeDisplayPath_AbsolutePathInSiblingFolder_ReturnsRelative()
     {
         string display = TexturePathHelper.ComputeDisplayPath(
-            @"C:\Project\Content\Hero.png",
-            @"C:\Project\Animations\Player.achx");
+            TestPaths.Abs("Project", "Content", "Hero.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"));
 
         // Absolute paths stored in the .achx should be displayed as relative.
         Assert.Equal("../Content/Hero.png", display);
@@ -86,8 +86,8 @@ public class TexturePathHelperTests
     public void ComputeDisplayPath_AbsolutePathInAchxFolder_ReturnsSimpleRelative()
     {
         string display = TexturePathHelper.ComputeDisplayPath(
-            @"C:\Project\Animations\Hero.png",
-            @"C:\Project\Animations\Player.achx");
+            TestPaths.Abs("Project", "Animations", "Hero.png"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"));
 
         Assert.Equal("Hero.png", display);
     }
@@ -97,7 +97,7 @@ public class TexturePathHelperTests
     {
         string display = TexturePathHelper.ComputeDisplayPath(
             null,
-            @"C:\Project\Animations\Player.achx");
+            TestPaths.Abs("Project", "Animations", "Player.achx"));
 
         Assert.Equal(string.Empty, display);
     }
@@ -107,7 +107,7 @@ public class TexturePathHelperTests
     {
         string display = TexturePathHelper.ComputeDisplayPath(
             string.Empty,
-            @"C:\Project\Animations\Player.achx");
+            TestPaths.Abs("Project", "Animations", "Player.achx"));
 
         Assert.Equal(string.Empty, display);
     }
@@ -115,7 +115,7 @@ public class TexturePathHelperTests
     [Fact]
     public void ComputeDisplayPath_NullAchxPath_ReturnsAbsoluteUnchanged()
     {
-        const string absolute = @"C:\Project\Content\Hero.png";
+        var absolute = TestPaths.Abs("Project", "Content", "Hero.png");
         string display = TexturePathHelper.ComputeDisplayPath(absolute, null);
 
         Assert.Equal(absolute, display);
@@ -126,7 +126,7 @@ public class TexturePathHelperTests
     [Fact]
     public void ResolveDisplayPath_EmptyDisplayPath_ReturnsEmpty()
     {
-        string resolved = TexturePathHelper.ResolveDisplayPath(string.Empty, @"C:\Project\Animations\");
+        string resolved = TexturePathHelper.ResolveDisplayPath(string.Empty, TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal(string.Empty, resolved);
     }
@@ -134,8 +134,8 @@ public class TexturePathHelperTests
     [Fact]
     public void ResolveDisplayPath_AbsolutePath_ReturnedUnchanged()
     {
-        const string absolute = @"C:\Project\Content\Hero.png";
-        string resolved = TexturePathHelper.ResolveDisplayPath(absolute, @"C:\Project\Animations\");
+        var absolute = TestPaths.Abs("Project", "Content", "Hero.png");
+        string resolved = TexturePathHelper.ResolveDisplayPath(absolute, TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal(absolute, resolved);
     }
@@ -151,20 +151,20 @@ public class TexturePathHelperTests
     [Fact]
     public void ResolveDisplayPath_SimpleRelativePath_ResolvesToAbsolute()
     {
-        string resolved = TexturePathHelper.ResolveDisplayPath("Hero.png", @"C:\Project\Animations\");
+        string resolved = TexturePathHelper.ResolveDisplayPath("Hero.png", TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal(
-            Path.GetFullPath(Path.Combine(@"C:\Project\Animations\", "Hero.png")),
+            Path.GetFullPath(Path.Combine(TestPaths.AbsDir("Project", "Animations"), "Hero.png")),
             resolved);
     }
 
     [Fact]
     public void ResolveDisplayPath_DotDotRelativePath_ResolvesToAbsolute()
     {
-        string resolved = TexturePathHelper.ResolveDisplayPath("../Content/Hero.png", @"C:\Project\Animations\");
+        string resolved = TexturePathHelper.ResolveDisplayPath("../Content/Hero.png", TestPaths.AbsDir("Project", "Animations"));
 
         Assert.Equal(
-            Path.GetFullPath(Path.Combine(@"C:\Project\Animations\", "../Content/Hero.png")),
+            Path.GetFullPath(Path.Combine(TestPaths.AbsDir("Project", "Animations"), "../Content/Hero.png")),
             resolved);
     }
 }


### PR DESCRIPTION
## Summary

Eliminates hardcoded Windows-style absolute paths from AnimationEditor test files so tests pass on both Windows and Linux CI.

## Changes

### New helpers
- `AnimationEditor.Core.Tests/TestPaths.cs` - `Abs()`, `AbsDir()`, `AltAbs()`, `InvalidPath()`
- `AnimationEditor.App.Tests/TestPaths.cs` - `Abs()`, `AltAbs()`

### Updated test files
- CommandLineArgParserTests, ProjectManagerLoadTests, IoManagerRecoveryTests, CommandDescriptionTests
- TextureCopyDeciderTests, TexturePathHelperTests, TextureDropProcessorTests
- AppCommandsLoadFailureTests, AppCommandsNewFileTests, ThumbnailServiceTests

### Docs
- `docs/DEVELOPMENT.md` - new "Writing Tests: Cross-Platform Absolute Paths" section

## Notes
- `FilePathTests.cs` paths are intentionally kept - they test `FilePath`'s own cross-platform normalization.
- `SetFrameTextureNameCommand.cs` production fix was already applied.
- All 1515 tests pass.

Closes #337
