### PR TITLE
docs: add terse repo setup .gitignore guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ The new project's `Content/` folder is pre-populated with starter assets (animat
 dotnet new frb2-desktop -n YourGameName --IncludeStarterContent false
 ```
 
+### Repo setup (`.gitignore`)
+
+Use `frb2-desktop` or `frb2-multiplatform` templates — they already include the recommended `.gitignore`.
+
+Manual baseline:
+
+```
+bin/
+obj/
+Content/obj/
+.vs/
+*.user
+*.suo
+```
+
+For web projects, keep the template's `wwwroot/Content/.gitignore` (that folder is build output).
+
 ### Step 3 — Build and run
 
 ```


### PR DESCRIPTION
## Summary
- add a short README section for repository setup and `.gitignore`
- include a minimal baseline ignore list for new FlatRedBall2 projects
- note that web projects should keep `wwwroot/Content/.gitignore`

Closes #357