### PR TITLE
Fix Preview pan clamp pinning offset sprites when zooming (#412)

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
+++ b/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
@@ -249,7 +249,7 @@
 | `FloodFillBoundsCalculatorTests.cs` *(new)* | II02 |
 | `AppCommandsSaveAsTests.cs` *(new)* | IO03 |
 | `AESettingsSaveRoundTripTests.cs` *(new)* | IO05 (guides + expanded nodes round-trip) |
-| `WireframeTransformTests.cs` *(new)* | WF01 (coordinate math layer), WF04 (zoom-toward math) |
+| `CanvasTransformTests.cs` *(new)* | WF01 (coordinate math layer), WF04 (zoom-toward math) |
 | `TreeBuilderTests.cs` *(new)* | TV01 (expand-state logic), TV02–TV04 (selection routing) |
 | `GridSnapperTests.cs` *(new)* | WF06 (snap-to-grid math layer) |
 | `FlipScaleCalculatorTests.cs` *(new)* | WF02 math layer, PL06 math layer |
@@ -357,7 +357,7 @@ sts pass in `AnimationEditor.App.Tests` (net8.0, xunit.v3 3.2.2).
 | MEDIUM | Add `AppCommands.FlipFrameHorizontally/Vertically` (F09/F10) | ✅ Done | F09–F10 now covered (+8 tests) |
 | MEDIUM | Wire TV01 two-way `IsExpanded` binding in AXAML | ✅ Done | TV01 fully closed (expand state roundtrips via model) |
 | MEDIUM | Extract flip-scale decision to `FlipScaleCalculator` | ✅ Done | WF02 + PL06 math layer (11 tests) |
-| MEDIUM | Add `WireframeTransform.Pan` + wire `WireframeControl` | ✅ Done | WF05 math layer (5 tests) |
+| MEDIUM | Add `CanvasTransform.Pan` + wire `WireframeControl` | ✅ Done | WF05 math layer (5 tests) |
 | MEDIUM | Extract `UnitConverter.ToDisplay`/`FromDisplay` | ✅ Done | WF08 display math (13 tests) |
 | MEDIUM | Add `AppCommands.RenameChain`/`RenameFrame` | ✅ Done | TV07–TV08 logic layer (8 tests) |
 | LOW | Add Avalonia headless rendering tests | Open | Would cover WF03, WF07 canvas drawing |
@@ -444,8 +444,8 @@ All Core logic is extracted and tested. The table below tracks which features ar
 *Report updated. 595 unit tests across 41 test files (feature inventory: 134 items; 125 covered, 9 untestable/UI-only).*
 *`AnimationEditor.Core.Tests` (net8.0, xUnit 2.9.2): 582 tests passing.*
 *`AnimationEditor.App.Tests` (net8.0, xunit.v3 3.2.2): 13 headless Avalonia tests passing (TV05 multi-select × 4, TV06 context menu × 9).*
-*Core modules: `PlaybackController`, `HandleKind`, `DragHandleHitTester`, `DragHandleApplier`, `BoundsRect`, `FloodFillBoundsCalculator`, `WireframeTransform` (+ `Pan`), `GridSnapper`, `FlipScaleCalculator`, `UnitConverter`, `IFileDialogService`, `NullFileDialogService`, `TreeNodeVm`, `TreeBuilder`, `DirectionNameSuggester`, `AdjustOffsetCalculator`, `FrameTimeScaler`, `BatchFrameBuilder`, `ClipboardPayload`, `TextureResizeAdjuster`, `SpriteAlignment` enum, `SpriteAlignmentOffsetCalculator`, `OffsetMultiplierConverter`, `CommandLineArgParser`, `TextureListBuilder`, `TileCoordinateCalculator`, `PixelFrameEditor`.*
+*Core modules: `PlaybackController`, `HandleKind`, `DragHandleHitTester`, `DragHandleApplier`, `BoundsRect`, `FloodFillBoundsCalculator`, `CanvasTransform` (+ `Pan`), `GridSnapper`, `FlipScaleCalculator`, `UnitConverter`, `IFileDialogService`, `NullFileDialogService`, `TreeNodeVm`, `TreeBuilder`, `DirectionNameSuggester`, `AdjustOffsetCalculator`, `FrameTimeScaler`, `BatchFrameBuilder`, `ClipboardPayload`, `TextureResizeAdjuster`, `SpriteAlignment` enum, `SpriteAlignmentOffsetCalculator`, `OffsetMultiplierConverter`, `CommandLineArgParser`, `TextureListBuilder`, `TileCoordinateCalculator`, `PixelFrameEditor`.*
 *AppCommands additions: `FlipFrameHorizontally`, `FlipFrameVertically`, `RenameChain`, `RenameFrame`, `AdjustOffsetsJustifyBottom`, `AdjustOffsetsAdjustAll`, `ScaleFrameTimesProportional`, `ScaleFrameTimesSetAllSame`, `AddMultipleFrames`, `AdjustUVAfterResize`, `NewFile`, `AddFrameFromPixelBounds`.*
 *AppState additions: `SpriteAlignment`, `OffsetMultiplier`.*
-*App: `AvaloniaFileDialogService`, `IsExpanded` binding via `TreeView.Styles` `{ReflectionBinding}`, `PreviewControl` delegates to `FlipScaleCalculator`, `WireframeControl` delegates to `WireframeTransform.Pan`.*
+*App: `AvaloniaFileDialogService`, `IsExpanded` binding via `TreeView.Styles` `{ReflectionBinding}`, `PreviewControl` delegates to `FlipScaleCalculator`, `WireframeControl` delegates to `CanvasTransform.Pan`.*
 *Test files added (session): `TileCoordinateCalculatorTests.cs`, `PixelFrameEditorTests.cs`.*

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -311,7 +311,7 @@ public class PreviewControl : Control
 
     public void SetZoomPercent(int pct)
     {
-        _zoom = Math.Clamp(pct / 100f, 0.05f, 32f);
+        _zoom = Math.Clamp(pct / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
         InvalidateVisual();
         ZoomChanged?.Invoke(_zoom * 100f);
     }
@@ -431,20 +431,28 @@ public class PreviewControl : Control
     private void ApplyWheelZoom(double x, double y, bool zoomIn)
     {
         float oldZoom = _zoom;
+        float targetZoom;
         if (WheelZoomPresets is { Length: > 0 } presets)
         {
             int newPct = ZoomPresetStepper.StepToNextPreset(_zoom * 100f, presets, zoomIn ? +1 : -1);
-            _zoom = Math.Clamp(newPct / 100f, 0.05f, 32f);
+            targetZoom = Math.Clamp(newPct / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
         }
         else
         {
-            _zoom = Math.Clamp(_zoom * (zoomIn ? 1.25f : 0.8f), 0.05f, 32f);
+            targetZoom = Math.Clamp(_zoom * (zoomIn ? 1.25f : 0.8f), CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
         }
-        float ratio = _zoom / oldZoom;
+
+        // Preview pan is relative to the canvas center; convert to the absolute pan
+        // (the origin's screen position) that CanvasTransform.ZoomToward operates on,
+        // then convert the result back.
         float cx0 = (float)((Bounds.Width  - RulerSize) / 2f + RulerSize);
         float cy0 = (float)((Bounds.Height - RulerSize) / 2f + RulerSize);
-        _panX = (float)((x - cx0) - (x - cx0 - _panX) * ratio);
-        _panY = (float)((y - cy0) - (y - cy0 - _panY) * ratio);
+        var (absPanX, absPanY, newZoom) = CanvasTransform.ZoomToward(
+            (float)x, (float)y, targetZoom / oldZoom, cx0 + _panX, cy0 + _panY, oldZoom);
+
+        _zoom = newZoom;
+        _panX = absPanX - cx0;
+        _panY = absPanY - cy0;
         ClampPan();
         InvalidateVisual();
         ZoomChanged?.Invoke(_zoom * 100f);
@@ -458,8 +466,10 @@ public class PreviewControl : Control
     }
 
     /// <summary>
-    /// Keeps the entity origin within the visible viewport so it never drifts fully off-screen.
-    /// No-op until layout has run (<c>Bounds.Width > 1</c>).
+    /// Keeps the displayed content within reach so it never drifts fully off-screen, while
+    /// letting the user scroll across it. The pan band scales with the content's on-screen
+    /// extent (content × zoom), so zooming in on content offset from the entity origin never
+    /// pins it to one edge (#412). No-op until layout has run (<c>Bounds.Width > 1</c>).
     /// </summary>
     private void ClampPan()
     {
@@ -468,8 +478,62 @@ public class PreviewControl : Control
         float viewW = (float)(Bounds.Width  - RulerSize);
         float viewH = (float)(Bounds.Height - RulerSize);
 
-        _panX = Math.Clamp(_panX, -(viewW / 2f + PanPadding), viewW / 2f + PanPadding);
-        _panY = Math.Clamp(_panY, -(viewH / 2f + PanPadding), viewH / 2f + PanPadding);
+        var (minX, maxX, minY, maxY) = ComputeContentExtentScreenPx();
+        (_panX, _panY) = CanvasTransform.ClampPan(
+            _panX, _panY, viewW, viewH, minX, maxX, minY, maxY, PanPadding);
+    }
+
+    /// <summary>
+    /// Bounding box of the displayed content (sprite frame + collision shapes) in screen
+    /// pixels, relative to the entity origin (world Y up is flipped to screen Y down).
+    /// The origin itself is always included, so empty content collapses the band back to
+    /// the simple "origin stays on screen" clamp.
+    /// </summary>
+    private (float MinX, float MaxX, float MinY, float MaxY) ComputeContentExtentScreenPx()
+    {
+        float minX = 0f, maxX = 0f, minY = 0f, maxY = 0f;
+        float om = _appState!.OffsetMultiplier * _zoom;
+
+        void Include(float cx, float cy, float halfW, float halfH)
+        {
+            minX = Math.Min(minX, cx - halfW); maxX = Math.Max(maxX, cx + halfW);
+            minY = Math.Min(minY, cy - halfH); maxY = Math.Max(maxY, cy + halfH);
+        }
+
+        var chain         = _selectedState!.SelectedChain;
+        var selectedFrame = _selectedState!.SelectedFrame;
+        AnimationFrameSave? displayFrame = selectedFrame;
+        if (displayFrame is null && chain is not null && chain.Frames.Count > 0)
+        {
+            int idx = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
+            displayFrame = chain.Frames[idx];
+        }
+
+        if (displayFrame is not null)
+        {
+            var (offX, offY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
+            // Sprite pixel size scales by zoom only (not OffsetMultiplier). Skip it when the
+            // texture isn't cached yet — the offset center alone keeps the frame reachable.
+            float hw = 0f, hh = 0f;
+            string? texPath = _thumbnailService!.ResolveTexturePath(displayFrame);
+            if (texPath is not null &&
+                _thumbnailService.BitmapCache.TryGetValue(texPath, out var bm) && bm is not null)
+            {
+                var (_, _, sw, sh) = ComputeSourceRect(displayFrame, bm.Width, bm.Height);
+                hw = sw * _zoom / 2f;
+                hh = sh * _zoom / 2f;
+            }
+            Include(offX * om, -offY * om, hw, hh);
+        }
+
+        foreach (var sh in BuildShapeInfos())
+        {
+            float halfW = sh.Param1 * om;
+            float halfH = (sh.Kind == PreviewShapeKind.Rect ? sh.Param2 : sh.Param1) * om;
+            Include(sh.X * om, -sh.Y * om, halfW, halfH);
+        }
+
+        return (minX, maxX, minY, maxY);
     }
     // -- Avalonia rendering ----------------------------------------------------
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -230,7 +230,7 @@ public class WireframeControl : Control
 
         private static SKRect ToScreen(SKRect r, RenderSnapshot s)
         {
-            var (l, t, rr, b) = WireframeTransform.TextureRectToScreen(
+            var (l, t, rr, b) = CanvasTransform.TextureRectToScreen(
                 r.Left, r.Top, r.Right, r.Bottom, s.PanX, s.PanY, s.Zoom);
             return new SKRect(l, t, rr, b);
         }
@@ -926,7 +926,7 @@ public class WireframeControl : Control
     /// <summary>Set zoom by whole-number percentage (e.g. 100 = 1× fit).</summary>
     public void SetZoomPercent(int percent)
     {
-        float newZoom = Math.Clamp(percent / 100f, WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+        float newZoom = Math.Clamp(percent / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
         float cx, cy;
         if (_scrollViewer != null && _scrollViewer.Viewport.Width > 1)
         {
@@ -1208,7 +1208,7 @@ public class WireframeControl : Control
         }
         else
         {
-            (_panX, _panY) = WireframeTransform.Pan(
+            (_panX, _panY) = CanvasTransform.Pan(
                 _panAnchorX, _panAnchorY,
                 (float)_panAnchor.X, (float)_panAnchor.Y,
                 vpX, vpY);
@@ -1301,7 +1301,7 @@ public class WireframeControl : Control
     public void CenterFitForSize(int width, int height)
     {
         if (_bitmap is null) return;
-        (_panX, _panY, _zoom) = WireframeTransform.CenterFit(
+        (_panX, _panY, _zoom) = CanvasTransform.CenterFit(
             _bitmap.Width, _bitmap.Height, width, height);
         InvalidateVisual();
     }
@@ -1315,7 +1315,7 @@ public class WireframeControl : Control
     /// </summary>
     /// <summary>
     /// Zooms to fit the frame's bounding box at 85 % of the viewport (same fraction
-    /// as <see cref="WireframeTransform.CenterFit"/> uses for the whole bitmap), then
+    /// as <see cref="CanvasTransform.CenterFit"/> uses for the whole bitmap), then
     /// scrolls so the frame centre lands at the viewport centre.
     /// </summary>
     public void CenterOnFrame(AnimationFrameSave frame)
@@ -1341,7 +1341,7 @@ public class WireframeControl : Control
         // Zoom so the frame fills 85 % of the viewport.
         _zoom = Math.Clamp(
             Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
-            WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+            CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
 
         // In scroll mode panX/Y must always equal EffectivePaddingX/Y.
         // Update them now — EffectivePaddingX/Y read _zoom which we just set.
@@ -1645,7 +1645,7 @@ public class WireframeControl : Control
                 // hasn't fired yet the two spaces differ by the stale scroll offset,
                 // causing an immediate pan jump on the first move event.
                 var freePanPos = _scrollViewer != null ? e.GetPosition(_scrollViewer) : pos;
-                (_panX, _panY) = WireframeTransform.Pan(
+                (_panX, _panY) = CanvasTransform.Pan(
                     _panAnchorX, _panAnchorY,
                     (float)_panAnchor.X, (float)_panAnchor.Y,
                     (float)freePanPos.X, (float)freePanPos.Y);
@@ -1845,7 +1845,7 @@ public class WireframeControl : Control
     private void ZoomToward(float sx, float sy, float factor)
     {
         float oldZoom = _zoom;
-        var (newPanX, newPanY, newZoom) = WireframeTransform.ZoomToward(sx, sy, factor, _panX, _panY, _zoom);
+        var (newPanX, newPanY, newZoom) = CanvasTransform.ZoomToward(sx, sy, factor, _panX, _panY, _zoom);
         _zoom = newZoom;
 
         if (_scrollViewer != null)
@@ -2173,13 +2173,13 @@ public class WireframeControl : Control
 
     private SKPoint ScreenToTexture(float sx, float sy)
     {
-        var (tx, ty) = WireframeTransform.ScreenToTexture(sx, sy, _panX, _panY, _zoom);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(sx, sy, _panX, _panY, _zoom);
         return new SKPoint(tx, ty);
     }
 
     private SKRect ToScreen(SKRect r)
     {
-        var (l, t, rr, b) = WireframeTransform.TextureRectToScreen(
+        var (l, t, rr, b) = CanvasTransform.TextureRectToScreen(
             r.Left, r.Top, r.Right, r.Bottom, _panX, _panY, _zoom);
         return new SKRect(l, t, rr, b);
     }
@@ -2270,7 +2270,7 @@ public class WireframeControl : Control
             ctrlH = (float)(Bounds.Height > 0 ? Bounds.Height : 600);
         }
 
-        (_panX, _panY, _zoom) = WireframeTransform.CenterFit(_bitmap.Width, _bitmap.Height, ctrlW, ctrlH);
+        (_panX, _panY, _zoom) = CanvasTransform.CenterFit(_bitmap.Width, _bitmap.Height, ctrlW, ctrlH);
 
         // After CenterFit the image is centred inside the viewport.  In scroll mode we
         // always apply padding so the scrollbars are active — set panX/panY to

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
@@ -3,7 +3,9 @@ using System;
 namespace AnimationEditor.Core.Rendering;
 
 /// <summary>
-/// Pure coordinate-transform math for a pan/zoom canvas.
+/// Pure coordinate-transform math for a pan/zoom canvas. Shared by both editor
+/// panels (Wireframe and Preview) so zoom-toward-cursor, fit-centering, and
+/// pan-clamping behave identically and only have to be fixed once.
 /// <para>
 /// Screen-space → texture-space:  textureX = (screenX − panX) / zoom<br/>
 /// Texture-space → screen-space:  screenX  = panX + textureX × zoom
@@ -11,7 +13,7 @@ namespace AnimationEditor.Core.Rendering;
 /// All methods are static and side-effect-free; they can be unit-tested
 /// without any UI or rendering infrastructure.
 /// </summary>
-public static class WireframeTransform
+public static class CanvasTransform
 {
     /// <summary>Minimum allowed zoom factor (5 %).</summary>
     public const float MinZoom = 0.05f;
@@ -96,4 +98,34 @@ public static class WireframeTransform
         float currentX,   float currentY)
         => (anchorPanX + currentX - anchorX,
             anchorPanY + currentY - anchorY);
+
+    /// <summary>
+    /// Clamps a center-relative pan so the displayed content can be scrolled across the
+    /// viewport but never fully off it. The allowed band scales with the content's
+    /// on-screen extent, so zooming in (which grows the extent) keeps every part of the
+    /// content reachable instead of pinning it to one edge.
+    /// <para>
+    /// Pan is the screen-pixel offset of the content origin from the viewport center
+    /// (the Preview panel's convention). The content extent is given in screen pixels
+    /// relative to that same origin: a point at origin-offset <c>e</c> renders at
+    /// <c>center + pan + e</c>. The band lets the content's far edge reach the opposite
+    /// viewport edge plus <paramref name="padding"/>; passing a zero-size extent
+    /// (<c>min == max == 0</c>) reproduces the simple "origin stays on screen" clamp.
+    /// </para>
+    /// </summary>
+    public static (float PanX, float PanY) ClampPan(
+        float panX, float panY,
+        float viewW, float viewH,
+        float contentMinX, float contentMaxX,
+        float contentMinY, float contentMaxY,
+        float padding = 0f)
+    {
+        float maxPanX =  viewW / 2f + padding - contentMinX;
+        float minPanX = -viewW / 2f - padding - contentMaxX;
+        float maxPanY =  viewH / 2f + padding - contentMinY;
+        float minPanY = -viewH / 2f - padding - contentMaxY;
+
+        return (Math.Clamp(panX, minPanX, maxPanX),
+                Math.Clamp(panY, minPanY, maxPanY));
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPanLimitTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPanLimitTests.cs
@@ -76,6 +76,39 @@ public class PreviewPanLimitTests
     }
 
     /// <summary>
+    /// Regression guard for #412: zooming in while centered on content that is offset
+    /// from the entity origin must keep that content reachable. The old fixed
+    /// ±viewport/2 pan band ignored zoom and pinned the sprite to the bottom edge.
+    /// </summary>
+    [AvaloniaFact]
+    public void WheelZoom_InOnOffsetShape_KeepsContentReachable()
+    {
+        var ctx = ResetSingletons();
+        ctx.AppState.OffsetMultiplier = 1f;
+
+        // A collision shape 100 world-units above the origin, shown as the selected
+        // frame's content so the content-aware clamp has a non-trivial extent.
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new CircleSave { X = 0f, Y = 100f, Radius = 10f });
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.Measure(new Size(400, 300));
+        ctrl.Arrange(new Rect(0, 0, 400, 300));
+        ctrl.SetZoomPercent(800);
+        ctrl.CenterOnEntityPoint(0f, 100f); // panY = 100 * 1 * 8 = 800
+
+        // Zoom in toward the canvas center; the shape must stay reachable rather than
+        // being clamped back to the old fixed band (≈ viewH/2 = 140).
+        float cx = (400f - 20f) / 2f + 20f; // 210
+        float cy = (300f - 20f) / 2f + 20f; // 160
+        ctrl.SimulateWheelZoom(cx, cy, zoomIn: true);
+
+        Assert.True(ctrl.PanOffset.Y > 300f,
+            $"PanY={ctrl.PanOffset.Y:F1} was pinned near the old fixed limit; content unreachable (#412)");
+    }
+
+    /// <summary>
     /// SetPan must preserve exact values (relied on by CenterOnEntityPoint) —
     /// it must NOT apply clamping.
     /// </summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
@@ -102,7 +102,7 @@ public class WireframeCenterOnFrameTests
             // Zoom should fit the frame at 85 % of the viewport.
             float expectedZoom = Math.Clamp(
                 Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
-                WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+                CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
 
             Assert.True(Math.Abs(ctrl.Zoom - expectedZoom) < 0.01f,
                 $"Zoom should fit frame; expected≈{expectedZoom:F3} actual={ctrl.Zoom:F3}");
@@ -181,7 +181,7 @@ public class WireframeCenterOnFrameTests
             float vpH = (float)sv.Viewport.Height;
             float frameFitZoom = Math.Clamp(
                 Math.Min(vpW / 25f, vpH / 25f) * 0.85f,
-                WireframeTransform.MinZoom, WireframeTransform.MaxZoom);
+                CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
             Assert.True(Math.Abs(ctrl.Zoom - frameFitZoom) < 0.01f,
                 $"Zoom should fit 25×25 frame; expected≈{frameFitZoom:F3} actual={ctrl.Zoom:F3}");
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
@@ -4,17 +4,17 @@ using Xunit;
 namespace AnimationEditor.Core.Tests;
 
 /// <summary>
-/// Tests for <see cref="WireframeTransform"/> — pure pan/zoom coordinate math.
+/// Tests for <see cref="CanvasTransform"/> — pure pan/zoom coordinate math.
 /// No UI, no SkiaSharp, no singleton dependencies.
 /// </summary>
-public class WireframeTransformTests
+public class CanvasTransformTests
 {
     // ── ScreenToTexture ───────────────────────────────────────────────────────
 
     [Fact]
     public void ScreenToTexture_NoPanZoom1_ReturnsSameCoords()
     {
-        var (tx, ty) = WireframeTransform.ScreenToTexture(10f, 20f, 0f, 0f, 1f);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(10f, 20f, 0f, 0f, 1f);
         Assert.Equal(10f, tx);
         Assert.Equal(20f, ty);
     }
@@ -23,7 +23,7 @@ public class WireframeTransformTests
     public void ScreenToTexture_WithPan_SubtractsPanBeforeDivide()
     {
         // screen(15, 25), pan(5, 5), zoom=1 → texture(10, 20)
-        var (tx, ty) = WireframeTransform.ScreenToTexture(15f, 25f, 5f, 5f, 1f);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(15f, 25f, 5f, 5f, 1f);
         Assert.Equal(10f, tx);
         Assert.Equal(20f, ty);
     }
@@ -31,7 +31,7 @@ public class WireframeTransformTests
     [Fact]
     public void ScreenToTexture_WithZoom2_HalvesCoordinates()
     {
-        var (tx, ty) = WireframeTransform.ScreenToTexture(20f, 40f, 0f, 0f, 2f);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(20f, 40f, 0f, 0f, 2f);
         Assert.Equal(10f, tx);
         Assert.Equal(20f, ty);
     }
@@ -39,7 +39,7 @@ public class WireframeTransformTests
     [Fact]
     public void ScreenToTexture_WithZoomHalf_DoublesCoordinates()
     {
-        var (tx, ty) = WireframeTransform.ScreenToTexture(10f, 20f, 0f, 0f, 0.5f);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(10f, 20f, 0f, 0f, 0.5f);
         Assert.Equal(20f, tx);
         Assert.Equal(40f, ty);
     }
@@ -48,7 +48,7 @@ public class WireframeTransformTests
     public void ScreenToTexture_WithPanAndZoom_CombinesBoth()
     {
         // screen(30, 50), pan(10, 10), zoom=2 → texture((30-10)/2, (50-10)/2) = (10, 20)
-        var (tx, ty) = WireframeTransform.ScreenToTexture(30f, 50f, 10f, 10f, 2f);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(30f, 50f, 10f, 10f, 2f);
         Assert.Equal(10f, tx);
         Assert.Equal(20f, ty);
     }
@@ -58,7 +58,7 @@ public class WireframeTransformTests
     [Fact]
     public void TextureRectToScreen_NoPanZoom1_ReturnsSameRect()
     {
-        var (l, t, r, b) = WireframeTransform.TextureRectToScreen(
+        var (l, t, r, b) = CanvasTransform.TextureRectToScreen(
             0f, 0f, 100f, 50f, 0f, 0f, 1f);
         Assert.Equal(0f,   l);
         Assert.Equal(0f,   t);
@@ -69,7 +69,7 @@ public class WireframeTransformTests
     [Fact]
     public void TextureRectToScreen_WithPan_ShiftsRect()
     {
-        var (l, t, r, b) = WireframeTransform.TextureRectToScreen(
+        var (l, t, r, b) = CanvasTransform.TextureRectToScreen(
             10f, 20f, 30f, 40f, 5f, 8f, 1f);
         Assert.Equal(15f, l);
         Assert.Equal(28f, t);
@@ -80,7 +80,7 @@ public class WireframeTransformTests
     [Fact]
     public void TextureRectToScreen_WithZoom2_ScalesRect()
     {
-        var (l, t, r, b) = WireframeTransform.TextureRectToScreen(
+        var (l, t, r, b) = CanvasTransform.TextureRectToScreen(
             0f, 0f, 10f, 10f, 0f, 0f, 2f);
         Assert.Equal(0f,  l);
         Assert.Equal(0f,  t);
@@ -91,7 +91,7 @@ public class WireframeTransformTests
     [Fact]
     public void TextureRectToScreen_ZeroSizeRect_PreservesDegenerate()
     {
-        var (l, t, r, b) = WireframeTransform.TextureRectToScreen(
+        var (l, t, r, b) = CanvasTransform.TextureRectToScreen(
             5f, 5f, 5f, 5f, 0f, 0f, 1f);
         Assert.Equal(5f, l);
         Assert.Equal(5f, t);
@@ -106,11 +106,11 @@ public class WireframeTransformTests
         float lIn = 10f, tIn = 20f, rIn = 40f, bIn = 60f;
         float panX = 15f, panY = 25f, zoom = 1.5f;
 
-        var (sl, st, sr, sb) = WireframeTransform.TextureRectToScreen(
+        var (sl, st, sr, sb) = CanvasTransform.TextureRectToScreen(
             lIn, tIn, rIn, bIn, panX, panY, zoom);
 
-        var (tlx, tty) = WireframeTransform.ScreenToTexture(sl, st, panX, panY, zoom);
-        var (trx, tby) = WireframeTransform.ScreenToTexture(sr, sb, panX, panY, zoom);
+        var (tlx, tty) = CanvasTransform.ScreenToTexture(sl, st, panX, panY, zoom);
+        var (trx, tby) = CanvasTransform.ScreenToTexture(sr, sb, panX, panY, zoom);
 
         Assert.Equal(lIn, tlx, 4);
         Assert.Equal(tIn, tty, 4);
@@ -123,7 +123,7 @@ public class WireframeTransformTests
     [Fact]
     public void ZoomToward_Factor1_NoChange()
     {
-        var (px, py, z) = WireframeTransform.ZoomToward(100f, 100f, 1f, 10f, 20f, 1f);
+        var (px, py, z) = CanvasTransform.ZoomToward(100f, 100f, 1f, 10f, 20f, 1f);
         Assert.Equal(10f, px);
         Assert.Equal(20f, py);
         Assert.Equal(1f,  z);
@@ -135,9 +135,9 @@ public class WireframeTransformTests
         // pan=(0,0), zoom=1, pivot screen=(50,50) → texture pivot = (50,50)
         // After zoom-in ×2 the same screen point should still map to texture (50,50)
         var (newPanX, newPanY, newZoom) =
-            WireframeTransform.ZoomToward(50f, 50f, 2f, 0f, 0f, 1f);
+            CanvasTransform.ZoomToward(50f, 50f, 2f, 0f, 0f, 1f);
 
-        var (tx, ty) = WireframeTransform.ScreenToTexture(50f, 50f, newPanX, newPanY, newZoom);
+        var (tx, ty) = CanvasTransform.ScreenToTexture(50f, 50f, newPanX, newPanY, newZoom);
         Assert.Equal(50f, tx, 4);
         Assert.Equal(50f, ty, 4);
     }
@@ -146,7 +146,7 @@ public class WireframeTransformTests
     public void ZoomToward_PivotAtOrigin_PanRemainsZero()
     {
         // pan=(0,0), pivot screen=(0,0) → no matter the factor the pan stays (0,0)
-        var (px, py, z) = WireframeTransform.ZoomToward(0f, 0f, 3f, 0f, 0f, 1f);
+        var (px, py, z) = CanvasTransform.ZoomToward(0f, 0f, 3f, 0f, 0f, 1f);
         Assert.Equal(0f, px);
         Assert.Equal(0f, py);
         Assert.Equal(3f, z);
@@ -156,16 +156,16 @@ public class WireframeTransformTests
     public void ZoomToward_ClampedAtMaxZoom()
     {
         // Start near max, zoom in with large factor
-        var (_, _, z) = WireframeTransform.ZoomToward(0f, 0f, 1.5f, 0f, 0f, 30f);
-        Assert.Equal(WireframeTransform.MaxZoom, z);
+        var (_, _, z) = CanvasTransform.ZoomToward(0f, 0f, 1.5f, 0f, 0f, 30f);
+        Assert.Equal(CanvasTransform.MaxZoom, z);
     }
 
     [Fact]
     public void ZoomToward_ClampedAtMinZoom()
     {
         // Start near min, zoom out
-        var (_, _, z) = WireframeTransform.ZoomToward(0f, 0f, 0.4f, 0f, 0f, 0.1f);
-        Assert.Equal(WireframeTransform.MinZoom, z);
+        var (_, _, z) = CanvasTransform.ZoomToward(0f, 0f, 0.4f, 0f, 0f, 0.1f);
+        Assert.Equal(CanvasTransform.MinZoom, z);
     }
 
     // ── CenterFit ─────────────────────────────────────────────────────────────
@@ -174,7 +174,7 @@ public class WireframeTransformTests
     public void CenterFit_SquareBitmapSquareControl_ProducesExpectedZoomAndPan()
     {
         // 100×100 in 200×200 → zoom = min(2,2)*0.85 = 1.7; pan = (200-170)/2 = 15
-        var (panX, panY, zoom) = WireframeTransform.CenterFit(100f, 100f, 200f, 200f);
+        var (panX, panY, zoom) = CanvasTransform.CenterFit(100f, 100f, 200f, 200f);
         Assert.Equal(1.7f, zoom,  4);
         Assert.Equal(15f,  panX, 4);
         Assert.Equal(15f,  panY, 4);
@@ -185,7 +185,7 @@ public class WireframeTransformTests
     {
         // 400×100 in 200×200 → zoom = min(0.5, 2)*0.85 = 0.425
         // panX = (200 - 400*0.425)/2 = 15, panY = (200 - 100*0.425)/2 = 78.75
-        var (panX, panY, zoom) = WireframeTransform.CenterFit(400f, 100f, 200f, 200f);
+        var (panX, panY, zoom) = CanvasTransform.CenterFit(400f, 100f, 200f, 200f);
         Assert.Equal(0.425f, zoom,  4);
         Assert.Equal(15f,    panX, 4);
         Assert.Equal(78.75f, panY, 4);
@@ -195,7 +195,7 @@ public class WireframeTransformTests
     public void CenterFit_TallBitmap_LimitedByHeight()
     {
         // 100×400 in 200×200 → zoom = min(2, 0.5)*0.85 = 0.425
-        var (panX, panY, zoom) = WireframeTransform.CenterFit(100f, 400f, 200f, 200f);
+        var (panX, panY, zoom) = CanvasTransform.CenterFit(100f, 400f, 200f, 200f);
         Assert.Equal(0.425f, zoom,  4);
         Assert.Equal(78.75f, panX, 4);
         Assert.Equal(15f,    panY, 4);
@@ -205,7 +205,7 @@ public class WireframeTransformTests
     public void CenterFit_VeryLargeControl_ZoomClampedAt4()
     {
         // 10×10 in 10000×10000 → raw zoom = 1000*0.85 = 850 → clamped to 4
-        var (panX, panY, zoom) = WireframeTransform.CenterFit(10f, 10f, 10000f, 10000f);
+        var (panX, panY, zoom) = CanvasTransform.CenterFit(10f, 10f, 10000f, 10000f);
         Assert.Equal(4f,    zoom);
         Assert.Equal(4980f, panX, 4);
         Assert.Equal(4980f, panY, 4);
@@ -215,8 +215,8 @@ public class WireframeTransformTests
     public void CenterFit_VerySmallControl_ZoomClampedAtMinZoom()
     {
         // 1000×1000 in 1×1 → raw zoom = (1/1000)*0.85 = 0.00085 → clamped to 0.05
-        var (_, _, zoom) = WireframeTransform.CenterFit(1000f, 1000f, 1f, 1f);
-        Assert.Equal(WireframeTransform.MinZoom, zoom, 4);
+        var (_, _, zoom) = CanvasTransform.CenterFit(1000f, 1000f, 1f, 1f);
+        Assert.Equal(CanvasTransform.MinZoom, zoom, 4);
     }
 
     // ── Pan ──────────────────────────────────────────────────────────────────
@@ -224,7 +224,7 @@ public class WireframeTransformTests
     [Fact]
     public void Pan_NoDelta_ReturnsSameAnchorPan()
     {
-        var (px, py) = WireframeTransform.Pan(100f, 200f, 50f, 60f, 50f, 60f);
+        var (px, py) = CanvasTransform.Pan(100f, 200f, 50f, 60f, 50f, 60f);
         Assert.Equal(100f, px);
         Assert.Equal(200f, py);
     }
@@ -232,7 +232,7 @@ public class WireframeTransformTests
     [Fact]
     public void Pan_PositiveDelta_AddsToAnchorPan()
     {
-        var (px, py) = WireframeTransform.Pan(0f, 0f, 0f, 0f, 30f, 40f);
+        var (px, py) = CanvasTransform.Pan(0f, 0f, 0f, 0f, 30f, 40f);
         Assert.Equal(30f, px);
         Assert.Equal(40f, py);
     }
@@ -240,7 +240,7 @@ public class WireframeTransformTests
     [Fact]
     public void Pan_NegativeDelta_SubtractsFromAnchorPan()
     {
-        var (px, py) = WireframeTransform.Pan(100f, 100f, 80f, 80f, 50f, 60f);
+        var (px, py) = CanvasTransform.Pan(100f, 100f, 80f, 80f, 50f, 60f);
         Assert.Equal(70f, px);  // 100 + (50-80) = 70
         Assert.Equal(80f, py);  // 100 + (60-80) = 80
     }
@@ -249,7 +249,7 @@ public class WireframeTransformTests
     public void Pan_AnchorPanOffsetPreserved()
     {
         // Starting pan (50, 75), anchor at (200, 100), current at (210, 90)
-        var (px, py) = WireframeTransform.Pan(50f, 75f, 200f, 100f, 210f, 90f);
+        var (px, py) = CanvasTransform.Pan(50f, 75f, 200f, 100f, 210f, 90f);
         Assert.Equal(60f, px);   // 50 + (210-200) = 60
         Assert.Equal(65f, py);   // 75 + (90-100)  = 65
     }
@@ -258,9 +258,46 @@ public class WireframeTransformTests
     public void Pan_IsDeltaBasedNotAccumulated()
     {
         // Two successive moves from the same anchor should produce independent results
-        var (px1, py1) = WireframeTransform.Pan(0f, 0f, 100f, 100f, 110f, 120f);
-        var (px2, py2) = WireframeTransform.Pan(0f, 0f, 100f, 100f, 150f, 160f);
+        var (px1, py1) = CanvasTransform.Pan(0f, 0f, 100f, 100f, 110f, 120f);
+        var (px2, py2) = CanvasTransform.Pan(0f, 0f, 100f, 100f, 150f, 160f);
         Assert.True(px2 > px1);
         Assert.True(py2 > py1);
+    }
+
+    // ── ClampPan ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ClampPan_PanWithinBand_Unchanged()
+    {
+        var (panX, panY) = CanvasTransform.ClampPan(
+            50f, -30f, 380f, 280f,
+            contentMinX: 0f, contentMaxX: 0f, contentMinY: 0f, contentMaxY: 0f);
+        Assert.Equal(50f,  panX, 4);
+        Assert.Equal(-30f, panY, 4);
+    }
+
+    [Fact]
+    public void ClampPan_ZeroExtent_ClampsToViewportHalf()
+    {
+        // Empty content (extent collapses to the origin) → band is ±viewport/2,
+        // matching the original "origin stays on screen" behavior.
+        var (panX, panY) = CanvasTransform.ClampPan(
+            9999f, -9999f, 380f, 280f,
+            contentMinX: 0f, contentMaxX: 0f, contentMinY: 0f, contentMaxY: 0f);
+        Assert.Equal(190f,  panX, 4);   //  viewW / 2
+        Assert.Equal(-140f, panY, 4);   // -viewH / 2
+    }
+
+    [Fact]
+    public void ClampPan_HighZoomOffsetContent_KeepsCenteringPan()
+    {
+        // #412: content centered 800 px above the origin at 8× zoom (world Y=100,
+        // offMult=1) has on-screen extent ≈ [-880, -720] on Y. The centering pan is
+        // +800; the content-aware band must preserve it. The old fixed ±140 band would
+        // pin it to 140, parking the sprite at the bottom edge.
+        var (_, panY) = CanvasTransform.ClampPan(
+            0f, 800f, 380f, 280f,
+            contentMinX: -10f, contentMaxX: 10f, contentMinY: -880f, contentMaxY: -720f);
+        Assert.Equal(800f, panY, 4);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #412 — zooming in on the bottom **Preview** panel pinned a sprite/shape that's offset from the entity origin to the bottom edge (scrollable down, not up). The top **Wireframe** panel was unaffected.

## Root cause
The Preview panel duplicated its own pan/zoom code. `PreviewControl.ClampPan` used a fixed `±viewport/2` band that ignored zoom and content offset. Since `CenterOnEntityPoint` sets `pan ∝ entity × zoom`, zooming in outgrew the band and the clamp pinned the content to one edge.

## Approach — focused fix + safe sharing
Per discussion, this does **not** reconcile the two panels' pan *architectures* (Wireframe uses a `ScrollViewer`; Preview is center-relative) — that's deferred as out-of-scope risk on working code. Instead it shares what's cleanly shareable and fixes the actual defect:

- **Rename** `WireframeTransform` → `CanvasTransform` (panel-agnostic shared math in `Core/Rendering`).
- Preview's `ApplyWheelZoom` now **delegates to `CanvasTransform.ZoomToward`** (via a center-relative ↔ absolute pan conversion) and uses the named `MinZoom`/`MaxZoom` instead of hardcoded `0.05f`/`32f`. The zoom-toward math is no longer duplicated.
- New pure **`CanvasTransform.ClampPan`** whose pan band **scales with the content's on-screen extent (content × zoom)**, so offset content stays reachable. Empty content collapses it to the original "origin stays on screen" band, so prior behavior is preserved.
- Preview computes its content extent (frame offset + sprite size + collision shapes) and feeds the shared clamp.

## Tests (test-first)
- `CanvasTransformTests.ClampPan_*` — pure math, including the #412 high-zoom offset-content regression.
- `PreviewPanLimitTests.WheelZoom_InOnOffsetShape_KeepsContentReachable` — end-to-end repro that **failed before the fix** (`PanY` pinned to 140) and passes after.
- Existing #321 empty-content clamp tests unchanged and still green.

Core suite: 1190 passed. Wireframe App suite: 83 passed. The only failing App tests (`TabSwitchUndoTests`, 2) are **pre-existing** and fail identically on `main` (verified by stashing).

> Note: matched the existing AnimationEditor test convention (xUnit `Assert.*`) rather than repo-wide Shouldly, for consistency within the tool's suite.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)