### PR TITLE
Shape right-click menu parity with frames (#458)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2300,6 +2300,7 @@ public partial class MainWindow : Window
 
         if (vm?.Data is AARectSave rect)
         {
+            AddShapeReorderItems(rect, _objectFinder.GetAnimationFrameContaining(rect));
             AddMenuItem("Match Frame Size", () =>
             {
                 var frame = _selectedState.SelectedFrame;
@@ -2310,6 +2311,13 @@ public partial class MainWindow : Window
                     _appCommands.SaveCurrentAnimationChainList();
                 }
             });
+            AddSeparator();
+            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Paste", () => _ = HandlePasteAsync());
+            AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(rect));
+            AddSeparator();
+            AddMenuItem("Rename…", () => BeginInlineRename(vm!, rect.Name));
+            AddSeparator();
             AddMenuItem("Delete Rectangle", () =>
             {
                 var frame = _objectFinder.GetAnimationFrameContaining(rect);
@@ -2319,6 +2327,13 @@ public partial class MainWindow : Window
         }
         else if (vm?.Data is CircleSave circle)
         {
+            AddShapeReorderItems(circle, _objectFinder.GetAnimationFrameContaining(circle));
+            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Paste", () => _ = HandlePasteAsync());
+            AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(circle));
+            AddSeparator();
+            AddMenuItem("Rename…", () => BeginInlineRename(vm!, circle.Name));
+            AddSeparator();
             AddMenuItem("Delete Circle", () =>
             {
                 var frame = _objectFinder.GetAnimationFrameContaining(circle);
@@ -2404,6 +2419,23 @@ public partial class MainWindow : Window
         AddSeparator();
         AddMenuItem("Sort Animations Alphabetically",
             () => _appCommands.SortAnimationsAlphabetically());
+    }
+
+    // Adds the four reorder items (To Top / Up / Down / To Bottom) for a shape,
+    // guarded by the shape's position within its frame's combined shape list — the
+    // same convention the frame menu uses. No-op when the frame has one shape or less.
+    private void AddShapeReorderItems(object shape, AnimationFrameSave? frame)
+    {
+        var shapes = frame?.ShapesSave?.Shapes;
+        if (shapes is null || shapes.Count <= 1) return;
+        int  index   = shapes.IndexOf(shape);
+        bool isFirst = index == 0;
+        bool isLast  = index == shapes.Count - 1;
+        if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveShapeToTop(shape, frame!));
+        if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveShape(shape, frame!, -1));
+        if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveShape(shape, frame!, +1));
+        if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveShapeToBottom(shape, frame!));
+        AddSeparator();
     }
 
     private void AddMenuItem(string header, Action onClick)
@@ -3453,6 +3485,8 @@ public partial class MainWindow : Window
                 // has temporarily lost focus (e.g. immediately after ALT+arrow reorder, where
                 // focus shifts before our Background-priority re-focus post runs).
                 var vm = AnimTree.SelectedItem as TreeNodeVm
+                      ?? (_selectedState.SelectedShape is { } ss
+                              ? TreeBuilder.FindNodeForData(_treeRoots, ss) : null)
                       ?? (_selectedState.SelectedFrame is { } sf
                               ? TreeBuilder.FindNodeForData(_treeRoots, sf) : null)
                       ?? (_selectedState.SelectedChain is { } sc
@@ -3464,6 +3498,10 @@ public partial class MainWindow : Window
                         BeginInlineRename(vm, chain.Name);
                     else if (vm.Data is AnimationFrameSave frame)
                         BeginInlineRename(vm, frame.HasCustomName ? frame.Name : string.Empty);
+                    else if (vm.Data is AARectSave rect)
+                        BeginInlineRename(vm, rect.Name);
+                    else if (vm.Data is CircleSave circle)
+                        BeginInlineRename(vm, circle.Name);
                 }
                 else
                     WireframeCtrl.ToggleDebugMode();
@@ -4206,6 +4244,20 @@ public partial class MainWindow : Window
         {
             if (!string.IsNullOrEmpty(newName))
                 _appCommands.RenameFrame(frame, newName);
+        }
+        else if (vm.Data is AARectSave rect)
+        {
+            if (!string.IsNullOrEmpty(newName) && newName != rect.Name)
+                _appCommands.SetRectProps(
+                    _objectFinder.GetAnimationFrameContaining(rect),
+                    rect, newName, rect.X, rect.Y, rect.ScaleX, rect.ScaleY);
+        }
+        else if (vm.Data is CircleSave circle)
+        {
+            if (!string.IsNullOrEmpty(newName) && newName != circle.Name)
+                _appCommands.SetCircleProps(
+                    _objectFinder.GetAnimationFrameContaining(circle),
+                    circle, newName, circle.X, circle.Y, circle.Radius);
         }
 
         AnimTree.Focus();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -562,6 +562,28 @@ namespace AnimationEditor.Core.CommandsAndState
                 delta > 0 ? "Move Shape Down" : "Move Shape Up"));
         }
 
+        public void MoveShapeToTop(object shape, AnimationFrameSave frame)
+        {
+            var shapes = frame.ShapesSave?.Shapes;
+            if (shapes is null || !shapes.Contains(shape)) return;
+            _undoManager.Execute(new ReorderCommand<object>(
+                shapes,
+                () => { shapes.Remove(shape); shapes.Insert(0, shape); },
+                this, _events, () => RefreshTreeNode(frame),
+                "Move Shape to Top"));
+        }
+
+        public void MoveShapeToBottom(object shape, AnimationFrameSave frame)
+        {
+            var shapes = frame.ShapesSave?.Shapes;
+            if (shapes is null || !shapes.Contains(shape)) return;
+            _undoManager.Execute(new ReorderCommand<object>(
+                shapes,
+                () => { shapes.Remove(shape); shapes.Add(shape); },
+                this, _events, () => RefreshTreeNode(frame),
+                "Move Shape to Bottom"));
+        }
+
         /// <summary>
         /// Moves the currently-selected shape, frame, or chain up (<paramref name="delta"/> = -1)
         /// or down (<paramref name="delta"/> = +1) in the tree.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -101,6 +101,8 @@ namespace AnimationEditor.Core.CommandsAndState
         void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain);
         void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain);
         void MoveShape(object shape, AnimationFrameSave frame, int delta);
+        void MoveShapeToTop(object shape, AnimationFrameSave frame);
+        void MoveShapeToBottom(object shape, AnimationFrameSave frame);
         void HandleReorder(int delta);
         void FlipFrameHorizontally(AnimationFrameSave frame);
         void FlipFrameVertically(AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeContextMenuTests.cs
@@ -114,4 +114,98 @@ public class TreeContextMenuTests
         }
         finally { window.Close(); }
     }
+
+    // ── Shape menus (issue #458): parity with the frame menu ──────────────────
+
+    // Builds a chain → frame holding two shapes so reorder items (guarded by
+    // position) are present, and returns the frame + both shapes.
+    private static (AnimationFrameSave Frame, AARectSave Rect, CircleSave Circle)
+        SetupFrameWithTwoShapes(TestServices ctx)
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "run.png", ShapesSave = new ShapesSave() };
+        var rect   = new AARectSave { Name = "Rect" };
+        var circle = new CircleSave { Name = "Circle" };
+        frame.ShapesSave.Shapes.Add(rect);    // index 0 → "first"
+        frame.ShapesSave.Shapes.Add(circle);  // index 1 → "last"
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        return (frame, rect, circle);
+    }
+
+    [AvaloniaFact]
+    public void RectMenu_HasCopyPasteDuplicateRenameAndMatchFrameSize()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var (_, rect, _) = SetupFrameWithTwoShapes(ctx);
+            var items = OpenMenuFor(window, rect, "Rect");
+
+            int copy = IndexOfItem(items, "Copy");
+            Assert.True(copy >= 0);
+            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.True(IndexOfItem(items, "Rename…")        >= 0);
+            Assert.True(IndexOfItem(items, "Match Frame Size") >= 0);
+            Assert.True(IndexOfItem(items, "Delete Rectangle") >= 0);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RectMenu_FirstOfTwoShapes_ShowsMoveDownButNotMoveUp()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // Rect is at index 0 → only the "move toward the end" items make sense.
+            var (_, rect, _) = SetupFrameWithTwoShapes(ctx);
+            var items = OpenMenuFor(window, rect, "Rect");
+
+            Assert.True(IndexOfItem(items, "v  Move Down")      >= 0);
+            Assert.True(IndexOfItem(items, "vv Move To Bottom") >= 0);
+            Assert.Equal(-1, IndexOfItem(items, "^  Move Up"));
+            Assert.Equal(-1, IndexOfItem(items, "^^ Move To Top"));
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CircleMenu_HasCopyPasteDuplicateRename_AndNoMatchFrameSize()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var (_, _, circle) = SetupFrameWithTwoShapes(ctx);
+            var items = OpenMenuFor(window, circle, "Circle");
+
+            int copy = IndexOfItem(items, "Copy");
+            Assert.True(copy >= 0);
+            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.True(IndexOfItem(items, "Rename…")      >= 0);
+            Assert.True(IndexOfItem(items, "Delete Circle") >= 0);
+            // Match Frame Size is rect-only.
+            Assert.Equal(-1, IndexOfItem(items, "Match Frame Size"));
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CommitInlineRename_Rectangle_RenamesShape()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var (_, rect, _) = SetupFrameWithTwoShapes(ctx);
+            var vm = new TreeNodeVm { Header = "Rect", Data = rect };
+
+            window.CommitInlineRenamePublic(vm, "Renamed");
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("Renamed", rect.Name);
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -338,6 +338,68 @@ public class AppCommandsReorderTests
         Assert.Equal(circB, frame.ShapesSave.Shapes[1]);
     }
 
+    // ── MoveShapeToBottom ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveShapeToBottom_FromMiddle_MovesShapeToEnd()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        var rectC = new AARectSave { Name = "C" };
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectC);
+
+        ctx.AppCommands.MoveShapeToBottom(rectA, frame);
+
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectC, frame.ShapesSave.Shapes[1]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[2]);
+    }
+
+    // ── MoveShapeToTop ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveShapeToTop_FromMiddle_MovesShapeToFront()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        var rectC = new AARectSave { Name = "C" };
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
+        frame.ShapesSave!.Shapes.Add(rectC);
+
+        ctx.AppCommands.MoveShapeToTop(rectC, frame);
+
+        Assert.Equal(rectC, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[1]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[2]);
+    }
+
+    [Fact]
+    public void MoveShapeToTop_Undo_RestoresOriginalOrder()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        frame.ShapesSave!.Shapes.Add(rectA);
+        frame.ShapesSave!.Shapes.Add(rectB);
+
+        ctx.AppCommands.MoveShapeToTop(rectB, frame);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(rectA, frame.ShapesSave.Shapes[0]);
+        Assert.Equal(rectB, frame.ShapesSave.Shapes[1]);
+    }
+
     // ── MoveShape — cross-type ────────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -225,7 +225,11 @@ public class UndoCoverageRosterTests
         yield return Row(nameof(IAppCommands.MoveShape),
             ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.MoveShapeToTop),
-            ctx => Sync(() => ctx.AppCommands.MoveShapeToTop(Circle(ctx), Zebra(ctx).Frames[0]))); // Circle is not already first
+            // The .achx format serializes shapes in FRB1's per-type lists, so the round-trip oracle
+            // only sees order changes *within* a type — cross-type position is not persisted (a V2
+            // unified-order format would change this). Move the *second* circle so the circles list
+            // actually reorders; moving the first circle would be a no-op in the serialized output.
+            ctx => Sync(() => ctx.AppCommands.MoveShapeToTop(SecondCircle(ctx), Zebra(ctx).Frames[0])));
         yield return Row(nameof(IAppCommands.MoveShapeToBottom),
             ctx => Sync(() => ctx.AppCommands.MoveShapeToBottom(Rect(ctx), Zebra(ctx).Frames[0]))); // Rect is not already last
         yield return Row(nameof(IAppCommands.HandleReorder),
@@ -357,6 +361,7 @@ public class UndoCoverageRosterTests
     private static AnimationChainSave Alpha(TestServices ctx) => ctx.Acls.AnimationChains[1];
     private static AARectSave Rect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves.First();
     private static CircleSave Circle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves.First();
+    private static CircleSave SecondCircle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves.ElementAt(1);
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -74,6 +74,8 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShape)]                    = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveShapeToTop)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveShapeToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.HandleReorder)]                = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameHorizontally)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipFrameVertically)]          = Category.MutatingUndoable,
@@ -222,6 +224,10 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MoveFrameToBottom(Zebra(ctx).Frames[0], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveShape),
             ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
+        yield return Row(nameof(IAppCommands.MoveShapeToTop),
+            ctx => Sync(() => ctx.AppCommands.MoveShapeToTop(Circle(ctx), Zebra(ctx).Frames[0]))); // Circle is not already first
+        yield return Row(nameof(IAppCommands.MoveShapeToBottom),
+            ctx => Sync(() => ctx.AppCommands.MoveShapeToBottom(Rect(ctx), Zebra(ctx).Frames[0]))); // Rect is not already last
         yield return Row(nameof(IAppCommands.HandleReorder),
             ctx => Sync(() => ctx.AppCommands.HandleReorder(+1))); // selection is set up by Arrange
         yield return Row(nameof(IAppCommands.FlipFrameHorizontally),


### PR DESCRIPTION
Closes #458

## What

Brings the tree-view right-click context menu for **shapes** (`AARectSave` / `CircleSave`) up to parity with the **frame** menu.

### Shape menu now offers
- **Copy / Paste / Duplicate** — wired to the existing `HandleCopyAsync` / `HandlePasteAsync` / `DuplicateShape` paths. Copy serializes the selected shape; paste targets the selected frame (selecting a shape sets `SelectedFrame` to its parent); all three are already undoable.
- **Reorder** — `^^ Move To Top` / `^ Move Up` / `v Move Down` / `vv Move To Bottom`, guarded by the shape's position within its frame's combined shape list, mirroring the frame menu.
- **Rename…** — inline rename (same TextBox-in-tree UX as frames/chains), committing through `SetRectProps` / `SetCircleProps`.
- **Match Frame Size** — kept rect-only, as the issue specified.

### Notes vs. the issue
- `DuplicateShape` was described as not-yet-existing, but it was already implemented and undoable — this PR just wires it into the menu.
- Added the only missing backend pieces: `MoveShapeToTop` / `MoveShapeToBottom` (previously only delta-based `MoveShape` existed). Both are undoable and registered in the undo-coverage roster.
- `CommitInlineRename` and the F2 keyboard path now also route rect/circle nodes, so menu and keyboard rename stay consistent.

## Tests
- **Core** (`AppCommandsReorderTests`): `MoveShapeToTop` / `MoveShapeToBottom` behavior + undo; new commands registered in `UndoCoverageRosterTests` (round-trip verified).
- **App** (`TreeContextMenuTests`): rect/circle menu structure (Copy/Paste/Duplicate consecutive, Rename present, Match Frame Size rect-only), position-guarded reorder items, and shape inline-rename routing.
- Full editor suite green: 1261 Core + 504 App.

Test-discipline note: assertions in the AnimationEditor test projects use xUnit `Assert.*` to match the existing convention across all ~1700 tests there (the repo-wide Shouldly preference predates this tool's suite).