### PR TITLE
Fix Animation Editor release chmod: binary renamed to AnimationEditor

### DIFF
--- a/.github/workflows/build-and-release-animation-editor.yml
+++ b/.github/workflows/build-and-release-animation-editor.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Mark binary executable (non-Windows)
         if: matrix.os != 'windows-latest'
-        run: chmod +x dist/publish/AnimationEditor.App
+        run: chmod +x dist/publish/AnimationEditor
 
       - name: Package (zip)
         if: matrix.archive == 'zip'


### PR DESCRIPTION
## Summary
- The Animation Editor assembly was renamed from `AnimationEditor.App` → `AnimationEditor` in 1c00ca2 (macOS Dock label fix), but `.github/workflows/build-and-release-animation-editor.yml` still ran `chmod +x dist/publish/AnimationEditor.App`, failing all three non-Windows matrix jobs (`linux-x64`, `osx-x64`, `osx-arm64`) on run [26365507308](https://github.com/vchelaru/FlatRedBall2/actions/runs/26365507308).
- Updates the chmod target to match the current binary name.

## Test plan
- [ ] Re-run the `Build and Release Animation Editor` workflow (test/draft kind) and confirm all four matrix jobs succeed
- [ ] Verify the published `AnimationEditor-linux-x64.tar.gz` and `AnimationEditor-osx-*.zip` artifacts contain an executable `AnimationEditor` binary