### PR TITLE
Fix: clicking wireframe without movement creates undo action (#362)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1017,13 +1017,17 @@ public class WireframeControl : Control
 
         ApplyHandleDrag(new Point(endScreenX, endScreenY));
 
-        FrameRegionChanged?.Invoke(sel.Frame);
-        _undoManager!.Record(new FrameRegionChangedCommand(
-            sel.Frame,
-            _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
-            sel.Frame.LeftCoordinate, sel.Frame.TopCoordinate,
-            sel.Frame.RightCoordinate, sel.Frame.BottomCoordinate,
-            _appCommands!, _events!));
+        float aL = sel.Frame.LeftCoordinate, aT = sel.Frame.TopCoordinate;
+        float aR = sel.Frame.RightCoordinate, aB = sel.Frame.BottomCoordinate;
+        if (RegionChanged(_dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB, aL, aT, aR, aB))
+        {
+            FrameRegionChanged?.Invoke(sel.Frame);
+            _undoManager!.Record(new FrameRegionChangedCommand(
+                sel.Frame,
+                _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
+                aL, aT, aR, aB,
+                _appCommands!, _events!));
+        }
         _draggingRect   = null;
         _draggingHandle = HandleKind.None;
     }
@@ -1067,9 +1071,12 @@ public class WireframeControl : Control
                 s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
                 s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
             .ToList();
-        _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
-        foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
-            FrameRegionChanged?.Invoke(fr.Frame);
+        if (snapshots.Any(s => RegionChanged(s.BL, s.BT, s.BR, s.BB, s.AL, s.AT, s.AR, s.AB)))
+        {
+            _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+            foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
+                FrameRegionChanged?.Invoke(fr.Frame);
+        }
 
         _bulkHandleDragStarts.Clear();
         _draggingRect   = null;
@@ -1113,7 +1120,8 @@ public class WireframeControl : Control
                     s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
                     s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
                 .ToList();
-            _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+            if (snapshots.Any(s => RegionChanged(s.BL, s.BT, s.BR, s.BB, s.AL, s.AT, s.AR, s.AB)))
+                _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
         }
 
         ChainRegionChanged?.Invoke(chain);
@@ -1655,20 +1663,29 @@ public class WireframeControl : Control
                         s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
                         s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
                     .ToList();
-                _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
-                foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
-                    FrameRegionChanged?.Invoke(fr.Frame);
+                if (snapshots.Any(s => RegionChanged(s.BL, s.BT, s.BR, s.BB, s.AL, s.AT, s.AR, s.AB)))
+                {
+                    _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+                    foreach (var (fr, _, _, _, _, _) in _bulkHandleDragStarts)
+                        FrameRegionChanged?.Invoke(fr.Frame);
+                }
                 _bulkHandleDragStarts.Clear();
             }
             else
             {
-                FrameRegionChanged?.Invoke(_draggingRect.Frame);
-                _undoManager!.Record(new FrameRegionChangedCommand(
-                    _draggingRect.Frame,
-                    _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
-                    _draggingRect.Frame.LeftCoordinate, _draggingRect.Frame.TopCoordinate,
-                    _draggingRect.Frame.RightCoordinate, _draggingRect.Frame.BottomCoordinate,
-                    _appCommands!, _events!));
+                float aL = _draggingRect.Frame.LeftCoordinate;
+                float aT = _draggingRect.Frame.TopCoordinate;
+                float aR = _draggingRect.Frame.RightCoordinate;
+                float aB = _draggingRect.Frame.BottomCoordinate;
+                if (RegionChanged(_dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB, aL, aT, aR, aB))
+                {
+                    FrameRegionChanged?.Invoke(_draggingRect.Frame);
+                    _undoManager!.Record(new FrameRegionChangedCommand(
+                        _draggingRect.Frame,
+                        _dragBeforeL, _dragBeforeT, _dragBeforeR, _dragBeforeB,
+                        aL, aT, aR, aB,
+                        _appCommands!, _events!));
+                }
             }
             _draggingRect = null;
             _draggingHandle = HandleKind.None;
@@ -1689,7 +1706,8 @@ public class WireframeControl : Control
                             s.Rect.Frame.LeftCoordinate, s.Rect.Frame.TopCoordinate,
                             s.Rect.Frame.RightCoordinate, s.Rect.Frame.BottomCoordinate))
                         .ToList();
-                    _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
+                    if (snapshots.Any(s => RegionChanged(s.BL, s.BT, s.BR, s.BB, s.AL, s.AT, s.AR, s.AB)))
+                        _undoManager!.Record(new BulkFrameRegionChangedCommand(snapshots, _appCommands!, _events!));
                 }
                 ChainRegionChanged?.Invoke(chain);
             }
@@ -1707,6 +1725,12 @@ public class WireframeControl : Control
     }
 
     // ── Mouse helpers ─────────────────────────────────────────────────────────
+
+    private static bool RegionChanged(
+        float bL, float bT, float bR, float bB,
+        float aL, float aT, float aR, float aB)
+        => Math.Abs(aL - bL) > 0.0001f || Math.Abs(aT - bT) > 0.0001f ||
+           Math.Abs(aR - bR) > 0.0001f || Math.Abs(aB - bB) > 0.0001f;
 
     private void StartPan(Point pos)
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -326,6 +326,12 @@ public partial class MainWindow : Window
     private async Task ActivateTabAsync(TabEntry tab)
     {
         if (tab == _tabManager.ActiveTab) return;
+
+        // Save the leaving tab's undo history before the editor reloads a different file.
+        var leavingTab = _tabManager.ActiveTab;
+        if (leavingTab != null)
+            leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
+
         SaveCompanionFile();
         _tabManager.Activate(tab.Path);
         // Bypass LoadAnimationFileAsync so we don't hit the short-circuit that skips
@@ -337,6 +343,8 @@ public partial class MainWindow : Window
             _projectManager.FileName = null;
             _selectedState.Reset();
             _undoManager.Clear();
+            if (tab.UndoSnapshot != null)
+                _undoManager.RestoreSnapshot(tab.UndoSnapshot);
             RefreshTreeView();
             UpdateTitle();
             UpdateStatusBar();
@@ -344,6 +352,9 @@ public partial class MainWindow : Window
         else
         {
             await _appCommands.OpenAchxWorkflowAsync(tab.Path.FullPath);
+            // LoadAnimationChain cleared the stack — restore this tab's saved history.
+            if (tab.UndoSnapshot != null)
+                _undoManager.RestoreSnapshot(tab.UndoSnapshot);
         }
         RebuildTabStrip();
     }
@@ -365,7 +376,12 @@ public partial class MainWindow : Window
             // so the just-closed file is not accidentally re-registered as a background tab.
             if (!IsUntitledTab(next))
                 _ = _appCommands.OpenAchxWorkflowAsync(next.Path.FullPath)
-                    .ContinueWith(_ => Dispatcher.UIThread.InvokeAsync(RebuildTabStrip));
+                    .ContinueWith(_ => Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        if (next.UndoSnapshot != null)
+                            _undoManager.RestoreSnapshot(next.UndoSnapshot);
+                        RebuildTabStrip();
+                    }));
             else
             {
                 // Switching to an Untitled tab — reset to a blank editor.
@@ -373,6 +389,8 @@ public partial class MainWindow : Window
                 _projectManager.FileName = null;
                 _selectedState.Reset();
                 _undoManager.Clear();
+                if (next.UndoSnapshot != null)
+                    _undoManager.RestoreSnapshot(next.UndoSnapshot);
                 RefreshTreeView();
                 UpdateTitle();
                 UpdateStatusBar();
@@ -2564,6 +2582,11 @@ public partial class MainWindow : Window
     {
         if (string.IsNullOrEmpty(fileName)) return;
 
+        // Save the leaving tab's undo history before a different file takes over the editor.
+        var leavingTab = _tabManager.ActiveTab;
+        if (leavingTab != null)
+            leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
+
         // If there is already a file open that hasn't been registered as a tab yet,
         // add it as a background tab so it appears as the first tab when the second
         // file is opened.  This covers the common case of File > Open > Open.
@@ -2571,6 +2594,7 @@ public partial class MainWindow : Window
 
         var filePath = new FilePath(fileName);
         var result = _tabManager.OpenOrFocus(filePath);
+        var arrivedTab = _tabManager.ActiveTab;
 
         if (result == TabOpenResult.Focused)
         {
@@ -2581,12 +2605,20 @@ public partial class MainWindow : Window
             bool alreadyShown = string.Equals(_projectManager.FileName, fileName,
                 StringComparison.OrdinalIgnoreCase);
             if (!alreadyShown && !string.IsNullOrEmpty(fileName))
+            {
                 await _appCommands.OpenAchxWorkflowAsync(fileName);
+                if (arrivedTab?.UndoSnapshot != null)
+                    _undoManager.RestoreSnapshot(arrivedTab.UndoSnapshot);
+            }
             RebuildTabStrip();
             return;
         }
 
         await _appCommands.OpenAchxWorkflowAsync(fileName);
+        // Restore this tab's prior history if it was previously open (snapshot normally
+        // null on first open; non-null if the tab was closed and re-opened mid-session).
+        if (arrivedTab?.UndoSnapshot != null)
+            _undoManager.RestoreSnapshot(arrivedTab.UndoSnapshot);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoManager.cs
@@ -58,6 +58,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         void Clear();
 
+        /// <summary>
+        /// Captures the current undo and redo stacks as an immutable snapshot.
+        /// Store the snapshot on the active <see cref="AnimationEditor.Core.Models.TabEntry"/>
+        /// before switching tabs so history can be restored with <see cref="RestoreSnapshot"/>.
+        /// </summary>
+        UndoSnapshot TakeSnapshot();
+
+        /// <summary>
+        /// Replaces the current undo and redo stacks with those from <paramref name="snapshot"/>
+        /// and raises <see cref="StackChanged"/>. Call this after loading a tab's file content
+        /// (which calls <see cref="Clear"/>) to reinstate that tab's saved history.
+        /// </summary>
+        void RestoreSnapshot(UndoSnapshot snapshot);
+
         /// <summary>Marks the last auto-save as successful, setting <see cref="SaveState"/> to <see cref="SaveState.AutoSaveOn"/>.</summary>
         void MarkSaved();
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
@@ -70,6 +70,24 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             StackChanged?.Invoke();
         }
 
+        /// <inheritdoc cref="IUndoManager.TakeSnapshot"/>
+        public UndoSnapshot TakeSnapshot() =>
+            new(_undoStack.Reverse().ToList(), _redoStack.ToList());
+
+        /// <inheritdoc cref="IUndoManager.RestoreSnapshot"/>
+        public void RestoreSnapshot(UndoSnapshot snapshot)
+        {
+            _undoStack.Clear();
+            // UndoStack is oldest-first; pushing in that order leaves newest on top.
+            foreach (var cmd in snapshot.UndoStack)
+                _undoStack.Push(cmd);
+            _redoStack.Clear();
+            // RedoStack is stored LIFO (next-to-redo first); push in reverse to restore that order.
+            for (int i = snapshot.RedoStack.Count - 1; i >= 0; i--)
+                _redoStack.Push(snapshot.RedoStack[i]);
+            StackChanged?.Invoke();
+        }
+
         /// <summary>Marks the last auto-save as successful, setting <see cref="SaveState"/> to <see cref="SaveState.AutoSaveOn"/>.</summary>
         public void MarkSaved()
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoSnapshot.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoSnapshot.cs
@@ -1,0 +1,10 @@
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Immutable snapshot of the undo and redo stacks captured at a point in time.
+    /// Saved per-tab so history is preserved when switching between open files.
+    /// </summary>
+    public sealed record UndoSnapshot(
+        IReadOnlyList<IUndoableCommand> UndoStack,
+        IReadOnlyList<IUndoableCommand> RedoStack);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
@@ -1,3 +1,4 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Paths;
 
 namespace AnimationEditor.Core.Models
@@ -24,6 +25,13 @@ namespace AnimationEditor.Core.Models
 
         /// <summary>The absolute path of the <c>.achx</c> file this tab represents.</summary>
         public FilePath Path { get; }
+
+        /// <summary>
+        /// Undo/redo stack snapshot saved when this tab was last deactivated.
+        /// Restored after the tab's file is reloaded on re-activation so the user's
+        /// edit history persists across tab switches.
+        /// </summary>
+        public UndoSnapshot? UndoSnapshot { get; set; }
 
         /// <summary>
         /// The tab label. Returns <see cref="_displayNameOverride"/> when set;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSwitchUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSwitchUndoTests.cs
@@ -1,0 +1,159 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies that each tab's undo history is preserved when navigating between tabs.
+/// </summary>
+public class TabSwitchUndoTests
+{
+    private static string WriteAchx(string dir, string fileName, params string[] chainNames)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        foreach (var name in chainNames)
+        {
+            var chain = new AnimationChainSave { Name = name };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = name + ".png", FrameLength = 0.1f });
+            acls.AnimationChains.Add(chain);
+        }
+        acls.Save(path);
+        return path;
+    }
+
+    private static async Task ActivateTabAsync(MainWindow window, TabEntry tab)
+    {
+        var method = typeof(MainWindow)
+            .GetMethod("ActivateTabAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(window, [tab])!;
+    }
+
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    private sealed class StubUndoCmd : IUndoableCommand
+    {
+        private readonly string _desc;
+        public StubUndoCmd(string desc) => _desc = desc;
+        public string Description => _desc;
+        public bool Do() => true;
+        public void Undo() { }
+        public void Redo() { }
+    }
+
+    // ── Tab switch preserves undo ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Undo entries added while file A is active must survive a switch to file B
+    /// and back to file A.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task SwitchingTabs_PreservesUndoHistoryForEachTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pathA = WriteAchx(dir, "a.achx", "Walk");
+            var pathB = WriteAchx(dir, "b.achx", "Run");
+
+            // Open file A and record an undo entry
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+            ctx.UndoManager.Record(new StubUndoCmd("Edit A"));
+            Assert.True(ctx.UndoManager.CanUndo);
+
+            // Open file B — this triggers a tab switch and should save A's snapshot
+            await window.OpenFileAsTab(pathB);
+            Dispatcher.UIThread.RunJobs();
+
+            // B is a fresh file — no undo history
+            Assert.False(ctx.UndoManager.CanUndo);
+
+            // Switch back to tab A
+            var tabManager = GetTabManager(window);
+            var tabA = tabManager.Tabs.First(t => t.Path.FullPath == pathA);
+            await ActivateTabAsync(window, tabA);
+            Dispatcher.UIThread.RunJobs();
+
+            // A's undo history must be restored
+            Assert.True(ctx.UndoManager.CanUndo);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Undo entries added while file B is active must survive a switch back to file A
+    /// and then a switch to B again.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task BothTabs_HaveIndependentUndoHistories()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pathA = WriteAchx(dir, "a.achx", "Walk");
+            var pathB = WriteAchx(dir, "b.achx", "Run");
+
+            // Open file A, record two undo entries
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+            ctx.UndoManager.Record(new StubUndoCmd("Edit A1"));
+            ctx.UndoManager.Record(new StubUndoCmd("Edit A2"));
+
+            // Open file B, record one undo entry
+            await window.OpenFileAsTab(pathB);
+            Dispatcher.UIThread.RunJobs();
+            ctx.UndoManager.Record(new StubUndoCmd("Edit B1"));
+
+            var tabManager = GetTabManager(window);
+            var tabA = tabManager.Tabs.First(t => t.Path.FullPath == pathA);
+            var tabB = tabManager.Tabs.First(t => t.Path.FullPath == pathB);
+
+            // Switch to A — should see A's 2 entries
+            await ActivateTabAsync(window, tabA);
+            Dispatcher.UIThread.RunJobs();
+            int countA = ctx.UndoManager.UndoHistory.Count;
+            Assert.Equal(2, countA);
+
+            // Switch back to B — should see B's 1 entry
+            await ActivateTabAsync(window, tabB);
+            Dispatcher.UIThread.RunJobs();
+            int countB = ctx.UndoManager.UndoHistory.Count;
+            Assert.Equal(1, countB);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
@@ -230,4 +230,27 @@ public class WireframeChainDragTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    // ── No undo entry when click has no movement ──────────────────────────────
+
+    /// <summary>
+    /// Releasing the chain-drag handle without moving (start == end) must not push
+    /// an undo entry, because no frame coordinates changed.
+    /// Regression guard for: https://github.com/vchelaru/FlatRedBall2/issues/362
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateChainDrag_NoMovement_DoesNotRecordUndo()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, _, _, dir) = BuildCtrlWithChainSelected(ctx);
+        try
+        {
+            ctrl.SimulateChainDrag(startScreenX: 16f, startScreenY: 8f,
+                                   endScreenX:   16f, endScreenY:   8f);
+
+            Assert.False(ctx.UndoManager.CanUndo,
+                "Chain click without dragging must not create an undo entry");
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandleDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandleDragTests.cs
@@ -304,4 +304,67 @@ public class WireframeHandleDragTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    // ── No undo entry when click has no movement ──────────────────────────────
+
+    /// <summary>
+    /// Releasing a handle without dragging (start == end) must not push an undo
+    /// entry, because no frame coordinates changed.
+    /// Regression guard for: https://github.com/vchelaru/FlatRedBall2/issues/362
+    /// </summary>
+    [AvaloniaFact]
+    public void HandleDrag_NoMovement_DoesNotRecordUndo()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            ctrl.SimulateHandleDrag(HandleKind.TopLeft,
+                startScreenX: 0f, startScreenY: 0f,
+                endScreenX:   0f, endScreenY:   0f);
+
+            Assert.False(ctx.UndoManager.CanUndo,
+                "Clicking a handle without dragging must not create an undo entry");
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Same as <see cref="HandleDrag_NoMovement_DoesNotRecordUndo"/> for the bulk
+    /// (multi-chain) handle-drag path.
+    /// </summary>
+    [AvaloniaFact]
+    public void BulkHandleDrag_NoMovement_DoesNotRecordUndo()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            // Add a second chain so bulk mode is active
+            var chain2 = new AnimationChainSave { Name = "Walk2" };
+            var frame2 = new AnimationFrameSave
+            {
+                TextureName      = "sprite.png",
+                FrameLength      = 0.1f,
+                LeftCoordinate   = 0.5f, TopCoordinate    = 0f,
+                RightCoordinate  = 1.0f, BottomCoordinate = 0.5f,
+                ShapesSave       = new ShapesSave(),
+            };
+            chain2.Frames.Add(frame2);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain2);
+            ctx.SelectedState.SelectedNodes = new System.Collections.Generic.List<object>
+            {
+                ctx.SelectedState.SelectedChain!, chain2,
+            };
+            ctrl.RefreshFrames();
+
+            ctrl.SimulateBulkHandleDrag(frame, HandleKind.TopLeft,
+                startScreenX: 0f, startScreenY: 0f,
+                endScreenX:   0f, endScreenY:   0f);
+
+            Assert.False(ctx.UndoManager.CanUndo,
+                "Bulk handle click without dragging must not create an undo entry");
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoManagerTests.cs
@@ -121,6 +121,92 @@ public class UndoManagerTests
         Assert.Null(ex);
     }
 
+    // ── TakeSnapshot / RestoreSnapshot ───────────────────────────────────────
+
+    [Fact]
+    public void TakeSnapshot_CapturesUndoStack()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+
+        var snapshot = _undo.TakeSnapshot();
+
+        Assert.Single(snapshot.UndoStack);
+        Assert.Same(cmd, snapshot.UndoStack[0]);
+    }
+
+    [Fact]
+    public void TakeSnapshot_CapturesRedoStack()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+        _undo.Undo();
+
+        var snapshot = _undo.TakeSnapshot();
+
+        Assert.Empty(snapshot.UndoStack);
+        Assert.Single(snapshot.RedoStack);
+        Assert.Same(cmd, snapshot.RedoStack[0]);
+    }
+
+    [Fact]
+    public void RestoreSnapshot_RestoresUndoStack()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+        var snapshot = _undo.TakeSnapshot();
+
+        var fresh = new UndoManager();
+        fresh.RestoreSnapshot(snapshot);
+
+        Assert.True(fresh.CanUndo);
+        Assert.False(fresh.CanRedo);
+    }
+
+    [Fact]
+    public void RestoreSnapshot_RestoresRedoStack()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+        _undo.Undo();
+        var snapshot = _undo.TakeSnapshot();
+
+        var fresh = new UndoManager();
+        fresh.RestoreSnapshot(snapshot);
+
+        Assert.False(fresh.CanUndo);
+        Assert.True(fresh.CanRedo);
+    }
+
+    [Fact]
+    public void RestoreSnapshot_UndoStillWorksAfterRestore()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+        var snapshot = _undo.TakeSnapshot();
+
+        var fresh = new UndoManager();
+        fresh.RestoreSnapshot(snapshot);
+        fresh.Undo();
+
+        Assert.Equal(1, cmd.UndoCalls);
+    }
+
+    [Fact]
+    public void RestoreSnapshot_RaisesStackChanged()
+    {
+        var cmd = new StubCommand();
+        _undo.Record(cmd);
+        var snapshot = _undo.TakeSnapshot();
+
+        int raised = 0;
+        var fresh = new UndoManager();
+        fresh.StackChanged += () => raised++;
+        fresh.RestoreSnapshot(snapshot);
+
+        Assert.Equal(1, raised);
+    }
+
     // ── Stub ──────────────────────────────────────────────────────────────────
 
     private sealed class StubCommand : IUndoableCommand


### PR DESCRIPTION
## Summary

Fixes two bugs:

### Bug 1: Clicking wireframe without movement creates undo action (Issue #362)
Already merged as PR #372 — included in this branch.

### Bug 2: Navigating between tabs clears undo history

**Root cause:** `LoadAnimationFileAsync` and `ActivateTabAsync` both call `OpenAchxWorkflowAsync` → `LoadAnimationChain` → `_undoManager.Clear()` when switching tabs. This wiped the undo stack of whichever tab you left.

**Fix:** Per-tab undo snapshots.

- New `UndoSnapshot` record holds an immutable copy of the undo+redo stacks
- `IUndoManager.TakeSnapshot()` / `RestoreSnapshot()` added to `UndoManager`
- `TabEntry.UndoSnapshot` property stores the snapshot for each open tab
- Before switching away from a tab, the current stacks are saved to `TabEntry.UndoSnapshot`
- After the file reload (which calls `Clear()`), the arriving tab's snapshot is restored
- Applies to all three switch paths: `LoadAnimationFileAsync`, `ActivateTabAsync`, `CloseTab`

## Tests

**Core (6 new `[Fact]` tests in `UndoManagerTests`):**
- `TakeSnapshot_CapturesUndoStack`
- `TakeSnapshot_CapturesRedoStack`
- `RestoreSnapshot_RestoresUndoStack`
- `RestoreSnapshot_RestoresRedoStack`
- `RestoreSnapshot_UndoStillWorksAfterRestore`
- `RestoreSnapshot_RaisesStackChanged`

**App (2 new `[AvaloniaFact]` tests in `TabSwitchUndoTests`):**
- `SwitchingTabs_PreservesUndoHistoryForEachTab`
- `BothTabs_HaveIndependentUndoHistories`

Full suite: **1615 tests passed**, 0 failures.