### PR TITLE
Center preview on frame offset when double-clicking a frame (#418)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3903,6 +3903,9 @@ public partial class MainWindow : Window
                 return true;
             case AnimationFrameSave frame:
                 WireframeCtrl.CenterOnFrame(frame);
+                // Bring the sprite into view in the preview too — center on the frame's
+                // offset, not the entity origin, or a large-offset frame stays off-screen.
+                PreviewCtrl.CenterOnEntityPoint(frame.RelativeX, frame.RelativeY);
                 return true;
             case AARectSave rect:
                 PreviewCtrl.CenterOnEntityPoint(rect.X, rect.Y);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCenterOnEntityPointTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCenterOnEntityPointTests.cs
@@ -144,6 +144,33 @@ public class PreviewCenterOnEntityPointTests
     }
 
     [AvaloniaFact]
+    public void HandleDoubleTap_FrameNode_PansPreviewToFrameOffset()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        ctx.AppState.OffsetMultiplier = 1f;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+
+        PreviewControl preview = window.FindControl<PreviewControl>("PreviewCtrl")
+            ?? throw new InvalidOperationException("PreviewCtrl not found");
+        preview.SetZoomPercent(200);
+
+        // Offset large enough that centering on the origin (0,0) instead of the
+        // sprite would leave a clearly different — and visibly off-screen — pan.
+        var frame = new AnimationFrameSave { RelativeX = 40f, RelativeY = 25f };
+        var vm    = new TreeNodeVm { Data = frame };
+
+        window.HandleAnimTreeNodeDoubleTap(vm);
+
+        (float px, float py) = preview.PanOffset;
+        // panX = -(40 * 1 * 2) = -80,  panY = +(25 * 1 * 2) = +50
+        Assert.Equal(-80f, px, precision: 3);
+        Assert.Equal( 50f, py, precision: 3);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void HandleDoubleTap_UnknownNodeType_ReturnsFalse()
     {
         var ctx    = TestHelpers.BuildServices();


### PR DESCRIPTION
## Summary

Double-clicking an animation frame node in the tree previously re-centered **only the wireframe panel**. The **preview panel** kept its existing pan, so a frame's sprite could stay off-screen.

This adds one call so the frame case also pans the preview onto the sprite — mirroring what the `AARectSave` / `CircleSave` cases already do:

```csharp
case AnimationFrameSave frame:
    WireframeCtrl.CenterOnFrame(frame);
    PreviewCtrl.CenterOnEntityPoint(frame.RelativeX, frame.RelativeY);
    return true;
```

The preview centers on the frame's **offset** (`RelativeX`/`RelativeY`), not the entity origin `(0,0)`, so a large-offset frame ends up visibly centered instead of pushed off-screen. `CenterOnEntityPoint` only changes pan, so zoom and `OffsetMultiplier` are preserved.

## Testing

TDD: added `HandleDoubleTap_FrameNode_PansPreviewToFrameOffset` to `PreviewCenterOnEntityPointTests`, which dispatches through the real double-tap handler with a large-offset frame (RelativeX=40, RelativeY=25, 200% zoom) and asserts the resulting preview pan (-80, +50). It failed (pan stayed at 0,0 = origin) before the change and passes after. Full App suite: 473 passing.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)