### PR TITLE
Fix: macOS title bar and system menu bar for Animation Editor

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -21,6 +21,7 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+        Name = TitleBarHelper.AppName;
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -6,6 +6,7 @@ using AnimationEditor.Core.IO;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -13,6 +14,7 @@ using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.IO;
+using System.Windows.Input;
 
 namespace AnimationEditor.App;
 
@@ -30,9 +32,10 @@ public partial class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            var mainWindow = services.GetRequiredService<MainWindow>();
-            mainWindow.Icon = LoadAppIcon();
-            desktop.MainWindow = mainWindow;
+            var window = services.GetRequiredService<MainWindow>();
+            window.Icon = LoadAppIcon();
+            desktop.MainWindow = window;
+            RegisterNativeMenu(window);
 
             // Post the Dock icon update to the next UI tick. Avalonia's macOS backend
             // may clear NSApplication.applicationIconImage during window assignment
@@ -59,6 +62,52 @@ public partial class App : Application
             new Uri("avares://AnimationEditor/Assets/icons/achx-icon-256.png"));
         return new WindowIcon(new Bitmap(stream));
     }
+
+    private void RegisterNativeMenu(MainWindow window)
+    {
+        var a = window.CreateNativeMenuActions();
+
+        var fileMenu = new NativeMenu();
+        fileMenu.Add(new NativeMenuItem("New")      { Command = Cmd(a.New),    Gesture = new KeyGesture(Key.N, KeyModifiers.Meta) });
+        fileMenu.Add(new NativeMenuItem("Open…")    { Command = Cmd(a.Load),   Gesture = new KeyGesture(Key.L, KeyModifiers.Meta) });
+
+        var recentMenu = new NativeMenu();
+        foreach (var (header, execute) in a.RecentFiles())
+            recentMenu.Add(new NativeMenuItem(header) { Command = Cmd(execute) });
+        fileMenu.Add(new NativeMenuItem("Open Recent") { Menu = recentMenu });
+
+        fileMenu.Add(new NativeMenuItemSeparator());
+        fileMenu.Add(new NativeMenuItem("Save")     { Command = Cmd(a.Save),   Gesture = new KeyGesture(Key.S, KeyModifiers.Meta) });
+        fileMenu.Add(new NativeMenuItem("Save As…") { Command = Cmd(a.SaveAs), Gesture = new KeyGesture(Key.S, KeyModifiers.Meta | KeyModifiers.Shift) });
+
+        var editMenu = new NativeMenu();
+        editMenu.Add(new NativeMenuItem("Undo")  { Command = Cmd(a.Undo),  Gesture = new KeyGesture(Key.Z, KeyModifiers.Meta) });
+        editMenu.Add(new NativeMenuItem("Redo")  { Command = Cmd(a.Redo),  Gesture = new KeyGesture(Key.Z, KeyModifiers.Meta | KeyModifiers.Shift) });
+        editMenu.Add(new NativeMenuItemSeparator());
+        editMenu.Add(new NativeMenuItem("Copy")  { Command = Cmd(a.Copy),  Gesture = new KeyGesture(Key.C, KeyModifiers.Meta) });
+        editMenu.Add(new NativeMenuItem("Paste") { Command = Cmd(a.Paste), Gesture = new KeyGesture(Key.V, KeyModifiers.Meta) });
+        editMenu.Add(new NativeMenuItemSeparator());
+        editMenu.Add(new NativeMenuItem("Reload from Disk")  { Command = Cmd(a.ReloadFromDisk) });
+        editMenu.Add(new NativeMenuItem("Enable Hot Reload") { Command = Cmd(a.ToggleHotReload) });
+        editMenu.Add(new NativeMenuItemSeparator());
+        editMenu.Add(new NativeMenuItem("Resize Texture…")  { Command = Cmd(a.ResizeTexture) });
+
+        var viewMenu = new NativeMenu();
+        viewMenu.Add(new NativeMenuItem("Show History") { Command = Cmd(a.ShowHistory) });
+
+        var helpMenu = new NativeMenu();
+        helpMenu.Add(new NativeMenuItem("About Animation Editor") { Command = Cmd(a.About) });
+
+        var appMenu = new NativeMenu();
+        appMenu.Add(new NativeMenuItem("File") { Menu = fileMenu });
+        appMenu.Add(new NativeMenuItem("Edit") { Menu = editMenu });
+        appMenu.Add(new NativeMenuItem("View") { Menu = viewMenu });
+        appMenu.Add(new NativeMenuItem("Help") { Menu = helpMenu });
+
+        NativeMenu.SetMenu(window, appMenu);
+    }
+
+    private static ICommand Cmd(Action action) => new RelayCommand(action);
 
     private static ServiceProvider BuildServices()
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -786,6 +786,10 @@ public partial class MainWindow : Window
         MenuShowHistory.IsEnabled = false;
 
         RefreshRecentFiles();
+
+        // On macOS the menus live in the system menu bar (NativeMenu); hide the duplicate in-window copy.
+        if (OperatingSystem.IsMacOS())
+            MainMenu.IsVisible = false;
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -788,6 +788,29 @@ public partial class MainWindow : Window
         RefreshRecentFiles();
     }
 
+    /// <summary>
+    /// Returns delegates for every actionable menu item so that the macOS NativeMenu
+    /// can be wired from <see cref="App"/> without reaching into private window state.
+    /// </summary>
+    internal NativeMenuActions CreateNativeMenuActions() => new(
+        New:             () => OnNewClick(null, null!),
+        Load:            () => _ = LoadAsync(),
+        RecentFiles:     () => _appSettings.RecentFiles
+                                    .Take(5)
+                                    .Select(f => (System.IO.Path.GetFileName(f), (Action)(() => _ = LoadAnimationFileAsync(f))))
+                                    .ToList(),
+        Save:            () => OnSaveClick(null, null!),
+        SaveAs:          () => _ = _appCommands.SaveCurrentAnimationChainListAsync(),
+        Undo:            () => _undoManager.Undo(),
+        Redo:            () => _undoManager.Redo(),
+        Copy:            () => _ = HandleCopyAsync(),
+        Paste:           () => _ = HandlePasteAsync(),
+        ReloadFromDisk:  () => { if (!string.IsNullOrEmpty(_projectManager.FileName)) _appCommands.ReloadAchxFromDisk(_projectManager.FileName); },
+        ToggleHotReload: () => { _appCommands.HotReloadWatcher.IsEnabled = !_appCommands.HotReloadWatcher.IsEnabled; },
+        ResizeTexture:   () => _ = DoResizeTextureAsync(),
+        ShowHistory:     () => SetHistoryVisible(true),
+        About:           () => _ = BuildAboutWindow().ShowDialog(this));
+
     private void RefreshRecentFiles()
     {
         MenuLoadRecent.Items.Clear();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace AnimationEditor.App;
+
+/// <summary>
+/// Delegates for every actionable menu item in the app, populated by <see cref="MainWindow"/>
+/// and consumed by the macOS <c>NativeMenu</c> registration in <see cref="App"/>.
+/// </summary>
+internal sealed record NativeMenuActions(
+    Action New,
+    Action Load,
+    Func<IReadOnlyList<(string Header, Action Execute)>> RecentFiles,
+    Action Save,
+    Action SaveAs,
+    Action Undo,
+    Action Redo,
+    Action Copy,
+    Action Paste,
+    Action ReloadFromDisk,
+    Action ToggleHotReload,
+    Action ResizeTexture,
+    Action ShowHistory,
+    Action About);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/RelayCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/RelayCommand.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Input;
+
+namespace AnimationEditor.App;
+
+/// <summary>Wraps a parameterless <see cref="Action"/> as an <see cref="ICommand"/> that always reports CanExecute = true.</summary>
+internal sealed class RelayCommand(Action execute) : ICommand
+{
+#pragma warning disable CS0067 // event is required by ICommand but never fired — CanExecute is always true
+    public event EventHandler? CanExecuteChanged;
+#pragma warning restore CS0067
+
+    public bool CanExecute(object? parameter) => true;
+
+    public void Execute(object? parameter) => execute();
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
@@ -5,6 +5,9 @@ namespace AnimationEditor.Core;
 /// <summary>Builds window title strings from an optional open-file path.</summary>
 public static class TitleBarHelper
 {
+    /// <summary>The branded application name shown in the macOS system menu bar and other OS surfaces.</summary>
+    public const string AppName = "FlatRedBall Animation Editor";
+
     /// <summary>
     /// Returns the window title for the animation editor.
     /// When <paramref name="filePath"/> is null or empty, returns <c>"AnimationEditor"</c>.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/TitleBarHelper.cs
@@ -5,8 +5,8 @@ namespace AnimationEditor.Core;
 /// <summary>Builds window title strings from an optional open-file path.</summary>
 public static class TitleBarHelper
 {
-    /// <summary>The branded application name shown in the macOS system menu bar and other OS surfaces.</summary>
-    public const string AppName = "FlatRedBall Animation Editor";
+    /// <summary>The application name shown in the macOS system menu bar and other OS surfaces.</summary>
+    public const string AppName = "Animation Editor";
 
     /// <summary>
     /// Returns the window title for the animation editor.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RelayCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RelayCommandTests.cs
@@ -1,0 +1,24 @@
+using AnimationEditor.App;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public sealed class RelayCommandTests
+{
+    [Fact]
+    public void Execute_CallsProvidedAction()
+    {
+        bool called = false;
+        var cmd = new RelayCommand(() => called = true);
+        cmd.Execute(null);
+        Assert.True(called);
+    }
+
+    [Fact]
+    public void CanExecute_AlwaysReturnsTrue()
+    {
+        var cmd = new RelayCommand(() => { });
+        Assert.True(cmd.CanExecute(null));
+        Assert.True(cmd.CanExecute("anything"));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
@@ -6,6 +6,12 @@ namespace AnimationEditor.Core.Tests;
 public sealed class TitleBarHelperTests
 {
     [Fact]
+    public void AppName_IsBrandedName()
+    {
+        Assert.Equal("FlatRedBall Animation Editor", TitleBarHelper.AppName);
+    }
+
+    [Fact]
     public void BuildWindowTitle_WhenNoFile_ReturnsAppNameOnly()
     {
         Assert.Equal("AnimationEditor", TitleBarHelper.BuildWindowTitle(null));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TitleBarHelperTests.cs
@@ -8,7 +8,7 @@ public sealed class TitleBarHelperTests
     [Fact]
     public void AppName_IsBrandedName()
     {
-        Assert.Equal("FlatRedBall Animation Editor", TitleBarHelper.AppName);
+        Assert.Equal("Animation Editor", TitleBarHelper.AppName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #354. Two changes:

### 1. Fix macOS title bar name
`Application.Name` was never set, so Avalonia fell back to "Avalonia Application". Now set to **"Animation Editor"** via `TitleBarHelper.AppName`.

### 2. Add File/Edit/View/Help to the macOS system menu bar
Registers an Avalonia `NativeMenu` from `App.axaml.cs` that mirrors the window title-bar menus. On macOS this populates the system menu bar (top-left); on Windows/Linux it is a no-op.

**Menus covered:**
- **File** — New, Open, Open Recent (last 5 files), Save, Save As
- **Edit** — Undo, Redo, Copy, Paste, Reload from Disk, Enable Hot Reload, Resize Texture
- **View** — Show History
- **Help** — About Animation Editor

**Keyboard shortcuts** in the system menu use the standard macOS ⌘ modifier (Cmd+N, Cmd+S, Cmd+Z, etc.).

## Implementation

- `NativeMenuActions.cs` — record of `Action` delegates for every menu item
- `RelayCommand.cs` — thin `ICommand` wrapper used by `NativeMenuItem.Command`
- `MainWindow.CreateNativeMenuActions()` — exposes window handlers without breaking encapsulation
- `App.RegisterNativeMenu(window)` — builds the `NativeMenu` tree and registers it

## Tests

- `TitleBarHelperTests.AppName_IsBrandedName` — verifies "Animation Editor"
- `RelayCommandTests` — verifies `Execute` dispatches and `CanExecute` is always true

**Untested wiring:** `NativeMenu.SetMenu(this, ...)` requires a live macOS Avalonia runtime; headless test builder uses a different App class. The wiring is a single call with no logic.