### PR TITLE
Animation Editor: multi-tab support for .achx files (#351)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -122,6 +122,14 @@ public partial class App : Application
 
     private static ICommand Cmd(Action action) => new RelayCommand(action);
 
+    internal static MainWindow CreateDetachedWindow()
+    {
+        var services = BuildServices();
+        var window = services.GetRequiredService<MainWindow>();
+        window.Icon = LoadAppIcon();
+        return window;
+    }
+
     private static ServiceProvider BuildServices()
     {
         var sc = new ServiceCollection();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -20,6 +20,12 @@ namespace AnimationEditor.App;
 
 public partial class App : Application
 {
+    /// <summary>
+    /// Set by <see cref="Program.Main"/> before Avalonia starts. Used to wire the
+    /// single-instance file-open pipe to the running <see cref="MainWindow"/>.
+    /// </summary>
+    internal static SingleInstanceServer? SingleInstance { get; set; }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -36,6 +42,13 @@ public partial class App : Application
             window.Icon = LoadAppIcon();
             desktop.MainWindow = window;
             RegisterNativeMenu(window);
+
+            // Wire single-instance IPC: file paths received from a second process open as tabs.
+            if (SingleInstance != null)
+            {
+                SingleInstance.FileOpenRequested += path =>
+                    Dispatcher.UIThread.InvokeAsync(() => window.OpenFileAsTab(path));
+            }
 
             // Post the Dock icon update to the next UI tick. Avalonia's macOS backend
             // may clear NSApplication.applicationIconImage during window assignment

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1177,6 +1177,7 @@
             </DockPanel>
         </Border>
         <!-- Resize grips — 4px edges + 8px corners, transparent overlays -->
+        <Canvas x:Name="DragOverlayCanvas" IsHitTestVisible="False" ZIndex="99" />
         <Border x:Name="GripN"  Height="4" VerticalAlignment="Top"    Background="Transparent" Cursor="TopSide"         PointerPressed="OnResizeGrip" />
         <Border x:Name="GripS"  Height="4" VerticalAlignment="Bottom" Background="Transparent" Cursor="BottomSide"      PointerPressed="OnResizeGrip" />
         <Border x:Name="GripW"  Width="4"  HorizontalAlignment="Left"  Background="Transparent" Cursor="LeftSide"        PointerPressed="OnResizeGrip" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -157,6 +157,21 @@
             </StackPanel>
             </Grid>
         </Border>
+        <!-- ── Tab bar: one tab per open .achx file ── -->
+        <Border x:Name="TabBarBorder"
+                DockPanel.Dock="Top"
+                Background="{StaticResource BgCanvas}"
+                BorderBrush="{StaticResource LineBrush}"
+                BorderThickness="0,0,0,1"
+                Height="30"
+                IsVisible="False">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Disabled">
+                <StackPanel x:Name="TabStrip"
+                            Orientation="Horizontal" />
+            </ScrollViewer>
+        </Border>
+
         <Border DockPanel.Dock="Bottom"
                 Background="{StaticResource BgRail}"
                 BorderBrush="{StaticResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -45,6 +45,11 @@ public partial class MainWindow : Window
 
     private AppSettingsModel _appSettings = new();
     private readonly TabManager _tabManager = new();
+
+    // ── Tab drag state ────────────────────────────────────────────────────────
+    private TabEntry? _dragTab;
+    private double _dragStartX;
+    private bool _isDragging;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
@@ -186,25 +191,80 @@ public partial class MainWindow : Window
             row.Children.Add(closeBtn);
             tabBorder.Child = row;
 
-            // Click on the tab label/body activates it
+            // Pointer handling: left-click activates, drag reorders, right-click shows context
+            // menu, middle-click closes.  Pointer capture is deferred until the drag threshold
+            // is exceeded so that the close button (✕) still receives its own Click event on
+            // short presses.
             tabBorder.PointerPressed += (_, args) =>
             {
-                if (args.GetCurrentPoint(tabBorder).Properties.IsLeftButtonPressed)
+                var pt = args.GetCurrentPoint(tabBorder);
+                if (pt.Properties.IsRightButtonPressed)
+                {
+                    var menu = new ContextMenu
+                    {
+                        Items =
+                        {
+                            new MenuItem
+                            {
+                                Header = "Detach to New Window",
+                                Command = new RelayCommand(() => DetachTab(captured)),
+                            },
+                            new MenuItem
+                            {
+                                Header = "Close Tab",
+                                Command = new RelayCommand(() => CloseTab(captured)),
+                            },
+                        },
+                    };
+                    menu.Open(tabBorder);
+                    args.Handled = true;
+                    return;
+                }
+
+                if (pt.Properties.IsLeftButtonPressed)
                 {
                     _ = ActivateTabAsync(captured);
+                    _dragTab = captured;
+                    _dragStartX = args.GetPosition(TabStrip).X;
+                    _isDragging = false;
                     args.Handled = true;
                 }
             };
 
-            // Middle-click closes the tab
+            tabBorder.PointerMoved += (_, args) =>
+            {
+                if (_dragTab != captured) return;
+                double x = args.GetPosition(TabStrip).X;
+                if (!_isDragging && Math.Abs(x - _dragStartX) > 4)
+                {
+                    _isDragging = true;
+                    args.Pointer.Capture(tabBorder);
+                    tabBorder.Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                }
+            };
+
             tabBorder.PointerReleased += (_, args) =>
             {
-                if (args.GetCurrentPoint(tabBorder).Properties.PointerUpdateKind ==
-                    PointerUpdateKind.MiddleButtonReleased)
+                var uk = args.GetCurrentPoint(tabBorder).Properties.PointerUpdateKind;
+
+                if (uk == PointerUpdateKind.MiddleButtonReleased)
                 {
                     CloseTab(captured);
                     args.Handled = true;
+                    return;
                 }
+
+                if (_dragTab == captured && _isDragging && uk == PointerUpdateKind.LeftButtonReleased)
+                {
+                    args.Pointer.Capture(null);
+                    tabBorder.Cursor = new Cursor(StandardCursorType.Hand);
+                    int targetIdx = ComputeTabIndexAt(args.GetPosition(TabStrip).X);
+                    _tabManager.Move(captured.Path, targetIdx);
+                    RebuildTabStrip();
+                }
+
+                _dragTab = null;
+                _isDragging = false;
             };
 
             TabStrip.Children.Add(tabBorder);
@@ -2426,7 +2486,14 @@ public partial class MainWindow : Window
 
         if (result == TabOpenResult.Focused)
         {
-            // File is already loaded in the editor — just rebuild the tab strip to highlight it.
+            // The tab is already registered and now active in TabManager, but the editor
+            // may still be displaying a different tab's content (e.g. user was on tab 1
+            // and re-opened tab 2's file via File > Open).  Load the file to ensure the
+            // panels and previews reflect the focused tab.
+            bool alreadyShown = string.Equals(_projectManager.FileName, fileName,
+                StringComparison.OrdinalIgnoreCase);
+            if (!alreadyShown && !string.IsNullOrEmpty(fileName))
+                await _appCommands.OpenAchxWorkflowAsync(fileName);
             RebuildTabStrip();
             return;
         }
@@ -2455,6 +2522,38 @@ public partial class MainWindow : Window
             // Unsaved new file with content — register an Untitled placeholder tab.
             _tabManager.RegisterBackground(new FilePath(null!), "Untitled");
         }
+    }
+
+    /// <summary>
+    /// Returns the tab index that corresponds to the given X coordinate (in the TabStrip
+    /// StackPanel's local coordinate space).  Finds the first tab whose centre is to the
+    /// right of <paramref name="xInTabStrip"/>; if none, returns the last tab index.
+    /// </summary>
+    private int ComputeTabIndexAt(double xInTabStrip)
+    {
+        var children = TabStrip.Children;
+        for (int i = 0; i < children.Count; i++)
+        {
+            var b = children[i].Bounds;
+            if (xInTabStrip < b.Left + b.Width / 2.0)
+                return i;
+        }
+        return Math.Max(0, children.Count - 1);
+    }
+
+    /// <summary>
+    /// Closes <paramref name="tab"/> in this window and opens it in a brand-new,
+    /// fully-independent <see cref="MainWindow"/> instance.
+    /// No-op for Untitled (unsaved) tabs — there is no file to move.
+    /// </summary>
+    private void DetachTab(TabEntry tab)
+    {
+        if (string.IsNullOrEmpty(tab.Path.Original)) return;
+        var filePath = tab.Path.FullPath;
+        CloseTab(tab);
+        var window = App.CreateDetachedWindow();
+        window.Show();
+        _ = window.OpenFileAsTab(filePath);
     }
 
     private void UpdateTitle()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -218,7 +218,21 @@ public partial class MainWindow : Window
         _tabManager.Activate(tab.Path);
         // Bypass LoadAnimationFileAsync so we don't hit the short-circuit that skips
         // the file load when the path is already the active tab.
-        await _appCommands.OpenAchxWorkflowAsync(tab.Path.FullPath);
+        if (string.IsNullOrEmpty(tab.Path.Original))
+        {
+            // Untitled tab — reset to a blank editor; there is no on-disk file to reload.
+            _projectManager.AnimationChainListSave = new AnimationChainListSave();
+            _projectManager.FileName = null;
+            _selectedState.Reset();
+            _undoManager.Clear();
+            RefreshTreeView();
+            UpdateTitle();
+            UpdateStatusBar();
+        }
+        else
+        {
+            await _appCommands.OpenAchxWorkflowAsync(tab.Path.FullPath);
+        }
         RebuildTabStrip();
     }
 
@@ -234,7 +248,13 @@ public partial class MainWindow : Window
         _tabManager.Close(tab.Path);
         var next = _tabManager.ActiveTab;
         if (next != null)
-            _ = LoadAnimationFileAsync(next.Path.FullPath);
+        {
+            // Use OpenAchxWorkflowAsync directly — bypasses EnsureCurrentEditorContentHasTab
+            // so the just-closed file is not accidentally re-registered as a background tab.
+            if (!string.IsNullOrEmpty(next.Path.Original))
+                _ = _appCommands.OpenAchxWorkflowAsync(next.Path.FullPath)
+                    .ContinueWith(_ => Dispatcher.UIThread.InvokeAsync(RebuildTabStrip));
+        }
         else
         {
             // All tabs closed — start fresh
@@ -266,11 +286,17 @@ public partial class MainWindow : Window
         if (valid.Count == 0) return;
 
         _tabManager.RestoreFrom(valid, _appSettings.ActiveTabPath);
+        RebuildTabStrip();
 
-        // Load the active tab's file into the editor
+        // Load the active tab's file directly — bypassing LoadAnimationFileAsync avoids
+        // the early-return in that method (OpenOrFocus would return Focused for a tab
+        // that RestoreFrom already registered, skipping the actual file load).
         var active = _tabManager.ActiveTab;
         if (active != null)
-            await LoadAnimationFileAsync(active.Path.FullPath);
+        {
+            await _appCommands.OpenAchxWorkflowAsync(active.Path.FullPath);
+            RebuildTabStrip();
+        }
     }
 
     // ── Startup ───────────────────────────────────────────────────────────────
@@ -2390,6 +2416,11 @@ public partial class MainWindow : Window
     {
         if (string.IsNullOrEmpty(fileName)) return;
 
+        // If there is already a file open that hasn't been registered as a tab yet,
+        // add it as a background tab so it appears as the first tab when the second
+        // file is opened.  This covers the common case of File > Open > Open.
+        EnsureCurrentEditorContentHasTab();
+
         var filePath = new FilePath(fileName);
         var result = _tabManager.OpenOrFocus(filePath);
 
@@ -2401,6 +2432,29 @@ public partial class MainWindow : Window
         }
 
         await _appCommands.OpenAchxWorkflowAsync(fileName);
+    }
+
+    /// <summary>
+    /// Registers the currently-loaded file (or an "Untitled" placeholder when the editor has
+    /// content but no saved path) as a background tab so it appears before the next file that
+    /// is about to be opened.
+    /// </summary>
+    private void EnsureCurrentEditorContentHasTab()
+    {
+        var currentPath = _projectManager.FileName;
+        if (!string.IsNullOrEmpty(currentPath))
+        {
+            // Saved file — add its tab if not already tracked.
+            var fp = new FilePath(currentPath);
+            if (_tabManager.Tabs.All(t => t.Path != fp))
+                _tabManager.RegisterBackground(fp);
+        }
+        else if (_tabManager.Tabs.Count == 0 &&
+                 _projectManager.AnimationChainListSave?.AnimationChains.Count > 0)
+        {
+            // Unsaved new file with content — register an Untitled placeholder tab.
+            _tabManager.RegisterBackground(new FilePath(null!), "Untitled");
+        }
     }
 
     private void UpdateTitle()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -50,6 +50,7 @@ public partial class MainWindow : Window
     private TabEntry? _dragTab;
     private double _dragStartX;
     private bool _isDragging;
+    private Border? _ghostBorder;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
@@ -244,7 +245,36 @@ public partial class MainWindow : Window
                 {
                     _isDragging = true;
                     tabBorder.Cursor = new Cursor(StandardCursorType.DragMove);
-                    tabBorder.Opacity = 0.65;
+                    tabBorder.Opacity = 0.4;
+
+                    // Create a floating ghost label that follows the pointer
+                    _ghostBorder = new Border
+                    {
+                        Background = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#3a4150")),
+                        BorderBrush = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#4a90d9")),
+                        BorderThickness = new Avalonia.Thickness(1),
+                        CornerRadius = new Avalonia.CornerRadius(3),
+                        Padding = new Avalonia.Thickness(10, 5),
+                        Opacity = 0.92,
+                        IsHitTestVisible = false,
+                        Child = new TextBlock
+                        {
+                            Text = captured.DisplayName,
+                            FontSize = 11,
+                            Foreground = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#d4d8de")),
+                        },
+                    };
+                    var initPos = args.GetPosition(DragOverlayCanvas);
+                    Canvas.SetLeft(_ghostBorder, initPos.X + 10);
+                    Canvas.SetTop(_ghostBorder, initPos.Y - 18);
+                    DragOverlayCanvas.Children.Add(_ghostBorder);
+                }
+
+                if (_isDragging && _ghostBorder != null)
+                {
+                    var pos = args.GetPosition(DragOverlayCanvas);
+                    Canvas.SetLeft(_ghostBorder, pos.X + 10);
+                    Canvas.SetTop(_ghostBorder, pos.Y - 18);
                 }
             };
 
@@ -265,6 +295,13 @@ public partial class MainWindow : Window
                 args.Pointer.Capture(null);
                 tabBorder.Cursor = new Cursor(StandardCursorType.Hand);
                 tabBorder.Opacity = 1.0;
+
+                // Remove ghost overlay
+                if (_ghostBorder != null)
+                {
+                    DragOverlayCanvas.Children.Remove(_ghostBorder);
+                    _ghostBorder = null;
+                }
 
                 if (_isDragging)
                 {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -480,6 +480,14 @@ public partial class MainWindow : Window
             RefreshRecentFiles();
             UpdateTitle();
             UpdateStatusBar();
+
+            // If the active tab was an Untitled sentinel, promote it to the real file path.
+            var active = _tabManager.ActiveTab;
+            if (active != null && IsUntitledTab(active))
+            {
+                _tabManager.Rename(active.Path, new FilePath(path));
+                RebuildTabStrip();
+            }
         });
         _events.AvailableTexturesChanged += () => Dispatcher.UIThread.InvokeAsync(RefreshTextureCombo);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -51,6 +51,7 @@ public partial class MainWindow : Window
     private double _dragStartX;
     private bool _isDragging;
     private Border? _ghostBorder;
+    private int _untitledCounter;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
@@ -329,7 +330,7 @@ public partial class MainWindow : Window
         _tabManager.Activate(tab.Path);
         // Bypass LoadAnimationFileAsync so we don't hit the short-circuit that skips
         // the file load when the path is already the active tab.
-        if (string.IsNullOrEmpty(tab.Path.Original))
+        if (IsUntitledTab(tab))
         {
             // Untitled tab — reset to a blank editor; there is no on-disk file to reload.
             _projectManager.AnimationChainListSave = new AnimationChainListSave();
@@ -362,9 +363,21 @@ public partial class MainWindow : Window
         {
             // Use OpenAchxWorkflowAsync directly — bypasses EnsureCurrentEditorContentHasTab
             // so the just-closed file is not accidentally re-registered as a background tab.
-            if (!string.IsNullOrEmpty(next.Path.Original))
+            if (!IsUntitledTab(next))
                 _ = _appCommands.OpenAchxWorkflowAsync(next.Path.FullPath)
                     .ContinueWith(_ => Dispatcher.UIThread.InvokeAsync(RebuildTabStrip));
+            else
+            {
+                // Switching to an Untitled tab — reset to a blank editor.
+                _projectManager.AnimationChainListSave = new AnimationChainListSave();
+                _projectManager.FileName = null;
+                _selectedState.Reset();
+                _undoManager.Clear();
+                RefreshTreeView();
+                UpdateTitle();
+                UpdateStatusBar();
+                RebuildTabStrip();
+            }
         }
         else
         {
@@ -381,8 +394,13 @@ public partial class MainWindow : Window
 
     private void SaveTabsToSettings()
     {
-        _appSettings.OpenTabPaths = _tabManager.OpenTabPaths.ToList();
-        _appSettings.ActiveTabPath = _tabManager.ActiveTab?.Path.FullPath;
+        // Exclude unsaved (sentinel) Untitled tabs — they have no on-disk path to restore.
+        _appSettings.OpenTabPaths = _tabManager.OpenTabPaths
+            .Where(p => !IsUntitledSentinel(p))
+            .ToList();
+        _appSettings.ActiveTabPath = IsUntitledTab(_tabManager.ActiveTab)
+            ? null
+            : _tabManager.ActiveTab?.Path.FullPath;
         SaveSettingsFile();
     }
 
@@ -1158,11 +1176,22 @@ public partial class MainWindow : Window
 
     private void OnNewClick(object? sender, RoutedEventArgs e)
     {
+        // Register the currently-open file (if any) as a tab before we clear it.
+        EnsureCurrentEditorContentHasTab();
+
         _projectManager.AnimationChainListSave = new AnimationChainListSave();
         _projectManager.FileName = null;
         _selectedState.Reset();
         _undoManager.Clear();
         RefreshTreeView();
+
+        // Open a new numbered Untitled tab and activate it.
+        var displayName = TabManager.ComputeUntitledDisplayName(
+            _tabManager.Tabs.Select(t => t.DisplayName).ToList());
+        var sentinelPath = new FilePath(NewUntitledSentinelPath());
+        _tabManager.OpenOrFocus(sentinelPath, displayName);
+        RebuildTabStrip();
+
         _ = _appCommands.SaveCurrentAnimationChainListAsync();
     }
 
@@ -2570,8 +2599,10 @@ public partial class MainWindow : Window
         else if (_tabManager.Tabs.Count == 0 &&
                  _projectManager.AnimationChainListSave?.AnimationChains.Count > 0)
         {
-            // Unsaved new file with content — register an Untitled placeholder tab.
-            _tabManager.RegisterBackground(new FilePath(null!), "Untitled");
+            // Unsaved new file with content — register a numbered Untitled placeholder tab.
+            var displayName = TabManager.ComputeUntitledDisplayName(
+                _tabManager.Tabs.Select(t => t.DisplayName).ToList());
+            _tabManager.RegisterBackground(new FilePath(NewUntitledSentinelPath()), displayName);
         }
     }
 
@@ -2592,6 +2623,20 @@ public partial class MainWindow : Window
         return Math.Max(0, children.Count - 1);
     }
 
+    // Sentinel paths use the prefix "__untitled__:" so they are distinguishable from real
+    // on-disk paths and are unique per new-file action within this window session.
+    private const string UntitledSentinelPrefix = "__untitled__:";
+
+    private static bool IsUntitledSentinel(string? path) =>
+        path?.StartsWith(UntitledSentinelPrefix, StringComparison.Ordinal) == true;
+
+    private static bool IsUntitledTab(TabEntry? tab) =>
+        tab != null &&
+        (string.IsNullOrEmpty(tab.Path.Original) || IsUntitledSentinel(tab.Path.Original));
+
+    private string NewUntitledSentinelPath() =>
+        $"{UntitledSentinelPrefix}{++_untitledCounter}";
+
     /// <summary>
     /// Closes <paramref name="tab"/> in this window and opens it in a brand-new,
     /// fully-independent <see cref="MainWindow"/> instance.
@@ -2599,7 +2644,7 @@ public partial class MainWindow : Window
     /// </summary>
     private void DetachTab(TabEntry tab)
     {
-        if (string.IsNullOrEmpty(tab.Path.Original)) return;
+        if (IsUntitledTab(tab)) return;
         var filePath = tab.Path.FullPath;
         CloseTab(tab);
         var window = App.CreateDetachedWindow();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -132,7 +132,7 @@ public partial class MainWindow : Window
         TabStrip.Children.Clear();
 
         var tabs = _tabManager.Tabs;
-        TabBarBorder.IsVisible = tabs.Count > 0;
+        TabBarBorder.IsVisible = tabs.Count > 1;
 
         foreach (var tab in tabs)
         {
@@ -191,10 +191,10 @@ public partial class MainWindow : Window
             row.Children.Add(closeBtn);
             tabBorder.Child = row;
 
-            // Pointer handling: left-click activates, drag reorders, right-click shows context
-            // menu, middle-click closes.  Pointer capture is deferred until the drag threshold
-            // is exceeded so that the close button (✕) still receives its own Click event on
-            // short presses.
+            // Pointer handling: immediate pointer-capture on press (so PointerMoved fires even
+            // when the cursor moves over other tabs).  Activation is deferred to PointerReleased
+            // so that RebuildTabStrip is never called while a drag is in-flight.
+            // Close-button presses are excluded from capture by checking args.Source.
             tabBorder.PointerPressed += (_, args) =>
             {
                 var pt = args.GetCurrentPoint(tabBorder);
@@ -223,7 +223,12 @@ public partial class MainWindow : Window
 
                 if (pt.Properties.IsLeftButtonPressed)
                 {
-                    _ = ActivateTabAsync(captured);
+                    // Skip close-button presses so Button.Click still fires normally.
+                    if (args.Source is Button) return;
+
+                    // Capture immediately so PointerMoved always arrives here even when the
+                    // cursor moves across other tabs.  Activation happens on release.
+                    args.Pointer.Capture(tabBorder);
                     _dragTab = captured;
                     _dragStartX = args.GetPosition(TabStrip).X;
                     _isDragging = false;
@@ -235,11 +240,11 @@ public partial class MainWindow : Window
             {
                 if (_dragTab != captured) return;
                 double x = args.GetPosition(TabStrip).X;
-                if (!_isDragging && Math.Abs(x - _dragStartX) > 4)
+                if (!_isDragging && Math.Abs(x - _dragStartX) > 5)
                 {
                     _isDragging = true;
-                    args.Pointer.Capture(tabBorder);
-                    tabBorder.Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                    tabBorder.Cursor = new Cursor(StandardCursorType.DragMove);
+                    tabBorder.Opacity = 0.65;
                 }
             };
 
@@ -254,13 +259,22 @@ public partial class MainWindow : Window
                     return;
                 }
 
-                if (_dragTab == captured && _isDragging && uk == PointerUpdateKind.LeftButtonReleased)
+                if (_dragTab != captured || uk != PointerUpdateKind.LeftButtonReleased)
+                    return;
+
+                args.Pointer.Capture(null);
+                tabBorder.Cursor = new Cursor(StandardCursorType.Hand);
+                tabBorder.Opacity = 1.0;
+
+                if (_isDragging)
                 {
-                    args.Pointer.Capture(null);
-                    tabBorder.Cursor = new Cursor(StandardCursorType.Hand);
                     int targetIdx = ComputeTabIndexAt(args.GetPosition(TabStrip).X);
                     _tabManager.Move(captured.Path, targetIdx);
                     RebuildTabStrip();
+                }
+                else
+                {
+                    _ = ActivateTabAsync(captured);
                 }
 
                 _dragTab = null;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -44,6 +44,7 @@ public partial class MainWindow : Window
     private readonly Services.ThumbnailService _thumbnailService;
 
     private AppSettingsModel _appSettings = new();
+    private readonly TabManager _tabManager = new();
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
@@ -97,6 +98,7 @@ public partial class MainWindow : Window
         WirePropertyPanel();
         WirePlaybackControls();
         WireKeyboard();
+        WireTabBar();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService);
@@ -104,12 +106,171 @@ public partial class MainWindow : Window
         Opened += OnOpened;
         Closed += (_, _) =>
         {
+            SaveTabsToSettings();
             _appCommands.HotReloadWatcher.Dispose();
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
             foreach (var vm in _timelineFrames)
                 (vm.Thumbnail as IDisposable)?.Dispose();
             DisposeTreeThumbnails();
         };
+    }
+
+    // ── Tab bar ───────────────────────────────────────────────────────────────
+
+    private void WireTabBar()
+    {
+        _tabManager.ActiveChanged += _ => Dispatcher.UIThread.InvokeAsync(RebuildTabStrip);
+    }
+
+    private void RebuildTabStrip()
+    {
+        TabStrip.Children.Clear();
+
+        var tabs = _tabManager.Tabs;
+        TabBarBorder.IsVisible = tabs.Count > 0;
+
+        foreach (var tab in tabs)
+        {
+            bool isActive = tab == _tabManager.ActiveTab;
+            var captured = tab;
+
+            // Tab container
+            var tabBorder = new Border
+            {
+                Background = isActive
+                    ? new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#2f3641"))
+                    : Avalonia.Media.Brushes.Transparent,
+                BorderBrush = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#2a2e36")),
+                BorderThickness = new Avalonia.Thickness(0, 0, 1, 0),
+                Padding = new Avalonia.Thickness(0),
+                Cursor = new Cursor(StandardCursorType.Hand),
+            };
+
+            ToolTip.SetTip(tabBorder, tab.Path.FullPath);
+
+            var row = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+                Margin = new Avalonia.Thickness(8, 0, 0, 0),
+            };
+
+            var label = new TextBlock
+            {
+                Text = tab.DisplayName,
+                FontSize = 11,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                Foreground = isActive
+                    ? new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#d4d8de"))
+                    : new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#9098a4")),
+            };
+            Grid.SetColumn(label, 0);
+
+            var closeBtn = new Button
+            {
+                Content = "✕",
+                FontSize = 9,
+                Width = 20,
+                Height = 20,
+                Padding = new Avalonia.Thickness(0),
+                Background = Avalonia.Media.Brushes.Transparent,
+                BorderThickness = new Avalonia.Thickness(0),
+                Foreground = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.Parse("#9098a4")),
+                HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+                VerticalContentAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                Margin = new Avalonia.Thickness(2, 0, 2, 0),
+            };
+            Grid.SetColumn(closeBtn, 1);
+            closeBtn.Click += (_, _) => CloseTab(captured);
+
+            row.Children.Add(label);
+            row.Children.Add(closeBtn);
+            tabBorder.Child = row;
+
+            // Click on the tab label/body activates it
+            tabBorder.PointerPressed += (_, args) =>
+            {
+                if (args.GetCurrentPoint(tabBorder).Properties.IsLeftButtonPressed)
+                {
+                    _ = ActivateTabAsync(captured);
+                    args.Handled = true;
+                }
+            };
+
+            // Middle-click closes the tab
+            tabBorder.PointerReleased += (_, args) =>
+            {
+                if (args.GetCurrentPoint(tabBorder).Properties.PointerUpdateKind ==
+                    PointerUpdateKind.MiddleButtonReleased)
+                {
+                    CloseTab(captured);
+                    args.Handled = true;
+                }
+            };
+
+            TabStrip.Children.Add(tabBorder);
+        }
+    }
+
+    private async Task ActivateTabAsync(TabEntry tab)
+    {
+        if (tab == _tabManager.ActiveTab) return;
+        SaveCompanionFile();
+        _tabManager.Activate(tab.Path);
+        // Bypass LoadAnimationFileAsync so we don't hit the short-circuit that skips
+        // the file load when the path is already the active tab.
+        await _appCommands.OpenAchxWorkflowAsync(tab.Path.FullPath);
+        RebuildTabStrip();
+    }
+
+    /// <summary>
+    /// Opens <paramref name="filePath"/> as a new tab (or focuses it if already open).
+    /// Called from <see cref="App"/> when the single-instance server receives a path from
+    /// a second process.
+    /// </summary>
+    public async Task OpenFileAsTab(string filePath) => await LoadAnimationFileAsync(filePath);
+
+    private void CloseTab(TabEntry tab)
+    {
+        _tabManager.Close(tab.Path);
+        var next = _tabManager.ActiveTab;
+        if (next != null)
+            _ = LoadAnimationFileAsync(next.Path.FullPath);
+        else
+        {
+            // All tabs closed — start fresh
+            _projectManager.AnimationChainListSave = new AnimationChainListSave();
+            _projectManager.FileName = null;
+            _selectedState.Reset();
+            _undoManager.Clear();
+            RefreshTreeView();
+            UpdateTitle();
+            UpdateStatusBar();
+        }
+    }
+
+    private void SaveTabsToSettings()
+    {
+        _appSettings.OpenTabPaths = _tabManager.OpenTabPaths.ToList();
+        _appSettings.ActiveTabPath = _tabManager.ActiveTab?.Path.FullPath;
+        SaveSettingsFile();
+    }
+
+    private async Task RestoreTabsAsync()
+    {
+        if (_appSettings.OpenTabPaths.Count == 0) return;
+
+        // Filter to paths that still exist on disk
+        var valid = _appSettings.OpenTabPaths
+            .Where(p => File.Exists(p))
+            .ToList();
+        if (valid.Count == 0) return;
+
+        _tabManager.RestoreFrom(valid, _appSettings.ActiveTabPath);
+
+        // Load the active tab's file into the editor
+        var active = _tabManager.ActiveTab;
+        if (active != null)
+            await LoadAnimationFileAsync(active.Path.FullPath);
     }
 
     // ── Startup ───────────────────────────────────────────────────────────────
@@ -120,6 +281,10 @@ public partial class MainWindow : Window
         if (args.Length >= 2 && File.Exists(args[1]))
         {
             _ = LoadAnimationFileAsync(args[1]);
+        }
+        else if (_appSettings.OpenTabPaths.Count > 0)
+        {
+            _ = RestoreTabsAsync();
         }
         else
         {
@@ -2223,8 +2388,19 @@ public partial class MainWindow : Window
 
     private async Task LoadAnimationFileAsync(string fileName)
     {
-        if (!string.IsNullOrEmpty(fileName))
-            await _appCommands.OpenAchxWorkflowAsync(fileName);
+        if (string.IsNullOrEmpty(fileName)) return;
+
+        var filePath = new FilePath(fileName);
+        var result = _tabManager.OpenOrFocus(filePath);
+
+        if (result == TabOpenResult.Focused)
+        {
+            // File is already loaded in the editor — just rebuild the tab strip to highlight it.
+            RebuildTabStrip();
+            return;
+        }
+
+        await _appCommands.OpenAchxWorkflowAsync(fileName);
     }
 
     private void UpdateTitle()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia;
+﻿using AnimationEditor.App.Services;
+using Avalonia;
 using System;
+using System.IO;
 
 namespace AnimationEditor.App;
 
@@ -11,11 +13,30 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        string? fileArg = args.Length >= 1 && File.Exists(args[0]) ? args[0] : null;
+
+        var singleInstance = new SingleInstanceServer();
+        if (!singleInstance.IsOwner)
+        {
+            // Another instance is running — forward the file path and exit.
+            if (fileArg != null)
+                SingleInstanceServer.SendToRunningInstanceAsync(fileArg).GetAwaiter().GetResult();
+            singleInstance.Dispose();
+            return;
+        }
+
+        // We are the primary instance. Start the pipe listener before Avalonia so requests
+        // that arrive during startup are queued in the server.
+        singleInstance.StartListening();
+
         // Set the Dock label BEFORE Avalonia calls [NSApplication sharedApplication]
         // (inside UsePlatformDetect). The Dock caches the process name at that point;
         // calling setProcessName: afterwards has no visible effect on the Dock label.
         MacOSDockIcon.SetProcessName("Animation Editor");
+        App.SingleInstance = singleInstance;
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+        singleInstance.Dispose();
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceServer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceServer.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Implements single-instance enforcement using a named <see cref="Mutex"/> and a named pipe.
+///
+/// <para>The first process to acquire the mutex starts a background pipe server. Subsequent
+/// processes find the mutex held, write their command-line argument (the .achx path) to the
+/// pipe, and exit immediately.</para>
+///
+/// <para>The running instance reads the path from the pipe and raises
+/// <see cref="FileOpenRequested"/> so the UI layer can open it as a new tab.</para>
+/// </summary>
+public sealed class SingleInstanceServer : IDisposable
+{
+    private const string MutexName   = "AnimationEditorAvalonia_SingleInstance";
+    private const string PipeName    = "AnimationEditorAvalonia_IPC";
+
+    private readonly Mutex _mutex;
+    private CancellationTokenSource? _cts;
+    private Task? _listenerTask;
+
+    /// <summary>
+    /// Whether this process successfully claimed the single-instance mutex.
+    /// When <c>false</c> the caller should send the file path to the running
+    /// instance via <see cref="SendToRunningInstanceAsync"/> and then exit.
+    /// </summary>
+    public bool IsOwner { get; }
+
+    /// <summary>
+    /// Raised on a background thread when the running instance receives a file
+    /// path from a second process. The UI layer must marshal to the UI thread.
+    /// </summary>
+    public event Action<string>? FileOpenRequested;
+
+    public SingleInstanceServer()
+    {
+        _mutex = new Mutex(initiallyOwned: true, name: MutexName, out bool createdNew);
+        IsOwner = createdNew;
+    }
+
+    /// <summary>
+    /// Starts the background pipe listener. Must only be called when <see cref="IsOwner"/> is <c>true</c>.
+    /// </summary>
+    public void StartListening()
+    {
+        if (!IsOwner) return;
+        _cts = new CancellationTokenSource();
+        _listenerTask = Task.Run(() => ListenLoopAsync(_cts.Token));
+    }
+
+    private async Task ListenLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var server = new NamedPipeServerStream(
+                    PipeName,
+                    PipeDirection.In,
+                    maxNumberOfServerInstances: 1,
+                    transmissionMode: PipeTransmissionMode.Byte,
+                    options: PipeOptions.Asynchronous);
+
+                await server.WaitForConnectionAsync(ct);
+
+                using var reader = new StreamReader(server);
+                var path = await reader.ReadLineAsync(ct);
+                if (!string.IsNullOrEmpty(path))
+                    FileOpenRequested?.Invoke(path);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // Connection errors on the listener side are transient — keep listening.
+                await Task.Delay(200, CancellationToken.None);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="filePath"/> to the running instance via the named pipe.
+    /// Called by the second process before it exits.
+    /// </summary>
+    public static async Task SendToRunningInstanceAsync(string filePath)
+    {
+        try
+        {
+            using var client = new NamedPipeClientStream(
+                ".", PipeName, PipeDirection.Out, PipeOptions.Asynchronous);
+
+            // 2-second timeout — if the server isn't listening yet, give up gracefully.
+            await client.ConnectAsync(2000);
+
+            using var writer = new StreamWriter(client) { AutoFlush = true };
+            await writer.WriteLineAsync(filePath);
+        }
+        catch
+        {
+            // Could not reach the running instance — silently ignore.
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _mutex.ReleaseMutex();
+        _mutex.Dispose();
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -8,6 +8,18 @@ namespace AnimationEditor.Core.Models
     {
         public List<string> RecentFiles { get; set; } = new List<string>();
 
+        /// <summary>
+        /// The full paths of all tabs that were open when the editor last closed.
+        /// Restored on next launch so the user picks up where they left off.
+        /// </summary>
+        public List<string> OpenTabPaths { get; set; } = new List<string>();
+
+        /// <summary>
+        /// The full path of the tab that was active when the editor last closed.
+        /// Used together with <see cref="OpenTabPaths"/> to restore the active tab on launch.
+        /// </summary>
+        public string? ActiveTabPath { get; set; }
+
         public void AddFile(FilePath filePath)
         {
             RecentFiles.RemoveAll(item => new FilePath(item) == filePath);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
@@ -9,15 +9,28 @@ namespace AnimationEditor.Core.Models
     /// </summary>
     public sealed class TabEntry
     {
-        public TabEntry(FilePath path)
+        /// <param name="path">The absolute path of the <c>.achx</c> file. Pass an empty <see cref="FilePath"/> for an unsaved file.</param>
+        /// <param name="displayNameOverride">
+        /// When set, overrides the tab label. Use <c>"Untitled"</c> for unsaved files
+        /// that have no on-disk path yet.
+        /// </param>
+        public TabEntry(FilePath path, string? displayNameOverride = null)
         {
             Path = path;
+            _displayNameOverride = displayNameOverride;
         }
+
+        private readonly string? _displayNameOverride;
 
         /// <summary>The absolute path of the <c>.achx</c> file this tab represents.</summary>
         public FilePath Path { get; }
 
-        /// <summary>The filename without directory, used as the tab label.</summary>
-        public string DisplayName => Path.NoPath;
+        /// <summary>
+        /// The tab label. Returns <see cref="_displayNameOverride"/> when set;
+        /// otherwise the filename without directory.
+        /// </summary>
+        public string DisplayName =>
+            _displayNameOverride
+            ?? (string.IsNullOrEmpty(Path.Original) ? "Untitled" : Path.NoPath);
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
@@ -1,0 +1,23 @@
+using AnimationEditor.Core.Paths;
+
+namespace AnimationEditor.Core.Models
+{
+    /// <summary>
+    /// Represents a single open tab in the Animation Editor.
+    /// View state (zoom, pan, grid) is persisted separately in each file's companion
+    /// <c>.aeproperties</c> file and restored automatically on load.
+    /// </summary>
+    public sealed class TabEntry
+    {
+        public TabEntry(FilePath path)
+        {
+            Path = path;
+        }
+
+        /// <summary>The absolute path of the <c>.achx</c> file this tab represents.</summary>
+        public FilePath Path { get; }
+
+        /// <summary>The filename without directory, used as the tab label.</summary>
+        public string DisplayName => Path.NoPath;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -170,6 +170,24 @@ namespace AnimationEditor.Core.Models
             _tabs.Insert(target, tab);
         }
 
+        /// <summary>
+        /// Replaces the tab for <paramref name="oldPath"/> with a new entry at the same
+        /// position using <paramref name="newPath"/>. If the tab was active it remains so.
+        /// No-op if <paramref name="oldPath"/> is not tracked.
+        /// Does not raise <see cref="ActiveChanged"/> (the active tab identity may have changed
+        /// but the user experience is a simple rename — callers should rebuild the strip).
+        /// </summary>
+        public void Rename(FilePath oldPath, FilePath newPath)
+        {
+            var tab = FindTab(oldPath);
+            if (tab == null) return;
+            int idx = _tabs.IndexOf(tab);
+            var replacement = new TabEntry(newPath);
+            _tabs[idx] = replacement;
+            if (ActiveTab == tab)
+                ActiveTab = replacement;
+        }
+
         // ── Private helpers ───────────────────────────────────────────────────
 
         private TabEntry? FindTab(FilePath path) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -34,24 +34,49 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public event Action<TabEntry?>? ActiveChanged;
 
-        /// <summary>
-        /// Opens <paramref name="path"/> as a new tab, or focuses its existing tab if it is
-        /// already open. The <see cref="ActiveTab"/> is updated in either case.
-        /// </summary>
-        public TabOpenResult OpenOrFocus(FilePath path)
+    /// <summary>
+    /// Opens <paramref name="path"/> as a new tab with an optional display-name override,
+    /// or focuses its existing tab if it is already open.
+    /// </summary>
+    public TabOpenResult OpenOrFocus(FilePath path, string? displayNameOverride)
+    {
+        var existing = FindTab(path);
+        if (existing != null)
         {
-            var existing = FindTab(path);
-            if (existing != null)
-            {
-                SetActive(existing);
-                return TabOpenResult.Focused;
-            }
-
-            var entry = new TabEntry(path);
-            _tabs.Add(entry);
-            SetActive(entry);
-            return TabOpenResult.Opened;
+            SetActive(existing);
+            return TabOpenResult.Focused;
         }
+
+        var entry = new TabEntry(path, displayNameOverride);
+        _tabs.Add(entry);
+        SetActive(entry);
+        return TabOpenResult.Opened;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="path"/> as a new tab, or focuses its existing tab if it is
+    /// already open. The <see cref="ActiveTab"/> is updated in either case.
+    /// </summary>
+    public TabOpenResult OpenOrFocus(FilePath path) => OpenOrFocus(path, null);
+
+    /// <summary>
+    /// Computes the next unique "Untitled" display name given the set of names already in
+    /// use.  Returns <c>"Untitled"</c> if available, then <c>"Untitled (1)"</c>,
+    /// <c>"Untitled (2)"</c>, etc.
+    /// </summary>
+    public static string ComputeUntitledDisplayName(IReadOnlyList<string> existingDisplayNames)
+    {
+        const string baseName = "Untitled";
+        if (!existingDisplayNames.Contains(baseName))
+            return baseName;
+        for (int i = 1; ; i++)
+        {
+            var candidate = $"{baseName} ({i})";
+            if (!existingDisplayNames.Contains(candidate))
+                return candidate;
+        }
+    }
+
 
         /// <summary>
         /// Activates the tab for <paramref name="path"/>. No-op if the path is not open.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -129,6 +129,22 @@ namespace AnimationEditor.Core.Models
             _tabs.Insert(0, new TabEntry(path, displayNameOverride));
         }
 
+        /// <summary>
+        /// Moves the tab for <paramref name="path"/> to <paramref name="newIndex"/>, clamped
+        /// to [0, Count-1]. No-op if <paramref name="path"/> is not tracked or is already at
+        /// the target index. Does not change <see cref="ActiveTab"/>.
+        /// </summary>
+        public void Move(FilePath path, int newIndex)
+        {
+            var tab = FindTab(path);
+            if (tab == null) return;
+            int current = _tabs.IndexOf(tab);
+            int target = Math.Clamp(newIndex, 0, _tabs.Count - 1);
+            if (current == target) return;
+            _tabs.RemoveAt(current);
+            _tabs.Insert(target, tab);
+        }
+
         // ── Private helpers ───────────────────────────────────────────────────
 
         private TabEntry? FindTab(FilePath path) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -114,6 +114,23 @@ namespace AnimationEditor.Core.Models
 
         // ── Private helpers ───────────────────────────────────────────────────
 
+        /// <summary>
+        /// Adds <paramref name="path"/> as a tab at position 0 without making it active
+        /// and without raising <see cref="ActiveChanged"/>. Intended for preserving the
+        /// currently open file as the first tab before a different file is opened.
+        /// Does nothing if <paramref name="path"/> is already tracked.
+        /// </summary>
+        /// <param name="displayNameOverride">
+        /// Tab label override — use <c>"Untitled"</c> for unsaved files with no on-disk path.
+        /// </param>
+        public void RegisterBackground(FilePath path, string? displayNameOverride = null)
+        {
+            if (FindTab(path) != null) return;
+            _tabs.Insert(0, new TabEntry(path, displayNameOverride));
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────────
+
         private TabEntry? FindTab(FilePath path) =>
             _tabs.FirstOrDefault(t => t.Path == path);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -1,0 +1,126 @@
+using AnimationEditor.Core.Paths;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.Models
+{
+    /// <summary>
+    /// Manages the set of open tabs in the Animation Editor.
+    /// Each tab corresponds to one open <c>.achx</c> file.
+    /// Per-tab view state (zoom, pan, grid) is persisted separately in each
+    /// file's companion <c>.aeproperties</c> file and therefore lives outside this class.
+    /// </summary>
+    public class TabManager
+    {
+        private readonly List<TabEntry> _tabs = new();
+
+        /// <summary>All open tabs, in the order they were opened.</summary>
+        public IReadOnlyList<TabEntry> Tabs => _tabs;
+
+        /// <summary>The currently active tab, or <c>null</c> when no files are open.</summary>
+        public TabEntry? ActiveTab { get; private set; }
+
+        /// <summary>
+        /// The full paths of all open tabs, in order. Suitable for serialisation into
+        /// <see cref="AnimationEditor.Core.Models.AppSettingsModel.OpenTabPaths"/>.
+        /// </summary>
+        public IReadOnlyList<string> OpenTabPaths =>
+            _tabs.Select(t => t.Path.FullPath).ToArray();
+
+        /// <summary>
+        /// Raised whenever <see cref="ActiveTab"/> changes.
+        /// The argument is the new active tab (may be <c>null</c> when all tabs are closed).
+        /// </summary>
+        public event Action<TabEntry?>? ActiveChanged;
+
+        /// <summary>
+        /// Opens <paramref name="path"/> as a new tab, or focuses its existing tab if it is
+        /// already open. The <see cref="ActiveTab"/> is updated in either case.
+        /// </summary>
+        public TabOpenResult OpenOrFocus(FilePath path)
+        {
+            var existing = FindTab(path);
+            if (existing != null)
+            {
+                SetActive(existing);
+                return TabOpenResult.Focused;
+            }
+
+            var entry = new TabEntry(path);
+            _tabs.Add(entry);
+            SetActive(entry);
+            return TabOpenResult.Opened;
+        }
+
+        /// <summary>
+        /// Activates the tab for <paramref name="path"/>. No-op if the path is not open.
+        /// </summary>
+        public void Activate(FilePath path)
+        {
+            var tab = FindTab(path);
+            if (tab != null)
+                SetActive(tab);
+        }
+
+        /// <summary>
+        /// Closes the tab for <paramref name="path"/>. No-op if the path is not open.
+        /// When the active tab is closed, the next tab is activated; if none follows,
+        /// the previous tab is activated; if none remain, <see cref="ActiveTab"/> becomes <c>null</c>.
+        /// </summary>
+        public void Close(FilePath path)
+        {
+            var tab = FindTab(path);
+            if (tab == null) return;
+
+            int idx = _tabs.IndexOf(tab);
+            _tabs.RemoveAt(idx);
+
+            if (tab != ActiveTab)
+                return; // no active-tab change needed
+
+            if (_tabs.Count == 0)
+            {
+                SetActive(null);
+                return;
+            }
+
+            // Prefer the tab that moved into this slot; fall back to the one before.
+            int nextIdx = Math.Min(idx, _tabs.Count - 1);
+            SetActive(_tabs[nextIdx]);
+        }
+
+        /// <summary>
+        /// Replaces the current tab list with entries rebuilt from <paramref name="paths"/>.
+        /// The tab whose path equals <paramref name="activePath"/> (if any) becomes active;
+        /// otherwise the first tab is active. If <paramref name="paths"/> is empty, all tabs
+        /// are cleared and <see cref="ActiveTab"/> is set to <c>null</c>.
+        /// </summary>
+        public void RestoreFrom(IReadOnlyList<string> paths, string? activePath)
+        {
+            _tabs.Clear();
+            foreach (var p in paths)
+                _tabs.Add(new TabEntry(new FilePath(p)));
+
+            if (_tabs.Count == 0)
+            {
+                SetActive(null);
+                return;
+            }
+
+            TabEntry? desired = activePath != null ? FindTab(new FilePath(activePath)) : null;
+            SetActive(desired ?? _tabs[0]);
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────────
+
+        private TabEntry? FindTab(FilePath path) =>
+            _tabs.FirstOrDefault(t => t.Path == path);
+
+        private void SetActive(TabEntry? tab)
+        {
+            ActiveTab = tab;
+            ActiveChanged?.Invoke(tab);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabOpenResult.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabOpenResult.cs
@@ -1,0 +1,11 @@
+namespace AnimationEditor.Core.Models
+{
+    /// <summary>Result of calling <see cref="TabManager.OpenOrFocus"/>.</summary>
+    public enum TabOpenResult
+    {
+        /// <summary>A new tab was created and activated.</summary>
+        Opened,
+        /// <summary>The path was already open; its existing tab was activated instead.</summary>
+        Focused,
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -409,4 +409,116 @@ public class TabManagerTests
 
         Assert.Equal("Untitled", entry.DisplayName);
     }
+
+    // ── Move ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Move_FirstToLast_ReordersCorrectly()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+
+        tm.Move(P(@"C:\a.achx"), 2);
+
+        Assert.Equal("a.achx", tm.Tabs[2].Path.NoPath);
+        Assert.Equal("b.achx", tm.Tabs[0].Path.NoPath);
+        Assert.Equal("c.achx", tm.Tabs[1].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_LastToFirst_ReordersCorrectly()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+
+        tm.Move(P(@"C:\c.achx"), 0);
+
+        Assert.Equal("c.achx", tm.Tabs[0].Path.NoPath);
+        Assert.Equal("a.achx", tm.Tabs[1].Path.NoPath);
+        Assert.Equal("b.achx", tm.Tabs[2].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_MiddleToEnd_ReordersCorrectly()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+
+        tm.Move(P(@"C:\b.achx"), 2);
+
+        Assert.Equal("a.achx", tm.Tabs[0].Path.NoPath);
+        Assert.Equal("c.achx", tm.Tabs[1].Path.NoPath);
+        Assert.Equal("b.achx", tm.Tabs[2].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_SameIndex_IsNoOp()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+
+        tm.Move(P(@"C:\a.achx"), 0);
+
+        Assert.Equal("a.achx", tm.Tabs[0].Path.NoPath);
+        Assert.Equal("b.achx", tm.Tabs[1].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_NegativeIndex_ClampsToZero()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+
+        tm.Move(P(@"C:\c.achx"), -5);
+
+        Assert.Equal("c.achx", tm.Tabs[0].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_IndexBeyondEnd_ClampsToLast()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+
+        tm.Move(P(@"C:\a.achx"), 99);
+
+        Assert.Equal("a.achx", tm.Tabs[2].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_UnknownPath_IsNoOp()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+
+        tm.Move(P(@"C:\nonexistent.achx"), 0); // must not throw
+
+        Assert.Equal(2, tm.Tabs.Count);
+        Assert.Equal("a.achx", tm.Tabs[0].Path.NoPath);
+    }
+
+    [Fact]
+    public void Move_DoesNotChangeActiveTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        tm.OpenOrFocus(P(@"C:\c.achx")); // c is active
+
+        tm.Move(P(@"C:\a.achx"), 2);
+
+        Assert.Equal(P(@"C:\c.achx"), tm.ActiveTab!.Path);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -48,6 +48,79 @@ public class TabManagerTests
     }
 
     [Fact]
+    public void OpenOrFocus_WithDisplayName_SetsDisplayName()
+    {
+        var tm = new TabManager();
+
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        Assert.Equal("Untitled", tm.ActiveTab!.DisplayName);
+    }
+
+    [Fact]
+    public void OpenOrFocus_WithDisplayName_DuplicatePath_ReturnsFocused()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        var result = tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        Assert.Equal(TabOpenResult.Focused, result);
+        Assert.Single(tm.Tabs);
+    }
+
+    [Fact]
+    public void OpenOrFocus_TwoUntitledSentinels_CreatesTwoTabs()
+    {
+        var tm = new TabManager();
+
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+        tm.OpenOrFocus(P("__untitled__:2"), "Untitled (1)");
+
+        Assert.Equal(2, tm.Tabs.Count);
+    }
+
+    // ── ComputeUntitledDisplayName ─────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeUntitledDisplayName_NoExisting_ReturnsUntitled()
+    {
+        var result = TabManager.ComputeUntitledDisplayName(new List<string>());
+
+        Assert.Equal("Untitled", result);
+    }
+
+    [Fact]
+    public void ComputeUntitledDisplayName_UntitledTaken_ReturnsUntitled1()
+    {
+        var result = TabManager.ComputeUntitledDisplayName(new List<string> { "Untitled" });
+
+        Assert.Equal("Untitled (1)", result);
+    }
+
+    [Fact]
+    public void ComputeUntitledDisplayName_UntitledAnd1Taken_ReturnsUntitled2()
+    {
+        var names = new List<string> { "Untitled", "Untitled (1)" };
+
+        var result = TabManager.ComputeUntitledDisplayName(names);
+
+        Assert.Equal("Untitled (2)", result);
+    }
+
+    [Fact]
+    public void ComputeUntitledDisplayName_GapInSequence_SkipsGap()
+    {
+        // "Untitled (1)" is taken but "Untitled (2)" is not — but first gap after base is (1).
+        var names = new List<string> { "Untitled", "Untitled (2)" };
+
+        var result = TabManager.ComputeUntitledDisplayName(names);
+
+        Assert.Equal("Untitled (1)", result);
+    }
+
+
+    [Fact]
     public void OpenOrFocus_SecondFile_SetsSecondAsActive()
     {
         var tm = new TabManager();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -298,4 +298,115 @@ public class TabManagerTests
 
         Assert.True(raised);
     }
+
+    // ── RegisterBackground ────────────────────────────────────────────────────
+
+    [Fact]
+    public void RegisterBackground_AddsTabAtPositionZero()
+    {
+        var tm = new TabManager();
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        Assert.Single(tm.Tabs);
+        Assert.Equal(P(@"C:\Games\existing.achx"), tm.Tabs[0].Path);
+    }
+
+    [Fact]
+    public void RegisterBackground_DoesNotActivateTab()
+    {
+        var tm = new TabManager();
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        Assert.Null(tm.ActiveTab);
+    }
+
+    [Fact]
+    public void RegisterBackground_DoesNotRaiseActiveChanged()
+    {
+        var tm = new TabManager();
+        bool raised = false;
+        tm.ActiveChanged += _ => raised = true;
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void RegisterBackground_IsNoOpIfPathAlreadyPresent()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\existing.achx"));
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        Assert.Single(tm.Tabs);
+    }
+
+    [Fact]
+    public void RegisterBackground_InsertsBeforeExistingTabs()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\second.achx"));
+
+        tm.RegisterBackground(P(@"C:\Games\first.achx"));
+
+        Assert.Equal(2, tm.Tabs.Count);
+        Assert.Equal(P(@"C:\Games\first.achx"), tm.Tabs[0].Path);
+        Assert.Equal(P(@"C:\Games\second.achx"), tm.Tabs[1].Path);
+    }
+
+    [Fact]
+    public void RegisterBackground_AfterRegister_OpenOrFocusActivatesNewFileButKeepsBoth()
+    {
+        var tm = new TabManager();
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        tm.OpenOrFocus(P(@"C:\Games\new.achx"));
+
+        Assert.Equal(2, tm.Tabs.Count);
+        Assert.Equal(P(@"C:\Games\existing.achx"), tm.Tabs[0].Path);
+        Assert.Equal(P(@"C:\Games\new.achx"), tm.Tabs[1].Path);
+        Assert.Equal(P(@"C:\Games\new.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void RegisterBackground_WithDisplayNameOverride_UsesOverrideInDisplayName()
+    {
+        var tm = new TabManager();
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"), "My Custom Label");
+
+        Assert.Single(tm.Tabs);
+        Assert.Equal("My Custom Label", tm.Tabs[0].DisplayName);
+    }
+
+    // ── TabEntry.DisplayName ──────────────────────────────────────────────────
+
+    [Fact]
+    public void TabEntry_DisplayName_UsesOverrideWhenProvided()
+    {
+        var entry = new TabEntry(P(@"C:\Games\foo.achx"), "My Override");
+
+        Assert.Equal("My Override", entry.DisplayName);
+    }
+
+    [Fact]
+    public void TabEntry_DisplayName_FallsBackToNoPathWhenNoOverride()
+    {
+        var entry = new TabEntry(P(@"C:\Games\foo.achx"));
+
+        Assert.Equal("foo.achx", entry.DisplayName);
+    }
+
+    [Fact]
+    public void TabEntry_DisplayName_ReturnsUntitledWhenPathOriginalIsNullOrEmpty()
+    {
+        // Construct via RegisterBackground with an empty-original FilePath sentinel.
+        var entry = new TabEntry(new FilePath(null!));
+
+        Assert.Equal("Untitled", entry.DisplayName);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -594,4 +594,67 @@ public class TabManagerTests
 
         Assert.Equal(P(@"C:\c.achx"), tm.ActiveTab!.Path);
     }
+
+    // ── Rename ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Rename_UpdatesTabPath()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        tm.Rename(P("__untitled__:1"), P(@"C:\projects\hero.achx"));
+
+        Assert.Equal(P(@"C:\projects\hero.achx"), tm.Tabs[0].Path);
+    }
+
+    [Fact]
+    public void Rename_DisplayNameBecomesFilename()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        tm.Rename(P("__untitled__:1"), P(@"C:\projects\hero.achx"));
+
+        Assert.Equal("hero.achx", tm.Tabs[0].DisplayName);
+    }
+
+    [Fact]
+    public void Rename_PreservesTabPosition()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+        tm.OpenOrFocus(P(@"C:\c.achx"));
+        tm.Activate(P("__untitled__:1"));
+
+        tm.Rename(P("__untitled__:1"), P(@"C:\b.achx"));
+
+        Assert.Equal("a.achx", tm.Tabs[0].Path.NoPath);
+        Assert.Equal("b.achx", tm.Tabs[1].Path.NoPath);
+        Assert.Equal("c.achx", tm.Tabs[2].Path.NoPath);
+    }
+
+    [Fact]
+    public void Rename_ActiveTabRemainsActive()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+
+        tm.Rename(P("__untitled__:1"), P(@"C:\hero.achx"));
+
+        Assert.Equal(P(@"C:\hero.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Rename_UnknownPath_IsNoOp()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+
+        tm.Rename(P(@"C:\nonexistent.achx"), P(@"C:\b.achx")); // must not throw
+
+        Assert.Single(tm.Tabs);
+        Assert.Equal("a.achx", tm.Tabs[0].Path.NoPath);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -1,0 +1,301 @@
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="TabManager"/> — open, focus, close, dedup, and restore logic.
+/// </summary>
+public class TabManagerTests
+{
+    private static FilePath P(string path) => new FilePath(path);
+
+    // ── OpenOrFocus ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenOrFocus_FirstFile_AddsTab()
+    {
+        var tm = new TabManager();
+
+        var result = tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.Equal(TabOpenResult.Opened, result);
+        Assert.Single(tm.Tabs);
+    }
+
+    [Fact]
+    public void OpenOrFocus_FirstFile_SetsActiveTab()
+    {
+        var tm = new TabManager();
+
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.NotNull(tm.ActiveTab);
+        Assert.Equal(P(@"C:\Games\hero.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void OpenOrFocus_SecondFile_AddsBothTabs()
+    {
+        var tm = new TabManager();
+
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\enemy.achx"));
+
+        Assert.Equal(2, tm.Tabs.Count);
+    }
+
+    [Fact]
+    public void OpenOrFocus_SecondFile_SetsSecondAsActive()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        tm.OpenOrFocus(P(@"C:\Games\enemy.achx"));
+
+        Assert.Equal(P(@"C:\Games\enemy.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void OpenOrFocus_DuplicatePath_ReturnsFocused()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\enemy.achx"));
+
+        var result = tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.Equal(TabOpenResult.Focused, result);
+    }
+
+    [Fact]
+    public void OpenOrFocus_DuplicatePath_DoesNotAddNewTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.Single(tm.Tabs);
+    }
+
+    [Fact]
+    public void OpenOrFocus_DuplicatePath_ActivatesExistingTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\enemy.achx"));
+
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.Equal(P(@"C:\Games\hero.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void OpenOrFocus_DuplicatePathDifferentCase_Deduplicates()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\Hero.achx"));
+
+        var result = tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        Assert.Equal(TabOpenResult.Focused, result);
+        Assert.Single(tm.Tabs);
+    }
+
+    // ── Close ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Close_OnlyTab_ClearsAll()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+
+        tm.Close(P(@"C:\Games\hero.achx"));
+
+        Assert.Empty(tm.Tabs);
+        Assert.Null(tm.ActiveTab);
+    }
+
+    [Fact]
+    public void Close_ActiveTabWithNext_ActivatesNextTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\c.achx"));
+        tm.Activate(P(@"C:\Games\b.achx"));
+
+        tm.Close(P(@"C:\Games\b.achx"));
+
+        Assert.Equal(P(@"C:\Games\c.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Close_ActiveLastTab_ActivatesPreviousTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+
+        tm.Close(P(@"C:\Games\b.achx"));
+
+        Assert.Equal(P(@"C:\Games\a.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Close_NonActiveTab_DoesNotChangeActiveTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+        // b is active
+        tm.Close(P(@"C:\Games\a.achx"));
+
+        Assert.Equal(P(@"C:\Games\b.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Close_UnknownPath_IsNoOp()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\hero.achx"));
+        int before = tm.Tabs.Count;
+
+        tm.Close(P(@"C:\Games\unknown.achx"));
+
+        Assert.Equal(before, tm.Tabs.Count);
+    }
+
+    // ── Activate ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Activate_KnownPath_SetsActiveTab()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+
+        tm.Activate(P(@"C:\Games\a.achx"));
+
+        Assert.Equal(P(@"C:\Games\a.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Activate_UnknownPath_IsNoOp()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+
+        tm.Activate(P(@"C:\Games\unknown.achx"));
+
+        Assert.Equal(P(@"C:\Games\a.achx"), tm.ActiveTab!.Path);
+    }
+
+    // ── RestoreFrom ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RestoreFrom_EmptyList_TabsStayEmpty()
+    {
+        var tm = new TabManager();
+
+        tm.RestoreFrom(new List<string>(), activePath: null);
+
+        Assert.Empty(tm.Tabs);
+        Assert.Null(tm.ActiveTab);
+    }
+
+    [Fact]
+    public void RestoreFrom_ListWithPaths_CreatesTabs()
+    {
+        var tm = new TabManager();
+
+        tm.RestoreFrom(
+            new List<string> { @"C:\Games\a.achx", @"C:\Games\b.achx" },
+            activePath: null);
+
+        Assert.Equal(2, tm.Tabs.Count);
+    }
+
+    [Fact]
+    public void RestoreFrom_WithActivePath_SetsCorrectActiveTab()
+    {
+        var tm = new TabManager();
+
+        tm.RestoreFrom(
+            new List<string> { @"C:\Games\a.achx", @"C:\Games\b.achx" },
+            activePath: @"C:\Games\b.achx");
+
+        Assert.Equal(P(@"C:\Games\b.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void RestoreFrom_ActivePathNotInList_FirstTabBecomesActive()
+    {
+        var tm = new TabManager();
+
+        tm.RestoreFrom(
+            new List<string> { @"C:\Games\a.achx" },
+            activePath: @"C:\Games\gone.achx");
+
+        Assert.Equal(P(@"C:\Games\a.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void RestoreFrom_ClearsExistingTabs()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\old.achx"));
+
+        tm.RestoreFrom(new List<string> { @"C:\Games\new.achx" }, activePath: null);
+
+        Assert.Single(tm.Tabs);
+        Assert.Equal(P(@"C:\Games\new.achx"), tm.Tabs[0].Path);
+    }
+
+    // ── OpenTabPaths helper ───────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenTabPaths_ReturnsFullPathsForAllTabs()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+
+        var paths = tm.OpenTabPaths;
+
+        // FilePath normalises separators to '/'; compare via FilePath equality.
+        Assert.Equal(2, paths.Count);
+        Assert.Equal(P(@"C:\Games\a.achx"), new FilePath(paths[0]));
+        Assert.Equal(P(@"C:\Games\b.achx"), new FilePath(paths[1]));
+    }
+
+    // ── ActiveChanged event ───────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenOrFocus_FirstFile_RaisesActiveChanged()
+    {
+        var tm = new TabManager();
+        bool raised = false;
+        tm.ActiveChanged += _ => raised = true;
+
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Close_RaisesActiveChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        bool raised = false;
+        tm.ActiveChanged += _ => raised = true;
+
+        tm.Close(P(@"C:\Games\a.achx"));
+
+        Assert.True(raised);
+    }
+}


### PR DESCRIPTION
Closes #351

## What's in this PR

### Core
- `TabEntry` record + `TabOpenResult` enum
- `TabManager` — open/focus/close/activate/restore, dedup by `FilePath` equality (23 unit tests)

### Persistence
- `AppSettingsModel` extended with `OpenTabPaths` + `ActiveTabPath` (serialised to `AESettings.json`)

### UI
- Tab bar added between title bar and status bar; hidden when no tabs are open
- Left-click activates, middle-click or × closes; active tab is highlighted
- `RestoreTabsAsync()` reloads open tabs on startup
- Per-tab zoom/pan restores automatically via the existing `.aeproperties` companion file mechanism

### Single-instance IPC
- Named `Mutex` determines the primary process
- Secondary process writes its `filePath` to a named pipe and exits
- Primary instance dispatches `OpenFileAsTab()` on the UI thread

## Tests
```
1571 tests: 1127 Core + 444 App — all passing
```