### PR TITLE
Isolate AnimationEditor App tests from real %APPDATA% settings (#438)

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -75,6 +75,10 @@ Tests build their own fresh graph per test via `TestHelpers.BuildServices()` (Ap
 
 When constructing an Avalonia control directly (`WireframeControl` / `PreviewControl`) — because Avalonia requires a parameterless constructor for XAML — call `ctx.CreateWireframeControl()` / `ctx.CreatePreviewControl()`, which wraps `new WireframeControl()` and `InitializeServices(...)` so the control's injected fields are populated before any method runs.
 
+## Tests must never write the developer's real settings
+
+`MainWindow` persists app settings (recent files, open tabs, theme) to `%APPDATA%\AnimationEditor\AESettings.json` in its `Closed` handler. A headless test that constructs and closes a window would otherwise overwrite the developer's real settings with test fixtures (issue #438). The application-data root is a `MainWindow` constructor parameter precisely so tests can redirect it: `ctx.CreateMainWindow()` passes `ctx.SettingsRoot` (a unique temp dir), while production (`App.axaml.cs`) passes `Environment.GetFolderPath(SpecialFolder.ApplicationData)`. Build the window through `ctx.CreateMainWindow()` — never reconstruct one with the production root in a test. General rule: any component that reads or writes a real per-user location (config, registry, recent-files) takes its root as an injected dependency, so tests land in temp and never on real user data.
+
 ## Cross-platform path operations — use `FilePath`, not `System.IO.Path`
 
 **Never use `System.IO.Path.GetFileName`, `Path.GetDirectoryName`, or `Path.Combine` on paths stored in `ProjectManager.FileName` or any user-supplied path.** These methods are OS-native: on Linux they only recognise `/` as a separator, so a Windows-authored `C:\foo\bar.achx` path would be returned whole by `Path.GetFileName`.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -190,7 +190,8 @@ public partial class App : Application
             sp.GetRequiredService<IObjectFinder>(),
             sp.GetRequiredService<IUndoManager>(),
             sp.GetRequiredService<ThumbnailService>(),
-            sp.GetRequiredService<IFileAssociationService>()));
+            sp.GetRequiredService<IFileAssociationService>(),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)));
 
         return sc.BuildServiceProvider();
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -68,12 +68,16 @@ public partial class MainWindow : Window
     private bool _suppressInterpolateSync;
     private System.Threading.CancellationTokenSource? _toastCts;
 
+    // The platform application-data root under which settings live. Injected (not read from
+    // Environment here) so headless tests can redirect it to a temp dir and never touch the
+    // developer's real %APPDATA%\AnimationEditor\AESettings.json (see issue #438).
+    private readonly string _applicationDataRoot;
+
     // Shared per-user config dir, NOT the build output — so recent files / tabs / theme survive
     // rebuilds, dotnet clean, and switching git worktrees (see issue #424). AppContext.BaseDirectory
     // resolves to bin/<Config>/<TFM>/, which is per-build / per-checkout.
     private FilePath SettingsFilePath =>
-        AppSettingsLocation.ForApplicationDataRoot(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+        AppSettingsLocation.ForApplicationDataRoot(_applicationDataRoot);
 
     public MainWindow(
         IProjectManager projectManager,
@@ -85,8 +89,11 @@ public partial class MainWindow : Window
         IObjectFinder objectFinder,
         IUndoManager undoManager,
         Services.ThumbnailService thumbnailService,
-        IFileAssociationService fileAssociation)
+        IFileAssociationService fileAssociation,
+        string applicationDataRoot)
     {
+        _applicationDataRoot = applicationDataRoot;
+
         _projectManager = projectManager;
         _selectedState = selectedState;
         _appCommands = appCommands;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsFileIsolationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsFileIsolationTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression guard for issue #438: headless App tests must never read or write the
+/// developer's real %APPDATA%\AnimationEditor\AESettings.json. Each <see cref="TestServices"/>
+/// owns a unique temp settings root, so constructing and closing a <see cref="MainWindow"/>
+/// persists settings there — leaving the production location untouched.
+/// </summary>
+public class SettingsFileIsolationTests
+{
+    [AvaloniaFact]
+    public void Close_PersistsSettingsUnderInjectedRoot_NotProductionAppData()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var expectedFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        window.Close();   // triggers SaveTabsToSettings -> SaveSettingsFile
+
+        // The save landed under the injected test root. If MainWindow still resolved the
+        // production %APPDATA% path, nothing would appear here.
+        Assert.True(File.Exists(expectedFile.FullPath),
+            $"Expected settings to be saved under the injected test root at {expectedFile.FullPath}");
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -25,6 +25,14 @@ internal sealed class TestServices
     public ThumbnailService ThumbnailService { get; }
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
 
+    /// <summary>
+    /// Unique-per-instance temp application-data root. Injected into the <see cref="MainWindow"/>
+    /// so its settings file resolves under here instead of the developer's real %APPDATA%
+    /// (issue #438). A fresh Guid also isolates tests from one another.
+    /// </summary>
+    public string SettingsRoot { get; } =
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), "AnimationEditorTests", System.Guid.NewGuid().ToString("N"));
+
     public TestServices()
     {
         ProjectManager    = new ProjectManager();
@@ -43,7 +51,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, ThumbnailService,
-            FileAssociationService);
+            FileAssociationService, SettingsRoot);
 
     public WireframeControl CreateWireframeControl()
     {


### PR DESCRIPTION
## Problem

Every `dotnet test` against `AnimationEditor.App.Tests` overwrote the developer's real editor settings at `%APPDATA%\AnimationEditor\AESettings.json`. ~60 headless tests construct a `MainWindow` via `ctx.CreateMainWindow()`; its `Closed` handler calls `SaveTabsToSettings()` → `SaveSettingsFile()`, persisting that test's in-memory `_appSettings` to the **production** location. Recent files / open tabs / theme got wiped or replaced with test fixtures (`%TEMP%\file0.achx`…).

## Root cause

`MainWindow.SettingsFilePath` hardcoded `Environment.GetFolderPath(SpecialFolder.ApplicationData)` — no test seam.

## Fix

Inject the application-data **root** into `MainWindow`:
- Production (`App.axaml.cs` DI) passes `Environment.GetFolderPath(SpecialFolder.ApplicationData)`.
- `TestServices` passes a unique per-instance temp dir (`SettingsRoot`), which also isolates tests from one another.

Path resolution still flows through the already-unit-tested `AppSettingsLocation.ForApplicationDataRoot(root)`, so both prod and test exercise the same code.

## TDD

`SettingsFileIsolationTests.Close_PersistsSettingsUnderInjectedRoot_NotProductionAppData` — constructs + closes a window and asserts the settings file lands under the injected temp root. Written first; failed to compile against the old constructor (red), passes after the fix (green). Full App.Tests suite: **470 passed**.

## Skill update

Per the request to make file-writing guidance wary of clobbering production files, added a gotcha to the `animation-editor` skill: tests must build windows through `ctx.CreateMainWindow()`, and — generalized — any component touching a real per-user location (config, registry, recent-files) must take its root as an injected dependency so tests land in temp.

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)