### PR TITLE
Mirror attached shape offsets on flip and duplicate-with-flip (#459)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -692,7 +692,11 @@ namespace AnimationEditor.Core.CommandsAndState
                 {
                     foreach (var shape in frame.ShapesSave.Shapes)
                         if (CloneShape(shape) is { } shapeCopy)
+                        {
+                            // Mirror the copy's offsets so collision tracks the flipped sprite.
+                            ShapeFlip.Mirror(shapeCopy, flipH, flipV);
                             fCopy.ShapesSave!.Shapes.Add(shapeCopy);
+                        }
                 }
                 copy.Frames.Add(fCopy);
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -684,8 +684,10 @@ namespace AnimationEditor.Core.CommandsAndState
                     FrameLength      = frame.FrameLength,
                     FlipHorizontal   = flipH ? !frame.FlipHorizontal : frame.FlipHorizontal,
                     FlipVertical     = flipV ? !frame.FlipVertical   : frame.FlipVertical,
-                    RelativeX        = frame.RelativeX,
-                    RelativeY        = frame.RelativeY,
+                    // Mirror the sprite offset about the entity origin so an off-center frame stays
+                    // aligned with its (also-mirrored) shapes after the flip.
+                    RelativeX        = flipH ? -frame.RelativeX : frame.RelativeX,
+                    RelativeY        = flipV ? -frame.RelativeY : frame.RelativeY,
                     ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave()
                 };
                 if (frame.ShapesSave != null)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
@@ -39,6 +39,12 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             {
                 if (_horizontal) frame.FlipHorizontal = !frame.FlipHorizontal;
                 else frame.FlipVertical = !frame.FlipVertical;
+
+                // Mirror attached shape offsets so collision geometry tracks the flipped sprite.
+                // Mirror is its own inverse, so undo/redo (which re-toggle) restore offsets exactly.
+                if (frame.ShapesSave != null)
+                    foreach (var shape in frame.ShapesSave.Shapes)
+                        ShapeFlip.Mirror(shape, _horizontal, !_horizontal);
             }
             _refresh();
             _events.RaiseAnimationChainsChanged();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
@@ -37,11 +37,20 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         {
             foreach (var frame in _frames)
             {
-                if (_horizontal) frame.FlipHorizontal = !frame.FlipHorizontal;
-                else frame.FlipVertical = !frame.FlipVertical;
+                if (_horizontal)
+                {
+                    frame.FlipHorizontal = !frame.FlipHorizontal;
+                    frame.RelativeX = -frame.RelativeX;   // mirror sprite offset about the entity origin
+                }
+                else
+                {
+                    frame.FlipVertical = !frame.FlipVertical;
+                    frame.RelativeY = -frame.RelativeY;
+                }
 
-                // Mirror attached shape offsets so collision geometry tracks the flipped sprite.
-                // Mirror is its own inverse, so undo/redo (which re-toggle) restore offsets exactly.
+                // Mirror attached shape offsets about the same origin so collision geometry tracks
+                // the flipped sprite. Negation is its own inverse, so undo/redo (which re-toggle)
+                // restore both the sprite offset and the shape offsets exactly.
                 if (frame.ShapesSave != null)
                     foreach (var shape in frame.ShapesSave.Shapes)
                         ShapeFlip.Mirror(shape, _horizontal, !_horizontal);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeFlip.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeFlip.cs
@@ -1,0 +1,47 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Mirrors a shape's stored offsets to match a frame flip so collision geometry tracks the
+/// mirrored sprite. A horizontal flip negates the shape's X, a vertical flip negates its Y,
+/// about the entity origin (0,0) — the same space shape offsets live in at runtime
+/// (the runtime mirrors only the sprite and applies shape offsets verbatim, so the editor
+/// bakes the mirror into the data). Negation is its own exact inverse, so re-applying the
+/// same flip restores the original offsets with no rounding drift.
+/// <para>
+/// Shared by <see cref="Commands.FlipCommand"/> (in-place flip) and the duplicate-with-flip
+/// path in <c>AppCommands.DuplicateChain</c> so both use identical logic.
+/// </para>
+/// </summary>
+public static class ShapeFlip
+{
+    /// <summary>Negates the offsets of <paramref name="shape"/> in place along each flipped axis.</summary>
+    public static void Mirror(object shape, bool flipHorizontal, bool flipVertical)
+    {
+        switch (shape)
+        {
+            case AARectSave r:
+                if (flipHorizontal) r.X = -r.X;
+                if (flipVertical)   r.Y = -r.Y;
+                break;
+            case CircleSave c:
+                if (flipHorizontal) c.X = -c.X;
+                if (flipVertical)   c.Y = -c.Y;
+                break;
+            case PolygonSave p:
+                // Mirror the origin and every vertex so the polygon outline flips too.
+                if (flipHorizontal)
+                {
+                    p.X = -p.X;
+                    foreach (var pt in p.Points) pt.X = -pt.X;
+                }
+                if (flipVertical)
+                {
+                    p.Y = -p.Y;
+                    foreach (var pt in p.Points) pt.Y = -pt.Y;
+                }
+                break;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -441,6 +441,22 @@ public class AppCommandsChainTests
     }
 
     [Fact]
+    public void DuplicateChain_WithFlipV_NegatesFrameRelativeY()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Walk", 1);
+        source.Frames[0].RelativeX = 20;
+        source.Frames[0].RelativeY = 7;
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipV: true);
+
+        Assert.Equal(20, copy!.Frames[0].RelativeX);  // horizontal offset untouched
+        Assert.Equal(-7, copy.Frames[0].RelativeY);   // vertical flip mirrors sprite offset
+        Assert.Equal(7, source.Frames[0].RelativeY);  // source untouched
+    }
+
+    [Fact]
     public void DuplicateChain_WithFlipH_NegatesFrameRelativeX()
     {
         var ctx = TestHelpers.SetupFreshAcls();
@@ -724,6 +740,32 @@ public class AppCommandsChainTests
         ctx.AppCommands.FlipFrameVertically(frame);
 
         Assert.False(frame.FlipVertical);
+    }
+
+    [Fact]
+    public void FlipFrameVertically_MirrorsAttachedShapeOffsets()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
+
+        ctx.AppCommands.FlipFrameVertically(frame);
+
+        var rect = frame.ShapesSave.AARectSaves.First();
+        Assert.Equal(12, rect.X);    // horizontal offset untouched
+        Assert.Equal(-5, rect.Y);    // vertical flip negates Y
+    }
+
+    [Fact]
+    public void FlipFrameVertically_NegatesFrameRelativeY()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { RelativeX = 20, RelativeY = 7 };
+
+        ctx.AppCommands.FlipFrameVertically(frame);
+
+        Assert.Equal(20, frame.RelativeX);   // horizontal offset untouched
+        Assert.Equal(-7, frame.RelativeY);   // sprite offset mirrors about the origin
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -405,6 +405,42 @@ public class AppCommandsChainTests
     }
 
     [Fact]
+    public void DuplicateChain_WithFlipH_MirrorsShapeOffsets()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Attack", 1);
+        source.Frames[0].ShapesSave!.Shapes.Add(new AARectSave { Name = "HitBox", X = 10, Y = 4 });
+        source.Frames[0].ShapesSave!.Shapes.Add(new CircleSave { Name = "Hurt", X = -6, Y = 3 });
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        var rect = copy!.Frames[0].ShapesSave!.AARectSaves.First();
+        Assert.Equal(-10, rect.X);   // horizontal flip negates X
+        Assert.Equal(4, rect.Y);     // vertical offset untouched
+        var circle = copy.Frames[0].ShapesSave!.CircleSaves.First();
+        Assert.Equal(6, circle.X);
+        Assert.Equal(3, circle.Y);
+        // Source must be untouched — duplicate copies, never mutates.
+        Assert.Equal(10, source.Frames[0].ShapesSave!.AARectSaves.First().X);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipV_MirrorsShapeYOffsets()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Attack", 1);
+        source.Frames[0].ShapesSave!.Shapes.Add(new AARectSave { Name = "HitBox", X = 10, Y = 4 });
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipV: true);
+
+        var rect = copy!.Frames[0].ShapesSave!.AARectSaves.First();
+        Assert.Equal(10, rect.X);    // horizontal offset untouched
+        Assert.Equal(-4, rect.Y);    // vertical flip negates Y
+    }
+
+    [Fact]
     public void DuplicateChain_CopiedChainNameIsUnique()
     {
         var ctx = TestHelpers.SetupFreshAcls();
@@ -562,6 +598,35 @@ public class AppCommandsChainTests
         ctx.AppCommands.FlipFrameHorizontally(frame);
 
         Assert.False(frame.FlipHorizontal);
+    }
+
+    [Fact]
+    public void FlipFrameHorizontally_MirrorsAttachedShapeOffsets()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
+
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+
+        var rect = frame.ShapesSave.AARectSaves.First();
+        Assert.Equal(-12, rect.X);   // horizontal flip negates X
+        Assert.Equal(5, rect.Y);     // vertical offset untouched
+    }
+
+    [Fact]
+    public void FlipFrameHorizontally_TwiceRestoresShapeOffsets()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
+
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+
+        var rect = frame.ShapesSave.AARectSaves.First();
+        Assert.Equal(12, rect.X);    // flip is its own inverse — exact restore
+        Assert.Equal(5, rect.Y);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -441,6 +441,24 @@ public class AppCommandsChainTests
     }
 
     [Fact]
+    public void DuplicateChain_WithFlipH_NegatesFrameRelativeX()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Walk", 1);
+        source.Frames[0].RelativeX = 20;
+        source.Frames[0].RelativeY = 7;
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        // Sprite offset mirrors about the entity origin, same pivot as the shapes,
+        // so an off-center frame stays aligned with its collision after the flip.
+        Assert.Equal(-20, copy!.Frames[0].RelativeX);
+        Assert.Equal(7, copy.Frames[0].RelativeY);   // vertical offset untouched
+        Assert.Equal(20, source.Frames[0].RelativeX); // source untouched
+    }
+
+    [Fact]
     public void DuplicateChain_CopiedChainNameIsUnique()
     {
         var ctx = TestHelpers.SetupFreshAcls();
@@ -598,6 +616,30 @@ public class AppCommandsChainTests
         ctx.AppCommands.FlipFrameHorizontally(frame);
 
         Assert.False(frame.FlipHorizontal);
+    }
+
+    [Fact]
+    public void FlipFrameHorizontally_NegatesFrameRelativeX()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { RelativeX = 20, RelativeY = 7 };
+
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+
+        Assert.Equal(-20, frame.RelativeX);   // sprite offset mirrors about the origin
+        Assert.Equal(7, frame.RelativeY);      // vertical offset untouched
+    }
+
+    [Fact]
+    public void FlipFrameHorizontally_TwiceRestoresFrameRelativeX()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { RelativeX = 20 };
+
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.FlipFrameHorizontally(frame);
+
+        Assert.Equal(20, frame.RelativeX);     // negation is its own inverse
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeFlipTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeFlipTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// ── ShapeFlip ──────────────────────────────────────────────────────────────────
+// Pure helper — negates a shape's offsets about the entity origin to match a frame flip.
+
+public class ShapeFlipTests
+{
+    [Fact]
+    public void Mirror_CircleFlipVertical_NegatesYOnly()
+    {
+        var c = new CircleSave { X = -6, Y = 3 };
+
+        ShapeFlip.Mirror(c, flipHorizontal: false, flipVertical: true);
+
+        Assert.Equal(-6, c.X);
+        Assert.Equal(-3, c.Y);
+    }
+
+    [Fact]
+    public void Mirror_PolygonFlipHorizontal_NegatesOriginAndPointXs()
+    {
+        var p = new PolygonSave { X = 4, Y = 2 };
+        p.Points.Add(new Vector2Save { X = 1, Y = 5 });
+        p.Points.Add(new Vector2Save { X = -3, Y = 7 });
+
+        ShapeFlip.Mirror(p, flipHorizontal: true, flipVertical: false);
+
+        Assert.Equal(-4, p.X);
+        Assert.Equal(2, p.Y);
+        Assert.Equal(-1, p.Points[0].X);
+        Assert.Equal(5, p.Points[0].Y);
+        Assert.Equal(3, p.Points[1].X);
+    }
+
+    [Fact]
+    public void Mirror_RectFlipHorizontal_NegatesXOnly()
+    {
+        var r = new AARectSave { X = 10, Y = 4 };
+
+        ShapeFlip.Mirror(r, flipHorizontal: true, flipVertical: false);
+
+        Assert.Equal(-10, r.X);
+        Assert.Equal(4, r.Y);
+    }
+
+    [Fact]
+    public void Mirror_RectFlipHorizontalTwice_RestoresExactly()
+    {
+        var r = new AARectSave { X = 10, Y = 4 };
+
+        ShapeFlip.Mirror(r, flipHorizontal: true, flipVertical: false);
+        ShapeFlip.Mirror(r, flipHorizontal: true, flipVertical: false);
+
+        Assert.Equal(10, r.X);   // negation is its own inverse — no drift
+        Assert.Equal(4, r.Y);
+    }
+}


### PR DESCRIPTION
## Summary

When a frame was flipped (or duplicated with a flip), the sprite rendered mirrored but **attached collision shapes stayed on the original side**. This mirrors the whole frame about the entity origin so sprite and shapes stay aligned:

- **Shape offsets** — negate each shape's `X` on a horizontal flip and `Y` on a vertical flip.
- **Sprite offset** — negate the frame's `RelativeX`/`RelativeY` on the same axis, so an off-center frame's sprite mirrors about the same origin as its shapes (previously the sprite mirrored in place about its own offset position, drifting out of alignment).

## Approach

- **`ShapeFlip.Mirror`** (new, in `AnimationEditor.Core.CommandsAndState`) centralizes the shape rule for `AARectSave`, `CircleSave`, and `PolygonSave` (origin + every vertex), unit-testable and shared.
- **`FlipCommand`** mirrors each frame's `RelativeX`/`RelativeY` and its shapes on toggle. Negation is its own exact inverse, so Do/Undo/Redo round-trip with no rounding drift.
- **`DuplicateChain`** negates the copied `RelativeX`/`RelativeY` and mirrors each cloned shape when `flipH`/`flipV` is set; the source is never mutated.

## Pivot

Everything is mirrored about the **entity origin** (a clean `-X` / `-Y` sign flip), matching the runtime coordinate space where shape and sprite offsets both live. No renderer change was needed — the preview reads offsets directly, so mirrored data renders correctly.

## Tests

- `ShapeFlipTests` — rect/circle/polygon negation + flip-twice exact restore.
- `AppCommandsChainTests` — duplicate- and flip-with-H/V mirror both shape offsets and frame `RelativeX`/`RelativeY` (source untouched); flip-twice restores exactly.

All 1276 `AnimationEditor.Core.Tests` pass.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)