### PR TITLE
Fix #363: grid mode double-click applies cell bounds to selected frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -978,6 +978,22 @@ public class WireframeControl : Control
     }
 
     /// <summary>
+    /// Applies the grid-snapped cell at the given screen position to the currently-selected frame
+    /// (via <see cref="ApplyRegionToSelectedFrame"/>). This is the double-click path in grid mode:
+    /// it bypasses handle hit-testing so frames that cover the entire texture can still be
+    /// assigned a specific cell.
+    /// No-ops when bitmap is null, grid is off, cell size is ≤ 0, or no frame is selected.
+    /// </summary>
+    public void SimulateGridSnapDoubleClick(float screenX, float screenY)
+    {
+        if (_bitmap is null || !_showGrid || _gridSize <= 0) return;
+        var world = ScreenToTexture(screenX, screenY);
+        int gx = GridSnapper.Snap(world.X, _gridSize);
+        int gy = GridSnapper.Snap(world.Y, _gridSize);
+        ApplyRegionToSelectedFrame(gx, gy, gx + _gridSize, gy + _gridSize);
+    }
+
+    /// <summary>
     /// Runs the hover-preview snap logic for the given screen point and returns
     /// the resulting preview state. Requires a loaded texture (returns ShowPreview=false otherwise).
     /// </summary>
@@ -1432,6 +1448,18 @@ public class WireframeControl : Control
         }
 
         if (!props.IsLeftButtonPressed) return;
+
+        // Grid mode double-click: bypass handle hit-testing so that a frame covering
+        // the entire texture (which would otherwise always hit HandleKind.Move) can still
+        // have a specific grid cell applied to it.
+        if (!isCtrl && !_isMagicWandMode && e.ClickCount == 2 && _showGrid && _gridSize > 0 && _bitmap != null)
+        {
+            var dblWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
+            int gx = GridSnapper.Snap(dblWorld.X, _gridSize);
+            int gy = GridSnapper.Snap(dblWorld.Y, _gridSize);
+            ApplyRegionToSelectedFrame(gx, gy, gx + _gridSize, gy + _gridSize);
+            return;
+        }
 
         // 1. Hit-test resize handles on the selected frame (skipped in Magic Wand mode)
         if (!isCtrl && !_isMagicWandMode)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -612,4 +612,130 @@ public class GridRenderTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    // ── Double-click: ApplyRegionToSelectedFrame ──────────────────────────────
+
+    /// <summary>
+    /// Helper: loads a 64×64 texture, creates a single full-sheet frame (UV 0→1),
+    /// selects it, and returns both the control and the frame.
+    /// </summary>
+    private static (WireframeControl ctrl, AnimationFrameSave frame, string dir)
+        BuildCtrlWithFullSheetFrame(TestServices ctx)
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black);
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = System.IO.Path.GetFileName(png),
+            LeftCoordinate   = 0f,
+            TopCoordinate    = 0f,
+            RightCoordinate  = 1f,
+            BottomCoordinate = 1f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);   // pan=(0,0), zoom=1 → screen ≡ texture coordinates
+        return (ctrl, frame, dir);
+    }
+
+    /// <summary>
+    /// Double-clicking at screen (20, 20) with cellSize=16, pan=(0,0), zoom=1 on a full-sheet
+    /// frame should update that frame's UV coordinates to the cell (16,16)→(32,32) (i.e. 0.25–0.5
+    /// on a 64×64 texture).
+    /// </summary>
+    [AvaloniaFact]
+    public void GridSnapDoubleClick_WithFullSheetFrame_UpdatesFrameUVToClickedCell()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        try
+        {
+            ctrl.SetGrid(true, 16);
+
+            ctrl.SimulateGridSnapDoubleClick(20f, 20f);
+
+            // Screen (20,20) → texture (20,20) → snap to 16 → cell (16,16,32,32) on 64×64
+            Assert.Equal(16f / 64f, frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(16f / 64f, frame.TopCoordinate,    precision: 5);
+            Assert.Equal(32f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(32f / 64f, frame.BottomCoordinate, precision: 5);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Verifies the grid-snap math: clicking at (0, 0) should map to the top-left cell (0,0,16,16).
+    /// </summary>
+    [AvaloniaFact]
+    public void GridSnapDoubleClick_SnapsToCorrectGridCell()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        try
+        {
+            ctrl.SetGrid(true, 16);
+
+            ctrl.SimulateGridSnapDoubleClick(5f, 5f);
+
+            // (5,5) snaps to (0,0,16,16) on 64×64 texture
+            Assert.Equal(0f,        frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(0f,        frame.TopCoordinate,    precision: 5);
+            Assert.Equal(16f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(16f / 64f, frame.BottomCoordinate, precision: 5);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// When the grid is disabled, SimulateGridSnapDoubleClick must not modify the selected frame.
+    /// </summary>
+    [AvaloniaFact]
+    public void GridSnapDoubleClick_GridDisabled_IsNoOp()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        try
+        {
+            ctrl.SetGrid(false, 16);
+
+            ctrl.SimulateGridSnapDoubleClick(20f, 20f);
+
+            // UV should remain at full-sheet values
+            Assert.Equal(0f, frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(0f, frame.TopCoordinate,    precision: 5);
+            Assert.Equal(1f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(1f, frame.BottomCoordinate, precision: 5);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// When no frame is selected, SimulateGridSnapDoubleClick must not throw and must be a no-op.
+    /// </summary>
+    [AvaloniaFact]
+    public void GridSnapDoubleClick_NoSelectedFrame_IsNoOp()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, _, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        try
+        {
+            ctx.SelectedState.SelectedFrame = null;
+            ctrl.SetGrid(true, 16);
+
+            // Must not throw
+            var ex = Record.Exception(() => ctrl.SimulateGridSnapDoubleClick(20f, 20f));
+            Assert.Null(ex);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 }


### PR DESCRIPTION
## Problem

When a frame's bounding box covers the entire sprite sheet (UV 0→1), clicking anywhere on the texture in Grid Mode was intercepted by `DragHandleHitTester.GetHandleAt`, which returns `HandleKind.Move` for any point inside the frame rectangle. This caused `OnPointerPressed` to enter the drag path and return early — the grid-cell application code was never reached, so double-clicking a cell had no effect.

## Fix

In `WireframeControl.OnPointerPressed`, before the handle hit-test, detect a double-click (`e.ClickCount == 2`) while grid mode is active. If true, compute the snapped grid cell and call `ApplyRegionToSelectedFrame` directly, bypassing the handle test entirely.

Also adds `SimulateGridSnapDoubleClick` as a public testable surface (parallel to the existing `SimulateGridSnapClick`).

## Tests

4 new `[AvaloniaFact]` tests in `GridRenderTests.cs`:

| Test | Covers |
|------|--------|
| `GridSnapDoubleClick_WithFullSheetFrame_UpdatesFrameUVToClickedCell` | Happy path: full-sheet frame → UV updated to clicked cell |
| `GridSnapDoubleClick_SnapsToCorrectGridCell` | Grid-snap math |
| `GridSnapDoubleClick_GridDisabled_IsNoOp` | Guard: no change when grid is off |
| `GridSnapDoubleClick_NoSelectedFrame_IsNoOp` | Guard: no-op / no throw when nothing selected |

All 1608 existing tests continue to pass.

Fixes #363