### PR TITLE
Fix: macOS window shows Windows-style chrome instead of native traffic lights

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -79,6 +79,10 @@ public partial class MainWindow : Window
         _thumbnailService = thumbnailService;
 
         InitializeComponent();
+
+        if (OperatingSystem.IsMacOS())
+            ApplyMacOSWindowChrome();
+
         InitToast();
         PropertyChanged += (_, e) => { if (e.Property == OffScreenMarginProperty) Padding = OffScreenMargin; };
         WireframeCtrl.AttachScrollViewer(WireframeScrollViewer);
@@ -696,6 +700,26 @@ public partial class MainWindow : Window
     }
 
     // ── Custom title bar ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Switches to native macOS window decorations (traffic-light buttons on the left)
+    /// and hides the custom title bar and resize grips, which are only needed on
+    /// Windows/Linux where <c>WindowDecorations="None"</c> is in effect.
+    /// macOS handles window resizing natively when <c>WindowDecorations.Full</c> is active.
+    /// </summary>
+    private void ApplyMacOSWindowChrome()
+    {
+        WindowDecorations = WindowDecorations.Full;
+        TitleBarBorder.IsVisible = false;
+        GripN.IsVisible  = false;
+        GripS.IsVisible  = false;
+        GripW.IsVisible  = false;
+        GripE.IsVisible  = false;
+        GripNW.IsVisible = false;
+        GripNE.IsVisible = false;
+        GripSW.IsVisible = false;
+        GripSE.IsVisible = false;
+    }
 
     private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
@@ -1,14 +1,19 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using System;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
 
 public class MainWindowChromeTests
 {
+    // ── Non-macOS: custom chrome ──────────────────────────────────────────────
+
     [AvaloniaFact]
-    public void MainWindow_RemovesOsTitleBar()
+    public void OnNonMacOS_WindowDecorations_IsNone()
     {
+        if (OperatingSystem.IsMacOS()) return; // macOS uses system decorations — tested separately
+
         var ctx = TestHelpers.BuildServices();
         var window = ctx.CreateMainWindow();
         window.Show();
@@ -50,6 +55,70 @@ public class MainWindowChromeTests
             Assert.NotNull(window.FindControl<Button>("MinimizeBtn"));
             Assert.NotNull(window.FindControl<Button>("MaximizeBtn"));
             Assert.NotNull(window.FindControl<Button>("CloseBtn"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // ── macOS: native traffic-light chrome ────────────────────────────────────
+
+    [AvaloniaFact]
+    public void OnMacOS_WindowDecorations_IsFull()
+    {
+        if (!OperatingSystem.IsMacOS()) return; // Windows/Linux use custom chrome — tested separately
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Assert.Equal(WindowDecorations.Full, window.WindowDecorations);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void OnMacOS_TitleBarBorder_IsHidden()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var titleBar = window.FindControl<Border>("TitleBarBorder");
+            Assert.NotNull(titleBar);
+            Assert.False(titleBar!.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void OnMacOS_ResizeGrips_AreHidden()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            string[] gripNames = ["GripN", "GripS", "GripW", "GripE", "GripNW", "GripNE", "GripSW", "GripSE"];
+            foreach (var name in gripNames)
+            {
+                var grip = window.FindControl<Border>(name);
+                Assert.NotNull(grip);
+                Assert.False(grip!.IsVisible, $"{name} should be hidden on macOS");
+            }
         }
         finally
         {


### PR DESCRIPTION
## Summary

Fixes #355.

On macOS the Animation Editor was showing custom minimize/maximize/close buttons on the **right** side (Windows-style) instead of the native macOS "traffic light" buttons on the **left**.

## Root cause

`WindowDecorations="None"` in `MainWindow.axaml` applies to all platforms. This is intentional for Windows/Linux (custom chrome), but on macOS it bypasses the native window chrome entirely.

## Fix

Added `ApplyMacOSWindowChrome()`, called from the `MainWindow` constructor after `InitializeComponent()` when `OperatingSystem.IsMacOS()` is true. It:

1. Sets `WindowDecorations = WindowDecorations.Full` — lets macOS render native traffic-light buttons (red/yellow/green) on the left.
2. Hides `TitleBarBorder` — the custom title bar is not needed on macOS; menus are already in the system menu bar via `NativeMenu`.
3. Hides all 8 resize grip overlays — macOS handles window resizing natively with system decorations.

No XAML changes were needed.

## Tests

- Renamed `MainWindow_RemovesOsTitleBar` → `OnNonMacOS_WindowDecorations_IsNone` (skips on macOS)
- Added `OnMacOS_WindowDecorations_IsFull`
- Added `OnMacOS_TitleBarBorder_IsHidden`
- Added `OnMacOS_ResizeGrips_AreHidden`

All 447 tests pass.