### PR TITLE
Paste frames after the selected frame, not at the chain end (#462)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3629,9 +3629,16 @@ public partial class MainWindow : Window
         else if (frames is { Count: > 0 })
         {
             AnimationChainSave? targetChain = null;
+            // With a frame selected, insert right after it (matching Duplicate). With a chain
+            // selected (or nothing), append (null index).
+            int? insertIndex = null;
             if (selectedData is AnimationChainSave c) targetChain = c;
             else if (selectedData is AnimationFrameSave f)
+            {
                 targetChain = _objectFinder.GetAnimationChainContaining(f);
+                int idx = targetChain?.Frames.IndexOf(f) ?? -1;
+                if (idx >= 0) insertIndex = idx + 1;
+            }
 
             if (targetChain is null && acls.AnimationChains.Count > 0)
                 targetChain = acls.AnimationChains[^1];
@@ -3642,7 +3649,7 @@ public partial class MainWindow : Window
                 pasted.ShapesSave ??= new ShapesSave();
 
             FramePasteLogic.AssignUniqueNames(targetChain.Frames, frames);
-            _appCommands.PasteFrames(targetChain, frames);
+            _appCommands.PasteFrames(targetChain, frames, insertIndex);
             _selectedState.SelectedFrame = frames[^1];
             _appCommands.RefreshWireframe();
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddFramesCommand.cs
@@ -15,18 +15,25 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly IApplicationEvents _events;
         private readonly ISelectedState _selectedState;
         private readonly AnimationFrameSave? _preAddFrame;
+        private readonly int? _insertIndex;
 
         public string Description { get; }
 
+        /// <param name="insertIndex">Where to place the frames. <c>null</c> appends at the
+        /// end (Add Multiple Frames, or pasting into a chain with no frame selected); a value
+        /// inserts the frames there in order (paste after the selected frame, matching
+        /// Duplicate). Out-of-range values fall back to appending.</param>
         public AddFramesCommand(
             AnimationFrameSave[] frames, AnimationChainSave chain,
-            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
+            IAppCommands commands, IApplicationEvents events, ISelectedState selectedState,
+            int? insertIndex = null)
         {
             _frames = frames;
             _chain = chain;
             _commands = commands;
             _events = events;
             _selectedState = selectedState;
+            _insertIndex = insertIndex;
             _preAddFrame = selectedState.SelectedFrame;
             Description = frames.Length == 1
                 ? $"Add Frame to '{chain.Name}'"
@@ -36,8 +43,16 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         public bool Do()
         {
             if (_frames.Length == 0) return false;
-            foreach (var frame in _frames)
-                _chain.Frames.Add(frame);
+            if (_insertIndex is int start && start >= 0 && start <= _chain.Frames.Count)
+            {
+                for (int i = 0; i < _frames.Length; i++)
+                    _chain.Frames.Insert(start + i, _frames[i]);
+            }
+            else
+            {
+                foreach (var frame in _frames)
+                    _chain.Frames.Add(frame);
+            }
             _commands.RefreshTreeNode(_chain);
             _events.RaiseAnimationChainsChanged();
             _commands.SaveCurrentAnimationChainList();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1095,8 +1095,9 @@ namespace AnimationEditor.Core.CommandsAndState
         }
 
         /// <inheritdoc cref="IAppCommands.PasteFrames"/>
-        public void PasteFrames(AnimationChainSave chain, IReadOnlyList<AnimationFrameSave> frames) =>
-            _undoManager.Execute(new AddFramesCommand(frames.ToArray(), chain, this, _events, _selectedState));
+        public void PasteFrames(AnimationChainSave chain, IReadOnlyList<AnimationFrameSave> frames,
+            int? insertIndex = null) =>
+            _undoManager.Execute(new AddFramesCommand(frames.ToArray(), chain, this, _events, _selectedState, insertIndex));
 
         /// <inheritdoc cref="IAppCommands.PasteRectangle"/>
         public void PasteRectangle(AnimationFrameSave frame, AARectSave rectangle) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -188,8 +188,11 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void PasteChains(IReadOnlyList<AnimationChainSave> chains);
 
-        /// <summary>Appends clipboard frames to <paramref name="chain"/>. Undoable.</summary>
-        void PasteFrames(AnimationChainSave chain, IReadOnlyList<AnimationFrameSave> frames);
+        /// <summary>Adds clipboard frames to <paramref name="chain"/>. Undoable.
+        /// <paramref name="insertIndex"/> <c>null</c> appends; a value inserts the frames
+        /// there in order (paste after the selected frame).</summary>
+        void PasteFrames(AnimationChainSave chain, IReadOnlyList<AnimationFrameSave> frames,
+            int? insertIndex = null);
 
         /// <summary>Adds a clipboard rectangle to <paramref name="frame"/>. Undoable.</summary>
         void PasteRectangle(AnimationFrameSave frame, AARectSave rectangle);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
@@ -102,6 +102,46 @@ public class CopyPasteFocusGateTests
     }
 
     /// <summary>
+    /// Issue #462: with a frame selected mid-chain, Ctrl+V inserts the pasted frame
+    /// immediately after the selected frame (matching Duplicate), not at the chain end.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task CtrlV_FrameSelectedMidChain_InsertsAfterSelectedFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var a = new AnimationFrameSave { TextureName = "a.png" };
+            var b = new AnimationFrameSave { TextureName = "b.png" };
+            var c = new AnimationFrameSave { TextureName = "c.png" };
+            chain.Frames.Add(a);
+            chain.Frames.Add(b);
+            chain.Frames.Add(c);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = b; // mid-list selection
+
+            var xml = ClipboardPayload.Serialize(
+                new List<AnimationFrameSave> { new() { TextureName = "pasted.png", FrameLength = 0.1f } });
+            await window.Clipboard!.SetTextAsync(xml);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            tree.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPress(Key.V, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(4, chain.Frames.Count);
+            Assert.Same(a, chain.Frames[0]);
+            Assert.Same(b, chain.Frames[1]);
+            Assert.Equal("pasted.png", chain.Frames[2].TextureName); // inserted after b
+            Assert.Same(c, chain.Frames[3]);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
     /// Ctrl+C with a TextBox focused must not overwrite clipboard text with
     /// frame XML (nothing in the tree is being copied from a text-editor context).
     /// </summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsPasteTests.cs
@@ -36,19 +36,43 @@ public class AppCommandsPasteTests
     }
 
     [Fact]
-    public void PasteFrames_AppendsFramesToTargetChainAndIsUndoable()
+    public void PasteFrames_WithoutInsertIndex_AppendsToTargetChainAndIsUndoable()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var original = chain.Frames[0];
         var f1 = TestHelpers.MakeFrame("a.png");
         var f2 = TestHelpers.MakeFrame("b.png");
 
         ctx.AppCommands.PasteFrames(chain, new List<AnimationFrameSave> { f1, f2 });
 
-        Assert.Equal(new[] { chain.Frames[0], f1, f2 }, chain.Frames);
+        Assert.Equal(new[] { original, f1, f2 }, chain.Frames);
 
         ctx.UndoManager.Undo();
-        Assert.Single(chain.Frames);
+        Assert.Equal(new[] { original }, chain.Frames);
+    }
+
+    [Fact]
+    public void PasteFrames_WithInsertIndex_InsertsAfterSelectionInOrderAndIsUndoable()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var f0 = chain.Frames[0];
+        var f1 = chain.Frames[1];
+        var f2 = chain.Frames[2];
+        var p1 = TestHelpers.MakeFrame("a.png");
+        var p2 = TestHelpers.MakeFrame("b.png");
+
+        // Selected frame is f1 (index 1) → pasted frames land at indices 2,3, keeping order.
+        ctx.AppCommands.PasteFrames(chain, new List<AnimationFrameSave> { p1, p2 }, insertIndex: 2);
+
+        Assert.Equal(new[] { f0, f1, p1, p2, f2 }, chain.Frames);
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(new[] { f0, f1, f2 }, chain.Frames);
+
+        ctx.UndoManager.Redo();
+        Assert.Equal(new[] { f0, f1, p1, p2, f2 }, chain.Frames);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #462. When pasting a frame (Ctrl+V) with a **frame selected mid-list**, the pasted frame(s) now land **immediately after the selected frame** — matching Duplicate (Ctrl+D) and typical editor conventions — instead of always appending at the chain end.

- **Frame selected** → insert after the selected frame (multiple frames keep their order at consecutive indices).
- **Chain selected, or pasting into a different chain with no frame selected** → append at the end, as before.

## Changes

- `AddFramesCommand` gains an optional `insertIndex` (`null` = append, mirroring `AddChainCommand`). Out-of-range falls back to append; undo/redo round-trips correctly.
- `IAppCommands.PasteFrames` / `AppCommands.PasteFrames` forward the optional `insertIndex`.
- `MainWindow.HandlePasteCoreAsync` computes the index from the selected frame's position in its chain; passes `null` when a chain (or nothing) is selected.

## Tests

- Split the pinned `PasteFrames_AppendsFramesToTargetChain` test into explicit **append** (null index) and **insert-after** (explicit index, with undo+redo) cases.
- Added an App-level `CtrlV_FrameSelectedMidChain_InsertsAfterSelectedFrame` test that drives the real key handler end-to-end.

Full Animation Editor Core (1280) + App (505) suites pass.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)