### PR TITLE
Per-frame ColorOperation (Multiply/Add) with live editor preview

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -13,6 +13,13 @@ tools/AnimationEditorAvalonia/
 
 > The legacy WinForms version (`FlatRedBall.AnimationEditorForms`) lives in the separate `FlatRedBall` (FRB1) repo at `FRBDK/FlatRedBall.AnimationEditorForms/`. Do **not** edit it for FRB2 issues — that codebase is being replaced. Issues filed in `vchelaru/FlatRedBall2` always refer to the Avalonia version.
 
+## `.achx` is a general-purpose format — the editor authors, runtimes interpret
+
+`.achx` is **not** an FRB2 file. It is a general-purpose animation/atlas format consumed by several runtimes that each render it their own way: Gum (across its Skia, raylib, and sokol.net backends), MonoGame/KNI/FNA, FRB1 (custom-shader rendering), and FRB2 (`SpriteBatch`). The editor authors the *format*; each runtime decides what to do with the data. This frames every feature decision here:
+
+- **A field the editor exposes does not obligate any runtime to apply it.** Store the data in the format; whether a given runtime renders it is that runtime's choice. Do not gate adding a frame field on FRB2 (or any single runtime) implementing it — e.g. per-frame `Red`/`Green`/`Blue` are authored and stored for game code to consume, while FRB2's `SpriteBatch` path never applies them itself.
+- **The preview is a reference rendering, not a per-runtime contract.** The bottom panel renders with SkiaSharp (`PreviewControl`, `SKCanvas`/`SKColorFilter` in `DrawFrameCore`), so it will diverge from what a MonoGame/FNA/FRB1 runtime produces for the same file. That divergence is inherent to a general-purpose tool and is not a bug — pick a sensible canonical interpretation. "The preview might not match a runtime" is never a reason to withhold an authoring feature.
+
 ## Project layout
 
 ```

--- a/src/Animation/AnimationFrame.cs
+++ b/src/Animation/AnimationFrame.cs
@@ -59,6 +59,13 @@ public class AnimationFrame
     public int? Blue;
 
     /// <summary>
+    /// Optional per-frame color operation for how <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/>
+    /// combine with the texture, or <c>null</c> for none. Not applied by the engine — read it (with the
+    /// channels) via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/> and apply it in game code.
+    /// </summary>
+    public ColorOperation? ColorOperation;
+
+    /// <summary>
     /// Per-frame shape definitions reconciled against the parent entity at frame switch time.
     /// Each entry must have a non-empty unique <see cref="AnimationShapeFrame.Name"/>. See
     /// <see cref="AnimationChainList"/> for the ownership rule that decides which entity shapes

--- a/src/Animation/ColorOperation.cs
+++ b/src/Animation/ColorOperation.cs
@@ -1,0 +1,17 @@
+namespace FlatRedBall2.Animation;
+
+/// <summary>
+/// How a frame's per-frame color (<see cref="AnimationFrame.Red"/>/<see cref="AnimationFrame.Green"/>/
+/// <see cref="AnimationFrame.Blue"/>) combines with the sprite's texture. A <c>null</c> operation
+/// means none. Like the channels themselves, this is authored in the Animation Editor and stored in
+/// the <c>.achx</c>, but whether a given runtime applies it is that runtime's choice — the <c>.achx</c>
+/// is a general-purpose format consumed by several renderers (Gum, MonoGame/FNA, FRB1, FRB2).
+/// </summary>
+public enum ColorOperation
+{
+    /// <summary>Multiply the texture by the color (darken / colorize). White is the identity.</summary>
+    Multiply,
+
+    /// <summary>Add the color to the texture (brighten / glow / flash). Black is the identity.</summary>
+    Add,
+}

--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -207,6 +207,7 @@ public class AnimationChainListSave
         if (frame.Red.HasValue) el.Add(new XElement("Red", frame.Red.Value));
         if (frame.Green.HasValue) el.Add(new XElement("Green", frame.Green.Value));
         if (frame.Blue.HasValue) el.Add(new XElement("Blue", frame.Blue.Value));
+        if (frame.ColorOperation.HasValue) el.Add(new XElement("ColorOperation", frame.ColorOperation.Value.ToString()));
 
         if (frame.HasCustomName && !string.IsNullOrEmpty(frame.Name))
         {
@@ -285,6 +286,7 @@ public class AnimationChainListSave
         frame.Red = IntElNullable(el, "Red");
         frame.Green = IntElNullable(el, "Green");
         frame.Blue = IntElNullable(el, "Blue");
+        frame.ColorOperation = ColorOperationEl(el, "ColorOperation");
         frame.Name = (string?)el.Element("Name") ?? string.Empty;
         frame.HasCustomName = BoolEl(el, "HasCustomName");
 
@@ -437,6 +439,12 @@ public class AnimationChainListSave
         return el != null ? int.Parse(el.Value, CultureInfo.InvariantCulture) : null;
     }
 
+    private static ColorOperation? ColorOperationEl(XElement parent, string name)
+    {
+        var el = parent.Element(name);
+        return el != null ? Enum.Parse<ColorOperation>(el.Value) : null;
+    }
+
     /// <summary>
     /// Converts this save object to a runtime <see cref="AnimationChainList"/>, loading
     /// all referenced textures through <see cref="ContentLoader.Load{T}"/>.
@@ -488,6 +496,7 @@ public class AnimationChainListSave
                     Red = frameSave.Red,
                     Green = frameSave.Green,
                     Blue = frameSave.Blue,
+                    ColorOperation = frameSave.ColorOperation,
                 };
 
                 frame.Texture = loadTexture(frameSave);

--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -50,6 +50,13 @@ public class AnimationFrameSave
     public int? Blue;
 
     /// <summary>
+    /// Optional per-frame color operation describing how <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/>
+    /// combine with the texture. <c>null</c> (the default) means none and is omitted from the saved
+    /// <c>.achx</c>. Like the channels, runtimes interpret this as they choose. See <see cref="FlatRedBall2.Animation.ColorOperation"/>.
+    /// </summary>
+    public ColorOperation? ColorOperation;
+
+    /// <summary>
     /// User-visible display label for this frame in the Animation Editor tree.
     /// Only meaningful when <see cref="HasCustomName"/> is <c>true</c>; when
     /// <c>false</c> the editor shows a dynamic position-based label ("Frame N")

--- a/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
@@ -31,6 +31,32 @@ public class AnimationFrameColorTests
     }
 
     [Fact]
+    public void Save_ThenFromFile_RoundTripsColorOperationAndOmitsNull()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Flash" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", ColorOperation = ColorOperation.Add });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png" }); // no operation -> element omitted
+        save.AnimationChains.Add(chain);
+
+        var path = Path.Combine(Path.GetTempPath(), $"frbcolorop_{Guid.NewGuid():N}.achx");
+        try
+        {
+            save.Save(path);
+            // Only the first frame authored an operation; the null frame must omit the element.
+            (File.ReadAllText(path).Split("<ColorOperation>").Length - 1).ShouldBe(1);
+
+            var frames = AnimationChainListSave.FromFile(path).AnimationChains[0].Frames;
+            frames[0].ColorOperation.ShouldBe(ColorOperation.Add);
+            frames[1].ColorOperation.ShouldBeNull();
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Save_ThenFromFile_RoundTripsSetChannelsAndOmitsNullChannel()
     {
         // Red and Blue are authored; Green is left null to prove null channels are not written.
@@ -71,5 +97,18 @@ public class AnimationFrameColorTests
         frame.Red.ShouldBe(255);
         frame.Green.ShouldBe(200);
         frame.Blue.ShouldBe(128);
+    }
+
+    [Fact]
+    public void ToAnimationChainList_CopiesColorOperationToRuntimeFrame()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Flash" };
+        chain.Frames.Add(new AnimationFrameSave { ColorOperation = ColorOperation.Multiply });
+        save.AnimationChains.Add(chain);
+
+        var frame = save.ToAnimationChainList(null!)[0][0];
+
+        frame.ColorOperation.ShouldBe(ColorOperation.Multiply);
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1716,8 +1716,9 @@ public class PreviewControl : Control
             Color = new SKColor(255, 255, 255, (byte)(255 * alpha))
         };
         // Reference render of the frame's color operation; runtimes apply it however they choose.
-        if (FrameColorFilter.Resolve(frame.ColorOperation, frame.Red, frame.Green, frame.Blue) is { } f)
-            paint.ColorFilter = SKColorFilter.CreateBlendMode(f.Color, f.Mode);
+        using var colorFilter = FrameColorFilter.Create(frame.ColorOperation, frame.Red, frame.Green, frame.Blue);
+        if (colorFilter is not null)
+            paint.ColorFilter = colorFilter;
         var sampling = zoom >= 1
             ? new SKSamplingOptions(SKFilterMode.Nearest)
             : new SKSamplingOptions(SKFilterMode.Linear);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1715,6 +1715,9 @@ public class PreviewControl : Control
         {
             Color = new SKColor(255, 255, 255, (byte)(255 * alpha))
         };
+        // Reference render of the frame's color operation; runtimes apply it however they choose.
+        if (FrameColorFilter.Resolve(frame.ColorOperation, frame.Red, frame.Green, frame.Blue) is { } f)
+            paint.ColorFilter = SKColorFilter.CreateBlendMode(f.Color, f.Mode);
         var sampling = zoom >= 1
             ? new SKSamplingOptions(SKFilterMode.Nearest)
             : new SKSamplingOptions(SKFilterMode.Linear);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FrameColorFilter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FrameColorFilter.cs
@@ -4,26 +4,37 @@ using SkiaSharp;
 namespace AnimationEditor.App;
 
 /// <summary>
-/// Maps a frame's <see cref="ColorOperation"/> + per-channel R/G/B to the SkiaSharp blend the preview
-/// applies. This is the editor's <em>reference</em> interpretation of the operation — runtimes that
-/// consume the same <c>.achx</c> render it however they choose (see the animation-editor skill).
+/// Maps a frame's <see cref="ColorOperation"/> + per-channel R/G/B to the SkiaSharp <c>SKColorFilter</c>
+/// the preview applies. This is the editor's <em>reference</em> interpretation of the operation — runtimes
+/// that consume the same <c>.achx</c> render it however they choose (see the animation-editor skill).
 /// </summary>
 public static class FrameColorFilter
 {
     /// <summary>
-    /// Returns the (blend mode, color) to build an <c>SKColorFilter</c> from, or <c>null</c> when
-    /// <paramref name="operation"/> is <c>null</c> (no color effect). Unset channels default to each
-    /// operation's identity — 255 for Multiply (×1), 0 for Add (+0) — so a partially-authored color
-    /// only affects the channels the artist set. Add uses alpha 0 so a flash never forces opacity.
+    /// Returns the <c>SKColorFilter</c> to assign to a paint, or <c>null</c> when <paramref name="operation"/>
+    /// is <c>null</c> (no color effect). Unset channels default to each operation's identity — 255 for
+    /// Multiply (×1), 0 for Add (+0) — so a partially-authored color only affects the channels the artist set.
     /// </summary>
-    public static (SKBlendMode Mode, SKColor Color)? Resolve(ColorOperation? operation, int? r, int? g, int? b)
+    public static SKColorFilter? Create(ColorOperation? operation, int? r, int? g, int? b)
     {
         switch (operation)
         {
             case ColorOperation.Multiply:
-                return (SKBlendMode.Modulate, new SKColor((byte)(r ?? 255), (byte)(g ?? 255), (byte)(b ?? 255), 255));
+                return SKColorFilter.CreateBlendMode(
+                    new SKColor((byte)(r ?? 255), (byte)(g ?? 255), (byte)(b ?? 255), 255),
+                    SKBlendMode.Modulate);
             case ColorOperation.Add:
-                return (SKBlendMode.Plus, new SKColor((byte)(r ?? 0), (byte)(g ?? 0), (byte)(b ?? 0), 0));
+                // A Plus blend can't do this: it blends in premultiplied space, so an alpha-0 color adds
+                // nothing, and an alpha-255 color would also add to alpha and force the sprite opaque.
+                // A color matrix adds the channel offsets to RGB and leaves the alpha row as identity.
+                // SkiaSharp's matrix works in normalized [0,1] space, so offsets are channel/255.
+                return SKColorFilter.CreateColorMatrix(new[]
+                {
+                    1f, 0f, 0f, 0f, (r ?? 0) / 255f,
+                    0f, 1f, 0f, 0f, (g ?? 0) / 255f,
+                    0f, 0f, 1f, 0f, (b ?? 0) / 255f,
+                    0f, 0f, 0f, 1f, 0f,
+                });
             default:
                 return null;
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FrameColorFilter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FrameColorFilter.cs
@@ -1,0 +1,31 @@
+using FlatRedBall2.Animation;
+using SkiaSharp;
+
+namespace AnimationEditor.App;
+
+/// <summary>
+/// Maps a frame's <see cref="ColorOperation"/> + per-channel R/G/B to the SkiaSharp blend the preview
+/// applies. This is the editor's <em>reference</em> interpretation of the operation — runtimes that
+/// consume the same <c>.achx</c> render it however they choose (see the animation-editor skill).
+/// </summary>
+public static class FrameColorFilter
+{
+    /// <summary>
+    /// Returns the (blend mode, color) to build an <c>SKColorFilter</c> from, or <c>null</c> when
+    /// <paramref name="operation"/> is <c>null</c> (no color effect). Unset channels default to each
+    /// operation's identity — 255 for Multiply (×1), 0 for Add (+0) — so a partially-authored color
+    /// only affects the channels the artist set. Add uses alpha 0 so a flash never forces opacity.
+    /// </summary>
+    public static (SKBlendMode Mode, SKColor Color)? Resolve(ColorOperation? operation, int? r, int? g, int? b)
+    {
+        switch (operation)
+        {
+            case ColorOperation.Multiply:
+                return (SKBlendMode.Modulate, new SKColor((byte)(r ?? 255), (byte)(g ?? 255), (byte)(b ?? 255), 255));
+            case ColorOperation.Add:
+                return (SKBlendMode.Plus, new SKColor((byte)(r ?? 0), (byte)(g ?? 0), (byte)(b ?? 0), 0));
+            default:
+                return null;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1027,18 +1027,28 @@
                                     </StackPanel>
                                 </Border>
 
-                                <!-- GAME-CONSUMED section: per-frame values the engine stores but never applies -->
+                                <!-- COLOR section: per-frame tint. Mode previews as a reference; runtimes apply it as they choose. -->
                                 <Border BorderBrush="{DynamicResource LineBrush}"
                                         BorderThickness="0,0,0,1"
                                         Padding="12,8,12,10">
                                     <StackPanel Spacing="8">
-                                        <TextBlock Text="GAME-CONSUMED (NOT PREVIEWED)"
+                                        <TextBlock Text="COLOR"
                                                    FontSize="11"
                                                    FontWeight="SemiBold"
                                                    Foreground="{DynamicResource InkMid}" />
                                         <TextBlock TextWrapping="Wrap" FontSize="10"
                                                    Foreground="{DynamicResource InkDim}"
-                                                   Text="Saved per-frame but not applied by the editor or engine. Your game reads sprite.CurrentFrame (Red/Green/Blue) and decides how to use them. Leave a field blank to omit it." />
+                                                   Text="Mode previews here as a reference; each runtime decides how to apply these. Your game can also read R/G/B from sprite.CurrentFrame. Leave a field blank to omit it." />
+                                        <Grid ColumnDefinitions="44,*">
+                                            <TextBlock Text="Mode" VerticalAlignment="Center"
+                                                       Foreground="{DynamicResource InkMid}" FontSize="11" />
+                                            <ComboBox x:Name="PropColorMode" Grid.Column="1"
+                                                      HorizontalAlignment="Stretch">
+                                                <ComboBoxItem>None</ComboBoxItem>
+                                                <ComboBoxItem>Multiply</ComboBoxItem>
+                                                <ComboBoxItem>Add</ComboBoxItem>
+                                            </ComboBox>
+                                        </Grid>
                                         <Grid ColumnDefinitions="*,6,*,6,*">
                                             <Grid Grid.Column="0" ColumnDefinitions="14,*">
                                                 <TextBlock Text="R" VerticalAlignment="Center"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -19,6 +19,7 @@ using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using Avalonia.Threading;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using System;
@@ -2456,6 +2457,7 @@ public partial class MainWindow : Window
         PropRed.ValueChanged       += (_, _) => ApplyFrameColor();
         PropGreen.ValueChanged     += (_, _) => ApplyFrameColor();
         PropBlue.ValueChanged      += (_, _) => ApplyFrameColor();
+        PropColorMode.SelectionChanged += (_, _) => ApplyFrameColorOperation();
         PropPixelX.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelY.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelW.ValueChanged    += (_, _) => ApplyFramePixelCoords();
@@ -2662,6 +2664,12 @@ public partial class MainWindow : Window
                 PropRed.Value        = frame.Red.HasValue   ? frame.Red.Value   : (decimal?)null;
                 PropGreen.Value      = frame.Green.HasValue ? frame.Green.Value : (decimal?)null;
                 PropBlue.Value       = frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null;
+                PropColorMode.SelectedIndex = frame.ColorOperation switch
+                {
+                    ColorOperation.Multiply => 1,
+                    ColorOperation.Add      => 2,
+                    _                       => 0, // None / null
+                };
                 PropTextureName.Text = TexturePathHelper.ComputeDisplayPath(
                     frame.TextureName, _projectManager.FileName);
 
@@ -2737,6 +2745,21 @@ public partial class MainWindow : Window
         // A blank NumericUpDown (null Value) means the channel is unset and is omitted from the .achx.
         static int? ToChannel(decimal? v) => v.HasValue ? (int)v.Value : null;
         _appCommands.SetFrameColor(frame, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
+    }
+
+    private void ApplyFrameColorOperation()
+    {
+        if (_suppressPropRefresh) return;
+        var frame = _selectedState.SelectedFrame;
+        if (frame is null) return;
+        // ComboBox order: 0 = None (null), 1 = Multiply, 2 = Add.
+        ColorOperation? operation = PropColorMode.SelectedIndex switch
+        {
+            1 => ColorOperation.Multiply,
+            2 => ColorOperation.Add,
+            _ => null,
+        };
+        _appCommands.SetFrameColorOperation(frame, operation);
     }
 
     private void ApplyFramePixelCoords()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -2,6 +2,7 @@
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Rendering;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
@@ -1048,6 +1049,14 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => { frame.Red = red; frame.Green = green; frame.Blue = blue; },
                 this, _events, false, "Set Frame Color"));
+        }
+
+        public void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation)
+        {
+            // Mode is game-consumed; not previewed by the engine, so no wireframe refresh is needed.
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () => frame.ColorOperation = operation,
+                this, _events, false, "Set Frame Color Mode"));
         }
 
         public void SetFramePixelRegion(AnimationFrameSave frame,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -1,3 +1,4 @@
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
@@ -15,12 +16,13 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         float FrameLength,
         float RelativeX, float RelativeY,
         float Left, float Right, float Top, float Bottom,
-        int? Red, int? Green, int? Blue)
+        int? Red, int? Green, int? Blue,
+        ColorOperation? ColorOperation)
     {
         public static FrameFieldSnapshot Capture(AnimationFrameSave f) =>
             new(f, f.FrameLength, f.RelativeX, f.RelativeY,
                 f.LeftCoordinate, f.RightCoordinate, f.TopCoordinate, f.BottomCoordinate,
-                f.Red, f.Green, f.Blue);
+                f.Red, f.Green, f.Blue, f.ColorOperation);
 
         public void RestoreToFrame()
         {
@@ -34,6 +36,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             Frame.Red              = Red;
             Frame.Green            = Green;
             Frame.Blue             = Blue;
+            Frame.ColorOperation   = ColorOperation;
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Rendering;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
@@ -134,6 +135,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetFrameLength(AnimationFrameSave frame, float newLength);
         void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY);
         void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue);
+        void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation);
         void SetFramePixelRegion(AnimationFrameSave frame, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
@@ -5,35 +5,83 @@ using Xunit;
 
 namespace AnimationEditor.App.Tests;
 
-// FrameColorFilter is the pure mapping from a frame's ColorOperation + RGB to a SkiaSharp blend filter.
-// It is the testable core of the preview's color rendering; DrawFrameCore is the thin wiring on top.
+// FrameColorFilter maps a frame's ColorOperation + RGB to the SkiaSharp SKColorFilter the preview applies.
+// These tests run the resulting filter through Skia's real raster pipeline and read the pixel back, so they
+// verify the *rendered* effect — a filter that builds without error but is a visual no-op (the Add bug:
+// Plus blend on a premultiplied alpha-0 color) still fails here. Pixels are fully opaque so premultiplied
+// readback equals straight color (no rounding), and no color space is set so blends use the raw byte values.
 public class FrameColorFilterTests
 {
-    [Fact]
-    public void Resolve_NullOperation_ReturnsNull()
+    private static SKColor Apply(SKColorFilter? filter, SKColor input)
     {
-        Assert.Null(FrameColorFilter.Resolve(null, 255, 0, 0));
+        var info = new SKImageInfo(1, 1, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var surface = SKSurface.Create(info);
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+        using var paint = new SKPaint { Color = input, ColorFilter = filter, IsAntialias = false };
+        canvas.DrawRect(new SKRect(0, 0, 1, 1), paint);
+        canvas.Flush();
+        using var image = surface.Snapshot();
+        using var bmp = SKBitmap.FromImage(image);
+        return bmp.GetPixel(0, 0);
     }
 
     [Fact]
-    public void Resolve_Multiply_UsesModulateAndDefaultsUnsetChannelsTo255()
+    public void Create_NullOperation_ReturnsNull()
     {
-        // 255 is the multiply identity, so an unset channel leaves that channel untouched.
-        var result = FrameColorFilter.Resolve(ColorOperation.Multiply, 128, null, 64);
+        Assert.Null(FrameColorFilter.Create(null, 255, 0, 0));
+    }
 
-        Assert.NotNull(result);
-        Assert.Equal(SKBlendMode.Modulate, result.Value.Mode);
-        Assert.Equal(new SKColor(128, 255, 64, 255), result.Value.Color);
+    private static void AssertNear(int expected, byte actual) =>
+        Assert.InRange((int)actual, expected - 1, expected + 1);
+
+    [Fact]
+    public void Create_Multiply_ScalesEachChannelAndLeavesAlpha()
+    {
+        // 255 is the multiply identity, so an unset channel (green) is left untouched.
+        using var filter = FrameColorFilter.Create(ColorOperation.Multiply, 128, null, 64);
+        var result = Apply(filter, new SKColor(128, 128, 128, 255));
+
+        AssertNear(64, result.Red);    // 128 * 128/255
+        AssertNear(128, result.Green); // 128 * 255/255 (unset = identity)
+        AssertNear(32, result.Blue);   // 128 * 64/255
+        Assert.Equal(255, result.Alpha);
     }
 
     [Fact]
-    public void Resolve_Add_UsesPlusAndDefaultsUnsetChannelsTo0WithZeroAlpha()
+    public void Create_Add_BrightensAndClampsWithoutTouchingAlpha()
     {
-        // 0 is the add identity; alpha 0 so an additive flash never forces the sprite opaque.
-        var result = FrameColorFilter.Resolve(ColorOperation.Add, 200, null, null);
+        // 0 is the add identity, so an unset channel (green/blue) adds nothing.
+        using var filter = FrameColorFilter.Create(ColorOperation.Add, 200, null, null);
+        var result = Apply(filter, new SKColor(100, 100, 100, 255));
 
-        Assert.NotNull(result);
-        Assert.Equal(SKBlendMode.Plus, result.Value.Mode);
-        Assert.Equal(new SKColor(200, 0, 0, 0), result.Value.Color);
+        AssertNear(255, result.Red);   // 100 + 200 clamps to 255
+        AssertNear(100, result.Green); // unset = +0
+        AssertNear(100, result.Blue);  // unset = +0
+        Assert.Equal(255, result.Alpha); // Add must never change alpha
+    }
+
+    [Fact]
+    public void Create_Add_AddsExactValueWhenNoClamp()
+    {
+        // Non-clamping case pins the additive math: 50 + 100 = 150, proving the offset is the literal
+        // channel value (not zeroed by premultiplication, the original Plus-blend bug).
+        using var filter = FrameColorFilter.Create(ColorOperation.Add, 100, 0, 0);
+        var result = Apply(filter, new SKColor(50, 50, 50, 255));
+
+        AssertNear(150, result.Red);
+        AssertNear(50, result.Green);
+        AssertNear(50, result.Blue);
+        Assert.Equal(255, result.Alpha);
+    }
+
+    [Fact]
+    public void Create_Add_PreservesPartialAlpha()
+    {
+        // A semi-transparent sprite stays semi-transparent under an additive flash.
+        using var filter = FrameColorFilter.Create(ColorOperation.Add, 200, 0, 0);
+        var result = Apply(filter, new SKColor(100, 100, 100, 128));
+
+        AssertNear(128, result.Alpha);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
@@ -1,0 +1,39 @@
+using AnimationEditor.App;
+using FlatRedBall2.Animation;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+// FrameColorFilter is the pure mapping from a frame's ColorOperation + RGB to a SkiaSharp blend filter.
+// It is the testable core of the preview's color rendering; DrawFrameCore is the thin wiring on top.
+public class FrameColorFilterTests
+{
+    [Fact]
+    public void Resolve_NullOperation_ReturnsNull()
+    {
+        Assert.Null(FrameColorFilter.Resolve(null, 255, 0, 0));
+    }
+
+    [Fact]
+    public void Resolve_Multiply_UsesModulateAndDefaultsUnsetChannelsTo255()
+    {
+        // 255 is the multiply identity, so an unset channel leaves that channel untouched.
+        var result = FrameColorFilter.Resolve(ColorOperation.Multiply, 128, null, 64);
+
+        Assert.NotNull(result);
+        Assert.Equal(SKBlendMode.Modulate, result.Value.Mode);
+        Assert.Equal(new SKColor(128, 255, 64, 255), result.Value.Color);
+    }
+
+    [Fact]
+    public void Resolve_Add_UsesPlusAndDefaultsUnsetChannelsTo0WithZeroAlpha()
+    {
+        // 0 is the add identity; alpha 0 so an additive flash never forces the sprite opaque.
+        var result = FrameColorFilter.Resolve(ColorOperation.Add, 200, null, null);
+
+        Assert.NotNull(result);
+        Assert.Equal(SKBlendMode.Plus, result.Value.Mode);
+        Assert.Equal(new SKColor(200, 0, 0, 0), result.Value.Color);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using Xunit;
 
@@ -41,6 +42,39 @@ public class InspectorPropertyUndoTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.SetFrameColor(frame, 255, 200, 128);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── SetFrameColorOperation ────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameColorOperation_Undo_RestoresOperation()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash");
+        var frame = TestHelpers.MakeFrame(); // starts with null operation
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameColorOperation(frame, ColorOperation.Add);
+        Assert.True(ctx.UndoManager.CanUndo);
+        Assert.Equal(ColorOperation.Add, frame.ColorOperation);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Null(frame.ColorOperation);
+    }
+
+    [Fact]
+    public void SetFrameColorOperation_SameValue_DoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash");
+        var frame = TestHelpers.MakeFrame();
+        frame.ColorOperation = ColorOperation.Multiply;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameColorOperation(frame, ColorOperation.Multiply);
 
         Assert.False(ctx.UndoManager.CanUndo);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
@@ -99,6 +100,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetFrameLength)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameRelative)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameColor)]                = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameColorOperation)]       = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFramePixelRegion)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.SetRectProps)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
@@ -274,6 +276,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetFrameRelative(Zebra(ctx).Frames[0], 99f, 88f)));
         yield return Row(nameof(IAppCommands.SetFrameColor),
             ctx => Sync(() => ctx.AppCommands.SetFrameColor(Zebra(ctx).Frames[0], 255, 200, 128)));
+        yield return Row(nameof(IAppCommands.SetFrameColorOperation),
+            ctx => Sync(() => ctx.AppCommands.SetFrameColorOperation(Zebra(ctx).Frames[0], ColorOperation.Add)));
         yield return Row(nameof(IAppCommands.SetFramePixelRegion),
             ctx => Sync(() => ctx.AppCommands.SetFramePixelRegion(Zebra(ctx).Frames[0], 4, 8, 12, 16, 64, 64)));
         yield return Row(nameof(IAppCommands.SetRectProps),


### PR DESCRIPTION
## What

Adds a per-frame **color operation** to animation frames — `Multiply` or `Add` — authored in the Animation Editor and rendered **live in the preview**. Builds on the per-frame RGB from #434.

## Design (per the constraints discussed)

- **`ColorOperation { Multiply, Add }`**, stored as a nullable `ColorOperation?` on the frame. **null = None**, omitted from the `.achx` so untinted files stay byte-identical (matches the nullable RGB ints).
- **Per-frame**, **hard-snap** — no interpolation between frames.
- **Editor:** a `Mode` dropdown (None / Multiply / Add) + R/G/B in the inspector's `COLOR` section, undoable via a new `SetFrameColorOperation` command. The preview renders the operation via SkiaSharp `SKColorFilter` (`Modulate` / `Plus`); unset channels default to each operation's identity (255 for Multiply, 0 for Add).
- **Reference, not contract.** Per the general-purpose-format principle (now in the `animation-editor` skill), the editor previews a *reference* interpretation. Each runtime — Gum, MonoGame/FNA, FRB1, FRB2 — applies the operation however it chooses. FRB2's `SpriteBatch` path does **not** apply it; game code reads `Sprite.CurrentFrame`.

## Why Multiply + Add (and not InterpolateTo)

They consume the existing per-frame R/G/B directly with no new field, are one-line Skia blends, and cover darken/colorize + brighten/glow. InterpolateTo would need a separate amount scalar (a 4th channel) — deferred until a case needs clean partial tinting.

## Surfaces

- Engine: `ColorOperation` enum, `ColorOperation?` on `AnimationFrameSave` + runtime `AnimationFrame`, serialize/parse/convert in `AnimationChainListSave`.
- Editor: `SetFrameColorOperation` (+ `IAppCommands`), `BulkFrameEditCommand` snapshot extended, inspector ComboBox + wiring, `FrameColorFilter` mapping, `PreviewControl.DrawFrameCore` applies it.

## Tests (TDD — failing first)

- `AnimationFrameColorTests` — serialization round-trip + null omission, Save→runtime copy.
- `InspectorPropertyUndoTests` — `SetFrameColorOperation` undo + no-op skip.
- `UndoCoverageRosterTests` — categorized + round-trip invocation.
- `FrameColorFilterTests` — the pure `ColorOperation?`+RGB → Skia blend mapping (testable core of the preview).

Full suites green: engine **1069**, editor Core **1224**, editor App **467**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)