### PR TITLE
Add per-frame Alpha (transparency) to AnimationEditor and runtime

### DIFF
--- a/src/Animation/AnimationFrame.cs
+++ b/src/Animation/AnimationFrame.cs
@@ -59,6 +59,14 @@ public class AnimationFrame
     public int? Blue;
 
     /// <summary>
+    /// Optional per-frame alpha (transparency) channel, 0–255, or <c>null</c> when unset. Straight
+    /// transparency, independent of <see cref="ColorOperation"/>. Like the color channels it is <b>not</b>
+    /// applied by the engine: read it via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/> and apply
+    /// it in game code (fade, dissolve, etc.).
+    /// </summary>
+    public int? Alpha;
+
+    /// <summary>
     /// Optional per-frame color operation for how <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/>
     /// combine with the texture, or <c>null</c> for none. Not applied by the engine — read it (with the
     /// channels) via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/> and apply it in game code.

--- a/src/Animation/Content/AnimationChainListSave.cs
+++ b/src/Animation/Content/AnimationChainListSave.cs
@@ -202,11 +202,12 @@ public class AnimationChainListSave
         if (frame.RelativeX != 0f) el.Add(new XElement("RelativeX", FloatStr(frame.RelativeX)));
         if (frame.RelativeY != 0f) el.Add(new XElement("RelativeY", FloatStr(frame.RelativeY)));
 
-        // Per-frame color channels are game-consumed and optional: write each only when set
+        // Per-frame color/alpha channels are game-consumed and optional: write each only when set
         // so frames without color stay byte-identical.
         if (frame.Red.HasValue) el.Add(new XElement("Red", frame.Red.Value));
         if (frame.Green.HasValue) el.Add(new XElement("Green", frame.Green.Value));
         if (frame.Blue.HasValue) el.Add(new XElement("Blue", frame.Blue.Value));
+        if (frame.Alpha.HasValue) el.Add(new XElement("Alpha", frame.Alpha.Value));
         if (frame.ColorOperation.HasValue) el.Add(new XElement("ColorOperation", frame.ColorOperation.Value.ToString()));
 
         if (frame.HasCustomName && !string.IsNullOrEmpty(frame.Name))
@@ -286,6 +287,7 @@ public class AnimationChainListSave
         frame.Red = IntElNullable(el, "Red");
         frame.Green = IntElNullable(el, "Green");
         frame.Blue = IntElNullable(el, "Blue");
+        frame.Alpha = IntElNullable(el, "Alpha");
         frame.ColorOperation = ColorOperationEl(el, "ColorOperation");
         frame.Name = (string?)el.Element("Name") ?? string.Empty;
         frame.HasCustomName = BoolEl(el, "HasCustomName");
@@ -496,6 +498,7 @@ public class AnimationChainListSave
                     Red = frameSave.Red,
                     Green = frameSave.Green,
                     Blue = frameSave.Blue,
+                    Alpha = frameSave.Alpha,
                     ColorOperation = frameSave.ColorOperation,
                 };
 

--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -37,9 +37,10 @@ public class AnimationFrameSave
 
     /// <summary>
     /// Optional per-frame red channel, 0–255. <c>null</c> (the default) means unset, so it is
-    /// omitted from the saved <c>.achx</c>. These values are <b>not</b> applied by the engine or
-    /// the Animation Editor — game code reads them via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/>
-    /// and decides how to use them (tint, flash, etc.). See <see cref="Green"/>, <see cref="Blue"/>.
+    /// omitted from the saved <c>.achx</c>. The Animation Editor previews these as a reference tint
+    /// (via <see cref="ColorOperation"/>); the FlatRedBall2 runtime does <b>not</b> auto-apply them —
+    /// game code reads them via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/> and decides how
+    /// to use them (tint, flash, etc.). See <see cref="Green"/>, <see cref="Blue"/>.
     /// </summary>
     public int? Red;
 
@@ -52,8 +53,8 @@ public class AnimationFrameSave
     /// <summary>
     /// Optional per-frame alpha (transparency) channel, 0–255. <c>null</c> (the default) means unset, so it
     /// is omitted from the saved <c>.achx</c>. Straight transparency, independent of <see cref="ColorOperation"/>.
-    /// Like the color channels it is <b>not</b> applied by the engine or the Animation Editor — game code reads
-    /// it via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/>. See <see cref="Red"/>.
+    /// The Animation Editor previews it as opacity (a reference render); the FlatRedBall2 runtime does <b>not</b>
+    /// auto-apply it — game code reads it via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/>. See <see cref="Red"/>.
     /// </summary>
     public int? Alpha;
 

--- a/src/Animation/Content/AnimationFrameSave.cs
+++ b/src/Animation/Content/AnimationFrameSave.cs
@@ -50,6 +50,14 @@ public class AnimationFrameSave
     public int? Blue;
 
     /// <summary>
+    /// Optional per-frame alpha (transparency) channel, 0–255. <c>null</c> (the default) means unset, so it
+    /// is omitted from the saved <c>.achx</c>. Straight transparency, independent of <see cref="ColorOperation"/>.
+    /// Like the color channels it is <b>not</b> applied by the engine or the Animation Editor — game code reads
+    /// it via <see cref="FlatRedBall2.Rendering.Sprite.CurrentFrame"/>. See <see cref="Red"/>.
+    /// </summary>
+    public int? Alpha;
+
+    /// <summary>
     /// Optional per-frame color operation describing how <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/>
     /// combine with the texture. <c>null</c> (the default) means none and is omitted from the saved
     /// <c>.achx</c>. Like the channels, runtimes interpret this as they choose. See <see cref="FlatRedBall2.Animation.ColorOperation"/>.

--- a/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationFrameColorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace FlatRedBall2.Tests.Animation;
 
-// Per-frame Red/Green/Blue (0-255, nullable) are stored on the frame and surfaced to game code,
+// Per-frame Red/Green/Blue/Alpha (0-255, nullable) are stored on the frame and surfaced to game code,
 // but are NOT applied by the engine — game code reads Sprite.CurrentFrame and decides how to use them.
 public class AnimationFrameColorTests
 {
@@ -16,7 +16,7 @@ public class AnimationFrameColorTests
     public void CurrentFrame_ReflectsPlaybackState()
     {
         var chain = new AnimationChain { Name = "Flash" };
-        chain.Add(new AnimationFrame { FrameLength = TimeSpan.FromSeconds(0.1), Red = 255 });
+        chain.Add(new AnimationFrame { FrameLength = TimeSpan.FromSeconds(0.1), Red = 255, Alpha = 128 });
         var list = new AnimationChainList();
         list.Add(chain);
 
@@ -28,6 +28,34 @@ public class AnimationFrameColorTests
 
         sprite.CurrentFrame.ShouldNotBeNull();
         sprite.CurrentFrame!.Red.ShouldBe(255);
+        sprite.CurrentFrame!.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void Save_ThenFromFile_RoundTripsAlphaAndOmitsNull()
+    {
+        // First frame authors Alpha; second leaves it null to prove null alpha is not written.
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Fade" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", Alpha = 128 });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png" }); // no alpha -> element omitted
+        save.AnimationChains.Add(chain);
+
+        var path = Path.Combine(Path.GetTempPath(), $"frbalpha_{Guid.NewGuid():N}.achx");
+        try
+        {
+            save.Save(path);
+            // Only the first frame authored alpha; the null frame must omit the element.
+            (File.ReadAllText(path).Split("<Alpha>").Length - 1).ShouldBe(1);
+
+            var frames = AnimationChainListSave.FromFile(path).AnimationChains[0].Frames;
+            frames[0].Alpha.ShouldBe(128);
+            frames[1].Alpha.ShouldBeNull();
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
     }
 
     [Fact]
@@ -81,6 +109,20 @@ public class AnimationFrameColorTests
         {
             if (File.Exists(path)) File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void ToAnimationChainList_CopiesAlphaToRuntimeFrame()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Fade" };
+        // Empty TextureName so conversion skips texture loading and the null ContentLoader is never used.
+        chain.Frames.Add(new AnimationFrameSave { Alpha = 128 });
+        save.AnimationChains.Add(chain);
+
+        var frame = save.ToAnimationChainList(null!)[0][0];
+
+        frame.Alpha.ShouldBe(128);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -1713,7 +1713,8 @@ public class PreviewControl : Control
 
         using var paint = new SKPaint
         {
-            Color = new SKColor(255, 255, 255, (byte)(255 * alpha))
+            // Per-frame Alpha previews as opacity (reference render); runtimes apply it however they choose.
+            Color = new SKColor(255, 255, 255, FramePreviewOpacity.Resolve(frame.Alpha, alpha))
         };
         // Reference render of the frame's color operation; runtimes apply it however they choose.
         using var colorFilter = FrameColorFilter.Create(frame.ColorOperation, frame.Red, frame.Green, frame.Blue);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FramePreviewOpacity.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/FramePreviewOpacity.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace AnimationEditor.App;
+
+/// <summary>
+/// The editor preview's <em>reference</em> interpretation of a frame's per-frame <c>Alpha</c> as
+/// opacity: the drawn sprite's alpha is the layer alpha (<c>1.0</c> for the live frame, <c>0.4</c>
+/// for onion skin) scaled by <c>Alpha/255</c>. A <c>null</c> frame alpha means fully opaque.
+/// Runtimes consuming the <c>.achx</c> apply alpha however they choose; this is only what the
+/// preview shows. Independent of <c>ColorOperation</c> — straight transparency, not a tint.
+/// </summary>
+public static class FramePreviewOpacity
+{
+    /// <param name="frameAlpha">Per-frame alpha 0–255, or <c>null</c> for fully opaque.</param>
+    /// <param name="layerAlpha">Base opacity of the layer being drawn (1.0 live frame, 0.4 onion).</param>
+    public static byte Resolve(int? frameAlpha, float layerAlpha)
+    {
+        float a = (frameAlpha ?? 255) / 255f;
+        return (byte)Math.Clamp((int)MathF.Round(255f * layerAlpha * a), 0, 255);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1038,7 +1038,7 @@
                                                    Foreground="{DynamicResource InkMid}" />
                                         <TextBlock TextWrapping="Wrap" FontSize="10"
                                                    Foreground="{DynamicResource InkDim}"
-                                                   Text="Mode previews here as a reference; each runtime decides how to apply these. Your game can also read R/G/B from sprite.CurrentFrame. Leave a field blank to omit it." />
+                                                   Text="Mode previews R/G/B here as a reference; each runtime decides how to apply these. Your game can also read R/G/B/A from sprite.CurrentFrame. A is straight transparency — stored and game-read, never previewed. Leave a field blank to omit it." />
                                         <Grid ColumnDefinitions="44,*">
                                             <TextBlock Text="Mode" VerticalAlignment="Center"
                                                        Foreground="{DynamicResource InkMid}" FontSize="11" />
@@ -1049,7 +1049,7 @@
                                                 <ComboBoxItem>Add</ComboBoxItem>
                                             </ComboBox>
                                         </Grid>
-                                        <Grid ColumnDefinitions="*,6,*,6,*">
+                                        <Grid ColumnDefinitions="*,6,*,6,*,6,*">
                                             <Grid Grid.Column="0" ColumnDefinitions="14,*">
                                                 <TextBlock Text="R" VerticalAlignment="Center"
                                                            Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
@@ -1066,6 +1066,12 @@
                                                 <TextBlock Text="B" VerticalAlignment="Center"
                                                            Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
                                                 <NumericUpDown x:Name="PropBlue" Grid.Column="1"
+                                                               Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                            </Grid>
+                                            <Grid Grid.Column="6" ColumnDefinitions="14,*">
+                                                <TextBlock Text="A" VerticalAlignment="Center"
+                                                           Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
+                                                <NumericUpDown x:Name="PropAlpha" Grid.Column="1"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
                                         </Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1049,33 +1049,35 @@
                                                 <ComboBoxItem>Add</ComboBoxItem>
                                             </ComboBox>
                                         </Grid>
-                                        <!-- Channel fields — 2×2 grid: [R][G] / [B][A] — so they degrade gracefully when the panel is narrow -->
-                                        <Grid ColumnDefinitions="*,6,*" RowDefinitions="Auto,4,Auto">
-                                            <Grid Grid.Column="0" Grid.Row="0" ColumnDefinitions="14,*">
+                                        <!-- Channel fields — responsive WrapPanel: each [label][textbox] unit has a MinWidth,
+                                             so units sit side-by-side when there's room and reflow one-per-row as the panel
+                                             narrows (the per-unit MinWidth is the wrap threshold). No overlap at any width. -->
+                                        <WrapPanel>
+                                            <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                 <TextBlock Text="R" VerticalAlignment="Center"
                                                            Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropRed" Grid.Column="1"
+                                                <NumericUpDown x:Name="PropRed" Grid.Column="1" MinWidth="66"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="2" Grid.Row="0" ColumnDefinitions="14,*">
+                                            <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                 <TextBlock Text="G" VerticalAlignment="Center"
                                                            Foreground="#6dd28d" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropGreen" Grid.Column="1"
+                                                <NumericUpDown x:Name="PropGreen" Grid.Column="1" MinWidth="66"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="0" Grid.Row="2" ColumnDefinitions="14,*">
+                                            <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                 <TextBlock Text="B" VerticalAlignment="Center"
                                                            Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropBlue" Grid.Column="1"
+                                                <NumericUpDown x:Name="PropBlue" Grid.Column="1" MinWidth="66"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="2" Grid.Row="2" ColumnDefinitions="14,*">
+                                            <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                 <TextBlock Text="A" VerticalAlignment="Center"
                                                            Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropAlpha" Grid.Column="1"
+                                                <NumericUpDown x:Name="PropAlpha" Grid.Column="1" MinWidth="66"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                        </Grid>
+                                        </WrapPanel>
                                     </StackPanel>
                                 </Border>
                             </StackPanel>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1038,7 +1038,7 @@
                                                    Foreground="{DynamicResource InkMid}" />
                                         <TextBlock TextWrapping="Wrap" FontSize="10"
                                                    Foreground="{DynamicResource InkDim}"
-                                                   Text="Mode previews R/G/B here as a reference; each runtime decides how to apply these. Your game can also read R/G/B/A from sprite.CurrentFrame. A is straight transparency — stored and game-read, never previewed. Leave a field blank to omit it." />
+                                                   Text="Previewed here as a reference — R/G/B tint via Mode, A as opacity. Each runtime applies these as it chooses; your game can also read R/G/B/A from sprite.CurrentFrame. Leave a field blank to omit it." />
                                         <Grid ColumnDefinitions="44,*">
                                             <TextBlock Text="Mode" VerticalAlignment="Center"
                                                        Foreground="{DynamicResource InkMid}" FontSize="11" />
@@ -1049,26 +1049,27 @@
                                                 <ComboBoxItem>Add</ComboBoxItem>
                                             </ComboBox>
                                         </Grid>
-                                        <Grid ColumnDefinitions="*,6,*,6,*,6,*">
-                                            <Grid Grid.Column="0" ColumnDefinitions="14,*">
+                                        <!-- Channel fields — 2×2 grid: [R][G] / [B][A] — so they degrade gracefully when the panel is narrow -->
+                                        <Grid ColumnDefinitions="*,6,*" RowDefinitions="Auto,4,Auto">
+                                            <Grid Grid.Column="0" Grid.Row="0" ColumnDefinitions="14,*">
                                                 <TextBlock Text="R" VerticalAlignment="Center"
                                                            Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
                                                 <NumericUpDown x:Name="PropRed" Grid.Column="1"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="2" ColumnDefinitions="14,*">
+                                            <Grid Grid.Column="2" Grid.Row="0" ColumnDefinitions="14,*">
                                                 <TextBlock Text="G" VerticalAlignment="Center"
                                                            Foreground="#6dd28d" FontSize="11" FontWeight="SemiBold" />
                                                 <NumericUpDown x:Name="PropGreen" Grid.Column="1"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="4" ColumnDefinitions="14,*">
+                                            <Grid Grid.Column="0" Grid.Row="2" ColumnDefinitions="14,*">
                                                 <TextBlock Text="B" VerticalAlignment="Center"
                                                            Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
                                                 <NumericUpDown x:Name="PropBlue" Grid.Column="1"
                                                                Minimum="0" Maximum="255" Increment="1" FormatString="0" />
                                             </Grid>
-                                            <Grid Grid.Column="6" ColumnDefinitions="14,*">
+                                            <Grid Grid.Column="2" Grid.Row="2" ColumnDefinitions="14,*">
                                                 <TextBlock Text="A" VerticalAlignment="Center"
                                                            Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
                                                 <NumericUpDown x:Name="PropAlpha" Grid.Column="1"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1038,13 +1038,23 @@
                                         BorderThickness="0,0,0,1"
                                         Padding="12,8,12,10">
                                     <StackPanel Spacing="8">
-                                        <TextBlock Text="COLOR"
-                                                   FontSize="11"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource InkMid}" />
-                                        <TextBlock TextWrapping="Wrap" FontSize="10"
-                                                   Foreground="{DynamicResource InkDim}"
-                                                   Text="Previewed here as a reference — R/G/B tint via Mode, A as opacity. Each runtime applies these as it chooses; your game can also read R/G/B/A from sprite.CurrentFrame. Leave a field blank to omit it." />
+                                        <!-- Header + info badge. The explanatory text lives in the badge's tooltip
+                                             (instead of an always-on wrapping paragraph that grew the panel when narrow). -->
+                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                            <TextBlock Text="COLOR"
+                                                       FontSize="11"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource InkMid}"
+                                                       VerticalAlignment="Center" />
+                                            <Border Width="14" Height="14" CornerRadius="7"
+                                                    BorderBrush="{DynamicResource InkDim}" BorderThickness="1"
+                                                    VerticalAlignment="Center" Cursor="Help"
+                                                    ToolTip.Tip="Previewed here as a reference — R/G/B tint via Mode, A as opacity. Each runtime applies these as it chooses; your game can also read R/G/B/A from sprite.CurrentFrame. Leave a field blank to omit it.">
+                                                <TextBlock Text="i" FontSize="9"
+                                                           Foreground="{DynamicResource InkDim}"
+                                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                            </Border>
+                                        </StackPanel>
                                         <Grid ColumnDefinitions="44,*">
                                             <TextBlock Text="Mode" VerticalAlignment="Center"
                                                        Foreground="{DynamicResource InkMid}" FontSize="11" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -900,34 +900,40 @@
                                                    FontSize="11"
                                                    FontWeight="SemiBold"
                                                    Foreground="{DynamicResource InkMid}" />
-                                        <!-- Pixel coord fields — 2×2 grid: [X][Y] / [W][H] -->
-                                        <Grid x:Name="PropPixelSection"
-                                              ColumnDefinitions="*,6,*" RowDefinitions="Auto,4,Auto">
-                                            <Grid Grid.Column="0" Grid.Row="0" ColumnDefinitions="18,*">
-                                                <TextBlock Text="X" VerticalAlignment="Center"
-                                                           Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropPixelX" Grid.Column="1"
-                                                               Minimum="-16384" Maximum="16384" Increment="1" />
-                                            </Grid>
-                                            <Grid Grid.Column="2" Grid.Row="0" ColumnDefinitions="18,*">
-                                                <TextBlock Text="Y" VerticalAlignment="Center"
-                                                           Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropPixelY" Grid.Column="1"
-                                                               Minimum="-16384" Maximum="16384" Increment="1" />
-                                            </Grid>
-                                            <Grid Grid.Column="0" Grid.Row="2" ColumnDefinitions="18,*">
-                                                <TextBlock Text="W" VerticalAlignment="Center"
-                                                           Foreground="#f0c674" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropPixelW" Grid.Column="1"
-                                                               Minimum="1" Maximum="16384" Increment="1" />
-                                            </Grid>
-                                            <Grid Grid.Column="2" Grid.Row="2" ColumnDefinitions="18,*">
-                                                <TextBlock Text="H" VerticalAlignment="Center"
-                                                           Foreground="#6dd28d" FontSize="11" FontWeight="SemiBold" />
-                                                <NumericUpDown x:Name="PropPixelH" Grid.Column="1"
-                                                               Minimum="1" Maximum="16384" Increment="1" />
-                                            </Grid>
-                                        </Grid>
+                                        <!-- Pixel coord fields — two pair-rows preserving the position/size pairing:
+                                             a position row (X, Y) then a size row (W, H). Each row is its own responsive
+                                             WrapPanel of [label][box] units (MinWidth 86) that reflows 2-across → 1-per-row
+                                             independently as the panel narrows. No overlap at any width. -->
+                                        <StackPanel x:Name="PropPixelSection">
+                                            <WrapPanel>
+                                                <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
+                                                    <TextBlock Text="X" VerticalAlignment="Center"
+                                                               Foreground="#f48b8b" FontSize="11" FontWeight="SemiBold" />
+                                                    <NumericUpDown x:Name="PropPixelX" Grid.Column="1" MinWidth="66"
+                                                                   Minimum="-16384" Maximum="16384" Increment="1" />
+                                                </Grid>
+                                                <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
+                                                    <TextBlock Text="Y" VerticalAlignment="Center"
+                                                               Foreground="#8bb6f4" FontSize="11" FontWeight="SemiBold" />
+                                                    <NumericUpDown x:Name="PropPixelY" Grid.Column="1" MinWidth="66"
+                                                                   Minimum="-16384" Maximum="16384" Increment="1" />
+                                                </Grid>
+                                            </WrapPanel>
+                                            <WrapPanel>
+                                                <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
+                                                    <TextBlock Text="W" VerticalAlignment="Center"
+                                                               Foreground="#f0c674" FontSize="11" FontWeight="SemiBold" />
+                                                    <NumericUpDown x:Name="PropPixelW" Grid.Column="1" MinWidth="66"
+                                                                   Minimum="1" Maximum="16384" Increment="1" />
+                                                </Grid>
+                                                <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
+                                                    <TextBlock Text="H" VerticalAlignment="Center"
+                                                               Foreground="#6dd28d" FontSize="11" FontWeight="SemiBold" />
+                                                    <NumericUpDown x:Name="PropPixelH" Grid.Column="1" MinWidth="66"
+                                                                   Minimum="1" Maximum="16384" Increment="1" />
+                                                </Grid>
+                                            </WrapPanel>
+                                        </StackPanel>
 
                                     </StackPanel>
                                 </Border>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2469,6 +2469,7 @@ public partial class MainWindow : Window
         PropRed.ValueChanged       += (_, _) => ApplyFrameColor();
         PropGreen.ValueChanged     += (_, _) => ApplyFrameColor();
         PropBlue.ValueChanged      += (_, _) => ApplyFrameColor();
+        PropAlpha.ValueChanged     += (_, _) => ApplyFrameAlpha();
         PropColorMode.SelectionChanged += (_, _) => ApplyFrameColorOperation();
         PropPixelX.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelY.ValueChanged    += (_, _) => ApplyFramePixelCoords();
@@ -2676,6 +2677,7 @@ public partial class MainWindow : Window
                 PropRed.Value        = frame.Red.HasValue   ? frame.Red.Value   : (decimal?)null;
                 PropGreen.Value      = frame.Green.HasValue ? frame.Green.Value : (decimal?)null;
                 PropBlue.Value       = frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null;
+                PropAlpha.Value      = frame.Alpha.HasValue ? frame.Alpha.Value : (decimal?)null;
                 PropColorMode.SelectedIndex = frame.ColorOperation switch
                 {
                     ColorOperation.Multiply => 1,
@@ -2757,6 +2759,15 @@ public partial class MainWindow : Window
         // A blank NumericUpDown (null Value) means the channel is unset and is omitted from the .achx.
         static int? ToChannel(decimal? v) => v.HasValue ? (int)v.Value : null;
         _appCommands.SetFrameColor(frame, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
+    }
+
+    private void ApplyFrameAlpha()
+    {
+        if (_suppressPropRefresh) return;
+        var frame = _selectedState.SelectedFrame;
+        if (frame is null) return;
+        // A blank NumericUpDown (null Value) means alpha is unset and is omitted from the .achx.
+        _appCommands.SetFrameAlpha(frame, PropAlpha.Value.HasValue ? (int)PropAlpha.Value.Value : null);
     }
 
     private void ApplyFrameColorOperation()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2466,10 +2466,16 @@ public partial class MainWindow : Window
         PropFrameLen.ValueChanged  += (_, _) => ApplyFrameLen();
         PropRelX.ValueChanged      += (_, _) => ApplyFrameRelative();
         PropRelY.ValueChanged      += (_, _) => ApplyFrameRelative();
-        PropRed.ValueChanged       += (_, _) => ApplyFrameColor();
-        PropGreen.ValueChanged     += (_, _) => ApplyFrameColor();
-        PropBlue.ValueChanged      += (_, _) => ApplyFrameColor();
-        PropAlpha.ValueChanged     += (_, _) => ApplyFrameAlpha();
+        // Color/alpha channels commit one undo entry on edit completion (focus loss / Enter), not
+        // per keystroke — NumericUpDown raises ValueChanged on every keypress while typing (#445).
+        PropRed.LostFocus          += (_, _) => ApplyFrameColor();
+        PropGreen.LostFocus        += (_, _) => ApplyFrameColor();
+        PropBlue.LostFocus         += (_, _) => ApplyFrameColor();
+        PropAlpha.LostFocus        += (_, _) => ApplyFrameAlpha();
+        PropRed.KeyDown            += (_, e) => CommitColorChannelOnEnter(e);
+        PropGreen.KeyDown          += (_, e) => CommitColorChannelOnEnter(e);
+        PropBlue.KeyDown           += (_, e) => CommitColorChannelOnEnter(e);
+        PropAlpha.KeyDown          += (_, e) => { if (e.Key == Key.Enter) ApplyFrameAlpha(); };
         PropColorMode.SelectionChanged += (_, _) => ApplyFrameColorOperation();
         PropPixelX.ValueChanged    += (_, _) => ApplyFramePixelCoords();
         PropPixelY.ValueChanged    += (_, _) => ApplyFramePixelCoords();
@@ -2759,6 +2765,11 @@ public partial class MainWindow : Window
         // A blank NumericUpDown (null Value) means the channel is unset and is omitted from the .achx.
         static int? ToChannel(decimal? v) => v.HasValue ? (int)v.Value : null;
         _appCommands.SetFrameColor(frame, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
+    }
+
+    private void CommitColorChannelOnEnter(KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) ApplyFrameColor();
     }
 
     private void ApplyFrameAlpha()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1059,6 +1059,14 @@ namespace AnimationEditor.Core.CommandsAndState
                 this, _events, false, "Set Frame Color Mode"));
         }
 
+        public void SetFrameAlpha(AnimationFrameSave frame, int? alpha)
+        {
+            // Alpha is straight transparency, game-consumed and not previewed, so no wireframe refresh is needed.
+            _undoManager.Execute(new BulkFrameEditCommand(
+                [frame], () => frame.Alpha = alpha,
+                this, _events, false, "Set Frame Alpha"));
+        }
+
         public void SetFramePixelRegion(AnimationFrameSave frame,
             int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -16,13 +16,13 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         float FrameLength,
         float RelativeX, float RelativeY,
         float Left, float Right, float Top, float Bottom,
-        int? Red, int? Green, int? Blue,
+        int? Red, int? Green, int? Blue, int? Alpha,
         ColorOperation? ColorOperation)
     {
         public static FrameFieldSnapshot Capture(AnimationFrameSave f) =>
             new(f, f.FrameLength, f.RelativeX, f.RelativeY,
                 f.LeftCoordinate, f.RightCoordinate, f.TopCoordinate, f.BottomCoordinate,
-                f.Red, f.Green, f.Blue, f.ColorOperation);
+                f.Red, f.Green, f.Blue, f.Alpha, f.ColorOperation);
 
         public void RestoreToFrame()
         {
@@ -36,6 +36,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             Frame.Red              = Red;
             Frame.Green            = Green;
             Frame.Blue             = Blue;
+            Frame.Alpha            = Alpha;
             Frame.ColorOperation   = ColorOperation;
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -136,6 +136,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY);
         void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue);
         void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation);
+        void SetFrameAlpha(AnimationFrameSave frame, int? alpha);
         void SetFramePixelRegion(AnimationFrameSave frame, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FramePreviewOpacityTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FramePreviewOpacityTests.cs
@@ -1,0 +1,35 @@
+using AnimationEditor.App;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+// FramePreviewOpacity maps a frame's per-frame Alpha (0-255, null = opaque) onto the preview's
+// drawn-sprite opacity, scaled by the layer alpha (1.0 live frame, 0.4 onion skin).
+public class FramePreviewOpacityTests
+{
+    [Fact]
+    public void Resolve_NullAlpha_FullyOpaqueAtFullLayer()
+    {
+        // Unset alpha must not dim the sprite.
+        Assert.Equal(255, FramePreviewOpacity.Resolve(null, 1.0f));
+    }
+
+    [Fact]
+    public void Resolve_HalfAlpha_HalvesOpacity()
+    {
+        Assert.Equal(128, FramePreviewOpacity.Resolve(128, 1.0f));
+    }
+
+    [Fact]
+    public void Resolve_ZeroAlpha_FullyTransparent()
+    {
+        Assert.Equal(0, FramePreviewOpacity.Resolve(0, 1.0f));
+    }
+
+    [Fact]
+    public void Resolve_CombinesFrameAlphaWithOnionLayer()
+    {
+        // Onion skin draws at layer 0.4; a fully opaque frame there is 255 * 0.4 ≈ 102.
+        Assert.Equal(102, FramePreviewOpacity.Resolve(255, 0.4f));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/InspectorChannelCommitTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/InspectorChannelCommitTests.cs
@@ -1,0 +1,88 @@
+using AnimationEditor.Core;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// The R/G/B/A inspector NumericUpDowns must commit a single undo entry on edit completion
+/// (focus loss / Enter), not one per keystroke. Avalonia's NumericUpDown raises ValueChanged
+/// on every keypress while typing, so wiring the undo command to ValueChanged spammed the undo
+/// stack (#445 follow-up). This is genuinely UI-bound wiring, hence a headless-Avalonia test.
+/// </summary>
+public class InspectorChannelCommitTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static AnimationFrameSave SelectFreshFrame(TestServices ctx)
+    {
+        var chain = new AnimationChainSave { Name = "Fade" };
+        var frame = new AnimationFrameSave { TextureName = "f.png", ShapesSave = new ShapesSave() };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.SelectedState.SelectedFrame = frame;
+        Dispatcher.UIThread.RunJobs();
+        return frame;
+    }
+
+    [AvaloniaFact]
+    public void AlphaField_ValueChurnThenEnter_RecordsSingleUndo()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var frame = SelectFreshFrame(ctx);
+            var alpha = window.FindControl<NumericUpDown>("PropAlpha")!;
+
+            // Typing "30" churns the value 3 -> 30; nothing commits until focus loss / Enter.
+            alpha.Value = 3;
+            alpha.Value = 30;
+            Assert.False(ctx.UndoManager.CanUndo);
+
+            alpha.RaiseEvent(new KeyEventArgs { RoutedEvent = InputElement.KeyDownEvent, Key = Key.Enter });
+
+            Assert.Equal(30, frame.Alpha);
+            Assert.Single(ctx.UndoManager.UndoHistory);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RedField_ValueChurnThenFocusLoss_RecordsSingleUndo()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var frame = SelectFreshFrame(ctx);
+            var red   = window.FindControl<NumericUpDown>("PropRed")!;
+            var blue  = window.FindControl<NumericUpDown>("PropBlue")!;
+
+            red.Focus();
+            Dispatcher.UIThread.RunJobs();
+            red.Value = 1;
+            red.Value = 200;
+            Assert.False(ctx.UndoManager.CanUndo);
+
+            // Moving focus to another field raises LostFocus on Red, committing once.
+            blue.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(200, frame.Red);
+            Assert.Single(ctx.UndoManager.UndoHistory);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -8,6 +8,39 @@ namespace AnimationEditor.Core.Tests;
 [Collection("SequentialSingletons")]
 public class InspectorPropertyUndoTests
 {
+    // ── SetFrameAlpha ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetFrameAlpha_Undo_RestoresAlpha()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Fade");
+        var frame = TestHelpers.MakeFrame(); // starts with null alpha
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameAlpha(frame, 128);
+        Assert.True(ctx.UndoManager.CanUndo);
+        Assert.Equal(128, frame.Alpha);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Null(frame.Alpha);
+    }
+
+    [Fact]
+    public void SetFrameAlpha_SameValue_DoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Fade");
+        var frame = TestHelpers.MakeFrame();
+        frame.Alpha = 128;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameAlpha(frame, 128);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
     // ── SetFrameColor ─────────────────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -19,7 +19,8 @@ public class InspectorPropertyUndoTests
         chain.Frames.Add(frame);
 
         ctx.AppCommands.SetFrameAlpha(frame, 128);
-        Assert.True(ctx.UndoManager.CanUndo);
+        // A single committed edit must record exactly one undo entry (not one per keystroke — #445).
+        Assert.Single(ctx.UndoManager.UndoHistory);
         Assert.Equal(128, frame.Alpha);
 
         ctx.UndoManager.Undo();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -99,6 +99,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetAllFramesTextureName)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameLength)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameRelative)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameAlpha)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameColor)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFrameColorOperation)]       = Category.MutatingUndoable,
         [nameof(IAppCommands.SetFramePixelRegion)]          = Category.MutatingUndoable,
@@ -274,6 +275,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetFrameLength(Zebra(ctx).Frames[0], 0.99f)));
         yield return Row(nameof(IAppCommands.SetFrameRelative),
             ctx => Sync(() => ctx.AppCommands.SetFrameRelative(Zebra(ctx).Frames[0], 99f, 88f)));
+        yield return Row(nameof(IAppCommands.SetFrameAlpha),
+            ctx => Sync(() => ctx.AppCommands.SetFrameAlpha(Zebra(ctx).Frames[0], 128)));
         yield return Row(nameof(IAppCommands.SetFrameColor),
             ctx => Sync(() => ctx.AppCommands.SetFrameColor(Zebra(ctx).Frames[0], 255, 200, 128)));
         yield return Row(nameof(IAppCommands.SetFrameColorOperation),


### PR DESCRIPTION
Completes #433. Per-frame color (Red/Green/Blue) shipped in #434; this PR adds the **transparency half** — a per-frame `int? Alpha` (0–255, nullable) — plus the inspector fixes the alpha work surfaced while wiring it into the Animation Editor.

Closes #433

## What's bundled (and why it's here)

The core feature is per-frame alpha. Implementing it in the editor inspector exposed a couple of pre-existing problems in the same R/G/B channel area, so they're fixed together in one reviewable bundle rather than left half-addressed:

1. **Per-frame `Alpha` (the #433 feature).** New `int? Alpha` on `AnimationFrame` / `AnimationFrameSave`, read/written in the `.achx` (omitted when null so existing files stay byte-identical), copied to the runtime frame. `Sprite.CurrentFrame` (from #434) surfaces it for free — the FRB2 runtime does **not** auto-apply it; game code reads it and decides how to use it.
2. **Alpha previews as opacity (editor preview only).** `DrawFrameCore` scales the drawn sprite's alpha by `Alpha/255` via the pure `FramePreviewOpacity.Resolve` (null = opaque; combines with the 0.4 onion-skin layer). Reference render only — runtimes apply it however they choose; the runtime `Sprite` is intentionally **not** wired this pass.
3. **Commit-on-blur single-undo across R/G/B/A.** Avalonia `NumericUpDown` raises `ValueChanged` on every keystroke, so the channel fields recorded one undo entry per keypress. Now they commit a single entry on edit completion (LostFocus / Enter). **This was a pre-existing bug shared by R/G/B** — the alpha work exposed it — so all four are fixed consistently. (Tradeoff: live tint/opacity preview now updates on commit, not per keystroke.)
4. **COLOR section responsive WrapPanel.** R/G/B/A are self-contained `[label][box]` units (MinWidth 86) in a WrapPanel that reflows 4→2→1 across as the panel narrows — no overlap at any width.
5. **COORDINATES section responsive WrapPanel.** Same pattern applied to X/Y/W/H, kept as two pair-rows (position X/Y, then size W/H) so the pairing can't pack as `X Y W / H`. **Pre-existing layout issue, bundled deliberately for momentum** while the WrapPanel pattern is fresh.
6. **COLOR helper text → info-icon tooltip.** The always-on wrapping helper paragraph grew the panel when narrow; the text moved verbatim into a fixed-footprint ⓘ badge tooltip next to the COLOR header.

## Design contract (alpha)
- 0–255, nullable, null omitted from the `.achx`.
- Game-consumed for the runtime: read `frame.Alpha` via `Sprite.CurrentFrame`. The editor previews it as a reference (opacity); the FRB2 runtime does not auto-apply it. Independent of `ColorOperation` (straight transparency, not a tint op).

## Tests
- Engine `AnimationFrameColorTests` — `.achx` round-trip incl. null-omission, save↔runtime conversion, `Sprite.CurrentFrame.Alpha`.
- Editor `InspectorPropertyUndoTests` + `UndoCoverageRosterTests` — alpha undo coverage; single-entry-per-commit assertion.
- `FramePreviewOpacityTests` — pure core for the opacity mapping.
- `InspectorChannelCommitTests` ([AvaloniaFact]) — value churn + commit = a single undo, covering both Enter and focus-loss.
- The two WrapPanel layouts and the info-icon are visual / not unit-tested; the App suite stays green (XAML compiles, by-name field lookups resolve).

All suites green: engine 1071, editor Core 1236, editor App 478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)