### PR TITLE
Fix copy/paste and undo/redo keyboard shortcuts on macOS

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2493,6 +2493,13 @@ public partial class MainWindow : Window
 
     // ── Keyboard wiring ───────────────────────────────────────────────────────
 
+    // Returns true when the platform command modifier is active.
+    // On macOS the Command key (⌘) maps to KeyModifiers.Meta; on Windows/Linux it is Control.
+    // Accepting both lets Ctrl+C/V/Z keep working in tests and on Windows/Linux while also
+    // handling Cmd+C/V/Z on macOS.
+    private static bool HasCommandModifier(KeyModifiers m)
+        => m.HasFlag(KeyModifiers.Control) || m.HasFlag(KeyModifiers.Meta);
+
     private void WireKeyboard()
     {
         // Use Tunnel routing so we intercept keys before child controls (e.g. the TreeView,
@@ -2502,13 +2509,13 @@ public partial class MainWindow : Window
         {
             if (e.Handled) return;
 
-            if (e.Key == Key.C && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            if (e.Key == Key.C && HasCommandModifier(e.KeyModifiers))
             {
                 if (IsTextInputFocused()) return;
                 e.Handled = true;
                 _ = HandleCopyAsync();
             }
-            else if (e.Key == Key.V && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            else if (e.Key == Key.V && HasCommandModifier(e.KeyModifiers))
             {
                 if (IsTextInputFocused()) return;
                 e.Handled = true;
@@ -2542,14 +2549,15 @@ public partial class MainWindow : Window
                 else
                     WireframeCtrl.ToggleDebugMode();
             }
-            else if (e.Key == Key.Z && e.KeyModifiers.HasFlag(KeyModifiers.Control) &&
+            else if (e.Key == Key.Z && HasCommandModifier(e.KeyModifiers) &&
                      !e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
                 _undoManager.Undo();
             }
-            else if ((e.Key == Key.Y && e.KeyModifiers.HasFlag(KeyModifiers.Control)) ||
-                     (e.Key == Key.Z && e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift)))
+            else if ((e.Key == Key.Y && HasCommandModifier(e.KeyModifiers)) ||
+                     (e.Key == Key.Z && (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) ||
+                                         e.KeyModifiers == (KeyModifiers.Meta    | KeyModifiers.Shift))))
             {
                 e.Handled = true;
                 _undoManager.Redo();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
@@ -1,5 +1,6 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
@@ -8,6 +9,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -123,6 +125,73 @@ public class CopyPasteFocusGateTests
 
             var clipboardText = await window.Clipboard!.TryGetTextAsync();
             Assert.Equal("plain text", clipboardText);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// macOS regression: Meta+V (Cmd+V) must trigger the paste handler just like
+    /// Ctrl+V does on Windows/Linux.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task MetaV_NonTextBoxFocused_PastesFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            var xml = ClipboardPayload.Serialize(
+                new List<AnimationFrameSave> { new() { TextureName = "run.png", FrameLength = 0.1f } });
+            await window.Clipboard!.SetTextAsync(xml);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            tree.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.V, RawInputModifiers.Meta, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(chain.Frames);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// macOS regression: Meta+C (Cmd+C) must copy the selected chain to the
+    /// clipboard, just like Ctrl+C does on Windows/Linux.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task MetaC_NonTextBoxFocused_CopiesChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Run" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            // Directly seed the tree and select the chain node, matching the pattern
+            // used by HeadlessTreeViewTests to avoid needing a full UI rebuild cycle.
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+            var chainVm = new TreeNodeVm { Header = "Run", Data = chain };
+            roots.Add(chainVm);
+            tree.SelectedItems!.Add(chainVm);
+            Dispatcher.UIThread.RunJobs();
+
+            // Seed the clipboard with plain text so we can detect when it changes.
+            await window.Clipboard!.SetTextAsync("unrelated");
+
+            tree.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.C, RawInputModifiers.Meta, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            var clipboardText = await window.Clipboard!.TryGetTextAsync();
+            Assert.NotEqual("unrelated", clipboardText);
+            Assert.False(string.IsNullOrWhiteSpace(clipboardText));
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
Fixes #353

## Root cause

`WireKeyboard()` in `MainWindow.axaml.cs` checked `KeyModifiers.Control` for every command shortcut (Ctrl+C/V/Z/Y). On macOS the ⌘ Command key maps to `KeyModifiers.Meta`, not `Control`, so all those shortcuts silently did nothing.

## Fix

Added a private static helper:

```csharp
private static bool HasCommandModifier(KeyModifiers m)
    => m.HasFlag(KeyModifiers.Control) || m.HasFlag(KeyModifiers.Meta);
```

Replaced all `HasFlag(KeyModifiers.Control)` in `WireKeyboard` with `HasCommandModifier`. Also extended the Ctrl+Shift+Z (redo) exact-equality check to also accept `Meta | Shift`.

This makes Ctrl+C/V/Z keep working on Windows/Linux while Cmd+C/V/Z now works on macOS.

## Tests

Added two new `[AvaloniaFact]` regression tests to `CopyPasteFocusGateTests`:
- `MetaV_NonTextBoxFocused_PastesFrame` — `RawInputModifiers.Meta + V` pastes a frame
- `MetaC_NonTextBoxFocused_CopiesChain` — `RawInputModifiers.Meta + C` copies a chain to clipboard

All 1540 tests pass.