### PR TITLE
Centralize the Apos.Shapes package version (#447)

### DIFF
--- a/frb-skills/shaders/SKILL.md
+++ b/frb-skills/shaders/SKILL.md
@@ -16,9 +16,11 @@ FlatRedBall2 ships precompiled `.xnb` shaders for its built-in Apos.Shapes depen
 
 Projects import `AposShapesPrecompiled.props` to use these instead of compiling from source. Unknown platforms fall back to normal Apos.Shapes shader compilation.
 
+The package version is centralized in `$(AposShapesVersion)` (`src/PrecompiledShaders/AposShapes.props`), imported by the engine. Apos.Shapes ships only `buildTransitive` assets, so both the version and the `SkipAposShapeContent` precompiled-XNB skip flow identically whether the package is referenced directly or transitively — sample Desktop projects inherit it from the engine and don't pin it. Re-adding a per-sample pin only reintroduces the drift `NU1605` then fails the build on; bump the prop instead.
+
 ### Version Guard
 
-`ShapesBatch.AposShapesVersion` (in `src/Rendering/Batches/ShapesBatch.cs`) must match the Apos.Shapes NuGet version. In Debug builds, a mismatch throws `InvalidOperationException`. See the comment on that constant for the update checklist.
+`ShapesBatch.AposShapesVersion` (in `src/Rendering/Batches/ShapesBatch.cs`) is a C# const that can't read MSBuild, so it mirrors `$(AposShapesVersion)` by hand. In Debug builds, a mismatch against the loaded Apos.Shapes assembly throws `InvalidOperationException`. See the comment on that constant (and `AposShapes.props`) for the rebuild checklist.
 
 ## Custom Shaders
 

--- a/samples/PlatformKing/PlatformKing.Desktop/PlatformKing.Desktop.csproj
+++ b/samples/PlatformKing/PlatformKing.Desktop/PlatformKing.Desktop.csproj
@@ -11,8 +11,11 @@
     <RootNamespace>PlatformKing</RootNamespace>
   </PropertyGroup>
 
+  <!-- Apos.Shapes is intentionally NOT pinned here. Its version flows transitively from
+       the engine, which is the single source of truth ($(AposShapesVersion) in
+       src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
+       wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>

--- a/samples/ShmupSpace/ShmupSpace.Desktop/ShmupSpace.Desktop.csproj
+++ b/samples/ShmupSpace/ShmupSpace.Desktop/ShmupSpace.Desktop.csproj
@@ -11,8 +11,11 @@
     <RootNamespace>ShmupSpace</RootNamespace>
   </PropertyGroup>
 
+  <!-- Apos.Shapes is intentionally NOT pinned here. Its version flows transitively from
+       the engine, which is the single source of truth ($(AposShapesVersion) in
+       src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
+       wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>

--- a/samples/Solitaire/Solitaire.Desktop/Solitaire.Desktop.csproj
+++ b/samples/Solitaire/Solitaire.Desktop/Solitaire.Desktop.csproj
@@ -11,8 +11,11 @@
     <RootNamespace>Solitaire</RootNamespace>
   </PropertyGroup>
 
+  <!-- Apos.Shapes is intentionally NOT pinned here. Its version flows transitively from
+       the engine, which is the single source of truth ($(AposShapesVersion) in
+       src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
+       wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
   </ItemGroup>

--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <!-- Single source of truth for $(AposShapesVersion); see that file before bumping it. -->
+  <Import Project="PrecompiledShaders/AposShapes.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -57,7 +60,7 @@
 
   <!-- MonoGame backend -->
   <ItemGroup Condition="'$(Backend)' == 'MonoGame'">
-    <PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
+    <PackageReference Include="Apos.Shapes" Version="$(AposShapesVersion)" />
     <PackageReference Include="Gum.MonoGame" Version="2026.6.26.1" />
     <PackageReference Include="Gum.Shapes.MonoGame" Version="2026.6.26.1" />
     <PackageReference Include="KernSmith.MonoGameGum" Version="0.13.*" />
@@ -69,7 +72,7 @@
 
   <!-- KNI backend (Blazor WebAssembly + future mobile targets) -->
   <ItemGroup Condition="'$(Backend)' == 'Kni'">
-    <PackageReference Include="Apos.Shapes.KNI" Version="0.6.10-alpha" />
+    <PackageReference Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
     <PackageReference Include="Gum.KNI" Version="2026.6.26.1" />
     <PackageReference Include="Gum.Shapes.KNI" Version="2026.6.26.1" />
     <PackageReference Include="KernSmith.KniGum" Version="0.13.*" />

--- a/src/PrecompiledShaders/AposShapes.props
+++ b/src/PrecompiledShaders/AposShapes.props
@@ -1,0 +1,39 @@
+<Project>
+  <!--
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │  SINGLE SOURCE OF TRUTH for the Apos.Shapes package version.              │
+    └─────────────────────────────────────────────────────────────────────────┘
+
+    The engine (src/FlatRedBall2.csproj) imports this file and drives both its
+    Apos.Shapes (MonoGame) and Apos.Shapes.KNI (BlazorGL/KNI) PackageReferences
+    from $(AposShapesVersion). Sample projects pick the version up transitively
+    through their reference to the engine — they do NOT pin it themselves.
+
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │  ⚠  WHEN YOU CHANGE THIS VERSION, YOU MUST REBUILD THE PRECOMPILED XNBs.  │
+    └─────────────────────────────────────────────────────────────────────────┘
+
+    Apos.Shapes ships an .fx shader that the MonoGame/KNI content pipeline must
+    compile. So macOS/Linux users don't need Wine, FlatRedBall2 ships precompiled
+    apos-shapes.xnb files under src/PrecompiledShaders/<platform>/ and skips the
+    library's own shader compilation (see AposShapesPrecompiled.props). Those XNBs
+    are produced from a SPECIFIC Apos.Shapes version's shader source — bumping the
+    package without rebuilding them ships a stale shader against a new runtime.
+
+    After changing $(AposShapesVersion):
+      1. Rebuild a sample on each platform (DesktopGL, BlazorGL) so the content
+         pipeline compiles fresh apos-shapes.xnb files.
+      2. Copy the new XNBs into src/PrecompiledShaders/<platform>/.
+      3. Update ShapesBatch.AposShapesVersion (a C# const — it can't read MSBuild)
+         to match this value.
+      4. Verify each sample runs and renders shapes correctly.
+
+    The runtime guard in ShapesBatch.ValidateAposShapesVersion() throws (DEBUG
+    builds) if the loaded Apos.Shapes assembly version doesn't match the const,
+    catching a forgotten rebuild — but it can only check the const, not this prop,
+    so keep the two in sync by hand.
+  -->
+  <PropertyGroup>
+    <AposShapesVersion>0.6.10-alpha</AposShapesVersion>
+  </PropertyGroup>
+</Project>

--- a/src/PrecompiledShaders/AposShapesPrecompiled.props
+++ b/src/PrecompiledShaders/AposShapesPrecompiled.props
@@ -8,12 +8,15 @@
 
     Unknown platforms fall back to normal compilation (Apos.Shapes' own MSBuild targets handle it).
 
+    The Apos.Shapes PACKAGE version is centralized in AposShapes.props (sibling file) as
+    $(AposShapesVersion) — see that file for the rule on rebuilding these XNBs after a bump.
+
     ALLOWLIST: Only platforms with a verified precompiled XNB in this directory are listed.
     To add a new platform:
       1. Build a sample on that platform so the content pipeline compiles apos-shapes.xnb
       2. Copy the resulting .xnb into a new subfolder here (e.g. DirectX/)
       3. Add the platform to the condition below
-      4. Update AposShapesVersion in FlatRedBall2's source to match (see ShapesBatch.cs)
+      4. Update ShapesBatch.AposShapesVersion (C# const) to match $(AposShapesVersion)
   -->
 
   <PropertyGroup>

--- a/src/Rendering/Batches/ShapesBatch.cs
+++ b/src/Rendering/Batches/ShapesBatch.cs
@@ -20,8 +20,13 @@ public class ShapesBatch : IRenderBatch
     // users don't need Wine for shader compilation. This constant must match the
     // version of Apos.Shapes whose shader was used to produce those XNBs.
     //
+    // The PACKAGE version lives in MSBuild as $(AposShapesVersion)
+    // (src/PrecompiledShaders/AposShapes.props) — the single source of truth that
+    // drives every csproj. A C# const can't read MSBuild, so this mirrors it by
+    // hand; keep the two equal. See AposShapes.props for the full rebuild procedure.
+    //
     // ONLY UPDATE THIS AFTER:
-    //   1. Updating the Apos.Shapes NuGet version in FlatRedBall2.csproj
+    //   1. Bumping $(AposShapesVersion) in src/PrecompiledShaders/AposShapes.props
     //   2. Rebuilding a sample on each platform (DesktopGL, BlazorGL) so the
     //      content pipeline compiles fresh apos-shapes.xnb files
     //   3. Copying the new XNBs into src/PrecompiledShaders/<platform>/


### PR DESCRIPTION
Closes #447.

## Problem

The `Apos.Shapes` version was hard-coded in multiple independent places — the engine's two backend `PackageReference`s, each sample's `*.Desktop.csproj` pin, and the `ShapesBatch` runtime-guard `const`. No single source of truth, so every bump needed a manual sweep and a missed sample pin failed its build outright with `NU1605` (this bit during #446).

## Fix

- **New `src/PrecompiledShaders/AposShapes.props`** — defines `$(AposShapesVersion)` as the single source of truth, with a prominent comment block on the **importance of rebuilding the precompiled `apos-shapes.xnb` shaders whenever the version changes** (the XNBs are baked from a specific Apos.Shapes shader source; a bump without a rebuild ships a stale shader).
- **Engine** imports it and drives both `Apos.Shapes` (MonoGame) and `Apos.Shapes.KNI` (KNI) from `$(AposShapesVersion)`.
- **Sample Desktop pins deleted** — they now resolve transitively from the engine. `buildTransitive/Apos.Shapes.props` (which wires `SkipAposShapeContent` + the precompiled-XNB skip) is imported identically for direct *and* transitive references, so the content pipeline is unaffected. Confirmed the built `apos-shapes.xnb` is **byte-identical before/after** (clean-rebuild md5 match).
- **`ShapesBatch.AposShapesVersion`** (a C# `const` — can't read MSBuild) stays, but is now cross-referenced to/from the prop and `AposShapesPrecompiled.props`.

Duplication drops **4 → 2** (one MSBuild prop + one C# const), explicitly cross-linked. One MSBuild edit now changes the version for the engine and every sample.

### Out of scope (intentional)
- `templates/` — copied downstream, so they can't reference the repo-internal props; they ship their own precompiled XNB and pin independently.
- `samples/auto/` — gitignored generated eval fleet.

## Verification (build matrix)
- Engine `net8` (KNI) + `net10` (MonoGame): resolve `Apos.Shapes(.KNI) 0.6.10-alpha` via the prop ✓
- `PlatformKing.Desktop`, `ShmupSpace.Desktop`, `Solitaire.Desktop`: build, transitive `0.6.10-alpha`, **no NU1605** ✓
- `PlatformKing.BlazorGL`: builds, transitive `Apos.Shapes.KNI 0.6.10-alpha` ✓
- 1078 engine tests pass ✓

### Test discipline (option b — no test added)
No runtime behavior changes: this is MSBuild version centralization plus comment updates, with no unit-testable core. The verification is the build matrix above plus the byte-identical-XNB check, not a new unit test.

### Note (pre-existing, not addressed here)
On Windows the content pipeline compiles `apos-shapes.fx` fresh rather than using the shipped precompiled XNB (the built XNB differs from `src/PrecompiledShaders/DesktopGL/apos-shapes.xnb`). This is unchanged by this PR and orthogonal to version centralization — flagging it as a separate latent question about whether the precompiled-XNB skip is actually engaging on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)