### PR TITLE
Add Gum UI helpers and startup font validation

### DIFF
--- a/frb-skills/gum-integration/SKILL.md
+++ b/frb-skills/gum-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gum-integration
-description: "Gum Integration in FlatRedBall2. Use when working with UI, HUD, menus, buttons, labels, text display, StackPanel, Panel, layout, Gum Forms controls, Add, screen-space vs world-space UI, or any Gum-related question. Also trigger when user asks about displaying text on screen."
+description: "Gum Integration in FlatRedBall2. Use when working with UI, HUD, menus, buttons, labels, text display, StackPanel, Panel, layout, Gum Forms controls, Add, AddOverlay, screen-space vs world-space UI, blurry or low-res text, FontSize, text opacity/alpha, or any Gum-related question. Also trigger when user asks about displaying text on screen."
 ---
 
 # Gum Integration in FlatRedBall2
@@ -119,6 +119,20 @@ var scoreText = new TextRuntime { Text = "0", FontSize = 48 };
 Add(scoreText);
 ```
 
+For `Label`, text styling still lives on the underlying `TextRuntime`. Changing `Label.Text` updates content only; change the visual for `FontSize`/opacity:
+
+```csharp
+using MonoGameGum.GueDeriving;
+
+if (scoreLabel.Visual is TextRuntime text)
+{
+    text.FontSize = 28;
+    text.Alpha = 180; // 0..255 opacity
+}
+```
+
+With Gum codegen, many text instances are already typed as `TextRuntime` properties (for example `mainMenu.TitleText`), so set `FontSize`/`Alpha` directly there.
+
 ## Render Ordering (Layers / Z)
 
 **Unlayered renderables draw behind layered ones.** Gum elements added without a layer will be hidden behind any layered game objects. Always assign Gum UI to an explicit layer.
@@ -163,6 +177,20 @@ Add(scoreLabel, layer: hudLayer);
 **Screen-space (default)**: `screen.Add(element)` places elements in Gum's native coordinate system (pixels, Y-down, origin top-left). Use for HUDs, menus.
 
 **World-space**: `entity.Add(element)` places a Gum element at the entity's world position. It follows the entity and shifts when the camera pans. The visual is automatically removed when the entity is destroyed. `entity.IsVisible = false` hides it — don't reach into `element.Visible`.
+
+## Overlay vs Camera UI: Rendering Quality
+
+`Add()` parents UI under the camera's `UiRoot`, whose canvas matches the design resolution. Gum generates font bitmaps at `FontSize` design pixels; the render batch upscales them by `Camera.PixelsPerUnit`. At 2× (e.g. 480→960 window), a 22px font bitmap renders at 44px — each source pixel becomes a 2×2 block on screen, visibly lowering quality.
+
+`AddOverlay()` parents UI under `Screen.OverlayRoot`, sized to the back-buffer and rendered 1:1. `FontSize=22` generates a 22px bitmap rendered at 22px — sharp at any `PixelsPerUnit`. Use `AddOverlay()` for any text-bearing screen-space HUD when the window is larger than the design resolution.
+
+Coordinate values for overlay elements are in back-buffer pixels (design coords × `PixelsPerUnit`). For hit-testing overlay UI from world-space cursor input:
+
+```csharp
+float s  = Camera.PixelsPerUnit;
+float cx = (worldPos.X - Camera.Left) * s;
+float cy = (Camera.Top - worldPos.Y)  * s;
+```
 
 ## Loading Gum Screens from a .gumx Project File
 
@@ -247,6 +275,8 @@ The API differs by type:
 - **"Keyboard navigation" on Forms controls means Tab/accessibility focus only — not arrow keys.** Game action menus (battle commands, pause menus) require custom logic: maintain a `_selectedIndex` int and drive selection with `WasKeyPressed(Keys.Up/Down/Left/Right)` in `Screen.CustomActivity`. Apply visual highlight by toggling a property on the selected element. Do not try to use `Button.IsFocused` or `OnKeyDown` for this — Forms focus is designed for form tab-order, not game input.
 - **Namespace**: `TextRuntime` is in `MonoGameGum.GueDeriving`. Forms controls (`Button`, `Label`, etc.) are in `Gum.Forms.Controls`. `Anchor`/`Dock` enums are in `Gum.Wireframe`. `GetFrameworkElementByName` extension is in `Gum.Forms`. Shapes (`ColoredCircleRuntime`, `RoundedRectangleRuntime`, `ArcRuntime`) are in `MonoGameGum.GueDeriving` — same namespace as other visual types. Do **not** use `MonoGameGum.Forms.Controls` — all types there are `[Obsolete(error: true)]`.
 - **Visibility by type** — `FrameworkElement` uses `.IsVisible`; visual types (`ColoredRectangleRuntime`, etc.) use `.Visible`. Do not use `element.Visual.Visible` directly on FrameworkElement.
+- **`Label` style knobs are on `label.Visual`**. `Label` itself does not expose `FontSize`/`Alpha`; cast `label.Visual` to `TextRuntime` when you need runtime size/opacity changes.
+- **`Add()` upscales fonts** when the window is larger than the design canvas (`PixelsPerUnit > 1`). At 2× scale a 22px font bitmap renders as a 44px upscale — blocky. Use `AddOverlay()` for text-bearing HUD to render at native back-buffer resolution (1:1). See *Overlay vs Camera UI: Rendering Quality* above.
 - **Gum coordinates are screen pixels, Y-down** — opposite of the game world (Y-up, centered). Use `Anchor`/`Dock` to avoid hard-coding pixel positions.
 - **Projected world coordinates under zoom** — `Camera.WorldToScreen` gives viewport pixels, but Gum applies zoom scaling during render. For projected Gum overlays (selection rectangles, tile highlights), convert viewport-pixel coordinates into Gum canvas units using zoom compensation (`1 / Camera.Zoom`) to avoid double-scaling drift.
 - **Initialize order**: Do not create Gum elements before `FlatRedBallService.Initialize`.

--- a/frb-skills/gumcli/SKILL.md
+++ b/frb-skills/gumcli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gumcli
-description: "Gum CLI tool for FlatRedBall2. Trigger at game/sample START — before any code is written — to ask the user whether the project will use Gum and which mode (code-only, project+dynamic, or project+codegen). Covers locating gumcli.exe, running gumcli new, .csproj content includes, and codegen."
+description: "Gum CLI tool for FlatRedBall2. Trigger at game/sample START — before any code is written — to ask the user whether the project will use Gum and which mode (code-only, project+dynamic, or project+codegen). Covers locating gumcli.exe, running gumcli new, .csproj content includes, codegen, and custom/Google font setup."
 ---
 
 # Gum CLI Setup
@@ -116,7 +116,7 @@ Exit codes: `0` = success, `1` = elements blocked by errors, `2` = load/config f
 
 ## Font Generation
 
-If the project uses custom bitmap fonts (Text elements with a Font variable set), generate the missing `.fnt` and `.png` files with:
+FRB2 can generate fonts in memory from installed system font families, so plain `Font="Arial"` style usage often works without pre-baked files. Use this command when the Gum project relies on generated bitmap caches (especially `UseCustomFont=true` + `CustomFontFile`) and needs deterministic `.fnt`/`.png` output:
 
 ```bash
 gumcli fonts Content/GumProject/GumProject.gumx
@@ -126,6 +126,23 @@ gumcli fonts Content/GumProject/GumProject.gumx
 - Only generates fonts that don't already exist on disk; safe to re-run.
 - Font files land in `FontCache/` next to the `.gumx` file. Add that folder to `.gitignore` or check it in depending on your CI setup.
 - Run this after `gumcli new` if the project template includes screens with font-bearing Text instances, or any time a new font/size combination is added in the Gum editor.
+
+### Google Font workflow (issue #371 class of requests)
+
+Google Fonts links are usually specimen pages, not runtime font files. The reliable flow is: download the `.ttf`/`.otf` into the Gum project, point Gum text styles at that file, then regenerate font caches.
+
+1. Save the font file under `Content/GumProject/Fonts/` (for example `Content/GumProject/Fonts/Inter-Regular.ttf`).
+2. In Gum (usually on a shared text style like `Styles/Normal`), set:
+   - `UseCustomFont = true`
+   - `CustomFontFile = Fonts/Inter-Regular.ttf` (project-relative path)
+3. Run `gumcli check`, then `gumcli fonts`:
+
+```bash
+gumcli check Content/GumProject/GumProject.gumx
+gumcli fonts Content/GumProject/GumProject.gumx
+```
+
+4. If using mode 3 (codegen), run `gumcli codegen` after the Gum XML change.
 
 ---
 

--- a/src/EngineInitSettings.cs
+++ b/src/EngineInitSettings.cs
@@ -1,4 +1,18 @@
+using System;
+using System.Collections.Generic;
+
 namespace FlatRedBall2;
+
+/// <summary>
+/// Controls how startup validation reacts when configured Gum font files are missing.
+/// </summary>
+public enum MissingGumFontFileBehavior
+{
+    /// <summary>Write a warning and continue startup.</summary>
+    Warn,
+    /// <summary>Throw and fail startup when any configured file is missing.</summary>
+    Throw
+}
 
 /// <summary>
 /// Startup configuration passed to <see cref="FlatRedBallService.Initialize"/>.
@@ -12,4 +26,17 @@ public class EngineInitSettings
     /// When null, Gum initializes in code-only mode using default V3 visuals.
     /// </summary>
     public string? GumProjectFile { get; init; }
+
+    /// <summary>
+    /// Optional Gum font files to validate at startup (for example entries used by
+    /// Text <c>CustomFontFile</c>). Relative paths are interpreted relative to the
+    /// directory containing <see cref="GumProjectFile"/>.
+    /// </summary>
+    public IReadOnlyList<string> GumFontFilesToValidate { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Controls whether missing entries in <see cref="GumFontFilesToValidate"/> throw
+    /// during startup or only produce a warning.
+    /// </summary>
+    public MissingGumFontFileBehavior MissingGumFontFileBehavior { get; init; } = MissingGumFontFileBehavior.Warn;
 }

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -272,6 +272,9 @@ public class FlatRedBallService
             _gum.Initialize(game, DefaultVisualsVersion.V3);
         }
 
+        if (settings is not null)
+            ValidateConfiguredGumFontFiles(settings);
+
         // KernSmith generates BitmapFonts in memory for any (family, size, style)
         // combination — TextRuntime / DrawString resolve fonts without requiring
         // pre-baked .fnt files in Content/FontCache/. Slots into Gum's font lookup
@@ -282,6 +285,100 @@ public class FlatRedBallService
         ShapeRenderer.Self.Initialize(game.GraphicsDevice, game.Content);
         System.Diagnostics.Debug.WriteLine("FlatRedBall2 initialized.");
     }
+
+    internal static IReadOnlyList<string> ResolveGumFontValidationPaths(EngineInitSettings settings)
+    {
+        if (settings.GumFontFilesToValidate.Count == 0)
+            return Array.Empty<string>();
+
+        var gumProjectDirectory = GetGumProjectDirectory(settings.GumProjectFile);
+        var resolved = new List<string>(settings.GumFontFilesToValidate.Count);
+
+        foreach (var configuredPath in settings.GumFontFilesToValidate)
+        {
+            if (string.IsNullOrWhiteSpace(configuredPath))
+                continue;
+
+            var path = NormalizePathSeparators(configuredPath);
+            if (!Path.IsPathRooted(path) && !string.IsNullOrWhiteSpace(gumProjectDirectory))
+                path = CombineForwardSlashPaths(gumProjectDirectory!, path);
+
+            resolved.Add(path);
+        }
+
+        return resolved;
+    }
+
+    internal static void ValidateConfiguredGumFontFiles(
+        EngineInitSettings settings,
+        Func<string, bool>? fileExists = null,
+        Action<string>? warn = null)
+    {
+        var resolvedPaths = ResolveGumFontValidationPaths(settings);
+        if (resolvedPaths.Count == 0)
+            return;
+
+        fileExists ??= ContentFileExists;
+        warn ??= static message => System.Diagnostics.Debug.WriteLine(message);
+
+        var missingPaths = resolvedPaths.Where(path => !fileExists(path)).ToArray();
+        if (missingPaths.Length == 0)
+            return;
+
+        var message = $"Configured Gum font file(s) were not found: {string.Join(", ", missingPaths)}.";
+        if (settings.MissingGumFontFileBehavior == MissingGumFontFileBehavior.Throw)
+            throw new InvalidOperationException(message);
+
+        warn(message);
+    }
+
+    private static string CombineForwardSlashPaths(string left, string right)
+    {
+        if (string.IsNullOrEmpty(left))
+            return NormalizePathSeparators(right);
+
+        var normalizedLeft = NormalizePathSeparators(left).TrimEnd('/');
+        var normalizedRight = NormalizePathSeparators(right).TrimStart('/');
+        return $"{normalizedLeft}/{normalizedRight}";
+    }
+
+    private static bool ContentFileExists(string relativePath)
+    {
+        var path = relativePath.TrimStart('/', '\\');
+        try
+        {
+            using var _ = Microsoft.Xna.Framework.TitleContainer.OpenStream(path);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static string? GetGumProjectDirectory(string? gumProjectFile)
+    {
+        if (string.IsNullOrWhiteSpace(gumProjectFile))
+            return null;
+
+        var normalized = NormalizePathSeparators(gumProjectFile).Trim();
+        var slashIndex = normalized.LastIndexOf('/');
+        if (slashIndex < 0)
+            return null;
+
+        return normalized.Substring(0, slashIndex);
+    }
+
+    private static string NormalizePathSeparators(string path)
+        => path.Replace('\\', '/');
 
     // Screen management
     /// <summary>

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -300,7 +300,7 @@ public class FlatRedBallService
                 continue;
 
             var path = NormalizePathSeparators(configuredPath);
-            if (!Path.IsPathRooted(path) && !string.IsNullOrWhiteSpace(gumProjectDirectory))
+            if (!IsAbsoluteContentPath(path) && !string.IsNullOrWhiteSpace(gumProjectDirectory))
                 path = CombineForwardSlashPaths(gumProjectDirectory!, path);
 
             resolved.Add(path);
@@ -379,6 +379,23 @@ public class FlatRedBallService
 
     private static string NormalizePathSeparators(string path)
         => path.Replace('\\', '/');
+
+    internal static bool IsAbsoluteContentPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var normalized = NormalizePathSeparators(path.Trim());
+        if (Path.IsPathRooted(normalized))
+            return true;
+
+        // Path.IsPathRooted("C:/...") is false on Unix, but these are still explicit absolute
+        // Windows paths that should not be rewritten as Gum-project-relative content.
+        return normalized.Length >= 3
+            && char.IsLetter(normalized[0])
+            && normalized[1] == ':'
+            && normalized[2] == '/';
+    }
 
     // Screen management
     /// <summary>

--- a/src/ScreenExtensions.cs
+++ b/src/ScreenExtensions.cs
@@ -1,4 +1,7 @@
 using System;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using FlatRedBall2.Rendering;
 
 namespace FlatRedBall2;
 
@@ -8,6 +11,34 @@ namespace FlatRedBall2;
 /// </summary>
 public static class ScreenExtensions
 {
+    /// <summary>
+    /// Adds a Forms control to the primary camera HUD (`screen.Add(...)`), which is
+    /// camera-scoped and scales with <see cref="Rendering.Camera.PixelsPerUnit"/>.
+    /// </summary>
+    public static void AddCameraUi(this Screen screen, FrameworkElement element, Layer? layer = null)
+        => screen.Add(element, layer);
+
+    /// <summary>
+    /// Adds a Gum visual to the primary camera HUD (`screen.Add(...)`), which is
+    /// camera-scoped and scales with <see cref="Rendering.Camera.PixelsPerUnit"/>.
+    /// </summary>
+    public static void AddCameraUi(this Screen screen, GraphicalUiElement visual, Layer? layer = null)
+        => screen.Add(visual, layer);
+
+    /// <summary>
+    /// Adds a Forms control to the screen overlay (`screen.AddOverlay(...)`), drawn once
+    /// after all camera passes at full-window scale.
+    /// </summary>
+    public static void AddScreenOverlay(this Screen screen, FrameworkElement element, Layer? layer = null)
+        => screen.AddOverlay(element, layer);
+
+    /// <summary>
+    /// Adds a Gum visual to the screen overlay (`screen.AddOverlay(...)`), drawn once
+    /// after all camera passes at full-window scale.
+    /// </summary>
+    public static void AddScreenOverlay(this Screen screen, GraphicalUiElement visual, Layer? layer = null)
+        => screen.AddOverlay(visual, layer);
+
     /// <summary>
     /// Restarts the current screen using <paramref name="newConfigure"/> instead of the previously
     /// retained callback. The new callback fully replaces the retained one — both for this restart

--- a/src/UI/GumLabelExtensions.cs
+++ b/src/UI/GumLabelExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using Gum.Forms.Controls;
+using MonoGameGum.GueDeriving;
+
+namespace FlatRedBall2.UI;
+
+/// <summary>
+/// Runtime text styling helpers for Gum <see cref="Label"/> controls.
+/// </summary>
+public static class GumLabelExtensions
+{
+    /// <summary>
+    /// Sets the backing <see cref="TextRuntime.FontSize"/> for a Forms
+    /// <see cref="Label"/> in pixels.
+    /// </summary>
+    public static void SetFontSize(this Label label, int fontSize)
+    {
+        if (fontSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(fontSize), "Font size must be greater than zero.");
+
+        GetTextRuntime(label).FontSize = fontSize;
+    }
+
+    /// <summary>
+    /// Sets label opacity in the unit range [0..1], mapped to
+    /// <see cref="TextRuntime.Alpha"/> [0..255].
+    /// </summary>
+    public static void SetOpacity(this Label label, float opacity)
+    {
+        if (float.IsNaN(opacity) || float.IsInfinity(opacity) || opacity < 0f || opacity > 1f)
+            throw new ArgumentOutOfRangeException(nameof(opacity), "Opacity must be in the range [0..1].");
+
+        GetTextRuntime(label).Alpha = (int)MathF.Round(opacity * 255f);
+    }
+
+    private static TextRuntime GetTextRuntime(Label label)
+    {
+        ArgumentNullException.ThrowIfNull(label);
+
+        if (label.Visual is TextRuntime text)
+            return text;
+
+        throw new InvalidOperationException(
+            $"Label visual is {label.Visual?.GetType().Name ?? "null"}; expected {nameof(TextRuntime)}.");
+    }
+}

--- a/tests/FlatRedBall2.Tests/FlatRedBallServiceGumFontValidationTests.cs
+++ b/tests/FlatRedBall2.Tests/FlatRedBallServiceGumFontValidationTests.cs
@@ -8,6 +8,13 @@ namespace FlatRedBall2.Tests;
 public class FlatRedBallServiceGumFontValidationTests
 {
     [Fact]
+    public void IsAbsoluteContentPath_WindowsDriveAndRelativePaths_ReturnsExpectedValues()
+    {
+        FlatRedBallService.IsAbsoluteContentPath("C:/fonts/NotoSans-Regular.ttf").ShouldBeTrue();
+        FlatRedBallService.IsAbsoluteContentPath("Fonts/Inter-Regular.ttf").ShouldBeFalse();
+    }
+
+    [Fact]
     public void ResolveGumFontValidationPaths_RelativeAndAbsolutePaths_UsesGumProjectDirectoryForRelative()
     {
         var settings = new EngineInitSettings

--- a/tests/FlatRedBall2.Tests/FlatRedBallServiceGumFontValidationTests.cs
+++ b/tests/FlatRedBall2.Tests/FlatRedBallServiceGumFontValidationTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests;
+
+public class FlatRedBallServiceGumFontValidationTests
+{
+    [Fact]
+    public void ResolveGumFontValidationPaths_RelativeAndAbsolutePaths_UsesGumProjectDirectoryForRelative()
+    {
+        var settings = new EngineInitSettings
+        {
+            GumProjectFile = "GumProject/GumProject.gumx",
+            GumFontFilesToValidate = new[]
+            {
+                "Fonts/Inter-Regular.ttf",
+                @"C:\fonts\NotoSans-Regular.ttf"
+            }
+        };
+
+        var paths = FlatRedBallService.ResolveGumFontValidationPaths(settings);
+
+        paths.Count.ShouldBe(2);
+        paths[0].ShouldBe("GumProject/Fonts/Inter-Regular.ttf");
+        paths[1].ShouldBe("C:/fonts/NotoSans-Regular.ttf");
+    }
+
+    [Fact]
+    public void ValidateConfiguredGumFontFiles_MissingAndThrowBehavior_ThrowsInvalidOperationException()
+    {
+        var settings = new EngineInitSettings
+        {
+            GumProjectFile = "GumProject/GumProject.gumx",
+            GumFontFilesToValidate = new[] { "Fonts/Inter-Regular.ttf" },
+            MissingGumFontFileBehavior = MissingGumFontFileBehavior.Throw
+        };
+
+        var warnings = new List<string>();
+
+        Should.Throw<InvalidOperationException>(() =>
+            FlatRedBallService.ValidateConfiguredGumFontFiles(settings, _ => false, warnings.Add));
+        warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ValidateConfiguredGumFontFiles_MissingAndWarnBehavior_ReportsWarningWithoutThrow()
+    {
+        var settings = new EngineInitSettings
+        {
+            GumProjectFile = "GumProject/GumProject.gumx",
+            GumFontFilesToValidate = new[] { "Fonts/Inter-Regular.ttf" },
+            MissingGumFontFileBehavior = MissingGumFontFileBehavior.Warn
+        };
+
+        var warnings = new List<string>();
+
+        FlatRedBallService.ValidateConfiguredGumFontFiles(settings, _ => false, warnings.Add);
+
+        warnings.Count.ShouldBe(1);
+        warnings[0].ShouldContain("GumProject/Fonts/Inter-Regular.ttf");
+    }
+}

--- a/tests/FlatRedBall2.Tests/ScreenExtensionsTests.cs
+++ b/tests/FlatRedBall2.Tests/ScreenExtensionsTests.cs
@@ -1,0 +1,34 @@
+using MonoGameGum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests;
+
+public class ScreenExtensionsTests
+{
+    private class TestScreen : Screen { }
+
+    [Fact]
+    public void AddCameraUi_GraphicalUiElement_ParentsToPrimaryCameraUiRoot()
+    {
+        var screen = new TestScreen();
+        var visual = new ContainerRuntime();
+
+        screen.AddCameraUi(visual);
+
+        screen.Cameras[0].UiRoot.Children.ShouldContain(visual);
+        screen.OverlayRoot.Children.ShouldNotContain(visual);
+    }
+
+    [Fact]
+    public void AddScreenOverlay_GraphicalUiElement_ParentsToOverlayRoot()
+    {
+        var screen = new TestScreen();
+        var visual = new ContainerRuntime();
+
+        screen.AddScreenOverlay(visual);
+
+        screen.OverlayRoot.Children.ShouldContain(visual);
+        screen.Cameras[0].UiRoot.Children.ShouldNotContain(visual);
+    }
+}

--- a/tests/FlatRedBall2.Tests/UI/GumLabelExtensionsTests.cs
+++ b/tests/FlatRedBall2.Tests/UI/GumLabelExtensionsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using FlatRedBall2.UI;
+using Gum.Forms.Controls;
+using MonoGameGum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.UI;
+
+public class GumLabelExtensionsTests
+{
+    private static Label CreateLabelWithVisual() => new Label(new TextRuntime());
+
+    [Fact]
+    public void SetFontSize_Label_UpdatesVisualFontSize()
+    {
+        var label = CreateLabelWithVisual();
+
+        label.SetFontSize(28);
+
+        var text = label.Visual as TextRuntime;
+        text.ShouldNotBeNull();
+        text.FontSize.ShouldBe(28);
+    }
+
+    [Fact]
+    public void SetOpacity_Label_UpdatesVisualAlpha()
+    {
+        var label = CreateLabelWithVisual();
+
+        label.SetOpacity(0.5f);
+
+        var text = label.Visual as TextRuntime;
+        text.ShouldNotBeNull();
+        text.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void SetOpacity_OpacityOutsideUnitRange_ThrowsArgumentOutOfRangeException()
+    {
+        var label = CreateLabelWithVisual();
+
+        Should.Throw<ArgumentOutOfRangeException>(() => label.SetOpacity(1.1f));
+    }
+}


### PR DESCRIPTION
## Why
AI sessions repeatedly hit the same Gum friction points: choosing `Add()` instead of `AddOverlay()` for text-bearing HUDs, trying to set `Label` font size/opacity directly, and configuring custom font files without runtime validation.

## What changed
- Added explicit screen UI intent helpers in `ScreenExtensions`:
  - `AddCameraUi(...)` routes to camera-scoped HUD (`Add`)
  - `AddScreenOverlay(...)` routes to full-window overlay (`AddOverlay`)
- Added `src/UI/GumLabelExtensions.cs` with runtime text helpers for `Label`:
  - `SetFontSize(int)`
  - `SetOpacity(float)`
- Extended `EngineInitSettings` with startup font validation configuration:
  - `GumFontFilesToValidate`
  - `MissingGumFontFileBehavior` (`Warn` or `Throw`)
- Added validation wiring in `FlatRedBallService.Initialize` and helper path resolution/validation methods.
- Updated skill guidance:
  - `frb-skills/gum-integration/SKILL.md`
  - `frb-skills/gumcli/SKILL.md`
- Added focused tests for all new behavior.

## Notes
- Font validation resolves relative font paths against the Gum project directory.
- Validation uses normalized content paths to match Gum/TitleContainer content resolution.
- This PR improves API clarity and setup reliability; it does not add automatic download/configuration from a Google Fonts URL.

Related to #382
Related to #375
Related to #371