### PR TITLE
Wire KernSmith as the in-memory font creator for Gum text

### DIFF
--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -58,6 +58,7 @@
     <PackageReference Include="Apos.Shapes" Version="*" />
     <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="Gum.Shapes.MonoGame" Version="2026.5.8.1" />
+    <PackageReference Include="KernSmith.MonoGameGum" Version="0.13.*" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -69,6 +70,7 @@
     <PackageReference Include="Apos.Shapes.KNI" Version="*" />
     <PackageReference Include="Gum.KNI" Version="2026.5.8.1" />
     <PackageReference Include="Gum.Shapes.KNI" Version="2026.5.8.1" />
+    <PackageReference Include="KernSmith.KniGum" Version="0.13.*" />
     <PackageReference Include="KNI.Extended" Version="6.0.0-preview.*" />
     <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
     <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -15,6 +15,7 @@ using FlatRedBall2.Rendering.Batches;
 using FlatRedBall2.Utilities;
 using Gum.Forms;
 using Gum.Wireframe;
+using KernSmith.Gum;
 using MonoGameGum;
 using MonoGameAndGum.Renderables;
 using Microsoft.Xna.Framework.Content;
@@ -270,6 +271,13 @@ public class FlatRedBallService
         {
             _gum.Initialize(game, DefaultVisualsVersion.V3);
         }
+
+        // KernSmith generates BitmapFonts in memory for any (family, size, style)
+        // combination — TextRuntime / DrawString resolve fonts without requiring
+        // pre-baked .fnt files in Content/FontCache/. Slots into Gum's font lookup
+        // cascade as IInMemoryFontCreator. Same wiring for both MonoGame and KNI.
+        CustomSetPropertyOnRenderable.InMemoryFontCreator =
+            new KernSmithFontCreator(game.GraphicsDevice);
         GumRenderBatch.Instance.Initialize();
         ShapeRenderer.Self.Initialize(game.GraphicsDevice, game.Content);
         System.Diagnostics.Debug.WriteLine("FlatRedBall2 initialized.");


### PR DESCRIPTION
## Summary
- Adds `KernSmith.MonoGameGum` (MonoGame backend) and `KernSmith.KniGum` (KNI backend) to `src/FlatRedBall2.csproj`, gated by the same `$(Backend)` condition that selects the rest of each backend's package set.
- Registers a `KernSmithFontCreator(game.GraphicsDevice)` on `CustomSetPropertyOnRenderable.InMemoryFontCreator` immediately after `_gum.Initialize(...)` in `FlatRedBallService.Initialize`. Same one-line wiring works for both backends because both KernSmith packages expose the type in the `KernSmith.Gum` namespace.

## Why
Without this, Gum's font lookup cascade falls through to `DefaultBitmapFont` (Font18Arial) whenever a `TextRuntime` requests a (family, size, style) that wasn't pre-baked into `Content/FontCache/`. There's no warning — text silently renders in the wrong font. KernSmith generates the BitmapFont in memory at runtime, so any combination resolves correctly. This is the same wiring the Gum samples already do manually; folding it into the engine means FRB2 consumers get it for free.

## Test plan
- [ ] Build a sample (e.g. Solitaire) and confirm text renders in the requested font/size when no matching `.fnt` exists under `Content/FontCache/`.
- [ ] Set `TextRuntime.FontSize = 24` (or any non-pre-baked size) at runtime and confirm the glyphs scale correctly instead of falling back to Font18Arial.
- [ ] Confirm `dotnet build src/FlatRedBall2.csproj` succeeds for both `net8.0` (KNI) and `net10.0` (MonoGame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)