### PR TITLE
Update CI to build AnimationChain NuGet packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,3 +97,28 @@ jobs:
 
       - name: Publish Templates to NuGet
         run: dotnet nuget push "out/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  publish-animationchain:
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore AnimationChain dependencies
+        run: dotnet restore src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
+
+      - name: Pack AnimationChain package
+        run: >
+          dotnet pack src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
+          -c Release
+          -p:PackageVersion=${{ needs.resolve-version.outputs.version }}
+          -o out
+
+      - name: Publish AnimationChain to NuGet
+        run: dotnet nuget push "out/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,47 @@ jobs:
       - name: Test AnimationEditor.App
         run: dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj --verbosity minimal --logger "console;verbosity=minimal"
 
+  animationchain-pack:
+    name: Pack AnimationChain NuGet (ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      # Package outputs land in out/animationchain and are uploaded as workflow artifacts.
+      - name: Pack AnimationChain package
+        run: >
+          dotnet pack src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
+          -c Release
+          -o out/animationchain
+
+      - name: Upload AnimationChain package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: animationchain-nuget-packages
+          path: out/animationchain/*.nupkg
+          if-no-files-found: error
+          retention-days: 7
+
   # Umbrella check that branch protection gates on. Stays named "dotnet test" so the
   # existing required-status-check entry in the main-protection ruleset keeps matching.
   test:
     name: dotnet test
     runs-on: ubuntu-latest
-    needs: [engine-tests]
+    needs: [engine-tests, animationchain-pack]
     steps:
-      - name: All test jobs passed
-        run: echo "engine-tests succeeded"
+      - name: All test and packaging jobs passed
+        run: echo "engine-tests and animationchain-pack succeeded"


### PR DESCRIPTION
## Summary
- add CI packaging job for AnimationChain in tests workflow
- upload AnimationChain .nupkg artifacts in CI
- gate umbrella test status on packaging success
- add release publish job for AnimationChain package

Closes #386