### PR TITLE
Animation Editor: preview-only frame-offset interpolation toggle

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -38,6 +38,7 @@ public class PreviewControl : Control
     // -- Settings --------------------------------------------------------------
     private bool _showOnionSkin;
     private bool _showGuides;
+    private bool _interpolateOffsets;
 
     // -- Pan drag --------------------------------------------------------------
     private bool  _isPanning;
@@ -76,6 +77,28 @@ public class PreviewControl : Control
         get => _showGuides;
         set { _showGuides = value; InvalidateVisual(); }
     }
+
+    /// <summary>
+    /// When <c>true</c>, the displayed sprite position eases between consecutive frames'
+    /// <c>RelativeX/Y</c> offsets instead of snapping at each frame switch. Preview-only:
+    /// the FlatRedBall runtime always snaps, so this does not reflect in-game behavior and
+    /// is not persisted. Auto-resets to <c>false</c> whenever the selected chain changes.
+    /// </summary>
+    public bool InterpolateOffsets
+    {
+        get => _interpolateOffsets;
+        set
+        {
+            if (_interpolateOffsets == value) return;
+            _interpolateOffsets = value;
+            InvalidateVisual();
+            InterpolateOffsetsChanged?.Invoke(value);
+        }
+    }
+
+    /// <summary>Fired when <see cref="InterpolateOffsets"/> changes, including the automatic
+    /// reset on selection change, so the toolbar toggle can resync its checked state.</summary>
+    public event Action<bool>? InterpolateOffsetsChanged;
 
     public double SpeedMultiplier
     {
@@ -151,12 +174,14 @@ public class PreviewControl : Control
         _thumbnailService.GetBitmap(texPath);
         _thumbnailService.GetBitmap(onionPath);
 
+        var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
+
         var snap   = new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
                                         _showGuides, texPath, onionPath, width, height,
                                         _appState!.OffsetMultiplier,
                                         _hGuides.ToArray(), _vGuides.ToArray(),
                                         _draggedGuideIdx, _draggingHGuide,
-                                        BuildShapeInfos());
+                                        BuildShapeInfos(), frameOffX, frameOffY);
         var bitmap = new SKBitmap(width, height);
         using var canvas = new SKCanvas(bitmap);
         RenderSkCore(canvas, snap, _thumbnailService.BitmapCache);
@@ -210,6 +235,12 @@ public class PreviewControl : Control
         // Subscriptions are deferred to InitializeServices (called from MainWindow)
 
         _playback.FrameIndexChanged += _ => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
+        // While interpolating, repaint every tick so the eased motion is smooth, not stepped
+        // to once-per-frame-switch like the snap path.
+        _playback.PlaybackTicked += () =>
+        {
+            if (_interpolateOffsets) Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
+        };
 
         _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
         _timer.Tick += OnTimerTick;
@@ -230,7 +261,24 @@ public class PreviewControl : Control
     private void OnSelectionChanged()
     {
         _playback.SetChain(_selectedState!.SelectedChain);
+        // Interpolation is a transient per-chain preview aid; clear it when the chain changes.
+        InterpolateOffsets = false;
         InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Resolves the (X, Y) offset for the display frame. During free playback the offset
+    /// honors <see cref="InterpolateOffsets"/>; when a frame is pinned via tree selection it
+    /// is shown statically at its own stored offset.
+    /// </summary>
+    private (float X, float Y) ResolveFrameOffset(
+        AnimationChainSave? chain, AnimationFrameSave? displayFrame, bool pinned)
+    {
+        if (pinned || displayFrame is null)
+            return (displayFrame?.RelativeX ?? 0f, displayFrame?.RelativeY ?? 0f);
+
+        return OffsetInterpolator.ComputeOffset(
+            chain, _playback.CurrentFrameIndex, _playback.FrameElapsed, _interpolateOffsets);
     }
 
     // -- Public API ------------------------------------------------------------
@@ -453,6 +501,8 @@ public class PreviewControl : Control
         _thumbnailService.GetBitmap(texPath);
         _thumbnailService.GetBitmap(onionPath);
 
+        var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
+
         ctx.Custom(new DrawOp(
             new RenderSnapshot(
                 displayFrame, onionFrame, _zoom, _panX, _panY, _showGuides,
@@ -460,7 +510,7 @@ public class PreviewControl : Control
                 _appState!.OffsetMultiplier,
                 _hGuides.ToArray(), _vGuides.ToArray(),
                 _draggedGuideIdx, _draggingHGuide,
-                BuildShapeInfos()),
+                BuildShapeInfos(), frameOffX, frameOffY),
             _thumbnailService.BitmapCache));
     }
 
@@ -1234,7 +1284,9 @@ public class PreviewControl : Control
         float[] VGuides,
         int    DraggedGuideIdx,
         bool   DraggingHGuide,
-        PreviewShapeInfo[] Shapes);
+        PreviewShapeInfo[] Shapes,
+        // Display-frame offset, already resolved for snap vs interpolate (see ResolveFrameOffset).
+        float  FrameOffsetX, float FrameOffsetY);
 
     // -- Shared SkiaSharp rendering (used by both live and off-screen paths) --
 
@@ -1264,8 +1316,8 @@ public class PreviewControl : Control
             s.TexturePath is not null &&
             cache.TryGetValue(s.TexturePath, out var bm) && bm is not null)
         {
-            float fcx = cx + s.Frame.RelativeX * s.OffsetMultiplier * s.Zoom;
-            float fcy = cy - s.Frame.RelativeY * s.OffsetMultiplier * s.Zoom;
+            float fcx = cx + s.FrameOffsetX * s.OffsetMultiplier * s.Zoom;
+            float fcy = cy - s.FrameOffsetY * s.OffsetMultiplier * s.Zoom;
             DrawFrameCore(canvas, s.Frame, bm, fcx, fcy, s.Zoom, alpha: 1.0f);
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -644,6 +644,14 @@
                                     <TextBlock Text="Guides" VerticalAlignment="Center" />
                                 </StackPanel>
                             </ToggleButton>
+                            <ToggleButton x:Name="InterpolateToggle"
+                                          Height="26"
+                                          Foreground="{StaticResource Ink}"
+                                          VerticalAlignment="Center"
+                                          Margin="0,0,4,0"
+                                          ToolTip.Tip="Ease the sprite between frame offsets during playback (preview only — the game snaps)">
+                                <TextBlock Text="Interpolate" VerticalAlignment="Center" />
+                            </ToggleButton>
 
                             <!-- Divider -->
                             <Border Width="1" Height="18" Background="{StaticResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -58,6 +58,7 @@ public partial class MainWindow : Window
     private bool _suppressPreviewZoomComboChanged;
     private bool _suppressTreeSelectionHandling;
     private bool _suppressCompanionSave;
+    private bool _suppressInterpolateSync;
     private System.Threading.CancellationTokenSource? _toastCts;
 
     // AppContext.BaseDirectory works under single-file publish; Assembly.Location is empty there (IL3000).
@@ -1339,6 +1340,19 @@ public partial class MainWindow : Window
 
         ShowGuidesCheck.IsCheckedChanged += (_, _) =>
             PreviewCtrl.ShowGuides = ShowGuidesCheck.IsChecked == true;
+
+        InterpolateToggle.IsCheckedChanged += (_, _) =>
+        {
+            if (_suppressInterpolateSync) return;
+            PreviewCtrl.InterpolateOffsets = InterpolateToggle.IsChecked == true;
+        };
+        // PreviewControl auto-resets InterpolateOffsets when the chain changes; resync the toggle.
+        PreviewCtrl.InterpolateOffsetsChanged += isOn =>
+        {
+            _suppressInterpolateSync = true;
+            InterpolateToggle.IsChecked = isOn;
+            _suppressInterpolateSync = false;
+        };
 
         TimelineStrip.ItemsSource = _timelineFrames;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/OffsetInterpolator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/OffsetInterpolator.cs
@@ -1,0 +1,50 @@
+using System;
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Computes the position offset (<c>RelativeX/Y</c>) to display during preview playback.
+/// <para>
+/// In snap mode the offset is exactly the current frame's — this mirrors the FlatRedBall
+/// runtime, which overwrites the sprite position on every frame switch and never blends.
+/// In interpolate mode the offset eases linearly toward the next frame across the current
+/// frame's display time; the last frame has no successor and holds its own offset until the
+/// preview loops. Interpolation is a <b>preview-only authoring aid</b>: it is not stored in
+/// the <c>.achx</c> and the runtime does not reproduce it.
+/// </para>
+/// </summary>
+public static class OffsetInterpolator
+{
+    /// <param name="chain">The chain being previewed.</param>
+    /// <param name="frameIndex">Index of the currently displayed frame (clamped to the chain).</param>
+    /// <param name="frameElapsed">Seconds elapsed within the current frame
+    /// (see <see cref="CommandsAndState.PlaybackController.FrameElapsed"/>).</param>
+    /// <param name="interpolate">When <c>false</c>, returns the current frame's offset unchanged (snap).</param>
+    /// <returns>The (X, Y) offset, in stored units, to render the sprite at.</returns>
+    public static (float X, float Y) ComputeOffset(
+        AnimationChainSave? chain, int frameIndex, double frameElapsed, bool interpolate)
+    {
+        if (chain is null || chain.Frames.Count == 0) return (0f, 0f);
+
+        frameIndex = Math.Clamp(frameIndex, 0, chain.Frames.Count - 1);
+        var current = chain.Frames[frameIndex];
+
+        // The last frame has no successor to ease toward: hold its offset rather than easing
+        // back toward frame 0, so a non-looping clip settles on its final position. (If the
+        // clip loops, the offset snaps at the same instant the image already hard-cuts.)
+        int lastIndex = chain.Frames.Count - 1;
+        if (!interpolate || frameIndex >= lastIndex)
+            return (current.RelativeX, current.RelativeY);
+
+        var next = chain.Frames[frameIndex + 1];
+
+        // 0.1s default matches PlaybackController's handling of unset frame lengths.
+        double frameLength = current.FrameLength > 0 ? current.FrameLength : 0.1;
+        float t = (float)Math.Clamp(frameElapsed / frameLength, 0.0, 1.0);
+
+        return (
+            current.RelativeX + (next.RelativeX - current.RelativeX) * t,
+            current.RelativeY + (next.RelativeY - current.RelativeY) * t);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewInterpolateToggleTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewInterpolateToggleTests.cs
@@ -1,0 +1,38 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for the preview-only "Interpolate" toggle (<see cref="PreviewControl.InterpolateOffsets"/>),
+/// which eases the sprite between frame offsets during playback. It is transient: selecting a
+/// different chain clears it.
+/// </summary>
+public class PreviewInterpolateToggleTests
+{
+    [AvaloniaFact]
+    public void InterpolateOffsets_ResetsToFalse_WhenSelectionChanges()
+    {
+        var ctx  = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+
+        var chain = new AnimationChainSave { Name = "A" };
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        ctx.SelectedState.SelectedChain = chain;
+        Dispatcher.UIThread.RunJobs();
+
+        ctrl.InterpolateOffsets = true;
+
+        // Selecting a different chain must clear the transient interpolate toggle.
+        var other = new AnimationChainSave { Name = "B" };
+        other.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        ctx.SelectedState.SelectedChain = other;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(ctrl.InterpolateOffsets);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OffsetInterpolatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OffsetInterpolatorTests.cs
@@ -1,0 +1,58 @@
+using AnimationEditor.Core.Rendering;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class OffsetInterpolatorTests
+{
+    private static AnimationChainSave MakeChain(params (float x, float y)[] offsets)
+    {
+        var chain = new AnimationChainSave { Name = "Test" };
+        foreach (var (x, y) in offsets)
+            chain.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f, RelativeX = x, RelativeY = y });
+        return chain;
+    }
+
+    [Fact]
+    public void ComputeOffset_SnapMode_IgnoresElapsed_ReturnsCurrentFrameOffset()
+    {
+        // Snap mirrors the FlatRedBall runtime: the offset is exactly the current frame's,
+        // regardless of how far into the frame playback has progressed.
+        var chain = MakeChain((10f, 20f), (50f, 60f));
+        var (x, y) = OffsetInterpolator.ComputeOffset(chain, frameIndex: 0, frameElapsed: 0.05, interpolate: false);
+        Assert.Equal(10f, x, precision: 4);
+        Assert.Equal(20f, y, precision: 4);
+    }
+
+    [Fact]
+    public void ComputeOffset_InterpolateAtMidFrame_ReturnsMidpointTowardNextFrame()
+    {
+        // frame 0 = (10,20), frame 1 = (50,60); 0.1s frame, halfway (0.05s) → midpoint (30,40).
+        var chain = MakeChain((10f, 20f), (50f, 60f));
+        var (x, y) = OffsetInterpolator.ComputeOffset(chain, frameIndex: 0, frameElapsed: 0.05, interpolate: true);
+        Assert.Equal(30f, x, precision: 4);
+        Assert.Equal(40f, y, precision: 4);
+    }
+
+    [Fact]
+    public void ComputeOffset_InterpolateOnLastFrame_HoldsLastFrameOffset()
+    {
+        // The last frame has no successor to ease toward, so it holds its own offset
+        // regardless of elapsed — the loop snaps back to frame 0 only when the image hard-cuts.
+        var chain = MakeChain((10f, 20f), (50f, 60f));
+        var (x, y) = OffsetInterpolator.ComputeOffset(chain, frameIndex: 1, frameElapsed: 0.05, interpolate: true);
+        Assert.Equal(50f, x, precision: 4);
+        Assert.Equal(60f, y, precision: 4);
+    }
+
+    [Fact]
+    public void ComputeOffset_InterpolateSingleFrameChain_ReturnsThatFrameOffset()
+    {
+        // Nothing to interpolate toward; return the only frame's offset.
+        var chain = MakeChain((10f, 20f));
+        var (x, y) = OffsetInterpolator.ComputeOffset(chain, frameIndex: 0, frameElapsed: 0.05, interpolate: true);
+        Assert.Equal(10f, x, precision: 4);
+        Assert.Equal(20f, y, precision: 4);
+    }
+}


### PR DESCRIPTION
## What

Adds an opt-in **Interpolate** toggle to the Animation Editor preview panel. By default the preview snaps the sprite between each frame's `RelativeX/Y` offset, matching the FlatRedBall runtime. With the toggle on, the sprite eases smoothly between consecutive frames' offsets during playback — an authoring aid for judging arc-style motion (e.g. a jump whose `RelativeY` climbs across frames).

## Why

The `.achx` format and the FRB runtime have no concept of interpolated offsets — they always snap. There's no good way to *preview* what eased motion would look like while authoring. This is a preview-only visualization; it is **not** stored in the `.achx` and the runtime does not reproduce it (the tooltip flags this).

## Behavior

- **Snap stays the default.** Interpolation is opt-in and transient.
- Interior frames ease linearly by `FrameElapsed / FrameLength` toward the next frame.
- **The last frame holds its own offset** (no ease-back): non-looping clips settle on their final position, and looping clips snap at the same instant the flipbook image already hard-cuts.
- The toggle **auto-resets to off whenever the selected chain changes** (not persisted anywhere).
- When the toggle is off, the render path is byte-for-byte the previous behavior; the per-tick repaint only happens while interpolating.

## Implementation

- `OffsetInterpolator.ComputeOffset` (`Core/Rendering`) — pure snap-vs-ease math, the testable core.
- `PreviewControl` threads the resolved offset through the render snapshot, repaints every playback tick only while interpolating, and resets the flag on selection change.
- `MainWindow` wires the toolbar toggle ↔ control with the existing suppression-flag sync pattern.

## Tests

- 4 `OffsetInterpolator` cases: snap, mid-frame ease, last-frame hold, single-frame guard.
- 1 `[AvaloniaFact]` locking the reset-on-selection-change.
- Core **1178/1178** pass. App suite passes except 2 pre-existing `TabSwitchUndoTests` failures that reproduce identically on `main` (unrelated to this change).

## Manual test

Load a multi-frame `.achx` with varying offsets (e.g. a Jump chain whose `RelativeY` climbs), play with Interpolate off → snaps; on → glides; last frame settles; switching chains clears the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)