### PR TITLE
Add scrollbars to the Preview panel (#415)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -224,9 +224,10 @@ public class PreviewControl : Control
         _thumbnailService = thumbnailService;
 
         _selectedState.SelectionChanged                        += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
-        _events.AnimationChainsChanged                         += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
+        // Content edits change the union extent, hence the scrollbar range — refresh alongside the repaint.
+        _events.AnimationChainsChanged                         += () => Dispatcher.UIThread.InvokeAsync(() => { InvalidateVisual(); RaiseViewChanged(); });
         _events.AchxLoaded                                     += _ => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
-        _appCommands.RefreshAnimationFrameDisplayRequested     += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
+        _appCommands.RefreshAnimationFrameDisplayRequested     += () => Dispatcher.UIThread.InvokeAsync(() => { InvalidateVisual(); RaiseViewChanged(); });
     }
 
     // -- Constructor -----------------------------------------------------------
@@ -238,6 +239,9 @@ public class PreviewControl : Control
 
         // Repaint when the app theme variant changes so the canvas/ruler colors update.
         ActualThemeVariantChanged += (_, _) => InvalidateVisual();
+
+        // A resize changes the viewport extent, hence the scrollbar range — refresh the host's scrollbars.
+        SizeChanged += (_, _) => RaiseViewChanged();
 
         // Subscriptions are deferred to InitializeServices (called from MainWindow)
 
@@ -271,6 +275,8 @@ public class PreviewControl : Control
         // Interpolation is a transient per-chain preview aid; clear it when the chain changes.
         InterpolateOffsets = false;
         InvalidateVisual();
+        // A new chain/frame changes the union extent → refresh the host's scrollbars.
+        RaiseViewChanged();
     }
 
     /// <summary>
@@ -300,6 +306,15 @@ public class PreviewControl : Control
     public event Action<float, float>? PanChanged;
 
     /// <summary>
+    /// Fired whenever the view (pan, zoom, content extent, or viewport size) changes, so the
+    /// host can refresh the Preview's scrollbars (#415). Distinct from <see cref="PanChanged"/>,
+    /// which only fires on pan-gesture completion for persistence.
+    /// </summary>
+    public event Action? ViewChanged;
+
+    private void RaiseViewChanged() => ViewChanged?.Invoke();
+
+    /// <summary>
     /// When non-null, mouse-wheel zoom steps through these preset percentages instead
     /// of applying a raw ×1.25/×0.8 multiplier.  Set by <c>MainWindow</c> on startup.
     /// <para>
@@ -312,8 +327,10 @@ public class PreviewControl : Control
     public void SetZoomPercent(int pct)
     {
         _zoom = Math.Clamp(pct / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
+        ClampPan();
         InvalidateVisual();
         ZoomChanged?.Invoke(_zoom * 100f);
+        RaiseViewChanged();
     }
 
     /// <summary>Current zoom factor (1.0 = 100 %).</summary>
@@ -333,6 +350,7 @@ public class PreviewControl : Control
         _panX = -entityX * offMult * _zoom;
         _panY =  entityY * offMult * _zoom;
         InvalidateVisual();
+        RaiseViewChanged();
     }
 
     /// <summary>Test-only: adds a horizontal guide at the given world-Y coordinate.</summary>
@@ -456,6 +474,7 @@ public class PreviewControl : Control
         ClampPan();
         InvalidateVisual();
         ZoomChanged?.Invoke(_zoom * 100f);
+        RaiseViewChanged();
     }
 
     public void SetPan(float panX, float panY)
@@ -463,6 +482,31 @@ public class PreviewControl : Control
         _panX = panX;
         _panY = panY;
         InvalidateVisual();
+        RaiseViewChanged();
+    }
+
+    /// <summary>
+    /// Sets the horizontal pan from a scrollbar-driven value (see <see cref="PanScrollBar"/>)
+    /// and repaints. Clamped defensively to the pan band.
+    /// </summary>
+    public void SetPanX(float panX)
+    {
+        _panX = panX;
+        ClampPan();
+        InvalidateVisual();
+        RaiseViewChanged();
+    }
+
+    /// <summary>
+    /// Sets the vertical pan from a scrollbar-driven value (see <see cref="PanScrollBar"/>)
+    /// and repaints. Clamped defensively to the pan band.
+    /// </summary>
+    public void SetPanY(float panY)
+    {
+        _panY = panY;
+        ClampPan();
+        InvalidateVisual();
+        RaiseViewChanged();
     }
 
     /// <summary>
@@ -484,10 +528,15 @@ public class PreviewControl : Control
     }
 
     /// <summary>
-    /// Bounding box of the displayed content (sprite frame + collision shapes) in screen
-    /// pixels, relative to the entity origin (world Y up is flipped to screen Y down).
-    /// The origin itself is always included, so empty content collapses the band back to
-    /// the simple "origin stays on screen" clamp.
+    /// Bounding box of the chain's content (every frame's sprite footprint + collision shapes)
+    /// in screen pixels, relative to the entity origin (world Y up is flipped to screen Y down).
+    /// The origin itself is always included, so empty content collapses the band back to the
+    /// simple "origin stays on screen" clamp.
+    /// <para>
+    /// The union of <b>all</b> frames (at their resting <c>RelativeX/Y</c> offsets) is used, not
+    /// the current playback frame, so the extent — and the scrollbar range and pan clamp derived
+    /// from it — stays stable during playback instead of breathing frame-to-frame (#415).
+    /// </para>
     /// </summary>
     private (float MinX, float MaxX, float MinY, float MaxY) ComputeContentExtentScreenPx()
     {
@@ -500,40 +549,51 @@ public class PreviewControl : Control
             minY = Math.Min(minY, cy - halfH); maxY = Math.Max(maxY, cy + halfH);
         }
 
-        var chain         = _selectedState!.SelectedChain;
-        var selectedFrame = _selectedState!.SelectedFrame;
-        AnimationFrameSave? displayFrame = selectedFrame;
-        if (displayFrame is null && chain is not null && chain.Frames.Count > 0)
+        void IncludeFrame(AnimationFrameSave frame)
         {
-            int idx = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
-            displayFrame = chain.Frames[idx];
-        }
-
-        if (displayFrame is not null)
-        {
-            var (offX, offY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
-            // Sprite pixel size scales by zoom only (not OffsetMultiplier). Skip it when the
-            // texture isn't cached yet — the offset center alone keeps the frame reachable.
-            float hw = 0f, hh = 0f;
-            string? texPath = _thumbnailService!.ResolveTexturePath(displayFrame);
+            // Sprite footprint at the frame's resting offset. Pixel size scales by zoom only
+            // (not OffsetMultiplier). Skip it when the texture isn't cached yet — the offset
+            // center alone still keeps the frame reachable.
+            string? texPath = _thumbnailService!.ResolveTexturePath(frame);
             if (texPath is not null &&
                 _thumbnailService.BitmapCache.TryGetValue(texPath, out var bm) && bm is not null)
             {
-                var (_, _, sw, sh) = ComputeSourceRect(displayFrame, bm.Width, bm.Height);
-                hw = sw * _zoom / 2f;
-                hh = sh * _zoom / 2f;
+                var (_, _, sw, sh) = ComputeSourceRect(frame, bm.Width, bm.Height);
+                Include(frame.RelativeX * om, -frame.RelativeY * om, sw * _zoom / 2f, sh * _zoom / 2f);
             }
-            Include(offX * om, -offY * om, hw, hh);
+
+            if (frame.ShapesSave is null) return;
+            foreach (var r in frame.ShapesSave.AARectSaves)
+                Include(r.X * om, -r.Y * om, r.ScaleX * om, r.ScaleY * om);
+            foreach (var c in frame.ShapesSave.CircleSaves)
+                Include(c.X * om, -c.Y * om, c.Radius * om, c.Radius * om);
         }
 
-        foreach (var sh in BuildShapeInfos())
-        {
-            float halfW = sh.Param1 * om;
-            float halfH = (sh.Kind == PreviewShapeKind.Rect ? sh.Param2 : sh.Param1) * om;
-            Include(sh.X * om, -sh.Y * om, halfW, halfH);
-        }
+        var chain = _selectedState!.SelectedChain;
+        if (chain is not null)
+            foreach (var frame in chain.Frames) IncludeFrame(frame);
+        else if (_selectedState!.SelectedFrame is not null)
+            IncludeFrame(_selectedState!.SelectedFrame);
 
         return (minX, maxX, minY, maxY);
+    }
+
+    /// <summary>
+    /// Scrollbar (Minimum, Maximum, Value, ViewportSize) for each axis, derived from the
+    /// current pan, viewport, and content extent. <c>MainWindow</c> applies these to the
+    /// Preview's two <c>ScrollBar</c>s; the value axis is the negation of the pan axis (see
+    /// <see cref="PanScrollBar"/>). Returns a degenerate (zero) range before layout has run.
+    /// </summary>
+    public (ScrollBarRange Horizontal, ScrollBarRange Vertical) GetScrollBarRanges()
+    {
+        float viewW = (float)(Bounds.Width  - RulerSize);
+        float viewH = (float)(Bounds.Height - RulerSize);
+        if (viewW <= 0 || viewH <= 0)
+            return (new ScrollBarRange(0f, 0f, 0f, 1f), new ScrollBarRange(0f, 0f, 0f, 1f));
+
+        var (minX, maxX, minY, maxY) = ComputeContentExtentScreenPx();
+        return (PanScrollBar.FromPan(_panX, viewW, minX, maxX, PanPadding),
+                PanScrollBar.FromPan(_panY, viewH, minY, maxY, PanPadding));
     }
     // -- Avalonia rendering ----------------------------------------------------
 
@@ -1248,6 +1308,7 @@ public class PreviewControl : Control
             ClampPan();
             _lastMousePt = pos;
             InvalidateVisual();
+            RaiseViewChanged();
             return;
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -722,24 +722,23 @@
                         </StackPanel>
                     </Border>
 
-                    <!-- Preview panel fills remaining height of the block, with scrollbars.
-                         Unlike the Wireframe (a static bitmap in a ScrollViewer), the Preview
-                         draws dynamic content, so its scrollbars drive the manual pan directly
-                         (#415) rather than hosting the content in a ScrollViewer. -->
-                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
-                        <controls:PreviewControl x:Name="PreviewCtrl"
-                                                 Grid.Row="0" Grid.Column="0" />
+                    <!-- Preview panel fills remaining height of the block. Unlike the Wireframe
+                         (a static bitmap in a ScrollViewer), the Preview draws dynamic content,
+                         so its scrollbars drive the manual pan directly (#415) rather than
+                         hosting the content in a ScrollViewer. The bars overlay the canvas edges
+                         and auto-hide (thin when idle, expand on hover) so they behave the same
+                         as the Wireframe's ScrollViewer scrollbars; overlaying (not reserving a
+                         cell) keeps the hover-expand from shifting the layout. -->
+                    <Grid Grid.Row="1">
+                        <controls:PreviewControl x:Name="PreviewCtrl" />
                         <ScrollBar x:Name="PreviewVScroll"
-                                   Grid.Row="0" Grid.Column="1"
                                    Orientation="Vertical"
-                                   AllowAutoHide="False" />
+                                   HorizontalAlignment="Right" VerticalAlignment="Stretch"
+                                   AllowAutoHide="True" />
                         <ScrollBar x:Name="PreviewHScroll"
-                                   Grid.Row="1" Grid.Column="0"
                                    Orientation="Horizontal"
-                                   AllowAutoHide="False" />
-                        <!-- Corner where the two scrollbars meet -->
-                        <Border Grid.Row="1" Grid.Column="1"
-                                Background="{DynamicResource BgRail}" />
+                                   HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+                                   AllowAutoHide="True" />
                     </Grid>
 
                     <!-- ── Timeline strip ── -->

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -722,8 +722,25 @@
                         </StackPanel>
                     </Border>
 
-                    <!-- Preview panel fills remaining height of the block -->
-                    <controls:PreviewControl x:Name="PreviewCtrl" Grid.Row="1" />
+                    <!-- Preview panel fills remaining height of the block, with scrollbars.
+                         Unlike the Wireframe (a static bitmap in a ScrollViewer), the Preview
+                         draws dynamic content, so its scrollbars drive the manual pan directly
+                         (#415) rather than hosting the content in a ScrollViewer. -->
+                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
+                        <controls:PreviewControl x:Name="PreviewCtrl"
+                                                 Grid.Row="0" Grid.Column="0" />
+                        <ScrollBar x:Name="PreviewVScroll"
+                                   Grid.Row="0" Grid.Column="1"
+                                   Orientation="Vertical"
+                                   AllowAutoHide="False" />
+                        <ScrollBar x:Name="PreviewHScroll"
+                                   Grid.Row="1" Grid.Column="0"
+                                   Orientation="Horizontal"
+                                   AllowAutoHide="False" />
+                        <!-- Corner where the two scrollbars meet -->
+                        <Border Grid.Row="1" Grid.Column="1"
+                                Background="{DynamicResource BgRail}" />
+                    </Grid>
 
                     <!-- ── Timeline strip ── -->
                     <Grid Grid.Row="2" RowDefinitions="14,*">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -59,6 +59,7 @@ public partial class MainWindow : Window
     private bool _suppressTextureComboChanged;
     private bool _suppressZoomComboChanged;
     private bool _suppressPreviewZoomComboChanged;
+    private bool _suppressPreviewScrollSync;
     private bool _suppressTreeSelectionHandling;
     private bool _suppressCompanionSave;
     private bool _suppressInterpolateSync;
@@ -1380,6 +1381,57 @@ public partial class MainWindow : Window
         PreviewCtrl.PanChanged  += (_, _) => SaveCompanionFile();
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
         PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
+
+        // ── Preview scrollbars (#415) ──
+        // Two-way sync between the manual pan and the scrollbars, mirroring the
+        // PreviewZoomCombo ↔ PreviewCtrl suppression pattern above. The scroll axis runs
+        // opposite the pan axis (PanScrollBar handles the inversion).
+        PreviewHScroll.ValueChanged += (_, _) => OnPreviewScrollValueChanged(horizontal: true);
+        PreviewVScroll.ValueChanged += (_, _) => OnPreviewScrollValueChanged(horizontal: false);
+        // Persist on scroll-end only (not per tick), matching the pan-drag save semantics.
+        PreviewHScroll.Scroll += OnPreviewScrollEnded;
+        PreviewVScroll.Scroll += OnPreviewScrollEnded;
+        PreviewCtrl.ViewChanged += RefreshPreviewScrollBars;
+    }
+
+    private void OnPreviewScrollValueChanged(bool horizontal)
+    {
+        if (_suppressPreviewScrollSync) return;
+        _suppressPreviewScrollSync = true;
+        if (horizontal)
+            PreviewCtrl.SetPanX(PanScrollBar.PanFromValue((float)PreviewHScroll.Value));
+        else
+            PreviewCtrl.SetPanY(PanScrollBar.PanFromValue((float)PreviewVScroll.Value));
+        _suppressPreviewScrollSync = false;
+    }
+
+    private void OnPreviewScrollEnded(object? sender, ScrollEventArgs e)
+    {
+        if (e.ScrollEventType == ScrollEventType.EndScroll) SaveCompanionFile();
+    }
+
+    /// <summary>
+    /// Pushes the Preview's current pan/zoom/content extent into the two scrollbars. Fired by
+    /// <see cref="PreviewControl.ViewChanged"/>. The suppression flag stops the resulting
+    /// <c>ValueChanged</c> from looping back into the pan.
+    /// </summary>
+    private void RefreshPreviewScrollBars()
+    {
+        if (_suppressPreviewScrollSync) return;
+        _suppressPreviewScrollSync = true;
+        var (h, v) = PreviewCtrl.GetScrollBarRanges();
+        ApplyScrollRange(PreviewHScroll, h);
+        ApplyScrollRange(PreviewVScroll, v);
+        _suppressPreviewScrollSync = false;
+    }
+
+    // Order matters: set Minimum/Maximum before Value so RangeBase doesn't coerce it.
+    private static void ApplyScrollRange(ScrollBar bar, ScrollBarRange r)
+    {
+        bar.Minimum      = r.Minimum;
+        bar.Maximum      = r.Maximum;
+        bar.ViewportSize = r.ViewportSize;
+        bar.Value        = r.Value;
     }
 
     private void OnPreviewPlaybackFrameIndexChanged(int index)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
@@ -120,12 +120,24 @@ public static class CanvasTransform
         float contentMinY, float contentMaxY,
         float padding = 0f)
     {
-        float maxPanX =  viewW / 2f + padding - contentMinX;
-        float minPanX = -viewW / 2f - padding - contentMaxX;
-        float maxPanY =  viewH / 2f + padding - contentMinY;
-        float minPanY = -viewH / 2f - padding - contentMaxY;
+        var (minPanX, maxPanX) = PanRange(viewW, contentMinX, contentMaxX, padding);
+        var (minPanY, maxPanY) = PanRange(viewH, contentMinY, contentMaxY, padding);
 
         return (Math.Clamp(panX, minPanX, maxPanX),
                 Math.Clamp(panY, minPanY, maxPanY));
     }
+
+    /// <summary>
+    /// The inclusive <c>[Min, Max]</c> band a single pan axis may take so the content stays
+    /// reachable — the per-axis band that <see cref="ClampPan"/> enforces, exposed so the same
+    /// limits can drive a scrollbar's value range (#415). <paramref name="viewExtent"/> is the
+    /// viewport size on that axis; <paramref name="contentMin"/>/<paramref name="contentMax"/>
+    /// are the content's on-screen extent relative to the origin. A zero-size extent
+    /// (<c>min == max == 0</c>) yields ±<paramref name="viewExtent"/>/2 — the simple
+    /// "origin stays on screen" band.
+    /// </summary>
+    public static (float Min, float Max) PanRange(
+        float viewExtent, float contentMin, float contentMax, float padding = 0f)
+        => (-viewExtent / 2f - padding - contentMax,
+             viewExtent / 2f + padding - contentMin);
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/PanScrollBar.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/PanScrollBar.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// A scrollbar's range and thumb derived from a pan axis: the four values an Avalonia
+/// <c>ScrollBar</c> needs (<see cref="Minimum"/>, <see cref="Maximum"/>, <see cref="Value"/>,
+/// <see cref="ViewportSize"/>).
+/// </summary>
+public readonly record struct ScrollBarRange(
+    float Minimum, float Maximum, float Value, float ViewportSize);
+
+/// <summary>
+/// Pure mapping between a center-relative pan axis and a scrollbar, used to drive the
+/// Preview panel's scrollbars from its existing manual pan (#415) instead of hosting the
+/// content in a <c>ScrollViewer</c>.
+/// <para>
+/// The scroll axis runs <b>opposite</b> to pan — scrolling toward the high end moves the
+/// content the other way, so the content origin's pan <i>decreases</i>. The mapping is
+/// therefore a negation: <c>value = -pan</c>. The value range is the pan band from
+/// <see cref="CanvasTransform.PanRange"/>, so it grows with zoom (which grows the on-screen
+/// content extent), and <see cref="ScrollBarRange.ViewportSize"/> is the viewport extent so
+/// the thumb reflects how much of the content is visible.
+/// </para>
+/// </summary>
+public static class PanScrollBar
+{
+    /// <summary>
+    /// Maps a center-relative <paramref name="pan"/> to a scrollbar range/thumb.
+    /// <paramref name="viewExtent"/> is the viewport size on this axis;
+    /// <paramref name="contentMin"/>/<paramref name="contentMax"/> are the content's on-screen
+    /// extent relative to the origin. The pan is clamped into the band so the thumb stays on
+    /// the track.
+    /// </summary>
+    public static ScrollBarRange FromPan(
+        float pan, float viewExtent, float contentMin, float contentMax, float padding = 0f)
+    {
+        var (min, max) = CanvasTransform.PanRange(viewExtent, contentMin, contentMax, padding);
+        float value = Math.Clamp(pan, min, max);
+        // Negate to invert direction; [min, max] → [-max, -min] stays ordered since max >= min.
+        return new ScrollBarRange(-max, -min, -value, viewExtent);
+    }
+
+    /// <summary>Inverse of <see cref="FromPan"/>: the pan a scrollbar value represents.</summary>
+    public static float PanFromValue(float scrollValue) => -scrollValue;
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewScrollBarSyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewScrollBarSyncTests.cs
@@ -37,6 +37,24 @@ public class PreviewScrollBarSyncTests
         => w.FindControl<T>(name)
            ?? throw new InvalidOperationException($"Control '{name}' not found");
 
+    // Consistency: both panels' scrollbars auto-hide (thin when idle, expand on hover). The
+    // Wireframe's ScrollViewer defaults to AllowAutoHide; the Preview's standalone ScrollBars
+    // opt in explicitly so they behave the same.
+    [AvaloniaFact]
+    public void PreviewAndWireframeScrollBars_AllAutoHide()
+    {
+        var ctx = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(FindCtrl<ScrollBar>(window, "PreviewHScroll").AllowAutoHide);
+        Assert.True(FindCtrl<ScrollBar>(window, "PreviewVScroll").AllowAutoHide);
+        Assert.True(FindCtrl<ScrollViewer>(window, "WireframeScrollViewer").AllowAutoHide);
+
+        window.Close();
+    }
+
     // Dragging the vertical scrollbar pans the preview, inverted (scroll value = -pan).
     [AvaloniaFact]
     public void PreviewVScroll_SetValue_MovesPanInverted()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewScrollBarSyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewScrollBarSyncTests.cs
@@ -1,0 +1,94 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Integration tests for the Preview panel's scrollbars (#415). The scrollbars are driven
+/// by the existing manual center-relative pan (no ScrollViewer): dragging a scrollbar pans
+/// the preview, and panning/zooming refreshes the scrollbars. Mirrors the wiring pattern in
+/// <see cref="PreviewZoomComboSyncTests"/>.
+/// </summary>
+public class PreviewScrollBarSyncTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static T FindCtrl<T>(MainWindow w, string name) where T : Control
+        => w.FindControl<T>(name)
+           ?? throw new InvalidOperationException($"Control '{name}' not found");
+
+    // Dragging the vertical scrollbar pans the preview, inverted (scroll value = -pan).
+    [AvaloniaFact]
+    public void PreviewVScroll_SetValue_MovesPanInverted()
+    {
+        var ctx = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var preview = FindCtrl<PreviewControl>(window, "PreviewCtrl");
+        var vscroll = FindCtrl<ScrollBar>(window, "PreviewVScroll");
+
+        Assert.True(vscroll.Minimum < 0, "expected a non-degenerate scroll range from real bounds");
+
+        vscroll.Value = vscroll.Minimum; // drag the thumb to the top
+        Dispatcher.UIThread.RunJobs();
+
+        // pan = -scrollValue
+        Assert.Equal(-(float)vscroll.Minimum, preview.PanOffset.Y, 3);
+    }
+
+    // Wheel-zooming with offset content grows the on-screen extent, so the scrollbar range
+    // grows too — proving the scrollbars refresh on zoom and derive from the content extent.
+    [AvaloniaFact]
+    public void PreviewVScroll_Range_GrowsAfterWheelZoomIn_WithOffsetContent()
+    {
+        var ctx = ResetSingletons();
+        ctx.AppState.OffsetMultiplier = 1f;
+
+        // A shape 100 world-units above the origin gives the extent something to scale.
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new CircleSave { X = 0f, Y = 100f, Radius = 50f });
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var preview = FindCtrl<PreviewControl>(window, "PreviewCtrl");
+        var vscroll = FindCtrl<ScrollBar>(window, "PreviewVScroll");
+
+        preview.SetZoomPercent(100);
+        Dispatcher.UIThread.RunJobs();
+        double before = vscroll.Maximum - vscroll.Minimum;
+
+        for (int i = 0; i < 3; i++)
+            preview.SimulateWheelZoom(100, 100, zoomIn: true);
+        Dispatcher.UIThread.RunJobs();
+
+        double after = vscroll.Maximum - vscroll.Minimum;
+        Assert.True(after > before, $"range did not grow with zoom: before={before:F1} after={after:F1}");
+
+        window.Close();
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSwitchUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSwitchUndoTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
@@ -90,7 +91,9 @@ public class TabSwitchUndoTests
 
             // Switch back to tab A
             var tabManager = GetTabManager(window);
-            var tabA = tabManager.Tabs.First(t => t.Path.FullPath == pathA);
+            // FilePath equality (not raw-string): FullPath is forward-slashed, but pathA
+            // from Path.Combine is backslashed on Windows, so a string compare never matches.
+            var tabA = tabManager.Tabs.First(t => t.Path == new FilePath(pathA));
             await ActivateTabAsync(window, tabA);
             Dispatcher.UIThread.RunJobs();
 
@@ -135,8 +138,8 @@ public class TabSwitchUndoTests
             ctx.UndoManager.Record(new StubUndoCmd("Edit B1"));
 
             var tabManager = GetTabManager(window);
-            var tabA = tabManager.Tabs.First(t => t.Path.FullPath == pathA);
-            var tabB = tabManager.Tabs.First(t => t.Path.FullPath == pathB);
+            var tabA = tabManager.Tabs.First(t => t.Path == new FilePath(pathA));
+            var tabB = tabManager.Tabs.First(t => t.Path == new FilePath(pathB));
 
             // Switch to A — should see A's 2 entries
             await ActivateTabAsync(window, tabA);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
@@ -300,4 +300,37 @@ public class CanvasTransformTests
             contentMinX: -10f, contentMaxX: 10f, contentMinY: -880f, contentMaxY: -720f);
         Assert.Equal(800f, panY, 4);
     }
+
+    // ── PanRange ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PanRange_ZeroExtent_ReturnsViewportHalfBand()
+    {
+        var (min, max) = CanvasTransform.PanRange(380f, 0f, 0f);
+        Assert.Equal(-190f, min, 4);
+        Assert.Equal(190f,  max, 4);
+    }
+
+    [Fact]
+    public void PanRange_OffsetContent_ShiftsBandToKeepContentReachable()
+    {
+        // Content extent [100, 200] (right of origin). Max pan brings its left edge to
+        // the right viewport edge (190 - 100); min pan brings its right edge to the
+        // left viewport edge (-190 - 200).
+        var (min, max) = CanvasTransform.PanRange(380f, 100f, 200f);
+        Assert.Equal(-390f, min, 4);
+        Assert.Equal(90f,   max, 4);
+    }
+
+    [Fact]
+    public void PanRange_MatchesClampPanBand()
+    {
+        // PanRange is exactly the band ClampPan enforces, so clamping past each end
+        // lands on the range's min/max.
+        var (min, max) = CanvasTransform.PanRange(380f, -30f, 60f);
+        var (clampedHigh, _) = CanvasTransform.ClampPan(9999f,  0f, 380f, 280f, -30f, 60f, 0f, 0f);
+        var (clampedLow,  _) = CanvasTransform.ClampPan(-9999f, 0f, 380f, 280f, -30f, 60f, 0f, 0f);
+        Assert.Equal(max, clampedHigh, 4);
+        Assert.Equal(min, clampedLow,  4);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PanScrollBarTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PanScrollBarTests.cs
@@ -1,0 +1,57 @@
+using AnimationEditor.Core.Rendering;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="PanScrollBar"/> — the pure mapping between a center-relative
+/// pan axis and a scrollbar's (Minimum, Maximum, Value, ViewportSize). No UI.
+/// Used to drive the Preview panel's scrollbars (#415).
+/// </summary>
+public class PanScrollBarTests
+{
+    // Empty content: pan band collapses to ±viewport/2, so the value range does too.
+    [Fact]
+    public void FromPan_EmptyContent_ValueRangeIsViewportHalfBand()
+    {
+        var r = PanScrollBar.FromPan(0f, 380f, 0f, 0f);
+        Assert.Equal(-190f, r.Minimum, 4);
+        Assert.Equal(190f, r.Maximum, 4);
+        Assert.Equal(380f, r.ViewportSize, 4);
+        Assert.Equal(0f, r.Value, 4);
+    }
+
+    // Scroll axis runs opposite pan: a positive pan maps to a negative scroll Value.
+    [Fact]
+    public void FromPan_InvertsPanIntoScrollValue()
+    {
+        var r = PanScrollBar.FromPan(50f, 380f, 0f, 0f);
+        Assert.Equal(-50f, r.Value, 4);
+    }
+
+    // Larger on-screen content extent (as produced by zooming in) widens the range.
+    [Fact]
+    public void FromPan_LargerContentExtent_WidensValueRange()
+    {
+        var small = PanScrollBar.FromPan(0f, 380f, -10f, 10f);
+        var large = PanScrollBar.FromPan(0f, 380f, -100f, 100f);
+        Assert.True(large.Maximum - large.Minimum > small.Maximum - small.Minimum);
+    }
+
+    // Out-of-band pan is clamped into the value range so the thumb can't leave the track.
+    [Fact]
+    public void FromPan_PanBeyondBand_ValueClampedToRange()
+    {
+        var r = PanScrollBar.FromPan(9999f, 380f, 0f, 0f);
+        Assert.Equal(r.Minimum, r.Value, 4); // pan clamps to +190 → Value = -190 = Minimum
+    }
+
+    // pan → Value → PanFromValue must recover the (in-band) pan exactly.
+    [Fact]
+    public void FromPan_RoundTripsThroughPanFromValue()
+    {
+        const float pan = 73f;
+        var r = PanScrollBar.FromPan(pan, 380f, -20f, 20f);
+        Assert.Equal(pan, PanScrollBar.PanFromValue(r.Value), 4);
+    }
+}


### PR DESCRIPTION
## What

Adds horizontal + vertical scrollbars to the **Preview (bottom) panel** of the Animation Editor, so it has the same navigability as the Wireframe panel. Previously the Preview could only be panned via middle-drag / Alt-drag / mouse wheel.

Closes #415.

## Approach (cheap path — no `ScrollViewer`)

The Wireframe hosts a static bitmap in a `ScrollViewer` with ~700 lines of deferred-scroll machinery to keep the offset stable as the extent grows on zoom. The Preview draws **dynamic** content, so instead the scrollbars drive its existing manual center-relative pan directly:

- **`CanvasTransform.PanRange`** — new pure helper exposing the per-axis pan band that `ClampPan` enforces. `ClampPan` now delegates to it (no behavior change).
- **`PanScrollBar`** (new, pure) — maps a pan axis ⇄ a scrollbar's `(Minimum, Maximum, Value, ViewportSize)`. The scroll axis is the **negation** of the pan axis (scroll right = content left = pan decreases), so `value = -pan`.
- **`PreviewControl`** — `GetScrollBarRanges()` derives both axes from the content extent + pan band; `SetPanX`/`SetPanY` accept scrollbar-driven pan; a new `ViewChanged` event fires on every pan/zoom/extent/resize change.
- **`MainWindow`** — two-way-syncs the scrollbars with a suppression flag, mirroring the existing `PreviewZoomCombo` ↔ `PreviewCtrl` pattern. Persists on scroll-end only.

## Key decision: what the scrollbar scrolls over

Per the issue's "Key decision" (and confirmed with the maintainer), the scroll extent is the **union of all frames in the chain** (option b), at their resting offsets — not the current playback frame. This keeps the scrollbar thumb from "breathing" every frame during playback, and as a bonus de-breathes the existing pan clamp (which previously used the per-frame extent).

## Tests

- `PanScrollBarTests` + `CanvasTransform.PanRange` tests — pure round-trip, inversion, and range-grows-with-zoom (no UI).
- `PreviewScrollBarSyncTests` (`[AvaloniaFact]`) — dragging the scrollbar pans the preview (inverted); wheel-zoom with offset content grows the scrollbar range.

App suite: 465 passed / 2 failed — both failures (`TabSwitchUndoTests`) are **pre-existing on `main`** and unrelated to this change. Core suite: 1198 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)