### PR TITLE
Fix sprite pan-centering stuck after bottom-right zoom

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1791,27 +1791,31 @@ public class WireframeControl : Control
             float newScrollY = Math.Min(rawScrollY, maxScrollY);
 
             // _panX absorbs the clamped overflow so the cursor pivot is preserved.
-            // When zooming toward blank space far from the image the raw value can go
-            // negative, placing the sprite to the left of scroll-origin-0.  Since scroll
-            // cannot go below 0, a negative _panX makes the image permanently unreachable
-            // (#319).  Clamp to 0 and pull newScrollX back so the image right/bottom edge
-            // stays visible at the post-zoom viewport position.
+            // When zooming toward blank space far from the image, the overflow
+            // (rawScrollX − maxScrollX) can reduce rawPanX below the threshold needed
+            // to pan/centre the sprite.
+            //
+            // The minimum panX that still allows centering is:
+            //   minPanX = max(0, vpW/2 − imgW*zoom/2)
+            // (centreScroll = panX + imgW*zoom/2 − vpW/2 ≥ 0 requires panX ≥ minPanX)
+            //
+            // When rawPanX falls below this threshold (including going negative as in #319),
+            // clamp to epX instead of 0.  Using 0 (#319 original fix) erased the
+            // effective-padding buffer, making the sprite's centre map to a negative scroll
+            // offset that is unreachable, so the user could no longer pan to centre (#341).
+            // Using epX restores the padding and ensures centreScroll > 0.
             float rawPanX = overflowX ? epX - (rawScrollX - newScrollX) : newPanX - scrollX;
             float rawPanY = overflowY ? epY - (rawScrollY - newScrollY) : newPanY - scrollY;
 
-            if (overflowX && _bitmap != null && rawPanX < 0f)
-            {
-                _panX      = 0f;
-                newScrollX = Math.Max(0f, Math.Min(newScrollX, _bitmap.Width  * _zoom - 1f));
-            }
-            else { _panX = rawPanX; }
+            float minPanX = overflowX && _bitmap != null
+                ? Math.Max(0f, (float)vp.Width  / 2f - _bitmap.Width  * _zoom / 2f)
+                : 0f;
+            float minPanY = overflowY && _bitmap != null
+                ? Math.Max(0f, (float)vp.Height / 2f - _bitmap.Height * _zoom / 2f)
+                : 0f;
 
-            if (overflowY && _bitmap != null && rawPanY < 0f)
-            {
-                _panY      = 0f;
-                newScrollY = Math.Max(0f, Math.Min(newScrollY, _bitmap.Height * _zoom - 1f));
-            }
-            else { _panY = rawPanY; }
+            _panX = rawPanX < minPanX ? epX : rawPanX;
+            _panY = rawPanY < minPanY ? epY : rawPanY;
 
             DebugLog("ZOOM_TOWARD",
                 $"factor={factor:F3} pivot=({sx:F1},{sy:F1}) zoom={oldZoom:F3}→{_zoom:F3} " +

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -15,6 +15,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
@@ -1746,6 +1747,24 @@ public class WireframeControl : Control
         }
     }
 
+    /// <summary>
+    /// Adjusts <c>_panX</c>, <c>_panY</c>, and the pending scroll target so that the
+    /// content-space point beneath viewport position (<paramref name="sx"/>, <paramref name="sy"/>)
+    /// stays fixed after a zoom by <paramref name="factor"/>.
+    /// </summary>
+    /// <remarks>
+    /// Post-conditions when a ScrollViewer is attached:
+    /// <list type="bullet">
+    ///   <item><c>_panX ≥ 0</c> — sprite never pushed off the left edge (#319).</item>
+    ///   <item><c>_panX + bitmap.Width × _zoom / 2 ≥ viewport.Width / 2</c> — sprite always
+    ///         pannable to the viewport centre (#341).</item>
+    /// </list>
+    /// The invariant floor is <c>epX = EffectivePaddingX()</c>, which is defined so that
+    /// <c>centreScroll = epX + imgW × zoom / 2 − vpW / 2 ≥ ExtraScrollable &gt; 0</c>.
+    /// Never substitute <c>0</c> as the clamp target — doing so erases the left-side
+    /// padding buffer and makes the sprite centre map to a negative (unreachable) scroll
+    /// offset (see #319 for the off-screen variant and #341 for the locked-centering variant).
+    /// </remarks>
     private void ZoomToward(float sx, float sy, float factor)
     {
         float oldZoom = _zoom;
@@ -1816,6 +1835,20 @@ public class WireframeControl : Control
 
             _panX = rawPanX < minPanX ? epX : rawPanX;
             _panY = rawPanY < minPanY ? epY : rawPanY;
+
+#if DEBUG
+            if (_bitmap != null)
+            {
+                float dbgCentreX = _panX + _bitmap.Width  * _zoom / 2f - (float)vp.Width  / 2f;
+                float dbgCentreY = _panY + _bitmap.Height * _zoom / 2f - (float)vp.Height / 2f;
+                Debug.Assert(dbgCentreX >= 0f,
+                    $"ZoomToward post-cond: centreScrollX={dbgCentreX:F2} < 0 " +
+                    $"(panX={_panX:F1}, imgW={_bitmap.Width}, zoom={_zoom:F3}, vpW={vp.Width:F1})");
+                Debug.Assert(dbgCentreY >= 0f,
+                    $"ZoomToward post-cond: centreScrollY={dbgCentreY:F2} < 0 " +
+                    $"(panY={_panY:F1}, imgH={_bitmap.Height}, zoom={_zoom:F3}, vpH={vp.Height:F1})");
+            }
+#endif
 
             DebugLog("ZOOM_TOWARD",
                 $"factor={factor:F3} pivot=({sx:F1},{sy:F1}) zoom={oldZoom:F3}→{_zoom:F3} " +

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframePanZoomTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframePanZoomTests.cs
@@ -58,6 +58,40 @@ public class WireframePanZoomTests
         => w.FindControl<T>(name)
            ?? throw new InvalidOperationException($"Control '{name}' not found");
 
+    /// <summary>
+    /// Asserts the core ZoomToward post-conditions that must hold after ANY zoom operation:
+    /// <list type="bullet">
+    ///   <item><c>panX/Y ≥ 0</c> — sprite not pushed off the left/top edge (#319).</item>
+    ///   <item>Sprite centre reachable by scrolling:
+    ///         <c>panX + imgW×zoom/2 ≥ vpW/2</c> — centering never locked (#341).</item>
+    /// </list>
+    /// These two invariants subsume every zoom bug we have fixed; a negative panX
+    /// violates the first, a too-small panX violates the second.
+    /// </summary>
+    private static void AssertZoomInvariants(WireframeControl ctrl, ScrollViewer sv, string context = "")
+    {
+        var (panX, panY, zoom) = ctrl.CameraState;
+        var (imgW, imgH)       = ctrl.BitmapSize;
+        float vpW = (float)sv.Viewport.Width;
+        float vpH = (float)sv.Viewport.Height;
+
+        Assert.True(panX >= 0f,
+            $"{context}: panX={panX:F1} < 0 — sprite pushed off the left edge " +
+            $"(zoom={zoom:F3}, vpW={vpW:F1}, imgW={imgW})");
+        Assert.True(panY >= 0f,
+            $"{context}: panY={panY:F1} < 0 — sprite pushed above the top edge " +
+            $"(zoom={zoom:F3}, vpH={vpH:F1}, imgH={imgH})");
+
+        float centreScrollX = panX + imgW * zoom / 2f - vpW / 2f;
+        float centreScrollY = panY + imgH * zoom / 2f - vpH / 2f;
+        Assert.True(centreScrollX >= 0f,
+            $"{context}: centreScrollX={centreScrollX:F1} < 0 — " +
+            $"sprite centre unreachable by scrolling (panX={panX:F1}, imgW={imgW}, zoom={zoom:F3}, vpW={vpW:F1})");
+        Assert.True(centreScrollY >= 0f,
+            $"{context}: centreScrollY={centreScrollY:F1} < 0 — " +
+            $"sprite centre unreachable by scrolling (panY={panY:F1}, imgH={imgH}, zoom={zoom:F3}, vpH={vpH:F1})");
+    }
+
     // ── LoadTexture centres small images ──────────────────────────────────────
 
     /// <summary>
@@ -1199,6 +1233,9 @@ public class WireframePanZoomTests
             ctrl.SimulateWheelZoom(vpX, (float)(vpH / 2), 2.0f);
             Dispatcher.UIThread.RunJobs();
 
+            // Invariant: zoom-toward-boundary must not break pan-centering (#341).
+            AssertZoomInvariants(ctrl, sv, "after 2× zoom at right scroll boundary");
+
             // ── Assert: content coord under cursor must be preserved ───────────
             // sv.Offset.X is the scroll actually applied (clamped to maxScrollX).
             // With the fix, _panX absorbs the overflow so the mapping is exact.
@@ -1270,30 +1307,8 @@ public class WireframePanZoomTests
                 ctrl.SimulateWheelZoom(pivotX, pivotY, 1.25f);
             Dispatcher.UIThread.RunJobs();
 
-            float panX   = ctrl.CameraState.PanX;
-            float panY   = ctrl.CameraState.PanY;
-            float zoom   = ctrl.CameraState.Zoom;
-            float scrollX = ctrl.ScrollTarget.X;
-            float scrollY = ctrl.ScrollTarget.Y;
-
-            // PanX/PanY must be >= 0: negative means the sprite is left of scroll-origin
-            // and permanently unreachable by scrolling (#319).
-            Assert.True(panX >= 0f,
-                $"PanX={panX:F1} went negative — sprite was pushed off the left edge " +
-                $"of the scrollable area (zoom={zoom:F3}, scrollX={scrollX:F1})");
-            Assert.True(panY >= 0f,
-                $"PanY={panY:F1} went negative — sprite was pushed above the scrollable " +
-                $"area (zoom={zoom:F3}, scrollY={scrollY:F1})");
-
-            // Image must also be visible at the current scroll: right/bottom edges must
-            // lie to the right/below of the viewport's current left/top edge.
-            const int imgSize = 32;
-            Assert.True(panX + imgSize * zoom > scrollX,
-                $"Image right edge ({panX + imgSize * zoom:F1}) ≤ scrollX ({scrollX:F1}): " +
-                $"image is off the left of the viewport");
-            Assert.True(panY + imgSize * zoom > scrollY,
-                $"Image bottom edge ({panY + imgSize * zoom:F1}) ≤ scrollY ({scrollY:F1}): " +
-                $"image is above the viewport");
+            // panX/Y ≥ 0 AND sprite centre reachable by scrolling (#319, #341).
+            AssertZoomInvariants(ctrl, sv, "after 8 blank-space zoom steps");
 
             window.Close();
         }
@@ -1359,6 +1374,9 @@ public class WireframePanZoomTests
             ctrl.SimulateWheelZoom(vpX, (float)(vpH / 2), 1.25f);
             ctrl.SimulateWheelZoom(vpX, (float)(vpH / 2), 1.25f);
             Dispatcher.UIThread.RunJobs();
+
+            // Invariant: rapid zoom at boundary must preserve pan-centering (#341).
+            AssertZoomInvariants(ctrl, sv, "after 3 rapid 1.25× zooms at right scroll boundary");
 
             float scrollX1 = (float)sv.Offset.X;
             float panX1    = ctrl.PanOffset.X;
@@ -1431,29 +1449,11 @@ public class WireframePanZoomTests
 
             Dispatcher.UIThread.RunJobs();
 
-            var (panX, _, zoom) = ctrl.CameraState;
+            // panX/Y ≥ 0 AND sprite centre reachable: covers #319 (sprite off-screen)
+            // and #341 (centreScroll < 0, centering blocked).
+            AssertZoomInvariants(ctrl, sv, "after 8 bottom-right zoom steps");
 
-            // ── Assert 1: PanX must be > 0 (effective-padding buffer preserved) ──
-            // Bug:  _panX was clamped to 0, erasing the left-side buffer.
-            // Fix:  _panX is clamped to epX > 0.
-            Assert.True(panX > 0,
-                $"After 8 bottom-right zoom steps PanX must be > 0 (effective-padding " +
-                $"buffer preserved); got panX={panX:F1}. " +
-                "Indicates _panX was clamped to 0 instead of epX — sprite stuck (#341).");
-
-            // ── Assert 2: sprite centre must be reachable by a rightward pan ──
-            // centreScroll = (image centre in content space) − (viewport half-width)
-            // Bug  (panX = 0):   centreScroll ≈ −305 → impossible (scroll ≥ 0)
-            // Fix  (panX = epX): centreScroll ≈ +49  → reachable
-            float imageCentreX  = panX + 32f * zoom / 2f;
-            float centreScroll  = imageCentreX - vpW / 2f;
-            Assert.True(centreScroll > 0f,
-                $"Sprite centre (content={imageCentreX:F1}) must lie beyond viewport " +
-                $"half-width ({vpW / 2f:F1}) so it can be panned to centre " +
-                $"(required scroll={centreScroll:F1}). " +
-                "With panX=0 (bug) this scroll is negative and unreachable (#341).");
-
-            // ── Assert 3: executing the rightward pan actually decreases scroll ──
+            // ── Assert: executing the rightward pan actually decreases scroll ──
             double scrollBefore = sv.Offset.X;
             const float panAmt = 50f;
             if (scrollBefore >= panAmt)
@@ -1469,6 +1469,60 @@ public class WireframePanZoomTests
                     $"before={scrollBefore:F1} after={scrollAfter:F1} " +
                     $"delta={scrollBefore - scrollAfter:F1}. Sprite is stuck (#341).");
             }
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Parameterized blank-space zoom invariants ─────────────────────────────
+
+    /// <summary>
+    /// Parameterized regression guard: zooming 8 notches toward any blank-space
+    /// viewport position must always satisfy the core ZoomToward post-conditions.
+    ///
+    /// Covers #319 (0.9 pivot), #341 (0.99 pivot), and additional fractions in
+    /// a single harness — a future incomplete clamping fix would fail at least
+    /// one of these cases even if it accidentally passes the others.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(0.5f,  0.5f,  "viewport centre")]
+    [InlineData(0.9f,  0.9f,  "#319 pivot (90% corner)")]
+    [InlineData(0.99f, 0.99f, "#341 pivot (99% far corner)")]
+    [InlineData(0.5f,  0.99f, "bottom-edge centre")]
+    [InlineData(0.99f, 0.5f,  "right-edge centre")]
+    public void ZoomTowardBlankSpace_AnyPivot_InvariantsHold(float fracX, float fracY, string label)
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir, "small.png", size: 32);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+            var sv   = FindCtrl<ScrollViewer>(window, "WireframeScrollViewer");
+
+            ctrl.LoadTexture(texPath);
+            Dispatcher.UIThread.RunJobs();
+
+            ctrl.SetZoomPercent(100);
+            Dispatcher.UIThread.RunJobs();
+
+            float vpW = (float)sv.Viewport.Width;
+            float vpH = (float)sv.Viewport.Height;
+
+            float pivotX = vpW * fracX;
+            float pivotY = vpH * fracY;
+            for (int i = 0; i < 8; i++)
+                ctrl.SimulateWheelZoom(pivotX, pivotY, 1.25f);
+            Dispatcher.UIThread.RunJobs();
+
+            AssertZoomInvariants(ctrl, sv, $"[{label}] after 8 blank-space zoom steps");
 
             window.Close();
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframePanZoomTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframePanZoomTests.cs
@@ -1376,4 +1376,102 @@ public class WireframePanZoomTests
         }
         finally { Directory.Delete(dir, true); }
     }
+
+    // ── Bottom-right zoom pan-centering bug (#341) ────────────────────────────
+
+    /// <summary>
+    /// Regression guard for the "sprite stuck near top-left after zooming from
+    /// bottom-right corner" pan-centering bug (#341).
+    ///
+    /// Root cause: after multiple zoom-in steps with the pivot at the bottom-right
+    /// corner, <c>ZoomToward</c> computes a very negative <c>rawPanX</c>.  The #319
+    /// guard clamped <c>_panX = 0</c>, erasing the effective-padding buffer.  With
+    /// <c>_panX = 0</c> and a small image the sprite's centre maps to a negative
+    /// scroll offset — unreachable because scroll ≥ 0 — so the user cannot pan the
+    /// sprite to the viewport centre.
+    ///
+    /// Fix: clamp to <c>epX</c> (effective-padding X) instead of 0, preserving the
+    /// left-side buffer so the sprite is always pannable to the viewport centre.
+    /// </summary>
+    [AvaloniaFact]
+    public void ZoomFromBottomRight_MultipleTimes_SpritePannableToCenter()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // 32×32 sprite — small enough that rawPanX becomes negative after ~5
+            // bottom-right zoom steps, reliably triggering the clamped branch.
+            var texPath = WriteSolidPng(dir, "small32.png", size: 32);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+            var sv   = FindCtrl<ScrollViewer>(window, "WireframeScrollViewer");
+
+            ctrl.LoadTexture(texPath);
+            Dispatcher.UIThread.RunJobs();
+
+            // Start from 100 % zoom for a deterministic initial state.
+            ctrl.SetZoomPercent(100);
+            Dispatcher.UIThread.RunJobs();
+
+            float vpW = (float)sv.Viewport.Width;
+            float vpH = (float)sv.Viewport.Height;
+
+            // Simulate 8 wheel-zoom-in notches from the bottom-right corner.
+            // rawPanX goes negative after ~5 steps, triggering the _panX clamp.
+            float pivotX = vpW - 10f;
+            float pivotY = vpH - 10f;
+            for (int i = 0; i < 8; i++)
+                ctrl.SimulateWheelZoom(pivotX, pivotY, 1.25f);
+
+            Dispatcher.UIThread.RunJobs();
+
+            var (panX, _, zoom) = ctrl.CameraState;
+
+            // ── Assert 1: PanX must be > 0 (effective-padding buffer preserved) ──
+            // Bug:  _panX was clamped to 0, erasing the left-side buffer.
+            // Fix:  _panX is clamped to epX > 0.
+            Assert.True(panX > 0,
+                $"After 8 bottom-right zoom steps PanX must be > 0 (effective-padding " +
+                $"buffer preserved); got panX={panX:F1}. " +
+                "Indicates _panX was clamped to 0 instead of epX — sprite stuck (#341).");
+
+            // ── Assert 2: sprite centre must be reachable by a rightward pan ──
+            // centreScroll = (image centre in content space) − (viewport half-width)
+            // Bug  (panX = 0):   centreScroll ≈ −305 → impossible (scroll ≥ 0)
+            // Fix  (panX = epX): centreScroll ≈ +49  → reachable
+            float imageCentreX  = panX + 32f * zoom / 2f;
+            float centreScroll  = imageCentreX - vpW / 2f;
+            Assert.True(centreScroll > 0f,
+                $"Sprite centre (content={imageCentreX:F1}) must lie beyond viewport " +
+                $"half-width ({vpW / 2f:F1}) so it can be panned to centre " +
+                $"(required scroll={centreScroll:F1}). " +
+                "With panX=0 (bug) this scroll is negative and unreachable (#341).");
+
+            // ── Assert 3: executing the rightward pan actually decreases scroll ──
+            double scrollBefore = sv.Offset.X;
+            const float panAmt = 50f;
+            if (scrollBefore >= panAmt)
+            {
+                ctrl.SimulatePanStart(vpW / 2f, vpH / 2f);
+                ctrl.SimulatePanMove(vpW / 2f + panAmt, vpH / 2f);
+                ctrl.SimulatePanEnd();
+                Dispatcher.UIThread.RunJobs();
+
+                double scrollAfter = sv.Offset.X;
+                Assert.True(Math.Abs(scrollBefore - scrollAfter - panAmt) < 5.0,
+                    $"Rightward pan of {panAmt}px must decrease scroll by ~{panAmt}px; " +
+                    $"before={scrollBefore:F1} after={scrollAfter:F1} " +
+                    $"delta={scrollBefore - scrollAfter:F1}. Sprite is stuck (#341).");
+            }
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the pan-centering bug where zooming in from the bottom-right corner of WireframeControl left the sprite stuck and unreachable.

## Root Cause

\ZoomToward()\ absorbs scroll overflow into \_panX\:
\\\
rawPanX = epX - (rawScrollX - maxScrollX)
\\\
When zooming far toward blank space, the overflow grows and rawPanX shrinks. The #319 guard only clamped the \awPanX < 0\ case. But values in the range \(0, vpW/2 - imgW*zoom/2)\ also make centering impossible — \centreScroll = panX + imgW*zoom/2 - vpW/2\ goes negative, and scroll cannot go below 0.

After ~5 bottom-right zoom steps, rawPanX goes negative (caught), but then recovers to a small positive value (uncaught) over the next steps, leaving the sprite stuck again.

## Fix

Compute the minimum panX that guarantees centreScroll ≥ 0:
\\\csharp
float minPanX = Math.Max(0f, vp.Width / 2f - bitmap.Width * zoom / 2f);
_panX = rawPanX < minPanX ? epX : rawPanX;
\\\

Using \pX\ (not \minPanX\) as the clamp target restores the full effective-padding buffer, giving comfortable panning headroom.

This condition subsumes the original \awPanX < 0\ guard (since \minPanX ≥ 0\) without affecting the cursor-pivot-preservation case, because the drift-test scenario produces \awPanX ≈ 290 >> minPanX ≈ 150\ — no clamp fires, drift stays within the existing 1.5 px tolerance.

## Tests

- ✅ **New**: \ZoomFromBottomRight_MultipleTimes_SpritePannableToCenter\ — regression guard for #341
- ✅ **Existing**: \ZoomTowardBlankSpace_Repeatedly_DoesNotPushSpriteOffScreen\ (#319)
- ✅ **Existing**: \ZoomIn_WhenScrollAtRightBound_CursorContentCoordIsPreserved\ (#138)
- ✅ All 426 tests pass

Closes #341