### PR TITLE
Store Animation Editor app settings in shared per-user dir (#424)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -67,10 +67,12 @@ public partial class MainWindow : Window
     private bool _suppressInterpolateSync;
     private System.Threading.CancellationTokenSource? _toastCts;
 
-    // AppContext.BaseDirectory works under single-file publish; Assembly.Location is empty there (IL3000).
-    // Path.Combine handles the platform-correct separator (was a hardcoded "\\" — would break on macOS/Linux).
+    // Shared per-user config dir, NOT the build output — so recent files / tabs / theme survive
+    // rebuilds, dotnet clean, and switching git worktrees (see issue #424). AppContext.BaseDirectory
+    // resolves to bin/<Config>/<TFM>/, which is per-build / per-checkout.
     private FilePath SettingsFilePath =>
-        new FilePath(Path.Combine(AppContext.BaseDirectory, "AESettings.json"));
+        AppSettingsLocation.ForApplicationDataRoot(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
 
     public MainWindow(
         IProjectManager projectManager,
@@ -2978,7 +2980,10 @@ public partial class MainWindow : Window
     {
         try
         {
-            File.WriteAllText(SettingsFilePath.FullPath,
+            var settingsFile = SettingsFilePath;
+            // The AnimationEditor subfolder under %APPDATA% won't exist on a fresh install.
+            Directory.CreateDirectory(settingsFile.GetDirectoryContainingThis().FullPath);
+            File.WriteAllText(settingsFile.FullPath,
                 JsonSerializer.Serialize(_appSettings, new JsonSerializerOptions { WriteIndented = true }));
         }
         catch (IOException)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AppSettingsLocation.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AppSettingsLocation.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Resolves where the app-global editor settings (recent files, restored tabs, theme,
+/// default-handler suppression) are stored. The location is the shared per-user config directory —
+/// deliberately NOT the build output — so settings survive rebuilds, <c>dotnet clean</c>, and
+/// switching between git worktrees.
+/// </summary>
+public static class AppSettingsLocation
+{
+    public const string FolderName = "AnimationEditor";
+    public const string FileName = "AESettings.json";
+
+    /// <param name="applicationDataRoot">
+    /// The platform's per-user application-data root — i.e.
+    /// <c>Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)</c>
+    /// (Windows <c>%APPDATA%\Roaming</c>, Linux/macOS <c>~/.config</c>).
+    /// </param>
+    public static FilePath ForApplicationDataRoot(string applicationDataRoot) =>
+        new FilePath(Path.Combine(applicationDataRoot, FolderName, FileName));
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsLocationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsLocationTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Core.Tests;
+
+public class AppSettingsLocationTests
+{
+    [Fact]
+    public void ForApplicationDataRoot_PlacesFileUnderAnimationEditorSubfolder()
+    {
+        // Backslash literal proves the cross-platform FilePath handling (the editor may run on
+        // Windows where ApplicationData is %APPDATA%\Roaming).
+        var result = AppSettingsLocation.ForApplicationDataRoot(@"C:\Users\dev\AppData\Roaming");
+
+        Assert.Equal(new FilePath(@"C:\Users\dev\AppData\Roaming\AnimationEditor\AESettings.json"), result);
+    }
+
+    [Fact]
+    public void ForApplicationDataRoot_ResultIsNotInBuildOutput()
+    {
+        // Regression guard for #424: settings must live in the shared per-user root, never under
+        // the build output (AppContext.BaseDirectory ends in bin/<Config>/<TFM>/).
+        var result = AppSettingsLocation.ForApplicationDataRoot("/home/dev/.config");
+
+        Assert.Contains("/AnimationEditor/", result.FullPath);
+        Assert.EndsWith("/AESettings.json", result.FullPath);
+        Assert.DoesNotContain("/bin/", result.FullPath);
+    }
+}


### PR DESCRIPTION
## What

App-global Animation Editor settings — **recent files**, restored open tabs, active tab, theme, and the default-handler suppression flag (`AppSettingsModel`) — were persisted to `AESettings.json` in the **build output directory**:

```csharp
new FilePath(Path.Combine(AppContext.BaseDirectory, "AESettings.json"))
```

`AppContext.BaseDirectory` resolves to `…/bin/<Config>/<TFM>/`, which is per-build / per-checkout. So the settings didn't survive a `dotnet clean`, a publish to a different output, or — how this was noticed — building the editor in a **fresh git worktree** (each worktree has its own `bin/`).

## Change

Resolve the file under the **shared per-user config directory** instead:

```
Environment.GetFolderPath(SpecialFolder.ApplicationData) + /AnimationEditor/AESettings.json
```

- Windows: `%APPDATA%\Roaming\AnimationEditor\AESettings.json`
- Linux/macOS: `~/.config/AnimationEditor/AESettings.json`

Uniform `SpecialFolder.ApplicationData` across all platforms (no per-OS special-casing).

Path resolution is extracted into `AnimationEditor.Core.IO.AppSettingsLocation.ForApplicationDataRoot(...)` so it is unit-testable independently of the Avalonia `MainWindow`. `SaveSettingsFile` now also creates the `AnimationEditor` subfolder (it won't exist on a fresh install).

### Decisions (issue open questions)
- **No migration.** `AESettings.json` is app-global config; per-project view state (zoom/pan/guides) stays in the `.aeproperties` companion next to the `.achx`. Prerelease, low stakes — start fresh rather than reading the old build-output file once.
- **Uniform folder mapping** — confirmed acceptable.

## Tests
New `AppSettingsLocationTests` (TDD — written failing first) pin the location and act as the regression guard that settings never drift back into `bin/`. Full suite green: **1211** Core + **460** App.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)