### PR TITLE
Preserve zoom when double-clicking a frame to center it (#427)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -972,11 +972,10 @@ public class WireframeControl : Control
     }
 
     /// <summary>
-    /// Zooms to fit <paramref name="frame"/>'s bounding box at 85 % of the viewport (same
-    /// fraction as <see cref="CanvasTransform.CenterFit"/> uses for the whole bitmap), then
-    /// pans so the frame centre lands at the viewport centre. Clamped to the valid pan band, so
-    /// a frame near the texture edge lands as close to centre as the dead-space allows.
-    /// Does nothing when no bitmap is loaded.
+    /// Pans so <paramref name="frame"/>'s centre lands at the viewport centre, preserving the
+    /// current zoom level (the zoom is never changed, so <see cref="ZoomChanged"/> does not fire).
+    /// Clamped to the valid pan band, so a frame near the texture edge lands as close to centre as
+    /// the dead-space allows. Does nothing when no bitmap is loaded.
     /// </summary>
     public void CenterOnFrame(AnimationFrameSave frame)
     {
@@ -990,26 +989,19 @@ public class WireframeControl : Control
         float pixR = frame.RightCoordinate * bmpW;
         float pixB = frame.BottomCoordinate * bmpH;
 
-        float frameW = Math.Max(1f, pixR - pixL);
-        float frameH = Math.Max(1f, pixB - pixT);
-        float texCX  = (pixL + pixR) / 2f;
-        float texCY  = (pixT + pixB) / 2f;
+        float texCX = (pixL + pixR) / 2f;
+        float texCY = (pixT + pixB) / 2f;
 
         float vpW = (float)Bounds.Width;
         float vpH = (float)Bounds.Height;
 
-        // Zoom so the frame fills 85 % of the viewport.
-        _zoom = Math.Clamp(
-            Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
-            CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
-
-        // Pan so the frame centre maps to the viewport centre (screenX = panX + texX*zoom).
+        // Pan so the frame centre maps to the viewport centre at the current zoom
+        // (screenX = panX + texX*zoom). The zoom is left untouched.
         _panX = vpW / 2f - texCX * _zoom;
         _panY = vpH / 2f - texCY * _zoom;
         ClampCamera();
 
         InvalidateVisual();
-        ZoomChanged?.Invoke(_zoom * 100f);
         RaiseViewChanged();
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeaderTextDoubleTapTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeaderTextDoubleTapTests.cs
@@ -75,7 +75,8 @@ public class HeaderTextDoubleTapTests
             wireframe.LoadTexture(WriteSolidPng(dir, "tex.png", 500, 500));
             Dispatcher.UIThread.RunJobs();
 
-            // Frame UV 0.6–0.8 → a 100×100 region; centering zooms to fit it.
+            // Frame UV 0.6–0.8 → a 100×100 region centred at texture pixel (350, 350).
+            const float texCX = 350f, texCY = 350f;
             var frame = new AnimationFrameSave
             {
                 LeftCoordinate  = 0.6f, TopCoordinate    = 0.6f,
@@ -83,15 +84,19 @@ public class HeaderTextDoubleTapTests
             };
             var vm = new TreeNodeVm { Data = frame };
 
-            float? zoomChanged = null;
-            wireframe.ZoomChanged += v => zoomChanged = v;
-
             window.HandleHeaderTextDoubleTap(vm);
             Dispatcher.UIThread.RunJobs();
 
             Assert.False(vm.IsEditing,
                 "Double-tapping a frame's text label must not start an inline rename.");
-            Assert.NotNull(zoomChanged); // wireframe re-zoomed to fit the frame → it centered
+
+            // Centering scrolls the frame centre to the viewport centre at the current zoom
+            // (screenX = panX + texX*zoom) → it centered on the frame.
+            var (panX, panY, zoom) = wireframe.CameraState;
+            float vpW = (float)wireframe.Bounds.Width;
+            float vpH = (float)wireframe.Bounds.Height;
+            Assert.Equal(vpW / 2f, panX + texCX * zoom, 1);
+            Assert.Equal(vpH / 2f, panY + texCY * zoom, 1);
 
             window.Close();
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeCenterOnFrameTests.cs
@@ -13,8 +13,8 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests for WireframeControl.CenterOnFrame — zooms to fit the frame and scrolls
-/// so the frame region is centred in the viewport.
+/// Tests for WireframeControl.CenterOnFrame — scrolls so the frame region is
+/// centred in the viewport at the current zoom, without changing the zoom.
 /// </summary>
 public class WireframeCenterOnFrameTests
 {
@@ -50,84 +50,11 @@ public class WireframeCenterOnFrameTests
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// CenterOnFrame zooms to fit the frame's bounding box at 85 % of the viewport
-    /// and scrolls so the frame centre lands at the viewport centre.
+    /// CenterOnFrame on a tiny frame near the texture corner preserves the current zoom and keeps
+    /// the camera inside the valid pan band (does not push the texture off-edge).
     /// </summary>
     [AvaloniaFact]
-    public void CenterOnFrame_ZoomsToFitFrameAndCenters()
-    {
-        var ctx = ResetSingletons();
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        try
-        {
-            // 500×500 texture; frame UV (0.6–0.8, 0.6–0.8) → 100×100 pixel region,
-            // centre at pixel (350, 350).
-            const float bmpW   = 500f;
-            const float bmpH   = 500f;
-            const float frameW = 100f;
-            const float frameH = 100f;
-            const float texCX  = 350f;
-            const float texCY  = 350f;
-
-            var texPath = WriteSolidPng(dir, "tex.png", (int)bmpW, (int)bmpH);
-            var frame = new AnimationFrameSave
-            {
-                LeftCoordinate   = 0.6f,
-                TopCoordinate    = 0.6f,
-                RightCoordinate  = 0.8f,
-                BottomCoordinate = 0.8f,
-            };
-
-            var window = ctx.CreateMainWindow();
-            window.Show();
-            Dispatcher.UIThread.RunJobs();
-
-            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
-
-            ctrl.LoadTexture(texPath);
-            Dispatcher.UIThread.RunJobs();
-
-            // Capture any ZoomChanged notification.
-            float? zoomChangedValue = null;
-            ctrl.ZoomChanged += v => zoomChangedValue = v;
-
-            ctrl.CenterOnFrame(frame);
-            Dispatcher.UIThread.RunJobs();
-
-            float vpW = (float)ctrl.Bounds.Width;
-            float vpH = (float)ctrl.Bounds.Height;
-
-            // Zoom should fit the frame at 85 % of the viewport.
-            float expectedZoom = Math.Clamp(
-                Math.Min(vpW / frameW, vpH / frameH) * 0.85f,
-                CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
-
-            Assert.True(Math.Abs(ctrl.Zoom - expectedZoom) < 0.01f,
-                $"Zoom should fit frame; expected≈{expectedZoom:F3} actual={ctrl.Zoom:F3}");
-
-            // ZoomChanged event must have fired with the new percentage.
-            Assert.NotNull(zoomChangedValue);
-            Assert.True(Math.Abs(zoomChangedValue!.Value - expectedZoom * 100f) < 1f,
-                $"ZoomChanged value should be {expectedZoom * 100f:F1}%; got {zoomChangedValue.Value:F1}%");
-
-            // The frame centre should land at the viewport centre: screenX = panX + texCX*zoom.
-            var (panX, panY, zoom) = ctrl.CameraState;
-            Assert.Equal(vpW / 2f, panX + texCX * zoom, 1);
-            Assert.Equal(vpH / 2f, panY + texCY * zoom, 1);
-
-            window.Close();
-        }
-        finally { Directory.Delete(dir, true); }
-    }
-
-    /// <summary>
-    /// CenterOnFrame on a tiny frame near the texture corner zooms in to fit the frame and clamps
-    /// the camera to the valid pan band (the frame lands as close to centre as the dead-space
-    /// allows) without pushing the texture off-edge.
-    /// </summary>
-    [AvaloniaFact]
-    public void CenterOnFrame_FrameNearFarEdge_ZoomsAndClampsCamera()
+    public void CenterOnFrame_FrameNearFarEdge_PreservesZoomAndClampsCamera()
     {
         var ctx = ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -154,18 +81,21 @@ public class WireframeCenterOnFrameTests
             ctrl.LoadTexture(texPath);
             Dispatcher.UIThread.RunJobs();
 
+            // Start at a deliberate 3× zoom; CenterOnFrame must leave it untouched.
+            ctrl.SetCamera(0f, 0f, 3f);
+
+            bool zoomChangedFired = false;
+            ctrl.ZoomChanged += _ => zoomChangedFired = true;
+
             ctrl.CenterOnFrame(frame);
             Dispatcher.UIThread.RunJobs();
 
             float vpW = (float)ctrl.Bounds.Width;
             float vpH = (float)ctrl.Bounds.Height;
 
-            // Zoom should fit the 25×25 frame at 85 % of the viewport.
-            float frameFitZoom = Math.Clamp(
-                Math.Min(vpW / 25f, vpH / 25f) * 0.85f,
-                CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
-            Assert.True(Math.Abs(ctrl.Zoom - frameFitZoom) < 0.01f,
-                $"Zoom should fit 25×25 frame; expected≈{frameFitZoom:F3} actual={ctrl.Zoom:F3}");
+            // Zoom is preserved and no zoom notification fires.
+            Assert.Equal(3f, ctrl.Zoom, 3);
+            Assert.False(zoomChangedFired, "CenterOnFrame must not raise ZoomChanged");
 
             // The camera must stay inside the valid pan band — re-clamping is a no-op.
             var (panX, panY, zoom) = ctrl.CameraState;
@@ -173,6 +103,68 @@ public class WireframeCenterOnFrameTests
             var (cx, cy) = CanvasTransform.ClampWireframePan(panX, panY, vpW, vpH, bw, bh, zoom);
             Assert.Equal(panX, cx, 1);
             Assert.Equal(panY, cy, 1);
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// CenterOnFrame preserves the current zoom level and scrolls so the frame centre lands at the
+    /// viewport centre.
+    /// </summary>
+    [AvaloniaFact]
+    public void CenterOnFrame_PreservesZoomAndCentersFrame()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // 500×500 texture; frame UV (0.6–0.8, 0.6–0.8) → 100×100 pixel region,
+            // centre at pixel (350, 350).
+            const float texCX = 350f;
+            const float texCY = 350f;
+
+            var texPath = WriteSolidPng(dir, "tex.png", 500, 500);
+            var frame = new AnimationFrameSave
+            {
+                LeftCoordinate   = 0.6f,
+                TopCoordinate    = 0.6f,
+                RightCoordinate  = 0.8f,
+                BottomCoordinate = 0.8f,
+            };
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var ctrl = FindCtrl<WireframeControl>(window, "WireframeCtrl");
+
+            ctrl.LoadTexture(texPath);
+            Dispatcher.UIThread.RunJobs();
+
+            // Start at a deliberate 1× zoom — far from the frame-fit zoom the old behaviour would
+            // have jumped to — so a preserved zoom is unambiguous.
+            ctrl.SetCamera(0f, 0f, 1f);
+
+            bool zoomChangedFired = false;
+            ctrl.ZoomChanged += _ => zoomChangedFired = true;
+
+            ctrl.CenterOnFrame(frame);
+            Dispatcher.UIThread.RunJobs();
+
+            float vpW = (float)ctrl.Bounds.Width;
+            float vpH = (float)ctrl.Bounds.Height;
+
+            // Zoom is left exactly as it was; no zoom notification fires.
+            Assert.Equal(1f, ctrl.Zoom, 3);
+            Assert.False(zoomChangedFired, "CenterOnFrame must not raise ZoomChanged");
+
+            // The frame centre lands at the viewport centre: screenX = panX + texCX*zoom.
+            var (panX, panY, zoom) = ctrl.CameraState;
+            Assert.Equal(vpW / 2f, panX + texCX * zoom, 1);
+            Assert.Equal(vpH / 2f, panY + texCY * zoom, 1);
 
             window.Close();
         }


### PR DESCRIPTION
## Summary

Double-clicking a frame (in the tree, or its text label) re-centered the **wireframe (top) panel** on the frame but also **zoomed** to fit it at 85% of the viewport. The zoom jump was disorienting. Now double-click brings the frame into view at the **current** zoom — pan only, no zoom change.

## Changes

- `WireframeControl.CenterOnFrame` — dropped the `_zoom` reassignment and the `ZoomChanged?.Invoke(...)`; it now pans the frame's centre to the viewport centre at the current zoom and clamps to the valid pan band. Removed the now-unused `frameW`/`frameH` locals.
- Collapsed the XML doc to a single correct summary. (Note: the live code had only **one** summary block, not the two stacked ones the issue described — that was stale text from an earlier revision. It still described the wrong zoom-to-fit behavior, so it's been rewritten.)
- `WireframeCenterOnFrameTests` — both tests flipped to assert zoom is **preserved** and `ZoomChanged` does **not** fire while the frame still centers. Also reordered alphabetically per code-style.
- `HeaderTextDoubleTapTests.HandleHeaderTextDoubleTap_FrameNode_CentersWireframeWithoutRenaming` — this test used `ZoomChanged` firing as a *proxy* for "the wireframe centered." Since centering no longer touches zoom, switched it to a pan-based proxy (frame centre lands at viewport centre).

## Testing (TDD)

Flipped the two `WireframeCenterOnFrameTests` first and confirmed they went **red** against the old code (zoom became 14.382 / 3.596 instead of the set 3 / 1), then made the production change and confirmed green. Full `AnimationEditor.App.Tests` suite: **460 passed**.

The clamp math guarantees this is exact: centering any point inside the texture (`texCX ∈ [0, bitmapW]`) always lands within the valid pan band, so the frame centre maps exactly to the viewport centre at any preserved zoom.

Scope: wireframe (top) panel only. Preview-panel centering on double-click (#418) is separate and unaffected.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)