### PR TITLE
Add FromStream/FromString overloads for .achx loading

### DIFF
--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -86,9 +86,34 @@ public class AnimationChainListSave
     public static AnimationChainListSave FromFile(string filePath, Func<string, Stream> streamProvider)
     {
         using var stream = streamProvider(filePath);
-        var doc = XDocument.Load(stream);
-        var root = doc.Root!;
+        var result = ParseXml(XDocument.Load(stream));
+        result.FileName = filePath;
+        return result;
+    }
 
+    /// <summary>
+    /// Parses .achx XML from an already-open <paramref name="stream"/>. <see cref="FileName"/>
+    /// is set to <see cref="string.Empty"/>; if <see cref="FileRelativeTextures"/> is <c>true</c>,
+    /// texture paths in the file are passed through as-is with no directory prefix prepended.
+    /// The caller retains ownership of <paramref name="stream"/> and is responsible for disposing it.
+    /// </summary>
+    public static AnimationChainListSave FromStream(Stream stream)
+        => ParseXml(XDocument.Load(stream));
+
+    /// <summary>
+    /// Parses .achx XML from an in-memory string. <see cref="FileName"/> is set to
+    /// <see cref="string.Empty"/>; if <see cref="FileRelativeTextures"/> is <c>true</c>,
+    /// texture paths in the file are passed through as-is with no directory prefix prepended.
+    /// </summary>
+    public static AnimationChainListSave FromString(string xml)
+    {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        return FromStream(stream);
+    }
+
+    private static AnimationChainListSave ParseXml(XDocument doc)
+    {
+        var root = doc.Root!;
         var result = new AnimationChainListSave();
 
         var frt = root.Element("FileRelativeTextures");
@@ -119,7 +144,6 @@ public class AnimationChainListSave
         var projectFileEl = root.Element("ProjectFile");
         if (projectFileEl != null) result.ProjectFile = projectFileEl.Value;
 
-        result.FileName = filePath;
         return result;
     }
 

--- a/src/AnimationChain.MonoGame/AchxLoader.cs
+++ b/src/AnimationChain.MonoGame/AchxLoader.cs
@@ -82,6 +82,25 @@ public sealed class AchxLoader : IDisposable
     }
 
     /// <summary>
+    /// Loads animation data from an already-open .achx XML <paramref name="achxStream"/>.
+    /// Because no file path is available, <see cref="AnimationChainListSave.FileRelativeTextures"/>
+    /// resolution is skipped — texture paths stored in the file are passed directly to
+    /// <paramref name="textureStreamProvider"/>. Supply a <paramref name="textureStreamProvider"/>
+    /// that handles those paths as written in the .achx XML.
+    /// </summary>
+    /// <param name="achxStream">A readable stream containing the .achx XML. The caller retains ownership.</param>
+    /// <param name="textureStreamProvider">
+    /// Optional override for texture loading. When <c>null</c>, falls back to
+    /// <see cref="File.OpenRead"/>. Return <c>null</c> to produce a frame with no texture.
+    /// </param>
+    public AnimationChainList Load(Stream achxStream, Func<string, Stream?>? textureStreamProvider = null)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var save = AnimationChainListSave.FromStream(achxStream);
+        return save.ToAnimationChainList(texPath => GetOrLoadTexture(texPath, textureStreamProvider));
+    }
+
+    /// <summary>
     /// Reloads an existing <see cref="AnimationChainList"/> in place from the .achx at
     /// <paramref name="achxPath"/>. Chains with matching names have their frames replaced
     /// (live <see cref="AnimationPlayer"/> references keep working); new chains are appended.

--- a/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
+++ b/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
@@ -77,9 +77,36 @@ public class AnimationChainListSave
     public static AnimationChainListSave FromFile(string filePath, Func<string, Stream> streamProvider)
     {
         using var stream = streamProvider(filePath);
-        var doc = XDocument.Load(stream);
-        var root = doc.Root!;
+        var result = ParseXml(XDocument.Load(stream));
+        // Store the absolute path so ToAnimationChainList always produces absolute texture paths,
+        // preventing double-resolution when callers (e.g. AchxLoader) also combine with achxDir.
+        result.FileName = Path.GetFullPath(filePath);
+        return result;
+    }
 
+    /// <summary>
+    /// Parses .achx XML from an already-open <paramref name="stream"/>. <see cref="FileName"/>
+    /// is set to <see cref="string.Empty"/>; if <see cref="FileRelativeTextures"/> is <c>true</c>,
+    /// texture paths in the file are passed through as-is with no directory prefix prepended.
+    /// The caller retains ownership of <paramref name="stream"/> and is responsible for disposing it.
+    /// </summary>
+    public static AnimationChainListSave FromStream(Stream stream)
+        => ParseXml(XDocument.Load(stream));
+
+    /// <summary>
+    /// Parses .achx XML from an in-memory string. <see cref="FileName"/> is set to
+    /// <see cref="string.Empty"/>; if <see cref="FileRelativeTextures"/> is <c>true</c>,
+    /// texture paths in the file are passed through as-is with no directory prefix prepended.
+    /// </summary>
+    public static AnimationChainListSave FromString(string xml)
+    {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+        return FromStream(stream);
+    }
+
+    private static AnimationChainListSave ParseXml(XDocument doc)
+    {
+        var root = doc.Root!;
         var result = new AnimationChainListSave();
 
         var frt = root.Element("FileRelativeTextures");
@@ -105,9 +132,6 @@ public class AnimationChainListSave
         var projectFileEl = root.Element("ProjectFile");
         if (projectFileEl != null) result.ProjectFile = projectFileEl.Value;
 
-        // Store the absolute path so ToAnimationChainList always produces absolute texture paths,
-        // preventing double-resolution when callers (e.g. AchxLoader) also combine with achxDir.
-        result.FileName = Path.GetFullPath(filePath);
         return result;
     }
 

--- a/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
@@ -234,6 +234,83 @@ public class AchxLoaderTests
         Assert.Null(list["NotHere"]);
     }
 
+    // ─── FromStream ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FromStream_ParsesChainNames()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleAchx));
+        var save = AnimationChainListSave.FromStream(stream);
+        Assert.Equal(2, save.AnimationChains.Count);
+        Assert.Equal("Run", save.AnimationChains[0].Name);
+        Assert.Equal("Idle", save.AnimationChains[1].Name);
+    }
+
+    [Fact]
+    public void FromStream_FileNameIsEmpty()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleAchx));
+        var save = AnimationChainListSave.FromStream(stream);
+        Assert.Equal(string.Empty, save.FileName);
+    }
+
+    [Fact]
+    public void FromStream_ParsesFrameCoordinates()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleAchx));
+        var save = AnimationChainListSave.FromStream(stream);
+        var f = save.AnimationChains[0].Frames[0];
+        Assert.Equal(0f,   f.LeftCoordinate,   precision: 5);
+        Assert.Equal(0.5f, f.RightCoordinate,  precision: 5);
+        Assert.Equal(0f,   f.TopCoordinate,    precision: 5);
+        Assert.Equal(1f,   f.BottomCoordinate, precision: 5);
+    }
+
+    [Fact]
+    public void FromStream_ParsesFrameLength_Milliseconds()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(MillisecondAchx));
+        var save = AnimationChainListSave.FromStream(stream);
+        Assert.Equal(100f, save.AnimationChains[0].Frames[0].FrameLength, precision: 5);
+    }
+
+    // ─── FromString ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FromString_ParsesChainNames()
+    {
+        var save = AnimationChainListSave.FromString(SimpleAchx);
+        Assert.Equal(2, save.AnimationChains.Count);
+        Assert.Equal("Run", save.AnimationChains[0].Name);
+        Assert.Equal("Idle", save.AnimationChains[1].Name);
+    }
+
+    [Fact]
+    public void FromString_FileNameIsEmpty()
+    {
+        var save = AnimationChainListSave.FromString(SimpleAchx);
+        Assert.Equal(string.Empty, save.FileName);
+    }
+
+    [Fact]
+    public void FromString_ParsesFrameCoordinates()
+    {
+        var save = AnimationChainListSave.FromString(SimpleAchx);
+        var f = save.AnimationChains[0].Frames[0];
+        Assert.Equal(0f,   f.LeftCoordinate,   precision: 5);
+        Assert.Equal(0.5f, f.RightCoordinate,  precision: 5);
+        Assert.Equal(0f,   f.TopCoordinate,    precision: 5);
+        Assert.Equal(1f,   f.BottomCoordinate, precision: 5);
+    }
+
+    [Fact]
+    public void FromString_ParsesFrameCount()
+    {
+        var save = AnimationChainListSave.FromString(SimpleAchx);
+        Assert.Equal(2, save.AnimationChains[0].Frames.Count);
+        Assert.Single(save.AnimationChains[1].Frames);
+    }
+
     // ─── Save / round-trip ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveLoadingTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveLoadingTests.cs
@@ -217,4 +217,105 @@ public class AnimationChainListSaveLoadingTests
 
         Should.Throw<InvalidOperationException>(() => save.ToAnimationChainList(null!));
     }
+
+    // ─── FromStream ──────────────────────────────────────────────────────────────
+
+    private static readonly string SimpleXml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+        "<AnimationChainArraySave>" +
+        "  <TimeMeasurementUnit>Second</TimeMeasurementUnit>" +
+        "  <CoordinateType>UV</CoordinateType>" +
+        "  <AnimationChain><Name>Walk</Name>" +
+        "    <Frame><TextureName>walk.png</TextureName><FrameLength>0.1</FrameLength>" +
+        "      <LeftCoordinate>0</LeftCoordinate><RightCoordinate>0.25</RightCoordinate>" +
+        "      <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>" +
+        "    </Frame>" +
+        "  </AnimationChain>" +
+        "  <AnimationChain><Name>Idle</Name>" +
+        "    <Frame><TextureName>idle.png</TextureName><FrameLength>0.5</FrameLength></Frame>" +
+        "  </AnimationChain>" +
+        "</AnimationChainArraySave>";
+
+    [Fact]
+    public void FromStream_ParsesChainNames()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml));
+        var save = AnimationChainListSave.FromStream(stream);
+        save.AnimationChains.Count.ShouldBe(2);
+        save.AnimationChains[0].Name.ShouldBe("Walk");
+        save.AnimationChains[1].Name.ShouldBe("Idle");
+    }
+
+    [Fact]
+    public void FromStream_FileNameIsEmpty()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml));
+        var save = AnimationChainListSave.FromStream(stream);
+        save.FileName.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void FromStream_ParsesFrameCoordinates()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml));
+        var save = AnimationChainListSave.FromStream(stream);
+        var f = save.AnimationChains[0].Frames[0];
+        f.LeftCoordinate.ShouldBe(0f);
+        f.RightCoordinate.ShouldBe(0.25f);
+        f.TopCoordinate.ShouldBe(0f);
+        f.BottomCoordinate.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void FromStream_ProducesEquivalentResultToFromFile()
+    {
+        var fromFile = AnimationChainListSave.FromFile("any.achx",
+            _ => new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml)));
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml));
+        var fromStream = AnimationChainListSave.FromStream(stream);
+
+        fromStream.AnimationChains.Count.ShouldBe(fromFile.AnimationChains.Count);
+        fromStream.AnimationChains[0].Name.ShouldBe(fromFile.AnimationChains[0].Name);
+        fromStream.TimeMeasurementUnit.ShouldBe(fromFile.TimeMeasurementUnit);
+        fromStream.CoordinateType.ShouldBe(fromFile.CoordinateType);
+    }
+
+    // ─── FromString ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FromString_ParsesChainNames()
+    {
+        var save = AnimationChainListSave.FromString(SimpleXml);
+        save.AnimationChains.Count.ShouldBe(2);
+        save.AnimationChains[0].Name.ShouldBe("Walk");
+        save.AnimationChains[1].Name.ShouldBe("Idle");
+    }
+
+    [Fact]
+    public void FromString_FileNameIsEmpty()
+    {
+        var save = AnimationChainListSave.FromString(SimpleXml);
+        save.FileName.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void FromString_ParsesFrameCount()
+    {
+        var save = AnimationChainListSave.FromString(SimpleXml);
+        save.AnimationChains[0].Frames.Count.ShouldBe(1);
+        save.AnimationChains[1].Frames.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void FromString_ProducesEquivalentResultToFromFile()
+    {
+        var fromFile = AnimationChainListSave.FromFile("any.achx",
+            _ => new MemoryStream(Encoding.UTF8.GetBytes(SimpleXml)));
+        var fromString = AnimationChainListSave.FromString(SimpleXml);
+
+        fromString.AnimationChains.Count.ShouldBe(fromFile.AnimationChains.Count);
+        fromString.AnimationChains[0].Name.ShouldBe(fromFile.AnimationChains[0].Name);
+        fromString.TimeMeasurementUnit.ShouldBe(fromFile.TimeMeasurementUnit);
+        fromString.CoordinateType.ShouldBe(fromFile.CoordinateType);
+    }
 }


### PR DESCRIPTION
## Summary

Adds non-file convenience overloads for loading .achx animation data, enabling web/WASM and stream-backed scenarios without requiring a file path.

### New API surface

**AnimationChainListSave** (both FlatRedBall2.Animation.Content and FlatRedBall.AnimationChain.Content):
- FromStream(Stream stream) — parses from an already-open stream; caller retains ownership
- FromString(string xml) — parses from an in-memory XML string

**AchxLoader**:
- Load(Stream achxStream, Func<string, Stream?>? textureStreamProvider = null) — loads animation chain list from a stream; texture paths are passed as-is (no directory prefix, since no base path is available)

### Behavior notes
- FileName is set to string.Empty for both new AnimationChainListSave overloads
- The internal parsing logic was extracted into a private ParseXml(XDocument) helper shared by all FromFile/FromStream/FromString overloads — no behavioral change to existing paths
- FileRelativeTextures resolution is deliberately skipped in Load(Stream) since there is no base directory; callers who need relative-path resolution should use Load(string, Func<string,Stream>) instead

### Tests added
- 8 new tests in FlatRedBall2.Tests (main engine AnimationChainListSave)
- 8 new tests in AnimationChain.MonoGame.Tests (MonoGame variant + AchxLoader)
- Covers: chain names, frame coordinates, FileName == string.Empty, and equivalence with FromFile

Closes #387