### PR TITLE
Make AnimationChain sample work in XNA Fiddle

### DIFF
--- a/samples/AnimationChainSample/Game1.cs
+++ b/samples/AnimationChainSample/Game1.cs
@@ -12,7 +12,7 @@ namespace AnimationChainSample;
 ///
 /// Controls:
 ///   Space  -- cycle Walk -> Run -> Idle -> Walk
-///   R      -- hot-reload hero.achx from disk (try editing frame timings while running)
+///   R      -- reload hero.achx from the content stream
 ///   Escape -- exit
 /// </summary>
 public class Game1 : Game
@@ -51,8 +51,7 @@ public class Game1 : Game
         // Load the real spritesheet PNG
         _spriteSheet = Content.Load<Texture2D>("AnimatedSpritesheet");
 
-        var save = AnimationChainListSave.FromFile(AchxPath);
-        _animations = save.ToAnimationChainList(_ => _spriteSheet);
+        _animations = LoadAnimations();
 
         // Build the chain order from all available animations
         _chainOrder = _animations.Select(ac => ac.Name).ToArray();
@@ -81,10 +80,10 @@ public class Game1 : Game
 
         if (IsPressed(keys, Keys.R))
         {
-            bool ok = _animations.TryReloadFrom(AchxPath, _ => _spriteSheet);
+            bool ok = TryReloadAnimations();
             Window.Title = ok
                 ? $"Reloaded! -- {CurrentStatus()}"
-                : "Reload failed (file busy?) -- try again";
+                : "Reload failed -- check Content/hero.achx and try again";
         }
 
         _player.Update(gameTime.ElapsedGameTime);
@@ -118,6 +117,26 @@ public class Game1 : Game
 
     private bool IsPressed(KeyboardState cur, Keys key) =>
         cur.IsKeyDown(key) && !_prevKeys.IsKeyDown(key);
+
+    private AnimationChainList LoadAnimations()
+    {
+        using var achxStream = TitleContainer.OpenStream(AchxPath);
+        var save = AnimationChainListSave.FromStream(achxStream);
+        return save.ToAnimationChainList(_ => _spriteSheet);
+    }
+
+    private bool TryReloadAnimations()
+    {
+        try
+        {
+            using var achxStream = TitleContainer.OpenStream(AchxPath);
+            return _animations.TryReloadFrom(achxStream, _ => _spriteSheet);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
 
     private string CurrentStatus() =>
         $"Chain: {_player.CurrentChain?.Name ?? "none"}  ({_player.CurrentChain?.Count ?? 0} frames)";

--- a/samples/AnimationChainSample/README.md
+++ b/samples/AnimationChainSample/README.md
@@ -1,0 +1,21 @@
+# AnimationChainSample
+
+Small sample showing `.achx` animation playback with `AnimationPlayer`.
+
+## Run locally
+
+```bash
+dotnet run --project samples/AnimationChainSample/AnimationChainSample.csproj
+```
+
+## Controls
+
+- **Space**: cycle animation chain
+- **R**: reload `Content/hero.achx`
+- **Escape**: exit
+
+## XNA Fiddle notes
+
+1. Upload both `Content/AnimatedSpritesheet.png` and `Content/hero.achx`.
+2. The sample loads `hero.achx` through `TitleContainer.OpenStream("Content/hero.achx")`, so it does not depend on direct `File.OpenRead` access.
+3. Press **R** to re-read the `.achx` stream and apply updated frame data.

--- a/src/AnimationChain.MonoGame/Runtime/AnimationChainList.cs
+++ b/src/AnimationChain.MonoGame/Runtime/AnimationChainList.cs
@@ -54,6 +54,42 @@ public class AnimationChainList : List<AnimationChain>
         catch (IOException) { return false; }
         catch (System.Xml.XmlException) { return false; }
 
+        ApplyReloadedChains(fresh);
+        return true;
+    }
+
+    /// <summary>
+    /// Re-parses .achx XML from an already-open <paramref name="achxStream"/> and applies
+    /// changes in place so live <see cref="AnimationPlayer"/> references keep working.
+    /// For each chain in the reloaded data, matches by <see cref="AnimationChain.Name"/>:
+    /// existing chains have their frames replaced in place (instance identity preserved);
+    /// new chains are appended.
+    /// <para>
+    /// Returns <c>false</c> on I/O or XML parse failure.
+    /// </para>
+    /// </summary>
+    /// <param name="achxStream">Readable stream containing .achx XML. Caller retains ownership.</param>
+    /// <param name="textureLoader">
+    /// Called with each texture path stored in the .achx data. May return <c>null</c> if
+    /// a texture is unavailable — affected frames keep a <c>null</c> texture.
+    /// </param>
+    public bool TryReloadFrom(Stream achxStream, Func<string, Texture2D?> textureLoader)
+    {
+        AnimationChainList fresh;
+        try
+        {
+            var save = Content.AnimationChainListSave.FromStream(achxStream);
+            fresh = save.ToAnimationChainList(textureLoader);
+        }
+        catch (IOException) { return false; }
+        catch (System.Xml.XmlException) { return false; }
+
+        ApplyReloadedChains(fresh);
+        return true;
+    }
+
+    private void ApplyReloadedChains(AnimationChainList fresh)
+    {
         foreach (var freshChain in fresh)
         {
             var existing = this[freshChain.Name];
@@ -67,6 +103,5 @@ public class AnimationChainList : List<AnimationChain>
                 Add(freshChain);
             }
         }
-        return true;
     }
 }

--- a/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
@@ -234,6 +234,66 @@ public class AchxLoaderTests
         Assert.Null(list["NotHere"]);
     }
 
+    // ─── AnimationChainList stream reload ─────────────────────────────────────────
+
+    [Fact]
+    public void TryReloadFrom_Stream_ReplacesExistingFramesAndAddsNewChains()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+
+        const string reloadXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AnimationChainArraySave>
+              <FileRelativeTextures>false</FileRelativeTextures>
+              <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+              <CoordinateType>UV</CoordinateType>
+              <AnimationChain>
+                <Name>Run</Name>
+                <Frame>
+                  <TextureName>tex.png</TextureName>
+                  <FrameLength>0.25</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate><RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>
+                </Frame>
+              </AnimationChain>
+              <AnimationChain>
+                <Name>Slide</Name>
+                <Frame>
+                  <TextureName>tex.png</TextureName>
+                  <FrameLength>0.5</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate><RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>
+                </Frame>
+              </AnimationChain>
+            </AnimationChainArraySave>
+            """;
+
+        using var reloadStream = new MemoryStream(Encoding.UTF8.GetBytes(reloadXml));
+        var ok = list.TryReloadFrom(reloadStream, _ => null);
+
+        Assert.True(ok);
+        Assert.Single(list["Run"]!);
+        Assert.Equal(TimeSpan.FromSeconds(0.25), list["Run"]![0].FrameLength);
+        Assert.NotNull(list["Slide"]);
+    }
+
+    [Fact]
+    public void TryReloadFrom_Stream_InvalidXml_ReturnsFalseAndLeavesListUntouched()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+        var beforeRunFrames = list["Run"]!.Count;
+
+        const string invalidXml = "<AnimationChainArraySave><AnimationChain>";
+        using var reloadStream = new MemoryStream(Encoding.UTF8.GetBytes(invalidXml));
+        var ok = list.TryReloadFrom(reloadStream, _ => null);
+
+        Assert.False(ok);
+        Assert.Equal(beforeRunFrames, list["Run"]!.Count);
+        Assert.Null(list["Slide"]);
+    }
+
     // ─── FromStream ──────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `AnimationChainList.TryReloadFrom(Stream, ...)` so animations can be reloaded without filesystem path APIs
- switch `AnimationChainSample` to stream-based `.achx` load/reload via `TitleContainer.OpenStream("Content/hero.achx")`
- add `samples/AnimationChainSample/README.md` with local run and XNA Fiddle usage notes
- add regression tests for stream-based reload behavior

## Validation
- `dotnet test tests/AnimationChain.MonoGame.Tests/AnimationChain.MonoGame.Tests.csproj --filter "TryReloadFrom_Stream|FromFile_ParsesChainNames"`
- `dotnet test tests/AnimationChain.MonoGame.Tests/AnimationChain.MonoGame.Tests.csproj`
- `dotnet build samples/AnimationChainSample/AnimationChainSample.csproj`

Closes #390