### PR TITLE
Add right-click Duplicate Frame to animation frame context menu (#366)

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
+++ b/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
@@ -54,6 +54,7 @@
 | F11 | Set relative X/Y offset | Sets `RelativeX` / `RelativeY` for animation position offsets |
 | F12 | Add multiple frames (batch) | "Add Multiple Frames" dialog; user enters count N; optional **Increment frame position** auto-advances `Left/Right/Top/BottomCoordinate` row-by-row based on the last frame's cell size; warns when increment would exceed texture bounds; N frames are added sequentially with each selecting the newly created frame |
 | F13 | Pixel-mode frame UV editing | When `UnitType` is `Pixel`, setting X/Y moves both the near and far edges by the pixel delta (preserving size); setting Width/Height adjusts only the far edge; all coordinates are rounded to the nearest pixel boundary after each change (mirroring `AnimationFrameDisplayer.CoordinateChange` in the WinForms app) |
+| F14 | Duplicate frame | Deep-copies a single frame (UV coordinates, timing, flip flags, relative offsets, texture, shapes) and inserts the copy immediately after the source frame in the chain; undoable |
 
 ### 1.3 Shape / Collision Management (per frame)
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2082,6 +2082,9 @@ public partial class MainWindow : Window
             AddMenuItem("Rename…", () =>
                 BeginInlineRename(vm!, frame2.HasCustomName ? frame2.Name : string.Empty));
             AddSeparator();
+            if (chain2 is not null)
+                AddMenuItem("Duplicate Frame", () => _appCommands.DuplicateFrame(frame2, chain2));
+            AddSeparator();
             AddMenuItem("Delete Frame", () =>
                 _appCommands.DeleteFrames(new List<AnimationFrameSave> { frame2 }));
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -745,6 +745,47 @@ namespace AnimationEditor.Core.CommandsAndState
             return copy;
         }
 
+        public AnimationFrameSave? DuplicateFrame(AnimationFrameSave source, AnimationChainSave chain)
+        {
+            if (!chain.Frames.Contains(source)) return null;
+
+            var copy = new AnimationFrameSave
+            {
+                TextureName      = source.TextureName,
+                LeftCoordinate   = source.LeftCoordinate,
+                RightCoordinate  = source.RightCoordinate,
+                TopCoordinate    = source.TopCoordinate,
+                BottomCoordinate = source.BottomCoordinate,
+                FrameLength      = source.FrameLength,
+                FlipHorizontal   = source.FlipHorizontal,
+                FlipVertical     = source.FlipVertical,
+                RelativeX        = source.RelativeX,
+                RelativeY        = source.RelativeY,
+                ShapesSave       = new FlatRedBall2.Animation.Content.ShapesSave()
+            };
+
+            if (source.ShapesSave != null)
+            {
+                foreach (var shape in source.ShapesSave.Shapes)
+                {
+                    switch (shape)
+                    {
+                        case AARectSave r:
+                            copy.ShapesSave!.Shapes.Add(
+                                new AARectSave { Name = r.Name, X = r.X, Y = r.Y, ScaleX = r.ScaleX, ScaleY = r.ScaleY });
+                            break;
+                        case CircleSave c:
+                            copy.ShapesSave!.Shapes.Add(
+                                new CircleSave { Name = c.Name, X = c.X, Y = c.Y, Radius = c.Radius });
+                            break;
+                    }
+                }
+            }
+
+            _undoManager.Execute(new DuplicateFrameCommand(source, copy, chain, this, _events, _selectedState));
+            return copy;
+        }
+
         public void SortAnimationsAlphabetically()
         {
             var acls = _pm.AnimationChainListSave;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateFrameCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateFrameCommand.cs
@@ -1,0 +1,71 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Undo/redo record for duplicating a single animation frame.
+    /// The copy is inserted immediately after the source frame so it appears
+    /// adjacent to the original in the tree.
+    /// </summary>
+    internal sealed class DuplicateFrameCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave _source;
+        private readonly AnimationFrameSave _copy;
+        private readonly AnimationChainSave _chain;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+        private readonly ISelectedState _selectedState;
+        private readonly int _insertIndex;
+
+        public string Description { get; }
+
+        public DuplicateFrameCommand(
+            AnimationFrameSave source,
+            AnimationFrameSave copy,
+            AnimationChainSave chain,
+            IAppCommands commands,
+            IApplicationEvents events,
+            ISelectedState selectedState)
+        {
+            _source = source;
+            _copy = copy;
+            _chain = chain;
+            _commands = commands;
+            _events = events;
+            _selectedState = selectedState;
+            _insertIndex = chain.Frames.IndexOf(source) + 1;
+            Description = $"Duplicate Frame in '{chain.Name}'";
+        }
+
+        public bool Do()
+        {
+            int idx = Math.Min(_insertIndex, _chain.Frames.Count);
+            _chain.Frames.Insert(idx, _copy);
+            RaiseSideEffects();
+            _selectedState.SelectedFrame = _copy;
+            return true;
+        }
+
+        public void Undo()
+        {
+            _chain.Frames.Remove(_copy);
+            RaiseSideEffects();
+            _selectedState.SelectedFrame = _source;
+        }
+
+        public void Redo()
+        {
+            int idx = Math.Min(_insertIndex, _chain.Frames.Count);
+            _chain.Frames.Insert(idx, _copy);
+            RaiseSideEffects();
+            _selectedState.SelectedFrame = _copy;
+        }
+
+        private void RaiseSideEffects()
+        {
+            _commands.RefreshTreeNode(_chain);
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -107,6 +107,13 @@ namespace AnimationEditor.Core.CommandsAndState
         void InvertFrameOrder(AnimationChainSave chain);
         void SetAllFrameLengths(AnimationChainSave chain, float frameLength);
         AnimationChainSave? DuplicateChain(AnimationChainSave source, bool flipH = false, bool flipV = false, string? newName = null);
+
+        /// <summary>
+        /// Deep-copies <paramref name="source"/> and inserts the copy immediately after it
+        /// in <paramref name="chain"/>. All UV coordinates, timing, flip flags, relative offsets,
+        /// and attached shapes are copied. Undoable.
+        /// </summary>
+        AnimationFrameSave? DuplicateFrame(AnimationFrameSave source, AnimationChainSave chain);
         void SortAnimationsAlphabetically();
         void AdjustOffsetsJustifyBottom(AnimationChainSave chain, Func<AnimationFrameSave, float?> getTextureHeight, float offsetMultiplier = 1f);
         void AdjustOffsetsAdjustAll(AnimationChainSave chain, float? deltaX, float? deltaY, bool relative);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
@@ -269,4 +269,153 @@ public class AppCommandsFrameTests
             ctx.ApplicationEvents.AnimationChainsChanged -= Handler;
         }
     }
+
+    // ── DuplicateFrame ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void DuplicateFrame_CreatesDeepCopy()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var source = chain.Frames[0];
+
+        var copy = ctx.AppCommands.DuplicateFrame(source, chain);
+
+        Assert.NotNull(copy);
+        Assert.NotSame(source, copy);
+    }
+
+    [Fact]
+    public void DuplicateFrame_CopiesTextureName()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        chain.Frames[0].TextureName = "hero.png";
+
+        var copy = ctx.AppCommands.DuplicateFrame(chain.Frames[0], chain);
+
+        Assert.Equal("hero.png", copy!.TextureName);
+    }
+
+    [Fact]
+    public void DuplicateFrame_CopiesUvCoordinates()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var source = chain.Frames[0];
+        source.LeftCoordinate   = 0.1f;
+        source.RightCoordinate  = 0.5f;
+        source.TopCoordinate    = 0.2f;
+        source.BottomCoordinate = 0.8f;
+        source.FrameLength      = 0.25f;
+        source.RelativeX        = 3f;
+        source.RelativeY        = -2f;
+
+        var copy = ctx.AppCommands.DuplicateFrame(source, chain);
+
+        Assert.Equal(0.1f,  copy!.LeftCoordinate);
+        Assert.Equal(0.5f,  copy.RightCoordinate);
+        Assert.Equal(0.2f,  copy.TopCoordinate);
+        Assert.Equal(0.8f,  copy.BottomCoordinate);
+        Assert.Equal(0.25f, copy.FrameLength);
+        Assert.Equal(3f,    copy.RelativeX);
+        Assert.Equal(-2f,   copy.RelativeY);
+    }
+
+    [Fact]
+    public void DuplicateFrame_CopiesFlipFlags()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Idle", 1);
+        chain.Frames[0].FlipHorizontal = true;
+        chain.Frames[0].FlipVertical   = true;
+
+        var copy = ctx.AppCommands.DuplicateFrame(chain.Frames[0], chain);
+
+        Assert.True(copy!.FlipHorizontal);
+        Assert.True(copy.FlipVertical);
+    }
+
+    [Fact]
+    public void DuplicateFrame_CopiesShapes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Attack", 1);
+        chain.Frames[0].ShapesSave!.Shapes.Add(
+            new AARectSave { Name = "HitBox", ScaleX = 4, ScaleY = 4 });
+
+        var copy = ctx.AppCommands.DuplicateFrame(chain.Frames[0], chain);
+
+        Assert.Single(copy!.ShapesSave!.AARectSaves);
+        Assert.Equal("HitBox", copy.ShapesSave!.AARectSaves.First().Name);
+        Assert.NotSame(chain.Frames[0].ShapesSave!.Shapes[0], copy.ShapesSave.Shapes[0]);
+    }
+
+    [Fact]
+    public void DuplicateFrame_InsertsImmediatelyAfterSource()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 3);
+        var source = chain.Frames[1]; // middle frame
+
+        var copy = ctx.AppCommands.DuplicateFrame(source, chain);
+
+        Assert.Equal(4, chain.Frames.Count);
+        Assert.Equal(2, chain.Frames.IndexOf(copy!));
+    }
+
+    [Fact]
+    public void DuplicateFrame_InsertsAfterLastFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 2);
+        var source = chain.Frames[1]; // last frame
+
+        var copy = ctx.AppCommands.DuplicateFrame(source, chain);
+
+        Assert.Equal(3, chain.Frames.Count);
+        Assert.Same(copy, chain.Frames[2]);
+    }
+
+    [Fact]
+    public void DuplicateFrame_SetsSelectedFrameToTheCopy()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+
+        var copy = ctx.AppCommands.DuplicateFrame(chain.Frames[0], chain);
+
+        Assert.Same(copy, ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void DuplicateFrame_FiresAnimationChainsChanged()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        bool fired = false;
+        void Handler() => fired = true;
+        ctx.ApplicationEvents.AnimationChainsChanged += Handler;
+        try
+        {
+            ctx.AppCommands.DuplicateFrame(chain.Frames[0], chain);
+            Assert.True(fired);
+        }
+        finally
+        {
+            ctx.ApplicationEvents.AnimationChainsChanged -= Handler;
+        }
+    }
+
+    [Fact]
+    public void DuplicateFrame_WhenSourceNotInChain_ReturnsNull()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var orphan = new AnimationFrameSave();
+
+        var result = ctx.AppCommands.DuplicateFrame(orphan, chain);
+
+        Assert.Null(result);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -85,6 +85,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.InvertFrameOrder)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetAllFrameLengths)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.DuplicateChain)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.DuplicateFrame)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SortAnimationsAlphabetically)] = Category.MutatingUndoable,
         [nameof(IAppCommands.AdjustOffsetsJustifyBottom)]   = Category.MutatingUndoable,
         [nameof(IAppCommands.AdjustOffsetsAdjustAll)]       = Category.MutatingUndoable,
@@ -244,6 +245,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetAllFrameLengths(Zebra(ctx), 0.5f)));
         yield return Row(nameof(IAppCommands.DuplicateChain),
             ctx => Sync(() => ctx.AppCommands.DuplicateChain(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.DuplicateFrame),
+            ctx => Sync(() => ctx.AppCommands.DuplicateFrame(Zebra(ctx).Frames[0], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.SortAnimationsAlphabetically),
             ctx => Sync(() => ctx.AppCommands.SortAnimationsAlphabetically())); // Zebra,Alpha -> Alpha,Zebra
         yield return Row(nameof(IAppCommands.AdjustOffsetsJustifyBottom),


### PR DESCRIPTION
## Summary

Fixes #366 — adds right-click duplicate support for **frames**.

> The animation (chain) side already had three Duplicate variants ("Duplicate (original)", "Duplicate (flip horizontally)", "Duplicate (flip vertically)"). The gap was that frames had no duplicate option.

## Changes

- **`DuplicateFrameCommand.cs`** (new) — undo/redo command that deep-copies a frame and inserts it immediately after the source frame in the chain
- **`IAppCommands`** — added `AnimationFrameSave? DuplicateFrame(source, chain)` signature with XML doc
- **`AppCommands`** — implements `DuplicateFrame`: null-guards if source not in chain, deep-copies all UV coords, timing, flip flags, relative offsets, texture name, and attached shapes, then executes the command
- **`MainWindow.axaml.cs`** — "Duplicate Frame" menu item in the frame branch of `OnTreeContextMenuOpening`
- **`AppCommandsFrameTests.cs`** — 9 new `DuplicateFrame_*` tests
- **`UndoCoverageRosterTests.cs`** — registered as `MutatingUndoable`
- **`FEATURE_COVERAGE_REPORT.md`** — F14 row added

## Design

- The duplicate is inserted **immediately after** the source frame for natural UX
- Deep-copy follows the same shape-copy logic used in `DuplicateChain`
- Undo restores selection to the source frame; redo re-selects the copy

## Test results

All 1174 Core tests + 458 App tests pass.