### PR TITLE
Persist Animation Editor tab session on change, not just on close (#439)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -148,6 +148,11 @@ public partial class MainWindow : Window
     private void WireTabBar()
     {
         _tabManager.ActiveChanged += _ => Dispatcher.UIThread.InvokeAsync(RebuildTabStrip);
+        // Persist the open-tab session on every change (open / switch / close / reorder), not just
+        // on graceful window close — a debugger Stop or crash never fires Closed and would otherwise
+        // lose the session (issue #439). Called synchronously so the write lands before any kill;
+        // SaveTabsToSettings only reads tab state and writes a file, touching no UI controls.
+        _tabManager.TabsChanged += SaveTabsToSettings;
     }
 
     private void RebuildTabStrip()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -34,6 +34,15 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public event Action<TabEntry?>? ActiveChanged;
 
+        /// <summary>
+        /// Raised whenever the open-tab set changes in a way worth persisting: a tab is opened,
+        /// focused, activated, closed, moved, renamed, registered, or the whole list is restored.
+        /// Unlike <see cref="ActiveChanged"/> this also fires for changes that leave
+        /// <see cref="ActiveTab"/> untouched — closing a background tab or reordering — so session
+        /// persistence can save on every change instead of only on graceful window close (issue #439).
+        /// </summary>
+        public event Action? TabsChanged;
+
     /// <summary>
     /// Opens <paramref name="path"/> as a new tab with an optional display-name override,
     /// or focuses its existing tab if it is already open.
@@ -44,12 +53,14 @@ namespace AnimationEditor.Core.Models
         if (existing != null)
         {
             SetActive(existing);
+            RaiseTabsChanged();
             return TabOpenResult.Focused;
         }
 
         var entry = new TabEntry(path, displayNameOverride);
         _tabs.Add(entry);
         SetActive(entry);
+        RaiseTabsChanged();
         return TabOpenResult.Opened;
     }
 
@@ -85,7 +96,10 @@ namespace AnimationEditor.Core.Models
         {
             var tab = FindTab(path);
             if (tab != null)
+            {
                 SetActive(tab);
+                RaiseTabsChanged();
+            }
         }
 
         /// <summary>
@@ -101,18 +115,19 @@ namespace AnimationEditor.Core.Models
             int idx = _tabs.IndexOf(tab);
             _tabs.RemoveAt(idx);
 
-            if (tab != ActiveTab)
-                return; // no active-tab change needed
-
-            if (_tabs.Count == 0)
+            // Re-pick the active tab only when the one closed was active. A background-tab
+            // close leaves ActiveTab as-is but still changes the open-tab set, so TabsChanged
+            // fires regardless (ActiveChanged would not).
+            if (tab == ActiveTab)
             {
-                SetActive(null);
-                return;
+                if (_tabs.Count == 0)
+                    SetActive(null);
+                else
+                    // Prefer the tab that moved into this slot; fall back to the one before.
+                    SetActive(_tabs[Math.Min(idx, _tabs.Count - 1)]);
             }
 
-            // Prefer the tab that moved into this slot; fall back to the one before.
-            int nextIdx = Math.Min(idx, _tabs.Count - 1);
-            SetActive(_tabs[nextIdx]);
+            RaiseTabsChanged();
         }
 
         /// <summary>
@@ -130,11 +145,14 @@ namespace AnimationEditor.Core.Models
             if (_tabs.Count == 0)
             {
                 SetActive(null);
-                return;
+            }
+            else
+            {
+                TabEntry? desired = activePath != null ? FindTab(new FilePath(activePath)) : null;
+                SetActive(desired ?? _tabs[0]);
             }
 
-            TabEntry? desired = activePath != null ? FindTab(new FilePath(activePath)) : null;
-            SetActive(desired ?? _tabs[0]);
+            RaiseTabsChanged();
         }
 
         // ── Private helpers ───────────────────────────────────────────────────
@@ -152,6 +170,7 @@ namespace AnimationEditor.Core.Models
         {
             if (FindTab(path) != null) return;
             _tabs.Insert(0, new TabEntry(path, displayNameOverride));
+            RaiseTabsChanged();
         }
 
         /// <summary>
@@ -168,6 +187,7 @@ namespace AnimationEditor.Core.Models
             if (current == target) return;
             _tabs.RemoveAt(current);
             _tabs.Insert(target, tab);
+            RaiseTabsChanged();
         }
 
         /// <summary>
@@ -186,6 +206,7 @@ namespace AnimationEditor.Core.Models
             _tabs[idx] = replacement;
             if (ActiveTab == tab)
                 ActiveTab = replacement;
+            RaiseTabsChanged();
         }
 
         // ── Private helpers ───────────────────────────────────────────────────
@@ -198,5 +219,7 @@ namespace AnimationEditor.Core.Models
             ActiveTab = tab;
             ActiveChanged?.Invoke(tab);
         }
+
+        private void RaiseTabsChanged() => TabsChanged?.Invoke();
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSessionPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabSessionPersistenceTests.cs
@@ -1,0 +1,122 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression guard for issue #439: the open-tab session (<see cref="AppSettingsModel.OpenTabPaths"/>
+/// / <see cref="AppSettingsModel.ActiveTabPath"/>) must be persisted as tabs change — not only from
+/// the window <c>Closed</c> handler. A debugger Stop or crash kills the process without firing
+/// <c>Closed</c>, so persisting only on close loses the session.
+/// </summary>
+public class TabSessionPersistenceTests
+{
+    private static string WriteAchx(string dir, string fileName, params string[] chainNames)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        foreach (var name in chainNames)
+        {
+            var chain = new AnimationChainSave { Name = name };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = name + ".png", FrameLength = 0.1f });
+            acls.AnimationChains.Add(chain);
+        }
+        acls.Save(path);
+        return path;
+    }
+
+    private static AppSettingsModel ReadPersistedSettings(TestServices ctx)
+    {
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        Assert.True(File.Exists(settingsFile.FullPath),
+            $"Expected settings to be persisted at {settingsFile.FullPath} without a window Close.");
+        return JsonSerializer.Deserialize<AppSettingsModel>(File.ReadAllText(settingsFile.FullPath))!;
+    }
+
+    /// <summary>
+    /// Opening a file must persist it into <see cref="AppSettingsModel.OpenTabPaths"/> /
+    /// <see cref="AppSettingsModel.ActiveTabPath"/> immediately — <b>without</b> the window
+    /// ever being closed. This is the exact scenario a VS Stop / crash hits.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task OpeningFile_PersistsTabSession_WithoutWindowClose()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var path = WriteAchx(dir, "hero.achx", "Walk");
+
+            await window.OpenFileAsTab(path);
+            Dispatcher.UIThread.RunJobs();
+
+            // No window.Close() — the session must already be on disk.
+            var settings = ReadPersistedSettings(ctx);
+            Assert.Contains(settings.OpenTabPaths, p => new FilePath(p) == new FilePath(path));
+            Assert.Equal(new FilePath(path), new FilePath(settings.ActiveTabPath!));
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Switching the active tab between two open files must update the persisted
+    /// <see cref="AppSettingsModel.ActiveTabPath"/> — again, with no window Close.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task SwitchingActiveTab_UpdatesPersistedActiveTabPath_WithoutWindowClose()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pathA = WriteAchx(dir, "a.achx", "Walk");
+            var pathB = WriteAchx(dir, "b.achx", "Run");
+
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+            await window.OpenFileAsTab(pathB);
+            Dispatcher.UIThread.RunJobs();
+
+            // B is active after opening it second.
+            var afterOpen = ReadPersistedSettings(ctx);
+            Assert.Equal(new FilePath(pathB), new FilePath(afterOpen.ActiveTabPath!));
+            Assert.Equal(2, afterOpen.OpenTabPaths.Count);
+
+            // Re-focus A — switching the active tab must re-persist.
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+
+            var afterSwitch = ReadPersistedSettings(ctx);
+            Assert.Equal(new FilePath(pathA), new FilePath(afterSwitch.ActiveTabPath!));
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -372,6 +372,131 @@ public class TabManagerTests
         Assert.True(raised);
     }
 
+    // ── TabsChanged event (issue #439) ────────────────────────────────────────
+
+    [Fact]
+    public void OpenOrFocus_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        int count = 0;
+        tm.TabsChanged += () => count++;
+
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Activate_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.Activate(P(@"C:\Games\a.achx"));
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Close_ActiveTab_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.Close(P(@"C:\Games\a.achx"));
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Close_BackgroundTab_RaisesTabsChanged_EvenThoughActiveChangedDoesNot()
+    {
+        // The core of issue #439: closing a non-active tab changes the open-tab set but
+        // leaves ActiveTab untouched, so ActiveChanged stays silent. TabsChanged must fire
+        // so the session is re-persisted.
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx")); // b is active
+        bool activeChanged = false, tabsChanged = false;
+        tm.ActiveChanged += _ => activeChanged = true;
+        tm.TabsChanged += () => tabsChanged = true;
+
+        tm.Close(P(@"C:\Games\a.achx")); // close the background tab
+
+        Assert.False(activeChanged);
+        Assert.True(tabsChanged);
+    }
+
+    [Fact]
+    public void Move_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.Move(P(@"C:\a.achx"), 1);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Move_SameIndex_DoesNotRaiseTabsChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\a.achx"));
+        tm.OpenOrFocus(P(@"C:\b.achx"));
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.Move(P(@"C:\a.achx"), 0); // already at index 0 — no change
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void RegisterBackground_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.RegisterBackground(P(@"C:\Games\existing.achx"));
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Rename_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P("__untitled__:1"), "Untitled");
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.Rename(P("__untitled__:1"), P(@"C:\hero.achx"));
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void RestoreFrom_RaisesTabsChanged()
+    {
+        var tm = new TabManager();
+        bool raised = false;
+        tm.TabsChanged += () => raised = true;
+
+        tm.RestoreFrom(new List<string> { @"C:\a.achx" }, activePath: null);
+
+        Assert.True(raised);
+    }
+
     // ── RegisterBackground ────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Problem

The Animation Editor's open-tab session (`OpenTabPaths` / `ActiveTabPath`) was persisted from exactly **one** place — the window `Closed` handler. A debugger **Stop ■** (and any crash) terminates the process without firing `Closed`, so the prior session was never saved and the previously-open `.achx` file did **not** auto-reopen on the next launch.

Recent files were unaffected — they already save immediately on open — which is the pattern this change mirrors for tabs.

## Fix

- Add `TabManager.TabsChanged`, raised on every mutation: open, focus, activate, **close (including a background/non-active tab)**, move, rename, register, and restore.
- `MainWindow.WireTabBar` subscribes and calls `SaveTabsToSettings` **synchronously**, so the session lands on disk the moment tabs change. `SaveTabsToSettings` only reads tab state and writes the settings file (no UI controls), so a synchronous handler is safe and crash-resistant.
- The `Closed` handler keeps its `SaveTabsToSettings` call as a final flush.

`TabsChanged` is intentionally distinct from `ActiveChanged`: closing a non-active tab or reordering changes the open-tab set **without** touching the active tab — exactly the cases `ActiveChanged` never fires for.

## Tests (TDD — red before, green after)

- **Core** (`TabManagerTests`): `TabsChanged` fires for open / activate / close-active / close-**background** / move / rename / register / restore, and does **not** fire on a no-op move. The background-close test also asserts `ActiveChanged` stays silent — proving why the new event is needed.
- **App** (`TabSessionPersistenceTests`, `[AvaloniaFact]`): opening a file, and switching the active tab, persist `OpenTabPaths` / `ActiveTabPath` to the injected temp settings root **without** a window `Close` — the exact VS-Stop scenario. Both were red before the fix.

Verified against the per-test temp settings root from #438 (no touching the real `%APPDATA%`).

Full suite: 1233 Core + 472 App tests pass.

Closes #439