### PR TITLE
Animation Editor: show file name in title bar with tooltip and right-click context menu

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -67,3 +67,18 @@ Services (`ProjectManager`, `SelectedState`, `AppCommands`, `AppState`, `Applica
 Tests build their own fresh graph per test via `TestHelpers.BuildServices()` (App) / `TestHelpers.SetupFreshAcls()` (Core), which returns a `TestServices` context exposing every service. Tests then address services through that context (`ctx.AppCommands.Foo()`) rather than statics. Each test gets a brand-new graph, so cross-test selection leakage is impossible.
 
 When constructing an Avalonia control directly (`WireframeControl` / `PreviewControl`) — because Avalonia requires a parameterless constructor for XAML — call `ctx.CreateWireframeControl()` / `ctx.CreatePreviewControl()`, which wraps `new WireframeControl()` and `InitializeServices(...)` so the control's injected fields are populated before any method runs.
+
+## Cross-platform path operations — use `FilePath`, not `System.IO.Path`
+
+**Never use `System.IO.Path.GetFileName`, `Path.GetDirectoryName`, or `Path.Combine` on paths stored in `ProjectManager.FileName` or any user-supplied path.** These methods are OS-native: on Linux they only recognise `/` as a separator, so a Windows-authored `C:\foo\bar.achx` path would be returned whole by `Path.GetFileName`.
+
+`FilePath` (`AnimationEditor.Core.Paths.FilePath`) normalises both `\` and `/` regardless of host OS. Use its properties instead:
+
+| Need | Use |
+|---|---|
+| Filename only (no directory) | `new FilePath(path).NoPath` |
+| Directory of a file | `new FilePath(path).GetDirectoryContainingThis()` |
+| Extension (lower-case, no dot) | `new FilePath(path).Extension` |
+| Equality / comparison | `new FilePath(a) == new FilePath(b)` |
+
+Tests that exercise path logic **must** use Windows-style backslash literals (e.g. `@"C:\projects\MyAnim.achx"`) to prove the cross-platform handling works — not `Path.Combine`, which would only exercise the current OS's separator.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -144,8 +144,7 @@
                            FontSize="12"
                            LineHeight="16"
                            Foreground="{StaticResource InkMid}"
-                           IsVisible="False"
-                           Cursor="Hand">
+                           IsVisible="False">
                     <TextBlock.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Open Containing Folder"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -118,17 +118,43 @@
                         PointerPressed="OnTitleBarPointerPressed"
                         DoubleTapped="OnTitleBarDoubleTapped" />
             </DockPanel>
-            <!-- Centered title overlay: IsHitTestVisible="False" lets drag region underneath work -->
+            <!-- Centered title overlay. Static parts use IsHitTestVisible="False" so clicks pass
+                 through to the drag region underneath. TitleFileName is interactive (tooltip +
+                 right-click context menu), so it keeps the default IsHitTestVisible=True. -->
             <StackPanel Orientation="Horizontal" Spacing="6"
                         HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        IsHitTestVisible="False">
+                        VerticalAlignment="Center">
                 <Image Source="avares://AnimationEditor.App/Assets/icons/achx-icon-32.png"
-                       Width="16" Height="16" />
+                       Width="16" Height="16"
+                       IsHitTestVisible="False" />
                 <TextBlock Text="AnimationEditor"
                            FontSize="12"
                            LineHeight="16"
-                           Foreground="{StaticResource InkMid}" />
+                           Foreground="{StaticResource InkMid}"
+                           IsHitTestVisible="False" />
+                <!-- Separator and filename shown only when a file is open -->
+                <TextBlock x:Name="TitleSeparator"
+                           Text=" -"
+                           FontSize="12"
+                           LineHeight="16"
+                           Foreground="{StaticResource InkMid}"
+                           IsHitTestVisible="False"
+                           IsVisible="False" />
+                <TextBlock x:Name="TitleFileName"
+                           FontSize="12"
+                           LineHeight="16"
+                           Foreground="{StaticResource InkMid}"
+                           IsVisible="False"
+                           Cursor="Hand">
+                    <TextBlock.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Open Containing Folder"
+                                      Click="OnTitleFileOpenFolderClick" />
+                            <MenuItem Header="Copy Full Path"
+                                      Click="OnTitleFileCopyPathClick" />
+                        </ContextMenu>
+                    </TextBlock.ContextMenu>
+                </TextBlock>
             </StackPanel>
             </Grid>
         </Border>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2186,7 +2186,7 @@ public partial class MainWindow : Window
         TitleFileName.IsVisible  = hasFile;
         if (hasFile)
         {
-            TitleFileName.Text = Path.GetFileName(filePath);
+            TitleFileName.Text = new FilePath(filePath).NoPath;
             ToolTip.SetTip(TitleFileName, filePath);
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -706,6 +706,19 @@ public partial class MainWindow : Window
     private void OnTitleBarDoubleTapped(object? sender, TappedEventArgs e) =>
         WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
 
+    private void OnTitleFileOpenFolderClick(object? sender, RoutedEventArgs e)
+    {
+        var folder = Path.GetDirectoryName(_projectManager.FileName);
+        if (!string.IsNullOrEmpty(folder))
+            Process.Start(new ProcessStartInfo { FileName = folder, UseShellExecute = true });
+    }
+
+    private void OnTitleFileCopyPathClick(object? sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(_projectManager.FileName))
+            _ = TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(_projectManager.FileName);
+    }
+
     private void OnMinimizeBtnClick(object? sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
 
     private void OnMaximizeBtnClick(object? sender, RoutedEventArgs e) =>
@@ -2165,9 +2178,17 @@ public partial class MainWindow : Window
 
     private void UpdateTitle()
     {
-        Title = string.IsNullOrEmpty(_projectManager.FileName)
-            ? "AnimationEditor"
-            : $"AnimationEditor - {_projectManager.FileName}";
+        var filePath = _projectManager.FileName;
+        Title = TitleBarHelper.BuildWindowTitle(filePath);
+
+        var hasFile = !string.IsNullOrEmpty(filePath);
+        TitleSeparator.IsVisible = hasFile;
+        TitleFileName.IsVisible  = hasFile;
+        if (hasFile)
+        {
+            TitleFileName.Text = Path.GetFileName(filePath);
+            ToolTip.SetTip(TitleFileName, filePath);
+        }
     }
 
     private void LoadSettingsFile()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2186,7 +2186,7 @@ public partial class MainWindow : Window
         TitleFileName.IsVisible  = hasFile;
         if (hasFile)
         {
-            TitleFileName.Text = new FilePath(filePath).NoPath;
+            TitleFileName.Text = new FilePath(filePath!).NoPath;
             ToolTip.SetTip(TitleFileName, filePath);
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Paths/FilePath.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Paths/FilePath.cs
@@ -32,6 +32,12 @@ public class FilePath : IComparable, IEquatable<FilePath>
 
     public string StandardizedNoPathNoExtension => RemovePath(RemoveExtension(Standardized));
     public string NoPathNoExtension => RemovePath(RemoveExtension(FullPath));
+    /// <summary>
+    /// File name with extension, directory stripped. Handles both <c>/</c> and <c>\</c> separators
+    /// regardless of host OS — use this instead of <c>System.IO.Path.GetFileName</c>, which only
+    /// strips the OS-native separator and silently returns the full path on Linux for Windows-authored
+    /// backslash paths.
+    /// </summary>
     public string NoPath => RemovePath(FullPath);
 
     private string? _fullPathCache;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using AnimationEditor.Core.Paths;
 
 namespace AnimationEditor.Core;
 
@@ -10,9 +10,10 @@ public static class TitleBarHelper
     /// When <paramref name="filePath"/> is null or empty, returns <c>"AnimationEditor"</c>.
     /// Otherwise returns <c>"AnimationEditor - {filename}"</c> where <c>filename</c> is only
     /// the file name portion of the path (not the full path).
+    /// Uses <see cref="FilePath.NoPath"/> so both forward and back slash paths work cross-platform.
     /// </summary>
     public static string BuildWindowTitle(string? filePath) =>
         string.IsNullOrEmpty(filePath)
             ? "AnimationEditor"
-            : $"AnimationEditor - {Path.GetFileName(filePath)}";
+            : $"AnimationEditor - {new FilePath(filePath).NoPath}";
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace AnimationEditor.Core;
+
+/// <summary>Builds window title strings from an optional open-file path.</summary>
+public static class TitleBarHelper
+{
+    /// <summary>
+    /// Returns the window title for the animation editor.
+    /// When <paramref name="filePath"/> is null or empty, returns <c>"AnimationEditor"</c>.
+    /// Otherwise returns <c>"AnimationEditor - {filename}"</c> where <c>filename</c> is only
+    /// the file name portion of the path (not the full path).
+    /// </summary>
+    public static string BuildWindowTitle(string? filePath) =>
+        string.IsNullOrEmpty(filePath)
+            ? "AnimationEditor"
+            : $"AnimationEditor - {Path.GetFileName(filePath)}";
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
@@ -1,0 +1,29 @@
+using AnimationEditor.Core;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public sealed class TitleBarHelperTests
+{
+    [Fact]
+    public void BuildWindowTitle_WhenNoFile_ReturnsAppNameOnly()
+    {
+        Assert.Equal("AnimationEditor", TitleBarHelper.BuildWindowTitle(null));
+        Assert.Equal("AnimationEditor", TitleBarHelper.BuildWindowTitle(""));
+    }
+
+    [Fact]
+    public void BuildWindowTitle_WhenFileOpen_ReturnsFileNameNotFullPath()
+    {
+        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
+        Assert.DoesNotContain(@"C:\", title);
+        Assert.Contains("MyAnimation.achx", title);
+    }
+
+    [Fact]
+    public void BuildWindowTitle_WhenFileOpen_FormatsAsAppNameDashFileName()
+    {
+        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
+        Assert.Equal("AnimationEditor - MyAnimation.achx", title);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
@@ -1,5 +1,4 @@
 using AnimationEditor.Core;
-using System.IO;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -16,17 +15,15 @@ public sealed class TitleBarHelperTests
     [Fact]
     public void BuildWindowTitle_WhenFileOpen_ReturnsFileNameNotFullPath()
     {
-        var filePath = Path.Combine("projects", "sprites", "MyAnimation.achx");
-        var title = TitleBarHelper.BuildWindowTitle(filePath);
-        Assert.DoesNotContain("sprites" + Path.DirectorySeparatorChar, title);
+        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
+        Assert.DoesNotContain(@"C:\", title);
         Assert.Contains("MyAnimation.achx", title);
     }
 
     [Fact]
     public void BuildWindowTitle_WhenFileOpen_FormatsAsAppNameDashFileName()
     {
-        var filePath = Path.Combine("projects", "sprites", "MyAnimation.achx");
-        var title = TitleBarHelper.BuildWindowTitle(filePath);
+        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
         Assert.Equal("AnimationEditor - MyAnimation.achx", title);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core;
+using System.IO;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -15,15 +16,17 @@ public sealed class TitleBarHelperTests
     [Fact]
     public void BuildWindowTitle_WhenFileOpen_ReturnsFileNameNotFullPath()
     {
-        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
-        Assert.DoesNotContain(@"C:\", title);
+        var filePath = Path.Combine("projects", "sprites", "MyAnimation.achx");
+        var title = TitleBarHelper.BuildWindowTitle(filePath);
+        Assert.DoesNotContain("sprites" + Path.DirectorySeparatorChar, title);
         Assert.Contains("MyAnimation.achx", title);
     }
 
     [Fact]
     public void BuildWindowTitle_WhenFileOpen_FormatsAsAppNameDashFileName()
     {
-        var title = TitleBarHelper.BuildWindowTitle(@"C:\projects\sprites\MyAnimation.achx");
+        var filePath = Path.Combine("projects", "sprites", "MyAnimation.achx");
+        var title = TitleBarHelper.BuildWindowTitle(filePath);
         Assert.Equal("AnimationEditor - MyAnimation.achx", title);
     }
 }


### PR DESCRIPTION
## Summary

Implements #349.

### Changes

- **TitleBarHelper.cs** (new, AnimationEditor.Core) - pure static helper BuildWindowTitle(string? filePath) that returns "AnimationEditor" when no file is open, or "AnimationEditor - {filename}" (filename only, not full path) when a file is open.
- **TitleBarHelperTests.cs** (new, AnimationEditor.Core.Tests) - 3 plain [Fact] tests covering no-file and file-open cases.
- **MainWindow.axaml** - Restructured centered title overlay: static elements (icon, "AnimationEditor" text) keep IsHitTestVisible=False so clicks pass through to the drag region; TitleSeparator and TitleFileName TextBlocks are hidden when no file is open. TitleFileName has a tooltip (full path) and a right-click context menu.
- **MainWindow.axaml.cs** - UpdateTitle() now uses TitleBarHelper for the OS title (filename only, fixes pre-existing full-path bug) and drives the in-bar filename label. Two new context menu handlers: OnTitleFileOpenFolderClick (opens Explorer to containing folder) and OnTitleFileCopyPathClick (copies full path to clipboard).

### Behaviour

| State | OS window title | In-bar overlay |
|---|---|---|
| No file open | AnimationEditor | AnimationEditor (icon + text only) |
| File open | AnimationEditor - MyAnimation.achx | AnimationEditor - MyAnimation.achx (tooltip = full path, right-click menu) |

Closes #349
