### PR TITLE
Add per-frame Red/Green/Blue values to the Animation Editor and runtime

### DIFF
--- a/src/Animation/AnimationFrame.cs
+++ b/src/Animation/AnimationFrame.cs
@@ -46,6 +46,19 @@ public class AnimationFrame
     public float RelativeY;
 
     /// <summary>
+    /// Optional per-frame red channel, 0–255, or <c>null</c> when unset. <b>Not</b> applied by the
+    /// engine: read it via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/> and apply it in
+    /// game code (tint, flash, etc.). See <see cref="Green"/>, <see cref="Blue"/>.
+    /// </summary>
+    public int? Red;
+
+    /// <summary>Optional per-frame green channel, 0–255, or <c>null</c> when unset. See <see cref="Red"/>.</summary>
+    public int? Green;
+
+    /// <summary>Optional per-frame blue channel, 0–255, or <c>null</c> when unset. See <see cref="Red"/>.</summary>
+    public int? Blue;
+
+    /// <summary>
     /// Per-frame shape definitions reconciled against the parent entity at frame switch time.
     /// Each entry must have a non-empty unique <see cref="AnimationShapeFrame.Name"/>. See
     /// <see cref="AnimationChainList"/> for the ownership rule that decides which entity shapes

--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -202,6 +202,12 @@ public class AnimationChainListSave
         if (frame.RelativeX != 0f) el.Add(new XElement("RelativeX", FloatStr(frame.RelativeX)));
         if (frame.RelativeY != 0f) el.Add(new XElement("RelativeY", FloatStr(frame.RelativeY)));
 
+        // Per-frame color channels are game-consumed and optional: write each only when set
+        // so frames without color stay byte-identical.
+        if (frame.Red.HasValue) el.Add(new XElement("Red", frame.Red.Value));
+        if (frame.Green.HasValue) el.Add(new XElement("Green", frame.Green.Value));
+        if (frame.Blue.HasValue) el.Add(new XElement("Blue", frame.Blue.Value));
+
         if (frame.HasCustomName && !string.IsNullOrEmpty(frame.Name))
         {
             el.Add(new XElement("Name", frame.Name));
@@ -276,6 +282,9 @@ public class AnimationChainListSave
         frame.FlipVertical = BoolEl(el, "FlipVertical");
         frame.RelativeX = FloatEl(el, "RelativeX");
         frame.RelativeY = FloatEl(el, "RelativeY");
+        frame.Red = IntElNullable(el, "Red");
+        frame.Green = IntElNullable(el, "Green");
+        frame.Blue = IntElNullable(el, "Blue");
         frame.Name = (string?)el.Element("Name") ?? string.Empty;
         frame.HasCustomName = BoolEl(el, "HasCustomName");
 
@@ -422,6 +431,12 @@ public class AnimationChainListSave
         return el != null ? bool.Parse(el.Value) : defaultValue;
     }
 
+    private static int? IntElNullable(XElement parent, string name)
+    {
+        var el = parent.Element(name);
+        return el != null ? int.Parse(el.Value, CultureInfo.InvariantCulture) : null;
+    }
+
     /// <summary>
     /// Converts this save object to a runtime <see cref="AnimationChainList"/>, loading
     /// all referenced textures through <see cref="ContentLoader.Load{T}"/>.
@@ -470,6 +485,9 @@ public class AnimationChainListSave
                     FlipVertical = frameSave.FlipVertical,
                     RelativeX = frameSave.RelativeX,
                     RelativeY = frameSave.RelativeY,
+                    Red = frameSave.Red,
+                    Green = frameSave.Green,
+                    Blue = frameSave.Blue,
                 };
 
                 frame.Texture = loadTexture(frameSave);

--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -36,6 +36,20 @@ public class AnimationFrameSave
     public float RelativeY;
 
     /// <summary>
+    /// Optional per-frame red channel, 0–255. <c>null</c> (the default) means unset, so it is
+    /// omitted from the saved <c>.achx</c>. These values are <b>not</b> applied by the engine or
+    /// the Animation Editor — game code reads them via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/>
+    /// and decides how to use them (tint, flash, etc.). See <see cref="Green"/>, <see cref="Blue"/>.
+    /// </summary>
+    public int? Red;
+
+    /// <summary>Optional per-frame green channel, 0–255. See <see cref="Red"/> for the game-consumed contract.</summary>
+    public int? Green;
+
+    /// <summary>Optional per-frame blue channel, 0–255. See <see cref="Red"/> for the game-consumed contract.</summary>
+    public int? Blue;
+
+    /// <summary>
     /// User-visible display label for this frame in the Animation Editor tree.
     /// Only meaningful when <see cref="HasCustomName"/> is <c>true</c>; when
     /// <c>false</c> the editor shows a dynamic position-based label ("Frame N")

--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -242,6 +242,7 @@ public class Sprite : IRenderable, IAttachable
         {
             _animationChains = value;
             _currentChainIndex = -1;
+            CurrentFrame = null;
         }
     }
 
@@ -269,6 +270,14 @@ public class Sprite : IRenderable, IAttachable
         _animationChains != null && _currentChainIndex >= 0 && _currentChainIndex < _animationChains.Count
             ? _animationChains[_currentChainIndex]
             : null;
+
+    /// <summary>
+    /// The <see cref="AnimationFrame"/> currently displayed, or <c>null</c> when no animation is playing.
+    /// Use this to read per-frame data the engine does not auto-apply — e.g.
+    /// <see cref="AnimationFrame.Red"/>/<see cref="AnimationFrame.Green"/>/<see cref="AnimationFrame.Blue"/> —
+    /// and apply it in game code.
+    /// </summary>
+    public AnimationFrame? CurrentFrame { get; private set; }
 
     /// <summary>Fired when a non-looping animation reaches its last frame.</summary>
     public event Action? AnimationFinished;
@@ -384,6 +393,7 @@ public class Sprite : IRenderable, IAttachable
         if (chain.Count == 0) return;
 
         var frame = chain[System.Math.Clamp(_currentFrameIndex, 0, chain.Count - 1)];
+        CurrentFrame = frame;
         _texture = frame.Texture;
         _sourceRectangle = frame.SourceRectangle;
         FlipHorizontal = frame.FlipHorizontal;

--- a/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using FlatRedBall2.Animation;
+using FlatRedBall2.Animation.Content;
+using FlatRedBall2.Rendering;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Animation;
+
+// Per-frame Red/Green/Blue (0-255, nullable) are stored on the frame and surfaced to game code,
+// but are NOT applied by the engine — game code reads Sprite.CurrentFrame and decides how to use them.
+public class AnimationFrameColorTests
+{
+    [Fact]
+    public void CurrentFrame_ReflectsPlaybackState()
+    {
+        var chain = new AnimationChain { Name = "Flash" };
+        chain.Add(new AnimationFrame { FrameLength = TimeSpan.FromSeconds(0.1), Red = 255 });
+        var list = new AnimationChainList();
+        list.Add(chain);
+
+        var sprite = new Sprite { AnimationChains = list };
+
+        sprite.CurrentFrame.ShouldBeNull(); // nothing playing yet
+
+        sprite.PlayAnimation("Flash");
+
+        sprite.CurrentFrame.ShouldNotBeNull();
+        sprite.CurrentFrame!.Red.ShouldBe(255);
+    }
+
+    [Fact]
+    public void Save_ThenFromFile_RoundTripsSetChannelsAndOmitsNullChannel()
+    {
+        // Red and Blue are authored; Green is left null to prove null channels are not written.
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Flash" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "car.png", FrameLength = 0.1f, Red = 255, Blue = 128 });
+        save.AnimationChains.Add(chain);
+
+        var path = Path.Combine(Path.GetTempPath(), $"frbcolor_{Guid.NewGuid():N}.achx");
+        try
+        {
+            save.Save(path);
+
+            File.ReadAllText(path).ShouldNotContain("<Green>"); // null channel omitted
+
+            var frame = AnimationChainListSave.FromFile(path).AnimationChains[0].Frames[0];
+            frame.Red.ShouldBe(255);
+            frame.Blue.ShouldBe(128);
+            frame.Green.ShouldBeNull();
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ToAnimationChainList_CopiesColorChannelsToRuntimeFrame()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Flash" };
+        // Empty TextureName so conversion skips texture loading and the null ContentLoader is never used.
+        chain.Frames.Add(new AnimationFrameSave { Red = 255, Green = 200, Blue = 128 });
+        save.AnimationChains.Add(chain);
+
+        var frame = save.ToAnimationChainList(null!)[0][0];
+
+        frame.Red.ShouldBe(255);
+        frame.Green.ShouldBe(200);
+        frame.Blue.ShouldBe(128);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1018,6 +1018,41 @@
                                         </Grid>
                                     </StackPanel>
                                 </Border>
+
+                                <!-- GAME-CONSUMED section: per-frame values the engine stores but never applies -->
+                                <Border BorderBrush="{DynamicResource LineBrush}"
+                                        BorderThickness="0,0,0,1"
+                                        Padding="12,8,12,10">
+                                    <StackPanel Spacing="8">
+                                        <TextBlock Text="GAME-CONSUMED (NOT PREVIEWED)"
+                                                   FontSize="11"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource InkMid}" />
+                                        <TextBlock TextWrapping="Wrap" FontSize="10"
+                                                   Foreground="{DynamicResource InkDim}"
+                                                   Text="Saved per-frame but not applied by the editor or engine. Your game reads sprite.CurrentFrame (Red/Green/Blue) and decides how to use them. Leave a field blank to omit it." />
+                                        <Grid ColumnDefinitions="*,6,*,6,*">
+                                            <Grid Grid.Column="0" ColumnDefinitions="14,*">
+                                                <TextBlock Text="R" VerticalAlignment="Center"
+                                                           Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
+                                                <NumericUpDown x:Name="PropRed" Grid.Column="1"
+                                                               Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                            </Grid>
+                                            <Grid Grid.Column="2" ColumnDefinitions="14,*">
+                                                <TextBlock Text="G" VerticalAlignment="Center"
+                                                           Foreground="#6dd28d" FontSize="11" FontWeight="SemiBold" />
+                                                <NumericUpDown x:Name="PropGreen" Grid.Column="1"
+                                                               Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                            </Grid>
+                                            <Grid Grid.Column="4" ColumnDefinitions="14,*">
+                                                <TextBlock Text="B" VerticalAlignment="Center"
+                                                           Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
+                                                <NumericUpDown x:Name="PropBlue" Grid.Column="1"
+                                                               Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                            </Grid>
+                                        </Grid>
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
 
                             <!-- ── Rectangle properties ── -->

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2409,6 +2409,9 @@ public partial class MainWindow : Window
         PropFrameLen.ValueChanged  += (_, _) => ApplyFrameLen();
         PropRelX.ValueChanged      += (_, _) => ApplyFrameRelative();
         PropRelY.ValueChanged      += (_, _) => ApplyFrameRelative();
+        PropRed.ValueChanged       += (_, _) => ApplyFrameColor();
+        PropGreen.ValueChanged     += (_, _) => ApplyFrameColor();
+        PropBlue.ValueChanged      += (_, _) => ApplyFrameColor();
         PropPixelX.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelY.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelW.ValueChanged    += (_, _) => ApplyFramePixelCoords();
@@ -2612,6 +2615,9 @@ public partial class MainWindow : Window
                 PropFrameLen.Value   = (decimal)frame.FrameLength;
                 PropRelX.Value       = (decimal)frame.RelativeX;
                 PropRelY.Value       = (decimal)frame.RelativeY;
+                PropRed.Value        = frame.Red.HasValue   ? frame.Red.Value   : (decimal?)null;
+                PropGreen.Value      = frame.Green.HasValue ? frame.Green.Value : (decimal?)null;
+                PropBlue.Value       = frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null;
                 PropTextureName.Text = TexturePathHelper.ComputeDisplayPath(
                     frame.TextureName, _projectManager.FileName);
 
@@ -2677,6 +2683,16 @@ public partial class MainWindow : Window
         var frame = _selectedState.SelectedFrame;
         if (frame is null || !PropRelX.Value.HasValue || !PropRelY.Value.HasValue) return;
         _appCommands.SetFrameRelative(frame, (float)PropRelX.Value.Value, (float)PropRelY.Value.Value);
+    }
+
+    private void ApplyFrameColor()
+    {
+        if (_suppressPropRefresh) return;
+        var frame = _selectedState.SelectedFrame;
+        if (frame is null) return;
+        // A blank NumericUpDown (null Value) means the channel is unset and is omitted from the .achx.
+        static int? ToChannel(decimal? v) => v.HasValue ? (int)v.Value : null;
+        _appCommands.SetFrameColor(frame, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
     }
 
     private void ApplyFramePixelCoords()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1042,6 +1042,14 @@ namespace AnimationEditor.Core.CommandsAndState
                 this, _events, true, desc));
         }
 
+        public void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue)
+        {
+            // Color is game-consumed and not previewed, so no wireframe refresh is needed.
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () => { frame.Red = red; frame.Green = green; frame.Blue = blue; },
+                this, _events, false, "Set Frame Color"));
+        }
+
         public void SetFramePixelRegion(AnimationFrameSave frame,
             int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -14,11 +14,13 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         AnimationFrameSave Frame,
         float FrameLength,
         float RelativeX, float RelativeY,
-        float Left, float Right, float Top, float Bottom)
+        float Left, float Right, float Top, float Bottom,
+        int? Red, int? Green, int? Blue)
     {
         public static FrameFieldSnapshot Capture(AnimationFrameSave f) =>
             new(f, f.FrameLength, f.RelativeX, f.RelativeY,
-                f.LeftCoordinate, f.RightCoordinate, f.TopCoordinate, f.BottomCoordinate);
+                f.LeftCoordinate, f.RightCoordinate, f.TopCoordinate, f.BottomCoordinate,
+                f.Red, f.Green, f.Blue);
 
         public void RestoreToFrame()
         {
@@ -29,6 +31,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             Frame.RightCoordinate  = Right;
             Frame.TopCoordinate    = Top;
             Frame.BottomCoordinate = Bottom;
+            Frame.Red              = Red;
+            Frame.Green            = Green;
+            Frame.Blue             = Blue;
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -133,6 +133,7 @@ namespace AnimationEditor.Core.CommandsAndState
 
         void SetFrameLength(AnimationFrameSave frame, float newLength);
         void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY);
+        void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue);
         void SetFramePixelRegion(AnimationFrameSave frame, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -7,6 +7,44 @@ namespace AnimationEditor.Core.Tests;
 [Collection("SequentialSingletons")]
 public class InspectorPropertyUndoTests
 {
+    // ── SetFrameColor ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameColor_Undo_RestoresChannels()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash");
+        var frame = TestHelpers.MakeFrame();
+        // Start with no authored color (all null).
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameColor(frame, 255, 200, 128);
+        Assert.True(ctx.UndoManager.CanUndo);
+        Assert.Equal(255, frame.Red);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Null(frame.Red);
+        Assert.Null(frame.Green);
+        Assert.Null(frame.Blue);
+    }
+
+    [Fact]
+    public void SetFrameColor_SameValues_DoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash");
+        var frame = TestHelpers.MakeFrame();
+        frame.Red = 255;
+        frame.Green = 200;
+        frame.Blue = 128;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameColor(frame, 255, 200, 128);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
     // ── SetFrameLength ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -98,6 +98,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetAllFramesTextureName)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameLength)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameRelative)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameColor)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFramePixelRegion)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.SetRectProps)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
@@ -271,6 +272,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetFrameLength(Zebra(ctx).Frames[0], 0.99f)));
         yield return Row(nameof(IAppCommands.SetFrameRelative),
             ctx => Sync(() => ctx.AppCommands.SetFrameRelative(Zebra(ctx).Frames[0], 99f, 88f)));
+        yield return Row(nameof(IAppCommands.SetFrameColor),
+            ctx => Sync(() => ctx.AppCommands.SetFrameColor(Zebra(ctx).Frames[0], 255, 200, 128)));
         yield return Row(nameof(IAppCommands.SetFramePixelRegion),
             ctx => Sync(() => ctx.AppCommands.SetFramePixelRegion(Zebra(ctx).Frames[0], 4, 8, 12, 16, 64, 64)));
         yield return Row(nameof(IAppCommands.SetRectProps),


### PR DESCRIPTION
## What

Adds optional per-frame **Red / Green / Blue** channels (`int?`, 0–255) to animation frames — authored in the Animation Editor, stored in the `.achx`, and surfaced to game code via a new `Sprite.CurrentFrame`.

Motivating use case: a car that flashes white before exploding. The artist wants per-frame color without baking tinted copies into the texture atlas. Rather than build the full FRB1-style `ColorOperation` system (custom shader + FRB2 runtime + XNA runtime), this is the minimal, **non-throwaway** first step.

## Key design decisions

- **`int?` 0–255, nullable.** `null` = unset, so null channels are **omitted from the `.achx`** — existing files stay byte-identical. 0–255 matches XNA `Color`, so the eventual real tint feature reads the same fields with no migration.
- **Game-consumed, not applied.** The engine/editor never apply these values. `Sprite.CurrentFrame` exposes the displayed `AnimationFrame`; game code reads `frame.Red/Green/Blue` and decides how to use them (e.g. lerp-to-white for a flash).
- **Explicit inspector framing.** Surfaced under a `GAME-CONSUMED (NOT PREVIEWED)` section with an in-panel note, so a fixed first-party field isn't mistaken for a broken/no-op control.
- **No FRB1 round-trip constraint.** FRB1's `AnimationFrameSave` has no color fields; opening an FRB2 color `.achx` in FRB1 simply drops the channels.

## Surfaces touched

- Engine: `AnimationFrameSave`, runtime `AnimationFrame`, `AnimationChainListSave` (write/parse/convert), `Sprite.CurrentFrame`.
- Editor: `AppCommands.SetFrameColor` (+ `IAppCommands`), `BulkFrameEditCommand` snapshot extended to cover color, inspector XAML + wiring.

## Tests (TDD — written failing first)

- `AnimationFrameColorTests` — serialization round-trip + null omission, Save→runtime copy, `Sprite.CurrentFrame`.
- `InspectorPropertyUndoTests` — `SetFrameColor` undo restore + no-op skip.
- `UndoCoverageRosterTests` — `SetFrameColor` categorized + round-trip invocation.

Full suites green: engine **1067**, editor Core **1207**, editor App **473**.

## Follow-ups (deliberately out of scope)

- The actual tint *operation* (Add / InterpolateTo) + shader + runtime application — the larger feature this steps toward.
- `Alpha` channel (trivial nullable add if per-frame opacity is wanted).
- Live in-editor preview of a color operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)