### PR TITLE
feat: remember per-file settings (#322)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -544,6 +544,19 @@ public class PreviewControl : Control
     }
 
     /// <summary>
+    /// Replaces all guides with the provided world-coordinate values.
+    /// Used to restore guide state from the companion .aeproperties file.
+    /// </summary>
+    internal void SetGuides(IReadOnlyList<float> hGuides, IReadOnlyList<float> vGuides)
+    {
+        _hGuides.Clear();
+        _hGuides.AddRange(hGuides);
+        _vGuides.Clear();
+        _vGuides.AddRange(vGuides);
+        InvalidateVisual();
+    }
+
+    /// <summary>
     /// Formats the coordinate label shown next to a guide while it is being dragged.
     /// Returns <c>"Y: N"</c> for horizontal guides and <c>"X: N"</c> for vertical ones.
     /// </summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -241,6 +241,9 @@ public class PreviewControl : Control
     /// </summary>
     public event Action<float>? ZoomChanged;
 
+    /// <summary>Fired when the user finishes a pan gesture (pointer released after drag).</summary>
+    public event Action<float, float>? PanChanged;
+
     /// <summary>
     /// When non-null, mouse-wheel zoom steps through these preset percentages instead
     /// of applying a raw ×1.25/×0.8 multiplier.  Set by <c>MainWindow</c> on startup.
@@ -1192,6 +1195,7 @@ public class PreviewControl : Control
         }
 
         _isPanning = false;
+        PanChanged?.Invoke(_panX, _panY);
         e.Pointer.Capture(null);
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -450,6 +450,9 @@ public class WireframeControl : Control
     /// </summary>
     public event Action<float>? ZoomChanged;
 
+    /// <summary>Fired when the user finishes a pan gesture (pointer released after drag).</summary>
+    public event Action<float, float>? PanChanged;
+
     /// <summary>
     /// When non-null, mouse-wheel zoom steps through these preset percentages instead of
     /// applying a raw ×1.25 / ÷1.25 multiplier.  Set by <c>MainWindow</c> on startup.
@@ -1634,6 +1637,7 @@ public class WireframeControl : Control
         if (_isPanning)
         {
             _isPanning = false;
+            PanChanged?.Invoke(_panX, _panY);
             e.Pointer.Capture(null);
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Data;
 using AnimationEditor.Core.DragDrop;
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
@@ -48,6 +49,7 @@ public partial class MainWindow : Window
     private bool _suppressZoomComboChanged;
     private bool _suppressPreviewZoomComboChanged;
     private bool _suppressTreeSelectionHandling;
+    private bool _suppressCompanionSave;
     private System.Threading.CancellationTokenSource? _toastCts;
 
     // AppContext.BaseDirectory works under single-file publish; Assembly.Location is empty there (IL3000).
@@ -183,6 +185,8 @@ public partial class MainWindow : Window
         _events.AchxReloadedFromDisk += path =>
             Dispatcher.UIThread.InvokeAsync(() =>
                 ShowToast($"Reloaded {System.IO.Path.GetFileName(path)}"));
+
+        _ioManager.SettingsLoaded += s => Dispatcher.UIThread.InvokeAsync(() => ApplyCompanionSettings(s));
     }
 
     // ── Wireframe toolbar wiring ──────────────────────────────────────────────
@@ -235,6 +239,7 @@ public partial class MainWindow : Window
         WireframeCtrl.SetGrid(
             SnapToGridCheck.IsChecked == true,
             GetGridSizeFromInput());
+        SaveCompanionFile();
     }
 
     private int GetGridSizeFromInput()
@@ -259,6 +264,7 @@ public partial class MainWindow : Window
         GridSizeInput.Text = size.ToString();
         if (SnapToGridCheck.IsChecked == true)
             WireframeCtrl.SetGrid(true, size);
+        SaveCompanionFile();
     }
 
     private void OnGridSizePlusBtnClick(object? sender, RoutedEventArgs e)
@@ -267,6 +273,7 @@ public partial class MainWindow : Window
         GridSizeInput.Text = size.ToString();
         if (SnapToGridCheck.IsChecked == true)
             WireframeCtrl.SetGrid(true, size);
+        SaveCompanionFile();
     }
 
     private void OnGridSizeMinusBtnClick(object? sender, RoutedEventArgs e)
@@ -275,6 +282,7 @@ public partial class MainWindow : Window
         GridSizeInput.Text = size.ToString();
         if (SnapToGridCheck.IsChecked == true)
             WireframeCtrl.SetGrid(true, size);
+        SaveCompanionFile();
     }
 
     // ── Editable zoom combo (top wireframe) ──────────────────────────────────
@@ -345,7 +353,7 @@ public partial class MainWindow : Window
         WireframeCtrl.ChainRegionChanged     += OnChainRegionChanged;
         WireframeCtrl.FrameLiveUpdated       += OnFrameLiveUpdated;
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
-        WireframeCtrl.ZoomChanged            += SyncZoomCombo;
+        WireframeCtrl.ZoomChanged            += zoomPct => { SyncZoomCombo(zoomPct); SaveCompanionFile(); };
     }
 
     private void OnChainRegionChanged(AnimationChainSave chain)
@@ -408,6 +416,7 @@ public partial class MainWindow : Window
         if (!string.IsNullOrEmpty(_projectManager.FileName))
         {
             _appCommands.SaveCurrentAnimationChainList();
+            SaveCompanionFile();
             UpdateTitle();
         }
 
@@ -429,6 +438,73 @@ public partial class MainWindow : Window
         Dispatcher.UIThread.InvokeAsync(RefreshPropertyPanel);
         // Refresh timeline strip
         Dispatcher.UIThread.InvokeAsync(RefreshTimelineStrip);
+    }
+
+    // ── Companion file (.aeproperties) ────────────────────────────────────────
+
+    private AESettingsSave BuildCompanionSettings() => new AESettingsSave
+    {
+        SnapToGrid           = SnapToGridCheck.IsChecked == true,
+        GridSize             = GetGridSizeFromInput(),
+        WireframeZoomPercent = (int)MathF.Round(WireframeCtrl.Zoom * 100f),
+        PreviewZoomPercent   = (int)MathF.Round(PreviewCtrl.Zoom * 100f),
+        OffsetMultiplier     = _appState.OffsetMultiplier,
+        ExpandedNodes        = TreeBuilder.GetExpandedChainNames(_treeRoots).ToList(),
+        HorizontalGuides     = PreviewCtrl.HGuides.ToList(),
+        VerticalGuides       = PreviewCtrl.VGuides.ToList(),
+    };
+
+    private void SaveCompanionFile()
+    {
+        if (_suppressCompanionSave) return;
+        if (string.IsNullOrEmpty(_projectManager.FileName)) return;
+        _ioManager.SaveCompanionFileFor(new FilePath(_projectManager.FileName), BuildCompanionSettings());
+    }
+
+    private void ApplyCompanionSettings(AESettingsSave settings)
+    {
+        _suppressCompanionSave = true;
+        try
+        {
+            SnapToGridCheck.IsChecked = settings.SnapToGrid;
+            GridSizeInput.Text        = settings.GridSize.ToString();
+            WireframeCtrl.SetGrid(settings.SnapToGrid, settings.GridSize);
+
+            WireframeCtrl.SetZoomPercent(settings.WireframeZoomPercent);
+            PreviewCtrl.SetZoomPercent(settings.PreviewZoomPercent);
+
+            var expandedSet = settings.ExpandedNodes.ToHashSet();
+            foreach (var node in _treeRoots)
+            {
+                if (node.Data is AnimationChainSave chain)
+                    node.IsExpanded = expandedSet.Contains(chain.Name);
+            }
+
+            PreviewCtrl.SetGuides(settings.HorizontalGuides, settings.VerticalGuides);
+        }
+        finally
+        {
+            _suppressCompanionSave = false;
+        }
+    }
+
+    private void WireTreeRootsCompanionSave()
+    {
+        _treeRoots.CollectionChanged += (_, args) =>
+        {
+            if (args.NewItems != null)
+                foreach (TreeNodeVm vm in args.NewItems)
+                    vm.PropertyChanged += OnTreeNodeIsExpandedChanged;
+            if (args.OldItems != null)
+                foreach (TreeNodeVm vm in args.OldItems)
+                    vm.PropertyChanged -= OnTreeNodeIsExpandedChanged;
+        };
+    }
+
+    private void OnTreeNodeIsExpandedChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TreeNodeVm.IsExpanded))
+            SaveCompanionFile();
     }
 
     // ── Status bar ────────────────────────────────────────────────────────────
@@ -823,7 +899,7 @@ public partial class MainWindow : Window
         PreviewZoomMinusBtn.Click += (_, _) => StepZoomPreset(PreviewCtrl.Zoom * 100f, _previewZoomPresets, -1, p => PreviewCtrl.SetZoomPercent(p));
         PreviewCtrl.WheelZoomPresets = _previewZoomPresets;
 
-        PreviewCtrl.ZoomChanged += SyncPreviewZoomCombo;
+        PreviewCtrl.ZoomChanged += zoomPct => { SyncPreviewZoomCombo(zoomPct); SaveCompanionFile(); };
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
         PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
     }
@@ -978,6 +1054,8 @@ public partial class MainWindow : Window
             InputElement.LostFocusEvent,
             OnInlineRenameLostFocus,
             RoutingStrategies.Bubble);
+
+        WireTreeRootsCompanionSave();
     }
 
     private void SetAllExpanded(bool expanded)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -354,6 +354,7 @@ public partial class MainWindow : Window
         WireframeCtrl.FrameLiveUpdated       += OnFrameLiveUpdated;
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
         WireframeCtrl.ZoomChanged            += zoomPct => { SyncZoomCombo(zoomPct); SaveCompanionFile(); };
+        WireframeCtrl.PanChanged             += (_, _) => SaveCompanionFile();
     }
 
     private void OnChainRegionChanged(AnimationChainSave chain)
@@ -448,6 +449,10 @@ public partial class MainWindow : Window
         GridSize             = GetGridSizeFromInput(),
         WireframeZoomPercent = (int)MathF.Round(WireframeCtrl.Zoom * 100f),
         PreviewZoomPercent   = (int)MathF.Round(PreviewCtrl.Zoom * 100f),
+        WireframePanX        = WireframeCtrl.CameraState.PanX,
+        WireframePanY        = WireframeCtrl.CameraState.PanY,
+        PreviewPanX          = PreviewCtrl.PanOffset.X,
+        PreviewPanY          = PreviewCtrl.PanOffset.Y,
         OffsetMultiplier     = _appState.OffsetMultiplier,
         ExpandedNodes        = TreeBuilder.GetExpandedChainNames(_treeRoots).ToList(),
         HorizontalGuides     = PreviewCtrl.HGuides.ToList(),
@@ -472,6 +477,9 @@ public partial class MainWindow : Window
 
             WireframeCtrl.SetZoomPercent(settings.WireframeZoomPercent);
             PreviewCtrl.SetZoomPercent(settings.PreviewZoomPercent);
+
+            WireframeCtrl.SetCamera(settings.WireframePanX, settings.WireframePanY, WireframeCtrl.CameraState.Zoom);
+            PreviewCtrl.SetPan(settings.PreviewPanX, settings.PreviewPanY);
 
             var expandedSet = settings.ExpandedNodes.ToHashSet();
             foreach (var node in _treeRoots)
@@ -900,6 +908,7 @@ public partial class MainWindow : Window
         PreviewCtrl.WheelZoomPresets = _previewZoomPresets;
 
         PreviewCtrl.ZoomChanged += zoomPct => { SyncPreviewZoomCombo(zoomPct); SaveCompanionFile(); };
+        PreviewCtrl.PanChanged  += (_, _) => SaveCompanionFile();
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
         PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
@@ -25,5 +25,7 @@ namespace AnimationEditor.Core.Data
 
         public bool SnapToGrid { get; set; }
         public int GridSize { get; set; } = 16;
+        public int WireframeZoomPercent { get; set; } = 100;
+        public int PreviewZoomPercent { get; set; } = 100;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/AESettingsSave.cs
@@ -27,5 +27,9 @@ namespace AnimationEditor.Core.Data
         public int GridSize { get; set; } = 16;
         public int WireframeZoomPercent { get; set; } = 100;
         public int PreviewZoomPercent { get; set; } = 100;
+        public float WireframePanX { get; set; }
+        public float WireframePanY { get; set; }
+        public float PreviewPanX { get; set; }
+        public float PreviewPanY { get; set; }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewControlSetGuidesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewControlSetGuidesTests.cs
@@ -1,0 +1,64 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreviewControl.SetGuides"/>, which bulk-restores
+/// guide positions from world coordinates (used when loading .aeproperties).
+/// </summary>
+public class PreviewControlSetGuidesTests
+{
+    private static PreviewControl BuildCtrl() =>
+        TestHelpers.BuildServices().CreatePreviewControl();
+
+    [AvaloniaFact]
+    public void SetGuides_RestoresHorizontalAndVerticalGuides()
+    {
+        var ctrl = BuildCtrl();
+
+        ctrl.SetGuides(
+            hGuides: new[] { 10f, 20f },
+            vGuides: new[] { 30f });
+
+        Assert.Equal(2, ctrl.HGuides.Count);
+        Assert.Single(ctrl.VGuides);
+        Assert.Equal(10f, ctrl.HGuides[0]);
+        Assert.Equal(20f, ctrl.HGuides[1]);
+        Assert.Equal(30f, ctrl.VGuides[0]);
+    }
+
+    [AvaloniaFact]
+    public void SetGuides_ReplacesExistingGuides()
+    {
+        var ctrl = BuildCtrl();
+
+        // Plant some guides first using SetGuides itself
+        ctrl.SetGuides(hGuides: new[] { 99f }, vGuides: new[] { 88f });
+
+        // A second call should replace, not append
+        ctrl.SetGuides(
+            hGuides: new[] { 5f },
+            vGuides: new[] { 7f, 9f });
+
+        Assert.Single(ctrl.HGuides);
+        Assert.Equal(5f, ctrl.HGuides[0]);
+        Assert.Equal(2, ctrl.VGuides.Count);
+        Assert.Equal(7f, ctrl.VGuides[0]);
+        Assert.Equal(9f, ctrl.VGuides[1]);
+    }
+
+    [AvaloniaFact]
+    public void SetGuides_WithEmptyLists_ClearsAllGuides()
+    {
+        var ctrl = BuildCtrl();
+
+        ctrl.SetGuides(hGuides: new[] { 5f }, vGuides: new[] { 6f });
+
+        ctrl.SetGuides(hGuides: System.Array.Empty<float>(), vGuides: System.Array.Empty<float>());
+
+        Assert.Empty(ctrl.HGuides);
+        Assert.Empty(ctrl.VGuides);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AESettingsSaveRoundTripTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AESettingsSaveRoundTripTests.cs
@@ -139,6 +139,34 @@ public class AESettingsSaveRoundTripTests
         Assert.Empty(loaded.ExpandedNodes);
     }
 
+    // ── Zoom fields ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WireframeZoomPercent_DefaultIs100()
+    {
+        Assert.Equal(100, new AESettingsSave().WireframeZoomPercent);
+    }
+
+    [Fact]
+    public void PreviewZoomPercent_DefaultIs100()
+    {
+        Assert.Equal(100, new AESettingsSave().PreviewZoomPercent);
+    }
+
+    [Fact]
+    public void WireframeZoomPercent_NonDefault_RoundTrip()
+    {
+        var s = new AESettingsSave { WireframeZoomPercent = 200 };
+        Assert.Equal(200, Deserialize(Serialize(s)).WireframeZoomPercent);
+    }
+
+    [Fact]
+    public void PreviewZoomPercent_NonDefault_RoundTrip()
+    {
+        var s = new AESettingsSave { PreviewZoomPercent = 150 };
+        Assert.Equal(150, Deserialize(Serialize(s)).PreviewZoomPercent);
+    }
+
     // ── Combined ─────────────────────────────────────────────────────────────
 
     [Fact]
@@ -146,9 +174,11 @@ public class AESettingsSaveRoundTripTests
     {
         var s = new AESettingsSave
         {
-            SnapToGrid  = true,
-            GridSize    = 8,
-            OffsetMultiplier = 2f
+            SnapToGrid           = true,
+            GridSize             = 8,
+            OffsetMultiplier     = 2f,
+            WireframeZoomPercent = 300,
+            PreviewZoomPercent   = 50,
         };
         s.HorizontalGuides.Add(50f);
         s.VerticalGuides.Add(75f);
@@ -157,7 +187,9 @@ public class AESettingsSaveRoundTripTests
         var loaded = Deserialize(Serialize(s));
 
         Assert.True(loaded.SnapToGrid);
-        Assert.Equal(8,  loaded.GridSize);
+        Assert.Equal(8,   loaded.GridSize);
+        Assert.Equal(300, loaded.WireframeZoomPercent);
+        Assert.Equal(50,  loaded.PreviewZoomPercent);
         Assert.Single(loaded.HorizontalGuides);
         Assert.Single(loaded.VerticalGuides);
         Assert.Single(loaded.ExpandedNodes);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AESettingsSaveRoundTripTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AESettingsSaveRoundTripTests.cs
@@ -167,6 +167,51 @@ public class AESettingsSaveRoundTripTests
         Assert.Equal(150, Deserialize(Serialize(s)).PreviewZoomPercent);
     }
 
+    // ── Pan fields ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WireframePanX_DefaultIsZero()
+    {
+        Assert.Equal(0f, new AESettingsSave().WireframePanX);
+    }
+
+    [Fact]
+    public void WireframePanY_DefaultIsZero()
+    {
+        Assert.Equal(0f, new AESettingsSave().WireframePanY);
+    }
+
+    [Fact]
+    public void PreviewPanX_DefaultIsZero()
+    {
+        Assert.Equal(0f, new AESettingsSave().PreviewPanX);
+    }
+
+    [Fact]
+    public void PreviewPanY_DefaultIsZero()
+    {
+        Assert.Equal(0f, new AESettingsSave().PreviewPanY);
+    }
+
+    [Fact]
+    public void PanFields_NonDefault_RoundTrip()
+    {
+        var s = new AESettingsSave
+        {
+            WireframePanX = 123.5f,
+            WireframePanY = -45.0f,
+            PreviewPanX   = 0.5f,
+            PreviewPanY   = 99.9f,
+        };
+
+        var loaded = Deserialize(Serialize(s));
+
+        Assert.Equal(123.5f, loaded.WireframePanX);
+        Assert.Equal(-45.0f, loaded.WireframePanY);
+        Assert.Equal(0.5f,   loaded.PreviewPanX);
+        Assert.Equal(99.9f,  loaded.PreviewPanY);
+    }
+
     // ── Combined ─────────────────────────────────────────────────────────────
 
     [Fact]
@@ -179,6 +224,10 @@ public class AESettingsSaveRoundTripTests
             OffsetMultiplier     = 2f,
             WireframeZoomPercent = 300,
             PreviewZoomPercent   = 50,
+            WireframePanX        = 10f,
+            WireframePanY        = -20f,
+            PreviewPanX          = 5f,
+            PreviewPanY          = 15f,
         };
         s.HorizontalGuides.Add(50f);
         s.VerticalGuides.Add(75f);
@@ -187,9 +236,13 @@ public class AESettingsSaveRoundTripTests
         var loaded = Deserialize(Serialize(s));
 
         Assert.True(loaded.SnapToGrid);
-        Assert.Equal(8,   loaded.GridSize);
-        Assert.Equal(300, loaded.WireframeZoomPercent);
-        Assert.Equal(50,  loaded.PreviewZoomPercent);
+        Assert.Equal(8,    loaded.GridSize);
+        Assert.Equal(300,  loaded.WireframeZoomPercent);
+        Assert.Equal(50,   loaded.PreviewZoomPercent);
+        Assert.Equal(10f,  loaded.WireframePanX);
+        Assert.Equal(-20f, loaded.WireframePanY);
+        Assert.Equal(5f,   loaded.PreviewPanX);
+        Assert.Equal(15f,  loaded.PreviewPanY);
         Assert.Single(loaded.HorizontalGuides);
         Assert.Single(loaded.VerticalGuides);
         Assert.Single(loaded.ExpandedNodes);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/IoManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/IoManagerTests.cs
@@ -139,6 +139,36 @@ public class IoManagerTests
     }
 
     [Fact]
+    public void SaveAndLoad_PreservesWireframeZoomPercent()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        using var dir = new TestHelpers.TempDir();
+        var achxPath = new FilePath(dir.Path + "/test.achx");
+        AESettingsSave? loaded = null;
+        ctx.IoManager.SettingsLoaded += s => loaded = s;
+
+        ctx.IoManager.SaveCompanionFileFor(achxPath, new AESettingsSave { WireframeZoomPercent = 200 });
+        ctx.IoManager.LoadAndApplyCompanionFileFor(achxPath.FullPath);
+
+        Assert.Equal(200, loaded?.WireframeZoomPercent);
+    }
+
+    [Fact]
+    public void SaveAndLoad_PreservesPreviewZoomPercent()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        using var dir = new TestHelpers.TempDir();
+        var achxPath = new FilePath(dir.Path + "/test.achx");
+        AESettingsSave? loaded = null;
+        ctx.IoManager.SettingsLoaded += s => loaded = s;
+
+        ctx.IoManager.SaveCompanionFileFor(achxPath, new AESettingsSave { PreviewZoomPercent = 150 });
+        ctx.IoManager.LoadAndApplyCompanionFileFor(achxPath.FullPath);
+
+        Assert.Equal(150, loaded?.PreviewZoomPercent);
+    }
+
+    [Fact]
     public void SaveCompanionFileFor_WhenDirectoryDoesNotExist_FiresSaveFailed()
     {
         var ctx = TestHelpers.SetupFreshAcls();


### PR DESCRIPTION
## Summary

Persists per-file editor state to a companion .aeproperties XML file alongside each .achx, restoring it automatically on next open.

### What's persisted
- **Wireframe zoom** (top panel)
- **Preview zoom** (bottom panel)
- **Snap-to-grid** checkbox and **grid size**
- **Expanded/collapsed** state for each animation chain in the tree
- **Horizontal and vertical guide** positions in the preview panel

### Implementation
- Added WireframeZoomPercent and PreviewZoomPercent fields to AESettingsSave
- Added PreviewControl.SetGuides(hGuides, vGuides) for bulk-restoring guide world-coordinates
- Wired IoManager.SettingsLoaded in MainWindow → ApplyCompanionSettings() which restores all settings after tree rebuild
- SaveCompanionFile() is triggered on: animation changes, zoom changes, grid setting changes, and tree expand/collapse
- _suppressCompanionSave flag prevents re-entrant saves during the load/restore cycle
- Stale ExpandedNodes entries (deleted animations) are silently ignored

### Tests added
- AESettingsSaveRoundTripTests — zoom field defaults and round-trip serialization
- IoManagerTests — SettingsLoaded carries zoom values through save/load cycle
- PreviewControlSetGuidesTests — SetGuides restores, replaces, and clears guides

Closes #322