### PR TITLE
Add Move/Magic Wand edit-mode toggle and wand-specific wireframe behavior

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconMove.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconMove.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- up arrow -->
+  <polyline points="12,3 9,6 12,3 15,6"/>
+  <line x1="12" y1="3" x2="12" y2="9"/>
+  <!-- down arrow -->
+  <polyline points="12,21 9,18 12,21 15,18"/>
+  <line x1="12" y1="21" x2="12" y2="15"/>
+  <!-- left arrow -->
+  <polyline points="3,12 6,9 3,12 6,15"/>
+  <line x1="3" y1="12" x2="9" y2="12"/>
+  <!-- right arrow -->
+  <polyline points="21,12 18,9 21,12 18,15"/>
+  <line x1="21" y1="12" x2="15" y2="12"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1353,7 +1353,7 @@ public class WireframeControl : Control
             snap.Frames.Add((fr.Bounds, fr.IsSelected));
 
         var sel = _frameRects.FirstOrDefault(f => f.IsSelected);
-        if (sel != null)
+        if (sel != null && !_isMagicWandMode)
         {
             snap.SelectedHandleBounds = sel.Bounds;
 
@@ -1425,8 +1425,8 @@ public class WireframeControl : Control
 
         if (!props.IsLeftButtonPressed) return;
 
-        // 1. Hit-test resize handles on the selected frame
-        if (!isCtrl)
+        // 1. Hit-test resize handles on the selected frame (skipped in Magic Wand mode)
+        if (!isCtrl && !_isMagicWandMode)
         {
             var (hitFrame, hitHandle) = HitTestHandle(pos);
             if (hitHandle != HandleKind.None)
@@ -1477,16 +1477,24 @@ public class WireframeControl : Control
         // 2. Magic-wand mode
         if (_isMagicWandMode && _inspectableImage != null)
         {
-            _inspectableImage.GetOpaqueWandBounds(
-                (int)world.X, (int)world.Y,
-                out int minX, out int minY, out int maxX, out int maxY);
-
-            if (maxX >= minX && maxY >= minY)
+            if (isCtrl)
             {
-                if (isCtrl)
+                // Ctrl+click: create a new frame from the wand's flood-fill bounds.
+                _inspectableImage.GetOpaqueWandBounds(
+                    (int)world.X, (int)world.Y,
+                    out int minX, out int minY, out int maxX, out int maxY);
+                if (maxX >= minX && maxY >= minY)
                     FrameCreatedFromRegion?.Invoke(minX, minY, maxX, maxY);
-                else
-                    ApplyRegionToSelectedFrame(minX, minY, maxX, maxY);
+            }
+            else if (e.ClickCount >= 2 && _showPreview)
+            {
+                // Double-click: apply the currently-hovered preview rect to the selected frame.
+                ApplyPreviewToSelectedFrame();
+            }
+            else
+            {
+                // Single-click: plain frame selection only.
+                TrySelectFrameAtPoint(world);
             }
             return;
         }
@@ -2083,6 +2091,19 @@ public class WireframeControl : Control
         FrameRegionChanged?.Invoke(frame);
     }
 
+    /// <summary>
+    /// Applies the current hover-preview rect (<see cref="_previewRect"/>) to the selected frame.
+    /// Used by Magic Wand double-click to commit the dashed-outline selection.
+    /// No-op when no frame is selected, no bitmap is loaded, or no preview is active.
+    /// </summary>
+    private void ApplyPreviewToSelectedFrame()
+    {
+        if (!_showPreview || _selectedState!.SelectedFrame is null || _bitmap is null) return;
+        ApplyRegionToSelectedFrame(
+            (int)_previewRect.Left, (int)_previewRect.Top,
+            (int)_previewRect.Right, (int)_previewRect.Bottom);
+    }
+
     // ── Coordinate transforms ─────────────────────────────────────────────────
 
     private SKPoint ScreenToTexture(float sx, float sy)
@@ -2260,6 +2281,21 @@ public class WireframeControl : Control
         var (minX, minY, maxX, maxY) = PlainClickFrameRegionCalculator.Compute(
             world.X, world.Y, _bitmap.Width, _bitmap.Height, lastW, lastH);
         FrameCreatedFromRegion?.Invoke(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
+    /// Test-only: simulates a Magic Wand double-click at the given screen position.
+    /// Updates the hover preview from the pixel at <paramref name="screenX"/>,
+    /// <paramref name="screenY"/> and then applies <see cref="ApplyPreviewToSelectedFrame"/>,
+    /// mirroring the double-click branch in <see cref="OnPointerPressed"/>.
+    /// No-op when magic-wand mode is off, the bitmap is null, or there is no preview.
+    /// </summary>
+    public void SimulateWandDoubleClick(float screenX, float screenY)
+    {
+        if (!_isMagicWandMode || _bitmap is null) return;
+        UpdatePreview(new Point(screenX, screenY));
+        if (_showPreview)
+            ApplyPreviewToSelectedFrame();
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -470,18 +470,40 @@
                                   PlaceholderText="(none)"
                                   IsVisible="False" />
 
-                        <ToggleButton x:Name="MagicWandToggle"
-                                      Height="26"
-                                      Foreground="{StaticResource Ink}"
-                                      ToolTip.Tip="Click = set frame; Ctrl+Click = add new frame">
-                            <StackPanel Orientation="Horizontal" Spacing="4">
-                                <svg:Svg Width="16" Height="16"
-                                         Path="avares://AnimationEditor/Assets/icons/svg/IconMagicWand.svg"
-                                         CurrentColor="#e6e8ec"
-                                         VerticalAlignment="Center" />
-                                <TextBlock Text="Magic Wand" VerticalAlignment="Center" />
+                        <!-- Edit-mode toggle: Move vs Magic Wand -->
+                        <Border BorderBrush="{StaticResource LineBrush}"
+                                BorderThickness="1" CornerRadius="4" ClipToBounds="True"
+                                Height="26" Margin="0,0,2,0" VerticalAlignment="Center">
+                            <StackPanel Orientation="Horizontal">
+                                <ToggleButton x:Name="MoveModeToggle"
+                                              Height="26"
+                                              Foreground="{StaticResource Ink}"
+                                              CornerRadius="3,0,0,3"
+                                              ToolTip.Tip="Move mode — drag handles to resize/move frames">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <svg:Svg Width="16" Height="16"
+                                                 Path="avares://AnimationEditor/Assets/icons/svg/IconMove.svg"
+                                                 CurrentColor="#e6e8ec"
+                                                 VerticalAlignment="Center" />
+                                        <TextBlock Text="Move" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </ToggleButton>
+                                <Border Width="1" Background="{StaticResource LineBrush}" />
+                                <ToggleButton x:Name="MagicWandToggle"
+                                              Height="26"
+                                              Foreground="{StaticResource Ink}"
+                                              CornerRadius="0,3,3,0"
+                                              ToolTip.Tip="Magic Wand mode — hover to preview region; double-click to apply; Ctrl+click to add new frame">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <svg:Svg Width="16" Height="16"
+                                                 Path="avares://AnimationEditor/Assets/icons/svg/IconMagicWand.svg"
+                                                 CurrentColor="#e6e8ec"
+                                                 VerticalAlignment="Center" />
+                                        <TextBlock Text="Magic Wand" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </ToggleButton>
                             </StackPanel>
-                        </ToggleButton>
+                        </Border>
 
                         <!-- Divider -->
                         <Border Width="1" Height="18" Background="{StaticResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -523,9 +523,12 @@ public partial class MainWindow : Window
 
     // ── Wireframe toolbar wiring ──────────────────────────────────────────────
 
+    private bool _suppressModeToggle;
+
     private void WireWireframeToolbar()
     {
         TextureCombo.SelectionChanged += OnTextureComboChanged;
+        MoveModeToggle.IsCheckedChanged += OnMoveModeToggled;
         MagicWandToggle.IsCheckedChanged += OnMagicWandToggled;
         SnapToGridCheck.IsCheckedChanged += OnSnapToGridChanged;
         GridSizeInput.LostFocus += OnGridSizeInputLostFocus;
@@ -538,6 +541,10 @@ public partial class MainWindow : Window
         ZoomPlusBtn.Click  += (_, _) => StepZoomPreset(WireframeCtrl.Zoom * 100f, _zoomPresets, +1, p => WireframeCtrl.SetZoomPercent(p));
         ZoomMinusBtn.Click += (_, _) => StepZoomPreset(WireframeCtrl.Zoom * 100f, _zoomPresets, -1, p => WireframeCtrl.SetZoomPercent(p));
         WireframeCtrl.WheelZoomPresets = _zoomPresets;
+
+        // Default to Move mode
+        MoveModeToggle.IsChecked = true;
+        WireframeCtrl.IsMagicWandMode = false;
 
         // Apply initial grid state
         WireframeCtrl.SetGrid(false, 16);
@@ -561,9 +568,24 @@ public partial class MainWindow : Window
         RefreshPropertyPanel();
     }
 
+    private void OnMoveModeToggled(object? sender, RoutedEventArgs e)
+    {
+        if (_suppressModeToggle) return;
+        if (MoveModeToggle.IsChecked != true) return;
+        _suppressModeToggle = true;
+        MagicWandToggle.IsChecked = false;
+        _suppressModeToggle = false;
+        WireframeCtrl.IsMagicWandMode = false;
+    }
+
     private void OnMagicWandToggled(object? sender, RoutedEventArgs e)
     {
-        WireframeCtrl.IsMagicWandMode = MagicWandToggle.IsChecked == true;
+        if (_suppressModeToggle) return;
+        if (MagicWandToggle.IsChecked != true) return;
+        _suppressModeToggle = true;
+        MoveModeToggle.IsChecked = false;
+        _suppressModeToggle = false;
+        WireframeCtrl.IsMagicWandMode = true;
     }
 
     private void OnSnapToGridChanged(object? sender, RoutedEventArgs e)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
@@ -1,0 +1,187 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for Magic Wand edit mode:
+///
+/// 1. Handles (resize handles + origin crosshair) are suppressed when
+///    <see cref="WireframeControl.IsMagicWandMode"/> is true, even when a frame is selected.
+///
+/// 2. A double-click via <see cref="WireframeControl.SimulateWandDoubleClick"/> while a
+///    hover preview is active applies the preview rect to the selected frame and fires
+///    <see cref="WireframeControl.FrameRegionChanged"/>.
+/// </summary>
+public class WireframeMagicWandModeTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier             = 1f;
+        return ctx;
+    }
+
+    /// <summary>
+    /// Writes a 64×64 solid opaque black PNG (no transparency) for use in handle tests.
+    /// </summary>
+    private static string WriteSolidBlackPng(string dir)
+    {
+        var path = Path.Combine(dir, $"{Guid.NewGuid():N}.png");
+        using var bm = new SKBitmap(64, 64);
+        bm.Erase(SKColors.Black);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// Writes a 64×64 PNG where pixels in [minPx, maxPx) × [minPy, maxPy) are opaque white,
+    /// and the remainder are fully transparent — useful for a well-defined wand flood-fill target.
+    /// </summary>
+    private static string WriteRegionPng(string dir, int minPx, int minPy, int maxPx, int maxPy)
+    {
+        var path = Path.Combine(dir, $"{Guid.NewGuid():N}.png");
+        using var bm = new SKBitmap(64, 64, SKColorType.Rgba8888, SKAlphaType.Premul);
+        for (int y = 0; y < 64; y++)
+            for (int x = 0; x < 64; x++)
+                bm.SetPixel(x, y, x >= minPx && x < maxPx && y >= minPy && y < maxPy
+                    ? new SKColor(255, 255, 255, 255)
+                    : new SKColor(0, 0, 0, 0));
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    // ── Test 1: handles suppressed in wand mode ───────────────────────────────
+
+    /// <summary>
+    /// When a frame is selected in Move mode, the top-left resize handle renders at pixel (3,3).
+    /// In Magic Wand mode, handles must be suppressed: pixel (3,3) must NOT be white.
+    ///
+    /// Frame at UV 0.125→0.875 on a 64×64 texture → screen rect (8,8,56,56) at camera(0,0,1).
+    /// TopLeft handle centre = (8−5, 8−5) = (3, 3) — white in Move mode, absent in Wand mode.
+    /// </summary>
+    [AvaloniaFact]
+    public void WandMode_HandlesHidden_WhenFrameSelected()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var png = WriteSolidBlackPng(dir);
+
+            var frame = new AnimationFrameSave
+            {
+                TextureName = png, FrameLength = 0.1f,
+                LeftCoordinate = 0.125f, TopCoordinate = 0.125f,
+                RightCoordinate = 0.875f, BottomCoordinate = 0.875f,
+                ShapesSave = new ShapesSave()
+            };
+            var chain = new AnimationChainSave { Name = "Test" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.RefreshFrames();
+            ctrl.SetCamera(0, 0, 1);
+            ctrl.IsMagicWandMode = true;
+
+            using var bm = ctrl.RenderToBitmap(64, 64);
+
+            // In Move mode pixel (3,3) would be white (handle fill).
+            // In Wand mode handles must be suppressed → pixel should remain dark.
+            var px = bm.GetPixel(3, 3);
+            Assert.True(px.Red < 200 || px.Green < 200 || px.Blue < 200,
+                $"Top-left handle pixel (3,3) should be suppressed in wand mode; " +
+                $"R={px.Red} G={px.Green} B={px.Blue}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── Test 2: double-click applies preview rect ─────────────────────────────
+
+    /// <summary>
+    /// In Magic Wand mode, <see cref="WireframeControl.SimulateWandDoubleClick"/> at a position
+    /// inside an opaque pixel island should:
+    /// <list type="bullet">
+    ///   <item>Fire <see cref="WireframeControl.FrameRegionChanged"/>.</item>
+    ///   <item>Update the selected frame's UV coords to the island's bounding box.</item>
+    /// </list>
+    ///
+    /// Texture: 64×64 with opaque pixels in [20,40) × [20,40) and transparent everywhere else.
+    /// Camera: pan=(0,0), zoom=1 → texture pixel (30,30) = screen pixel (30,30).
+    /// Expected frame UV after double-click: left≈20/64, top≈20/64, right≈40/64, bottom≈40/64.
+    /// </summary>
+    [AvaloniaFact]
+    public void WandMode_DoubleClick_AppliesPreviewRectToSelectedFrame()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            const int IslandMin = 20, IslandMax = 40;
+            var png = WriteRegionPng(dir, IslandMin, IslandMin, IslandMax, IslandMax);
+
+            // Start with frame covering the full texture.
+            var frame = new AnimationFrameSave
+            {
+                TextureName = png, FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f,
+                RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave()
+            };
+            var chain = new AnimationChainSave { Name = "Test" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.RefreshFrames();
+            ctrl.SetCamera(0, 0, 1);
+            ctrl.IsMagicWandMode = true;
+
+            AnimationFrameSave? changedFrame = null;
+            ctrl.FrameRegionChanged += f => changedFrame = f;
+
+            // Double-click at screen (30,30) → texture pixel (30,30) which is inside the island.
+            ctrl.SimulateWandDoubleClick(30f, 30f);
+
+            Assert.NotNull(changedFrame);
+            Assert.Same(frame, changedFrame);
+
+            const float Eps = 1.5f / 64f;   // 1.5 pixel tolerance in UV space
+            Assert.True(Math.Abs(frame.LeftCoordinate   - IslandMin / 64f) < Eps,
+                $"LeftCoordinate expected ≈{IslandMin}/64 but was {frame.LeftCoordinate}");
+            Assert.True(Math.Abs(frame.TopCoordinate    - IslandMin / 64f) < Eps,
+                $"TopCoordinate expected ≈{IslandMin}/64 but was {frame.TopCoordinate}");
+            Assert.True(Math.Abs(frame.RightCoordinate  - IslandMax / 64f) < Eps,
+                $"RightCoordinate expected ≈{IslandMax}/64 but was {frame.RightCoordinate}");
+            Assert.True(Math.Abs(frame.BottomCoordinate - IslandMax / 64f) < Eps,
+                $"BottomCoordinate expected ≈{IslandMax}/64 but was {frame.BottomCoordinate}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}


### PR DESCRIPTION
Fixes #364

## Changes

### UI toggle (`MainWindow.axaml` + `.cs`)
- Replaced the single `MagicWandToggle` with a two-button mutually-exclusive toolbar control: **Move** (new `IconMove.svg`) and **Magic Wand** (existing icon), grouped in a shared border.
- Move mode is the default on startup.
- Code-behind uses a `_suppressModeToggle` flag to ensure checking one button unchecks the other without feedback loops.

### Handles + crosshair suppression (`WireframeControl.BuildSnapshot`)
- When `_isMagicWandMode` is `true`, `BuildSnapshot` skips setting `SelectedHandleBounds` and `OriginTexX/Y`. This removes resize handles and the origin crosshair from the rendered output in wand mode.

### Pointer behavior in Magic Wand mode (`WireframeControl.OnPointerPressed`)
- Handle hit-test (step 1) is **skipped** in wand mode.
- **Single-click**: falls through to `TrySelectFrameAtPoint` (frame selection only).
- **Ctrl+click**: creates a new frame from the wand flood-fill bounds (preserved).
- **Double-click**: applies the current hover-preview rect to the selected frame via new `ApplyPreviewToSelectedFrame()`.

### New helpers
- `private ApplyPreviewToSelectedFrame()` — maps `_previewRect` to UV coords and fires `FrameRegionChanged`.
- `public SimulateWandDoubleClick(float, float)` — test-only helper.
- `Assets/icons/svg/IconMove.svg` — new 4-arrows move icon.

## Tests

`WireframeMagicWandModeTests.cs` (2 new `[AvaloniaFact]` tests):
1. `WandMode_HandlesHidden_WhenFrameSelected` — verifies the top-left handle pixel is suppressed in wand mode even when a frame is selected.
2. `WandMode_DoubleClick_AppliesPreviewRectToSelectedFrame` — verifies `SimulateWandDoubleClick` fires `FrameRegionChanged` and updates the frame UV to match the pixel island bounds.

All 1606 tests pass (1157 Core + 449 App).