### PR TITLE
Add AnimationChain.KNI.csproj — separate NuGet packages for MonoGame and KNI

### DIFF
--- a/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
+++ b/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
@@ -6,12 +6,13 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet Metadata -->
-    <PackageId>FlatRedBall.AnimationChain.MonoGame</PackageId>
+    <PackageId>FlatRedBall.AnimationChain.KNI</PackageId>
     <Authors>Victor Chelaru</Authors>
     <Description>
-      A standalone MonoGame (DesktopGL) library for loading and playing .achx animation files
-      created by the FlatRedBall Animation Editor. No FlatRedBall2 engine dependency required.
-      For KNI / Blazor WASM targets, use FlatRedBall.AnimationChain.KNI instead.
+      A standalone KNI (nkast) library for loading and playing .achx animation files created
+      by the FlatRedBall Animation Editor. Targets Blazor WASM and other KNI platforms.
+      No FlatRedBall2 engine dependency required.
+      For MonoGame DesktopGL targets, use FlatRedBall.AnimationChain.MonoGame instead.
     </Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/vchelaru/FlatRedBall2</PackageProjectUrl>
@@ -20,14 +21,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>AnimationChain.MonoGame.Tests</_Parameter1>
+      <_Parameter1>AnimationChain.KNI.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/FlatRedBall2.slnx
+++ b/src/FlatRedBall2.slnx
@@ -1,7 +1,9 @@
 <Solution>
   <Project Path="../tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj" />
   <Project Path="../tests/AnimationChain.MonoGame.Tests/AnimationChain.MonoGame.Tests.csproj" />
+  <Project Path="../tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj" />
   <Project Path="FlatRedBall2.csproj" />
   <Project Path="FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
   <Project Path="AnimationChain.MonoGame/AnimationChain.MonoGame.csproj" />
+  <Project Path="AnimationChain.MonoGame/AnimationChain.KNI.csproj" />
 </Solution>

--- a/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
+++ b/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!--
+    The AnimationChain.KNI.csproj uses PrivateAssets=All on its nkast references, so we must
+    pull them in directly here for type resolution (e.g. Texture2D in AnimationFrame).
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AnimationChain.MonoGame\AnimationChain.KNI.csproj" />
+  </ItemGroup>
+
+  <!-- Link to the shared test sources rather than duplicate them. -->
+  <ItemGroup>
+    <Compile Include="..\AnimationChain.MonoGame.Tests\AchxLoaderTests.cs" Link="AchxLoaderTests.cs" />
+    <Compile Include="..\AnimationChain.MonoGame.Tests\AnimationPlayerTests.cs" Link="AnimationPlayerTests.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Creates a separate project file for the KNI backend alongside the existing MonoGame one, producing two distinct NuGet packages from the same shared source.

## Changes

- **\AnimationChain.MonoGame.csproj\** — \PackageId\ renamed from \FlatRedBall.AnimationChain\ → \FlatRedBall.AnimationChain.MonoGame\ for clarity
- **\AnimationChain.KNI.csproj\** (new, same folder) — targets \
et8.0\, references \
kast.Xna.Framework\ + \
kast.Xna.Framework.Graphics\ (\PrivateAssets=All\), \PackageId: FlatRedBall.AnimationChain.KNI\
- **\	ests/AnimationChain.KNI.Tests/\** (new) — mirrors the 30 existing tests against the KNI build using linked \<Compile Include>\ files (no code duplication)
- **\src/FlatRedBall2.slnx\** — adds both new projects

## Key design note

Both MonoGame and KNI expose the **same \Microsoft.Xna.Framework.*\ API surface**, so all source files in \AnimationChain.MonoGame/\ compile unchanged for KNI. Both \.csproj\ files rely on the SDK's default \\*\*/\*.cs\ glob to include all shared code — no \<Compile Include>\ wiring required.

\dotnet pack\ produces:
- \FlatRedBall.AnimationChain.MonoGame.x.y.z.nupkg\
- \FlatRedBall.AnimationChain.KNI.x.y.z.nupkg\

Closes #385