### PR TITLE
Smooth (animated) wheel zoom in the wireframe panel (#425)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -251,6 +251,19 @@ public class WireframeControl : Control
     // ScrollViewer; the control IS the viewport and two ScrollBars are driven from this pan.
     private float _panX, _panY;
 
+    // ── Smooth (animated) wheel zoom (#425) ───────────────────────────────────
+    // A wheel notch retargets _zoomTarget; the timer eases _zoom toward it via ZoomChase,
+    // applying each stepped value through the existing pivot-preserving ZoomToward. The pivot
+    // is stored in VIEWPORT space and re-used every tick, so the point under the cursor stays
+    // fixed for the whole animation — the per-tick factors compose to the same result as one
+    // instant notch. Rapid notches retarget the in-flight animation rather than stacking.
+    private DispatcherTimer? _zoomTimer;
+    private bool  _zoomAnimating;
+    private float _zoomTarget;      // destination zoom factor (1.0 = 100 %)
+    private float _zoomPivotVpX;    // cursor pivot, viewport space
+    private float _zoomPivotVpY;
+    private const float ZoomAnimIntervalSeconds = 1f / 60f;
+
     private bool _showGrid;
     private int _gridSize = 16;
 
@@ -498,6 +511,9 @@ public class WireframeControl : Control
             RaiseViewChanged();
         };
 
+        // Stop the smooth-zoom timer if the control leaves the tree mid-animation.
+        DetachedFromVisualTree += (_, _) => StopZoomTimer();
+
         // Subscriptions are deferred to InitializeServices (called from MainWindow)
     }
 
@@ -664,6 +680,7 @@ public class WireframeControl : Control
     /// centre of the viewport.</summary>
     public void SetZoomPercent(int percent)
     {
+        CancelZoomAnimation();   // an explicit zoom overrides any in-flight wheel ease
         float newZoom = Math.Clamp(percent / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
         ZoomToward((float)Bounds.Width / 2f, (float)Bounds.Height / 2f, newZoom / _zoom);
     }
@@ -683,6 +700,7 @@ public class WireframeControl : Control
     /// </summary>
     public void SetCamera(float panX, float panY, float zoom)
     {
+        CancelZoomAnimation();
         _panX = panX;
         _panY = panY;
         _zoom = zoom;
@@ -915,12 +933,65 @@ public class WireframeControl : Control
     public void SimulateWheelZoom(float vpX, float vpY, float factor) => ZoomToward(vpX, vpY, factor);
 
     /// <summary>
-    /// Test-only: simulates a single mouse-wheel zoom event toward the given
-    /// <b>viewport-space</b> point, using preset stepping when <see cref="WheelZoomPresets"/>
-    /// is set. Mirrors <see cref="OnPointerWheelChanged"/>.
+    /// Test-only: simulates one mouse-wheel notch toward the given <b>viewport-space</b> point
+    /// using preset stepping (<see cref="WheelZoomPresets"/>) and runs the resulting smooth-zoom
+    /// animation to completion synchronously, so the camera lands on its settled state. Use
+    /// <see cref="SimulateWheelZoomBegin"/> instead to observe the animation mid-flight.
     /// </summary>
-    public void SimulateWheelZoom(float vpX, float vpY, bool zoomIn) =>
-        ZoomToward(vpX, vpY, ComputeWheelFactor(zoomIn));
+    public void SimulateWheelZoom(float vpX, float vpY, bool zoomIn)
+    {
+        BeginAnimatedZoom(vpX, vpY, zoomIn);
+        SettleZoomAnimation();
+    }
+
+    /// <summary>
+    /// Test-only: begins a smooth wheel-zoom toward the <b>viewport-space</b> pivot WITHOUT
+    /// settling, so a test can drive <see cref="StepZoomAnimation"/> tick-by-tick and observe the
+    /// ease and retargeting. Mirrors the live <see cref="OnPointerWheelChanged"/> path.
+    /// </summary>
+    public void SimulateWheelZoomBegin(float vpX, float vpY, bool zoomIn) =>
+        BeginAnimatedZoom(vpX, vpY, zoomIn);
+
+    /// <summary>True while a smooth wheel-zoom (#425) is easing toward its target. The host gates
+    /// per-frame companion-file persistence on this so only the settled state is saved, not every
+    /// intermediate tick.</summary>
+    public bool IsZoomAnimating => _zoomAnimating;
+
+    /// <summary>Test-only: the zoom factor the in-flight animation is easing toward (1.0 = 100 %).</summary>
+    public float TargetZoom => _zoomTarget;
+
+    /// <summary>
+    /// Advances the in-flight smooth zoom by <paramref name="dtSeconds"/>, easing toward the
+    /// target via <see cref="ZoomChase"/> and applying each step through the pivot-preserving
+    /// <see cref="ZoomToward"/>. Returns <c>true</c> while still animating, <c>false</c> once
+    /// settled (at which point the timer is stopped). The live 60 fps timer calls this; tests
+    /// call it directly for deterministic stepping.
+    /// </summary>
+    public bool StepZoomAnimation(float dtSeconds)
+    {
+        if (!_zoomAnimating) return false;
+
+        float next = ZoomChase.Step(_zoom, _zoomTarget, dtSeconds);
+        bool settling = ZoomChase.IsSettled(next, _zoomTarget);
+
+        // Clear the flag BEFORE ZoomToward fires ZoomChanged on the settling tick, so the host
+        // sees IsZoomAnimating == false and persists the companion file exactly once (on settle).
+        if (settling) { _zoomAnimating = false; StopZoomTimer(); }
+
+        // factor is relative to the current zoom; the viewport pivot is constant across ticks, so
+        // the factors compose to the same result as a single notch (the pivot stays anchored).
+        ZoomToward(_zoomPivotVpX, _zoomPivotVpY, next / _zoom);
+        return !settling;
+    }
+
+    /// <summary>Runs <see cref="StepZoomAnimation"/> to completion synchronously. Used by the
+    /// instant test overloads and available to any caller that must force the settled state.</summary>
+    public void SettleZoomAnimation()
+    {
+        // The 1000-iteration cap is a non-convergence backstop; ZoomChase settles far sooner.
+        for (int i = 0; _zoomAnimating && i < 1000; i++)
+            StepZoomAnimation(ZoomAnimIntervalSeconds);
+    }
 
     /// <summary>Test-only: current camera pan (screen position of texture pixel (0,0)).</summary>
     public (float X, float Y) PanOffset => (_panX, _panY);
@@ -966,6 +1037,7 @@ public class WireframeControl : Control
     public void CenterFitForSize(int width, int height)
     {
         if (_bitmap is null) return;
+        CancelZoomAnimation();
         (_panX, _panY, _zoom) = CanvasTransform.CenterFit(
             _bitmap.Width, _bitmap.Height, width, height);
         InvalidateVisual();
@@ -980,6 +1052,7 @@ public class WireframeControl : Control
     public void CenterOnFrame(AnimationFrameSave frame)
     {
         if (_bitmap is null) return;
+        CancelZoomAnimation();   // double-click centring overrides any in-flight wheel ease
 
         float bmpW = _bitmap.Width;
         float bmpH = _bitmap.Height;
@@ -1059,23 +1132,66 @@ public class WireframeControl : Control
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
-        float factor = ComputeWheelFactor(e.Delta.Y > 0);
         // The control IS the viewport now (no ScrollViewer), so e.GetPosition(this) is the
-        // viewport-space pivot ZoomToward expects.
+        // viewport-space pivot. Smooth-zoom retargets and eases toward the next preset (#425).
         var pivot = e.GetPosition(this);
-        ZoomToward((float)pivot.X, (float)pivot.Y, factor);
+        BeginAnimatedZoom((float)pivot.X, (float)pivot.Y, e.Delta.Y > 0);
+        StartZoomTimer();   // live driver; tests drive StepZoomAnimation directly instead
         e.Handled = true;
     }
 
-    /// <summary>Computes the zoom factor for one wheel notch, using preset stepping when available.</summary>
-    private float ComputeWheelFactor(bool zoomIn)
+    // ── Smooth (animated) wheel zoom (#425) ───────────────────────────────────
+
+    /// <summary>
+    /// Retargets the smooth zoom toward the next/previous preset from the given viewport-space
+    /// pivot. A notch while already animating steps from the in-flight <see cref="_zoomTarget"/>,
+    /// so rapid spins accumulate through the presets rather than re-targeting the same one from the
+    /// mid-animation zoom. Does NOT start the driving timer — the live wheel handler starts it;
+    /// tests drive <see cref="StepZoomAnimation"/> directly for determinism.
+    /// </summary>
+    private void BeginAnimatedZoom(float pivotVpX, float pivotVpY, bool zoomIn)
     {
-        if (WheelZoomPresets is { Length: > 0 } presets)
-        {
-            int newPct = ZoomPresetStepper.StepToNextPreset(_zoom * 100f, presets, zoomIn ? +1 : -1);
-            return newPct / 100f / _zoom;
-        }
-        return zoomIn ? 1.25f : 1f / 1.25f;
+        float basis = _zoomAnimating ? _zoomTarget : _zoom;
+        _zoomTarget   = ComputeTargetZoom(basis, zoomIn);
+        _zoomPivotVpX = pivotVpX;
+        _zoomPivotVpY = pivotVpY;
+        _zoomAnimating = true;
+    }
+
+    /// <summary>Stops any in-flight wheel-zoom animation, holding the camera at its current value.
+    /// Competing camera actions (pan, combo zoom, centre-on-frame, load) call this so they don't
+    /// fight the easing timer.</summary>
+    private void CancelZoomAnimation()
+    {
+        if (!_zoomAnimating) return;
+        _zoomAnimating = false;
+        StopZoomTimer();
+    }
+
+    /// <summary>The zoom factor one wheel notch targets from <paramref name="basisZoom"/>, using
+    /// preset stepping when <see cref="WheelZoomPresets"/> is set, else a 1.25× multiplier. Clamped
+    /// to [<see cref="CanvasTransform.MinZoom"/>, <see cref="CanvasTransform.MaxZoom"/>].</summary>
+    private float ComputeTargetZoom(float basisZoom, bool zoomIn)
+    {
+        float targetPct = WheelZoomPresets is { Length: > 0 } presets
+            ? ZoomPresetStepper.StepToNextPreset(basisZoom * 100f, presets, zoomIn ? +1 : -1)
+            : basisZoom * 100f * (zoomIn ? 1.25f : 1f / 1.25f);
+        return Math.Clamp(targetPct / 100f, CanvasTransform.MinZoom, CanvasTransform.MaxZoom);
+    }
+
+    private void StartZoomTimer()
+    {
+        _zoomTimer ??= CreateZoomTimer();
+        _zoomTimer.Start();
+    }
+
+    private void StopZoomTimer() => _zoomTimer?.Stop();
+
+    private DispatcherTimer CreateZoomTimer()
+    {
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(ZoomAnimIntervalSeconds) };
+        timer.Tick += (_, _) => StepZoomAnimation(ZoomAnimIntervalSeconds);
+        return timer;
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
@@ -1350,6 +1466,7 @@ public class WireframeControl : Control
 
     private void StartPan(Point pos)
     {
+        CancelZoomAnimation();   // panning takes over from any in-flight wheel ease
         _isPanning = true;
         _panAnchor = pos;
         _panAnchorX = _panX;   // camera pan at drag start
@@ -1700,6 +1817,7 @@ public class WireframeControl : Control
     private void CenterTexture()
     {
         if (_bitmap is null) return;
+        CancelZoomAnimation();   // a fresh texture/centre overrides any in-flight wheel ease
 
         // Defer until layout has produced a real viewport; the first SizeChanged re-centers.
         if (Bounds.Width <= 1)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -765,7 +765,13 @@ public partial class MainWindow : Window
         WireframeCtrl.ChainRegionChanged     += OnChainRegionChanged;
         WireframeCtrl.FrameLiveUpdated       += OnFrameLiveUpdated;
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
-        WireframeCtrl.ZoomChanged            += zoomPct => { SyncZoomCombo(zoomPct); SaveCompanionFile(); };
+        // The combo follows every tick of a smooth wheel-zoom (#425); the companion file is only
+        // persisted once the animation settles (IsZoomAnimating == false), not on every frame.
+        WireframeCtrl.ZoomChanged            += zoomPct =>
+        {
+            SyncZoomCombo(zoomPct);
+            if (!WireframeCtrl.IsZoomAnimating) SaveCompanionFile();
+        };
         WireframeCtrl.PanChanged             += (_, _) => SaveCompanionFile();
 
         // ── Wireframe scrollbars (#422) ──

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/ZoomChase.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/ZoomChase.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Pure, frame-rate-independent easing for a "chase the target" zoom animation (#425).
+/// Each <see cref="Step"/> moves the current zoom a fraction of the remaining distance
+/// toward the target using exponential smoothing, so the curve is identical whether driven
+/// by one large timestep or several small ones (a dropped frame doesn't change the feel).
+/// <para>
+/// Stateless by design: the caller owns the current zoom and the target. Feed each stepped
+/// value into <see cref="CanvasTransform.ZoomToward"/> to apply it while keeping the cursor
+/// pivot anchored — the animation only changes <em>how fast</em> the zoom scalar reaches its
+/// destination, never <em>how</em> the destination (pan/scroll/clamp) is computed.
+/// </para>
+/// </summary>
+public static class ZoomChase
+{
+    /// <summary>
+    /// Smoothing time constant in seconds. The bulk of the motion (~95 %) completes in
+    /// roughly 3× this value, so 0.045 s gives a ~135 ms perceived zoom. Lower = snappier.
+    /// This is the single knob to tune the zoom feel.
+    /// </summary>
+    public const float DefaultTimeConstantSeconds = 0.045f;
+
+    /// <summary>
+    /// Relative distance (fraction of the target's magnitude) within which the chase snaps
+    /// exactly to the target and reports settled, cutting the otherwise-asymptotic tail so
+    /// the animation terminates instead of dribbling indefinitely.
+    /// </summary>
+    public const float SnapRelativeThreshold = 0.0015f;
+
+    /// <summary>
+    /// Eases <paramref name="current"/> toward <paramref name="target"/> over
+    /// <paramref name="dtSeconds"/> and returns the new zoom. Snaps to the exact target once
+    /// within <see cref="SnapRelativeThreshold"/> so repeated application terminates.
+    /// </summary>
+    /// <param name="timeConstantSeconds">Smoothing time constant; defaults to
+    /// <see cref="DefaultTimeConstantSeconds"/>.</param>
+    public static float Step(
+        float current, float target, float dtSeconds,
+        float timeConstantSeconds = DefaultTimeConstantSeconds)
+    {
+        if (IsSettled(current, target)) return target;
+
+        // Exponential approach: the fraction of the remaining gap closed this tick is
+        // 1 − e^(−dt/τ). Splitting dt into sub-steps yields the identical result because
+        // e^(−(a+b)/τ) = e^(−a/τ)·e^(−b/τ) — hence frame-rate independence.
+        float alpha = 1f - MathF.Exp(-dtSeconds / timeConstantSeconds);
+        float next = current + (target - current) * alpha;
+        return IsSettled(next, target) ? target : next;
+    }
+
+    /// <summary>
+    /// True when <paramref name="current"/> is within <see cref="SnapRelativeThreshold"/> of
+    /// <paramref name="target"/> (relative to the target's magnitude) — the chase should stop
+    /// and hold the exact target.
+    /// </summary>
+    public static bool IsSettled(float current, float target)
+        => MathF.Abs(target - current) <= SnapRelativeThreshold * MathF.Max(1e-4f, MathF.Abs(target));
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeAnimatedZoomTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeAnimatedZoomTests.cs
@@ -1,0 +1,114 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Smooth (animated) wheel zoom (#425). The wheel handler now retargets a single
+/// <c>_targetZoom</c> and eases toward it via <see cref="ZoomChase"/>, applying each
+/// stepped value through the existing pivot-preserving <c>ZoomToward</c>.
+///
+/// The pure easing is covered headlessly in <c>ZoomChaseTests</c>; these tests cover the
+/// control-level wiring: target computation, retargeting in-flight, exact settle, and that
+/// the cursor pivot stays anchored for the whole animation (not just at the end).
+/// </summary>
+public class WireframeAnimatedZoomTests
+{
+    private static readonly int[] _presets = { 50, 100, 150, 200 };
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        return ctx;
+    }
+
+    private static WireframeControl MakeControl(TestServices ctx)
+    {
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.Measure(new Size(400, 300));
+        ctrl.Arrange(new Rect(0, 0, 400, 300));
+        ctrl.WheelZoomPresets = _presets;
+        return ctrl;
+    }
+
+    [AvaloniaFact]
+    public void SimulateWheelZoomBegin_RapidNotches_RetargetsToAccumulatedPreset()
+    {
+        var ctrl = MakeControl(ResetSingletons());
+        ctrl.SetZoomPercent(100);
+
+        ctrl.SimulateWheelZoomBegin(200f, 150f, zoomIn: true);   // target 150 %
+        ctrl.StepZoomAnimation(0.016f);                          // ease partway toward 150 %
+        ctrl.SimulateWheelZoomBegin(200f, 150f, zoomIn: true);   // second notch before arrival
+
+        // The second notch must step the TARGET to the next preset (200 %), not re-step
+        // from the mid-animation zoom (which would re-target 150 %).
+        Assert.Equal(2.0f, ctrl.TargetZoom, precision: 5);
+
+        ctrl.SettleZoomAnimation();
+        Assert.Equal(2.0f, ctrl.CameraState.Zoom, precision: 5);
+        Assert.False(ctrl.IsZoomAnimating);
+    }
+
+    [AvaloniaFact]
+    public void SimulateWheelZoomBegin_ZoomIn_TargetsNextPresetAndEasesPartway()
+    {
+        var ctrl = MakeControl(ResetSingletons());
+        ctrl.SetZoomPercent(100);
+
+        ctrl.SimulateWheelZoomBegin(200f, 150f, zoomIn: true);
+
+        Assert.True(ctrl.IsZoomAnimating);
+        Assert.Equal(1.5f, ctrl.TargetZoom, precision: 5);
+
+        // One 16 ms tick eases toward — but does not reach — the target.
+        ctrl.StepZoomAnimation(0.016f);
+        float z = ctrl.CameraState.Zoom;
+        Assert.True(z > 1.0f && z < 1.5f, $"expected zoom in (1.0, 1.5) after one tick, got {z}");
+
+        ctrl.SettleZoomAnimation(); // clean up the timer
+    }
+
+    [AvaloniaFact]
+    public void StepZoomAnimation_PivotStaysAnchoredDuringAnimation()
+    {
+        var ctrl = MakeControl(ResetSingletons());
+        // Known camera: pan (0,0), zoom 1× → texture coord under viewport (200,150) is (200,150).
+        ctrl.SetCamera(0f, 0f, 1f);
+        const float pivotX = 200f, pivotY = 150f;
+        var (texX, texY) = CanvasTransform.ScreenToTexture(pivotX, pivotY, 0f, 0f, 1f);
+
+        ctrl.SimulateWheelZoomBegin(pivotX, pivotY, zoomIn: true);
+        ctrl.StepZoomAnimation(0.016f); // mid-animation (zoom now between 1.0 and 1.5)
+
+        var (panX, panY, zoom) = ctrl.CameraState;
+        var (texAfterX, texAfterY) = CanvasTransform.ScreenToTexture(pivotX, pivotY, panX, panY, zoom);
+        Assert.Equal(texX, texAfterX, precision: 2);
+        Assert.Equal(texY, texAfterY, precision: 2);
+
+        ctrl.SettleZoomAnimation();
+    }
+
+    [AvaloniaFact]
+    public void StepZoomAnimation_RunToCompletion_LandsExactlyOnTargetAndStops()
+    {
+        var ctrl = MakeControl(ResetSingletons());
+        ctrl.SetZoomPercent(100);
+
+        ctrl.SimulateWheelZoomBegin(200f, 150f, zoomIn: true); // target 150 %
+        ctrl.SettleZoomAnimation();
+
+        Assert.Equal(1.5f, ctrl.CameraState.Zoom, precision: 5);
+        Assert.False(ctrl.IsZoomAnimating);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ZoomChaseTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ZoomChaseTests.cs
@@ -1,0 +1,70 @@
+using AnimationEditor.Core.Rendering;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="ZoomChase"/> — the pure, frame-rate-independent easing that
+/// drives smooth (animated) mouse-wheel zoom (#425). No UI, no timer.
+/// </summary>
+public class ZoomChaseTests
+{
+    [Fact]
+    public void IsSettled_FarApart_ReturnsFalse()
+    {
+        Assert.False(ZoomChase.IsSettled(1.0f, 1.5f));
+    }
+
+    [Fact]
+    public void IsSettled_WithinThreshold_ReturnsTrue()
+    {
+        // 1.4995 is within SnapRelativeThreshold (0.15 %) of 1.5.
+        Assert.True(ZoomChase.IsSettled(1.4995f, 1.5f));
+    }
+
+    [Fact]
+    public void Step_CurrentAboveTarget_MovesDownTowardTarget()
+    {
+        float next = ZoomChase.Step(2.0f, 1.5f, 0.016f);
+        Assert.True(next < 2.0f && next > 1.5f, $"expected value in (1.5, 2.0), got {next}");
+    }
+
+    [Fact]
+    public void Step_CurrentBelowTarget_MovesUpTowardTargetWithoutOvershooting()
+    {
+        float next = ZoomChase.Step(1.0f, 1.5f, 0.016f);
+        Assert.True(next > 1.0f && next < 1.5f, $"expected value in (1.0, 1.5), got {next}");
+    }
+
+    [Fact]
+    public void Step_FrameRateIndependent_OneStepEqualsTwoHalfSteps()
+    {
+        // Exponential smoothing is exact under timestep splitting: a single 32 ms step
+        // must equal two consecutive 16 ms steps (so a dropped frame doesn't change the curve).
+        float oneStep = ZoomChase.Step(1.0f, 1.5f, 0.032f);
+        float twoHalf = ZoomChase.Step(ZoomChase.Step(1.0f, 1.5f, 0.016f), 1.5f, 0.016f);
+        Assert.Equal(oneStep, twoHalf, precision: 4);
+    }
+
+    [Fact]
+    public void Step_RepeatedApplication_ConvergesExactlyAndTerminates()
+    {
+        // Chasing 1.0 → 2.0 at 60 fps must settle on the exact target within ~1 s of ticks,
+        // not dribble forever down the asymptotic tail.
+        float z = 1.0f;
+        int iterations = 0;
+        while (!ZoomChase.IsSettled(z, 2.0f) && iterations < 1000)
+        {
+            z = ZoomChase.Step(z, 2.0f, 0.016f);
+            iterations++;
+        }
+        Assert.Equal(2.0f, z);
+        Assert.True(iterations < 60, $"chase should settle within ~1 s of 60 fps ticks; took {iterations}");
+    }
+
+    [Fact]
+    public void Step_WithinSnapThreshold_ReturnsTargetExactly()
+    {
+        Assert.Equal(1.5f, ZoomChase.Step(1.4995f, 1.5f, 0.016f));
+    }
+}


### PR DESCRIPTION
## Summary

A mouse-wheel notch in the **wireframe (top) panel** now eases to the target zoom over a short ease-out instead of snapping, keeping the cursor-anchored pivot fixed for the whole animation. The bottom (Preview) panel is unchanged (out of scope per the issue discussion).

## Approach

Exactly the "target zoom + chase" model from the issue:

- A wheel notch retargets a single `_zoomTarget`; a 60 fps `DispatcherTimer` eases `_zoom` toward it via a pure, frame-rate-independent `ZoomChase` helper and applies each stepped value through the **existing** pivot-preserving `ZoomToward`.
- The easing only changes *how fast* the zoom scalar reaches its destination — the hard-won pan/clamp math (`CanvasTransform.ZoomWireframe`) is reused untouched, so there is no second source of truth and **no commit-time pop**.
- Because the viewport pivot is constant across ticks, the per-tick factors **compose to the same result as one instant notch**, so the settled state matches the previous instant zoom *exactly* — except in a narrow near-edge clamp case, where it lands at a valid clamped position a few px off (acceptable per the issue's "round-trip only at rest").

## Behaviour details (the issue's open questions, resolved)

- **Rapid notches** retarget the in-flight animation (accumulate through presets) rather than stacking discrete animations.
- **Combo cadence:** the zoom combo updates every tick (smooth), but the companion file is persisted **only once on settle** (`IsZoomAnimating` gate in `MainWindow`).
- **Preset stepping:** animates *between* presets; the combo still lands on round numbers.
- **Competing actions** (pan, combo zoom, centre-on-frame, fit, load) cancel any in-flight animation so they don't fight the timer; the timer also stops on settle and on detach-from-tree.
- **No off switch** (per the issue discussion).
- The raw-factor `SimulateWheelZoom` overload stays **instant** (deterministic pivot math for the existing pan/zoom regression tests); only the preset/bool path eases.
- Feel is one tunable constant: `ZoomChase.DefaultTimeConstantSeconds` (~135 ms perceived).

## Testing

TDD throughout (failing test first):

- `ZoomChaseTests` (Core, headless `[Fact]`) — the pure exponential ease: moves toward target, snaps exactly within threshold, frame-rate independence (one big step == two half steps), and bounded convergence.
- `WireframeAnimatedZoomTests` (`[AvaloniaFact]`) — control-level wiring: target computation, retargeting an in-flight notch, exact settle + stop, and **cursor pivot stays anchored mid-animation**, by driving `StepZoomAnimation` deterministically.
- The live `DispatcherTimer` is the thin untested wiring layer; tests never start a real timer, so the suite stays deterministic.

Full `AnimationEditor.Core.Tests` (1218) and `AnimationEditor.App.Tests` (464) pass; the App suite was run 3× to confirm no flakiness.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)