### PR TITLE
Offer to register the editor as the default .achx handler (#408)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -173,6 +173,13 @@ public partial class App : Application
         sc.AddSingleton<ThumbnailService>(sp =>
             new ThumbnailService(sp.GetRequiredService<IProjectManager>()));
 
+        // File association is registry-based on Windows; other platforms get the no-op
+        // service so the startup prompt simply never appears (IsSupported == false).
+        if (OperatingSystem.IsWindows())
+            sc.AddSingleton<IFileAssociationService, WindowsFileAssociationService>();
+        else
+            sc.AddSingleton<IFileAssociationService, NullFileAssociationService>();
+
         sc.AddTransient<MainWindow>(sp => new MainWindow(
             sp.GetRequiredService<IProjectManager>(),
             sp.GetRequiredService<ISelectedState>(),
@@ -182,7 +189,8 @@ public partial class App : Application
             sp.GetRequiredService<IIoManager>(),
             sp.GetRequiredService<IObjectFinder>(),
             sp.GetRequiredService<IUndoManager>(),
-            sp.GetRequiredService<ThumbnailService>()));
+            sp.GetRequiredService<ThumbnailService>(),
+            sp.GetRequiredService<IFileAssociationService>()));
 
         return sc.BuildServiceProvider();
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -178,6 +178,38 @@
             </ScrollViewer>
         </Border>
 
+        <!-- ── Default-handler prompt: offers to register the editor for .achx files.
+             Shown on startup only when not already the default and not dismissed. ── -->
+        <Border x:Name="DefaultHandlerBanner"
+                DockPanel.Dock="Top"
+                IsVisible="False"
+                Background="{DynamicResource BgRail}"
+                BorderBrush="{DynamicResource LineBrush}"
+                BorderThickness="0,0,0,1"
+                Padding="12,6">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Right"
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            VerticalAlignment="Center">
+                    <Button x:Name="MakeDefaultBtn"
+                            Content="Make default"
+                            Padding="10,3"
+                            FontSize="12" />
+                    <Button x:Name="DismissDefaultHandlerBtn"
+                            Content="Don't show again"
+                            Padding="10,3"
+                            FontSize="12"
+                            Background="Transparent"
+                            Foreground="{DynamicResource InkMid}" />
+                </StackPanel>
+                <TextBlock Text="Make the Animation Editor the default app for .achx files?"
+                           VerticalAlignment="Center"
+                           FontSize="12"
+                           Foreground="{DynamicResource Ink}" />
+            </DockPanel>
+        </Border>
+
         <Border DockPanel.Dock="Bottom"
                 Background="{DynamicResource BgRail}"
                 BorderBrush="{DynamicResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -45,6 +45,7 @@ public partial class MainWindow : Window
     private readonly IObjectFinder _objectFinder;
     private readonly IUndoManager _undoManager;
     private readonly Services.ThumbnailService _thumbnailService;
+    private readonly IFileAssociationService _fileAssociation;
 
     private AppSettingsModel _appSettings = new();
     private readonly TabManager _tabManager = new();
@@ -79,7 +80,8 @@ public partial class MainWindow : Window
         IIoManager ioManager,
         IObjectFinder objectFinder,
         IUndoManager undoManager,
-        Services.ThumbnailService thumbnailService)
+        Services.ThumbnailService thumbnailService,
+        IFileAssociationService fileAssociation)
     {
         _projectManager = projectManager;
         _selectedState = selectedState;
@@ -90,6 +92,7 @@ public partial class MainWindow : Window
         _objectFinder = objectFinder;
         _undoManager = undoManager;
         _thumbnailService = thumbnailService;
+        _fileAssociation = fileAssociation;
 
         InitializeComponent();
 
@@ -113,6 +116,7 @@ public partial class MainWindow : Window
         WirePlaybackControls();
         WireKeyboard();
         WireTabBar();
+        WireDefaultHandlerBanner();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService);
@@ -466,6 +470,37 @@ public partial class MainWindow : Window
         {
             _projectManager.AnimationChainListSave =
                 new AnimationChainListSave();
+        }
+
+        ShowDefaultHandlerBannerIfAppropriate();
+    }
+
+    // ── Default-handler prompt banner ─────────────────────────────────────────
+
+    private void WireDefaultHandlerBanner()
+    {
+        MakeDefaultBtn.Click += (_, _) =>
+        {
+            _fileAssociation.RegisterAsDefault();
+            DefaultHandlerBanner.IsVisible = false;
+            ShowStatusMessage("Opened Windows settings — choose Animation Editor for .achx files.");
+        };
+
+        DismissDefaultHandlerBtn.Click += (_, _) =>
+        {
+            _appSettings.SuppressDefaultHandlerPrompt = true;
+            SaveSettingsFile();
+            DefaultHandlerBanner.IsVisible = false;
+        };
+    }
+
+    private void ShowDefaultHandlerBannerIfAppropriate()
+    {
+        bool isDefault = _fileAssociation.IsSupported && _fileAssociation.IsDefault();
+        if (DefaultHandlerPromptDecider.ShouldPrompt(
+                _fileAssociation.IsSupported, isDefault, _appSettings.SuppressDefaultHandlerPrompt))
+        {
+            DefaultHandlerBanner.IsVisible = true;
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using AnimationEditor.Core.IO;
+using Microsoft.Win32;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Windows implementation of <see cref="IFileAssociationService"/>. Registers a per-user
+/// ProgId under <c>HKCU\Software\Classes</c> and detects the current default by reading the
+/// extension's <c>UserChoice</c>.
+///
+/// <para>Modern Windows (8+) hash-protects <c>HKCU\…\.achx\UserChoice</c>, so an app cannot
+/// silently force itself as the default. <see cref="RegisterAsDefault"/> therefore registers
+/// the ProgId and then opens the system default-apps settings for the user to confirm.</para>
+///
+/// <para>Pure helpers (<see cref="BuildOpenCommand"/>, <see cref="IsOurProgId"/>) are unit-tested;
+/// the registry reads/writes and the settings deep-link are the thin untested wiring.</para>
+/// </summary>
+internal sealed class WindowsFileAssociationService : IFileAssociationService
+{
+    /// <summary>The file extension this editor handles, including the leading dot.</summary>
+    internal const string Extension = ".achx";
+
+    /// <summary>
+    /// The per-user ProgId the editor registers under <c>HKCU\Software\Classes</c>. Namespaced
+    /// to avoid colliding with any system or third-party handler for the same extension.
+    /// </summary>
+    internal const string ProgId = "FlatRedBall.AnimationEditor.achx";
+
+    private const string ClassesRoot = @"HKEY_CURRENT_USER\Software\Classes";
+
+    public bool IsSupported => OperatingSystem.IsWindows();
+
+    public bool IsDefault()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        return IsDefaultWindows();
+    }
+
+    public void RegisterAsDefault()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        RegisterAsDefaultWindows();
+    }
+
+    /// <summary>Builds the <c>shell\open\command</c> value: the quoted exe followed by the quoted
+    /// <c>%1</c> argument placeholder Windows substitutes with the launched file path.</summary>
+    internal static string BuildOpenCommand(string exePath) => $"\"{exePath}\" \"%1\"";
+
+    /// <summary>Whether a ProgId read from the registry is the one this editor registers
+    /// (case-insensitive; <c>null</c>/empty means no association and returns false).</summary>
+    internal static bool IsOurProgId(string? registeredProgId) =>
+        string.Equals(registeredProgId, ProgId, StringComparison.OrdinalIgnoreCase);
+
+    [SupportedOSPlatform("windows")]
+    private static bool IsDefaultWindows()
+    {
+        // An explicit per-user choice (set via the Windows "Open with" / default-apps UI) wins.
+        var userChoice = Registry.GetValue(
+            $@"{ClassesRoot}\{Extension}\UserChoice", "ProgId", null) as string;
+        if (!string.IsNullOrEmpty(userChoice))
+            return IsOurProgId(userChoice);
+
+        // No explicit choice — fall back to the extension's default ProgId (what RegisterAsDefault sets).
+        var fallback = Registry.GetValue($@"{ClassesRoot}\{Extension}", null, null) as string;
+        return IsOurProgId(fallback);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RegisterAsDefaultWindows()
+    {
+        string? exe = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exe))
+            return;
+
+        try
+        {
+            string progIdKey = $@"{ClassesRoot}\{ProgId}";
+            Registry.SetValue(progIdKey, null, "FlatRedBall Animation Chain");
+            Registry.SetValue($@"{progIdKey}\DefaultIcon", null, $"\"{exe}\",0");
+            Registry.SetValue($@"{progIdKey}\shell\open\command", null, BuildOpenCommand(exe));
+
+            // Point the extension at our ProgId. On modern Windows this is only a fallback —
+            // an existing hash-protected UserChoice still wins, which is why we open the
+            // default-apps settings below for the user to confirm.
+            Registry.SetValue($@"{ClassesRoot}\{Extension}", null, ProgId);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine($"Failed to register .achx ProgId: {e}");
+        }
+
+        OpenDefaultAppsSettings();
+    }
+
+    private static void OpenDefaultAppsSettings()
+    {
+        try
+        {
+            // ms-settings: is the only reliable, version-stable deep-link; there is no
+            // per-extension page across Windows versions, so we land on Default apps.
+            Process.Start(new ProcessStartInfo("ms-settings:defaultapps") { UseShellExecute = true });
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine($"Failed to open default-apps settings: {e}");
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/DefaultHandlerPromptDecider.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/DefaultHandlerPromptDecider.cs
@@ -1,0 +1,29 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Pure decision logic for whether to surface the "make me the default .achx handler"
+/// prompt on startup. Kept separate from the platform-specific
+/// <see cref="IFileAssociationService"/> so the three-state rule can be unit-tested
+/// without touching the registry or the UI.
+/// </summary>
+public static class DefaultHandlerPromptDecider
+{
+    /// <summary>
+    /// Returns <c>true</c> only when the platform supports file association, the editor is
+    /// not already the default handler, and the user has not previously dismissed the prompt.
+    /// </summary>
+    /// <param name="isSupported">Whether file association is implemented on the current platform.</param>
+    /// <param name="isDefault">Whether the editor is already the registered default for <c>.achx</c>.</param>
+    /// <param name="isPromptSuppressed">Whether the user clicked "Don't show again".</param>
+    public static bool ShouldPrompt(bool isSupported, bool isDefault, bool isPromptSuppressed)
+    {
+        if (!isSupported)
+            return false;
+        if (isDefault)
+            return false;
+        if (isPromptSuppressed)
+            return false;
+
+        return true;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileAssociationService.cs
@@ -1,0 +1,31 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Registers the editor as the operating-system default handler for <c>.achx</c> files
+/// and reports whether it currently is. Implementations are platform-specific (Windows
+/// registry, macOS Launch Services, Linux XDG); platforms without an implementation use
+/// <see cref="NullFileAssociationService"/> and report <see cref="IsSupported"/> as false.
+/// </summary>
+public interface IFileAssociationService
+{
+    /// <summary>
+    /// Whether file association is implemented on the current platform. When false, callers
+    /// should neither call <see cref="IsDefault"/>/<see cref="RegisterAsDefault"/> nor prompt
+    /// the user.
+    /// </summary>
+    bool IsSupported { get; }
+
+    /// <summary>
+    /// Whether this editor is the current default handler for <c>.achx</c> files. Only
+    /// meaningful when <see cref="IsSupported"/> is true.
+    /// </summary>
+    bool IsDefault();
+
+    /// <summary>
+    /// Registers the editor's file-type association and surfaces the OS confirmation UI.
+    /// Modern Windows blocks an app from silently forcing itself as the default, so this
+    /// registers the association and then opens the system default-apps settings for the
+    /// user to confirm. No-op when <see cref="IsSupported"/> is false.
+    /// </summary>
+    void RegisterAsDefault();
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileAssociationService.cs
@@ -1,0 +1,15 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// No-op <see cref="IFileAssociationService"/> for platforms without a file-association
+/// implementation (currently macOS and Linux). Reports <see cref="IsSupported"/> as false
+/// so <see cref="DefaultHandlerPromptDecider.ShouldPrompt"/> never offers the prompt.
+/// </summary>
+public sealed class NullFileAssociationService : IFileAssociationService
+{
+    public bool IsSupported => false;
+
+    public bool IsDefault() => false;
+
+    public void RegisterAsDefault() { }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -26,6 +26,14 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public AppTheme Theme { get; set; } = AppTheme.Dark;
 
+        /// <summary>
+        /// When <c>true</c>, the editor never offers to register itself as the default
+        /// application for <c>.achx</c> files. Set when the user clicks "Don't show again"
+        /// on the file-association prompt. Defaults to <c>false</c> so the prompt can appear
+        /// once on a fresh install.
+        /// </summary>
+        public bool SuppressDefaultHandlerPrompt { get; set; }
+
         public void AddFile(FilePath filePath)
         {
             RecentFiles.RemoveAll(item => new FilePath(item) == filePath);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -23,6 +23,7 @@ internal sealed class TestServices
     public UndoManager UndoManager { get; }
     public AppCommands AppCommands { get; }
     public ThumbnailService ThumbnailService { get; }
+    public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
 
     public TestServices()
     {
@@ -41,7 +42,8 @@ internal sealed class TestServices
     public MainWindow CreateMainWindow() =>
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
-            ApplicationEvents, IoManager, ObjectFinder, UndoManager, ThumbnailService);
+            ApplicationEvents, IoManager, ObjectFinder, UndoManager, ThumbnailService,
+            FileAssociationService);
 
     public WireframeControl CreateWireframeControl()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WindowsFileAssociationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WindowsFileAssociationTests.cs
@@ -1,0 +1,48 @@
+using AnimationEditor.App.Services;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests the pure, platform-agnostic helpers on <see cref="WindowsFileAssociationService"/>
+/// (the shell-open-command string and ProgId comparison). The registry I/O and the
+/// open-settings deep-link are thin, untested wiring around these.
+/// </summary>
+public class WindowsFileAssociationTests
+{
+    [Fact]
+    public void BuildOpenCommand_QuotesExeAndArgPlaceholder()
+    {
+        string command = WindowsFileAssociationService.BuildOpenCommand(
+            @"C:\Program Files\AnimationEditor\AnimationEditor.exe");
+
+        Assert.Equal(
+            "\"C:\\Program Files\\AnimationEditor\\AnimationEditor.exe\" \"%1\"",
+            command);
+    }
+
+    [Fact]
+    public void IsOurProgId_DifferentCase_ReturnsTrue()
+    {
+        bool result = WindowsFileAssociationService.IsOurProgId(
+            WindowsFileAssociationService.ProgId.ToUpperInvariant());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsOurProgId_ForeignProgId_ReturnsFalse()
+    {
+        bool result = WindowsFileAssociationService.IsOurProgId("SomeOther.App.achx");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsOurProgId_Null_ReturnsFalse()
+    {
+        bool result = WindowsFileAssociationService.IsOurProgId(null);
+
+        Assert.False(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using AnimationEditor.Core.Models;
 using Xunit;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
@@ -125,5 +126,24 @@ public class AppSettingsModelTests
         model.AddFile(path);
 
         Assert.Single(model.RecentFiles);
+    }
+
+    [Fact]
+    public void SuppressDefaultHandlerPrompt_DefaultsToFalse()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.False(model.SuppressDefaultHandlerPrompt);
+    }
+
+    [Fact]
+    public void SuppressDefaultHandlerPrompt_SurvivesJsonRoundTrip()
+    {
+        var model = new AppSettingsModel { SuppressDefaultHandlerPrompt = true };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.True(restored!.SuppressDefaultHandlerPrompt);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DefaultHandlerPromptDeciderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DefaultHandlerPromptDeciderTests.cs
@@ -1,0 +1,48 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests the three-state decision for the "make me the default .achx handler" prompt:
+/// already-default and user-dismissed both stay silent; only a supported, non-default,
+/// not-yet-dismissed state prompts.
+/// </summary>
+public class DefaultHandlerPromptDeciderTests
+{
+    [Fact]
+    public void ShouldPrompt_AlreadyDefault_ReturnsFalse()
+    {
+        bool result = DefaultHandlerPromptDecider.ShouldPrompt(
+            isSupported: true, isDefault: true, isPromptSuppressed: false);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldPrompt_NotDefaultAndNotSuppressed_ReturnsTrue()
+    {
+        bool result = DefaultHandlerPromptDecider.ShouldPrompt(
+            isSupported: true, isDefault: false, isPromptSuppressed: false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldPrompt_NotSupportedPlatform_ReturnsFalse()
+    {
+        bool result = DefaultHandlerPromptDecider.ShouldPrompt(
+            isSupported: false, isDefault: false, isPromptSuppressed: false);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldPrompt_SuppressedByUser_ReturnsFalse()
+    {
+        bool result = DefaultHandlerPromptDecider.ShouldPrompt(
+            isSupported: true, isDefault: false, isPromptSuppressed: true);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
On startup the Animation Editor now offers — via a non-modal banner across the top — to register itself as the OS default for `.achx` files. The banner follows the three-state UX from the issue:

1. **Already the default** → no banner.
2. **Not the default, never dismissed** → banner: *"Make the Animation Editor the default app for .achx files?"* with **[Make default]** and **[Don't show again]**.
3. **Not the default, user clicked "Don't show again"** → stays silent.

Windows-only behind an interface, as agreed; macOS/Linux are follow-ups.

## What's in here
- **`IFileAssociationService`** (Core) — `IsSupported` / `IsDefault()` / `RegisterAsDefault()`.
- **`WindowsFileAssociationService`** — registers a per-user ProgId under `HKCU\Software\Classes` (`shell\open\command` = `"<exe>" "%1"`, `.achx` → ProgId). Detects the default by reading `…\.achx\UserChoice\ProgId` (falling back to the extension's default ProgId). Because modern Windows hash-protects `UserChoice` (an app **cannot** silently force itself as the default), `RegisterAsDefault()` registers the ProgId and then opens **`ms-settings:defaultapps`** for the user to confirm.
- **`NullFileAssociationService`** — non-Windows; `IsSupported == false`, so the prompt never appears.
- **`DefaultHandlerPromptDecider`** — pure three-state logic.
- **`AppSettingsModel.SuppressDefaultHandlerPrompt`** — persists "Don't show again" (JSON, with the existing app settings).

No `Microsoft.Win32.Registry` package is needed — the registry APIs resolve on the `net10.0` TFM, and the `OperatingSystem.IsWindows()` guards satisfy the platform analyzer (clean build, 0 warnings).

## Testing
Tests-first. Covered:
- `DefaultHandlerPromptDecider` — all branches (not-supported / already-default / suppressed / should-prompt).
- `AppSettingsModel.SuppressDefaultHandlerPrompt` — defaults false + JSON round-trip.
- Pure Windows helpers — `BuildOpenCommand` quoting, `IsOurProgId` (case-insensitive / foreign / null).

**Untested residue (repo test-first rule, option b):** the registry `GetValue`/`SetValue` calls, the `Process.Start("ms-settings:…")` deep-link, and the Avalonia button-click banner wiring. These are OS/UI side effects with no observable return value to assert; the testable cores (state decision, settings persistence, command/ProgId building) were extracted and covered, leaving only thin platform/UI glue.

Core: 1204 passed · App: 472 passed.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)