### PR TITLE
Fix tab right-click context menus stacking (#472)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -217,6 +217,28 @@ public partial class MainWindow : Window
             row.Children.Add(closeBtn);
             tabBorder.Child = row;
 
+            // Attach a single managed ContextMenu (right-click → Detach / Close).  Letting Avalonia
+            // own the menu via the ContextMenu property — rather than constructing and Open()-ing a
+            // fresh ContextMenu on every right-click PointerPressed — is what prevents the menus from
+            // stacking and failing to dismiss (issue #472): Avalonia reuses this one instance and
+            // light-dismisses it on the next click.
+            tabBorder.ContextMenu = new ContextMenu
+            {
+                Items =
+                {
+                    new MenuItem
+                    {
+                        Header = "Detach to New Window",
+                        Command = new RelayCommand(() => DetachTab(captured)),
+                    },
+                    new MenuItem
+                    {
+                        Header = "Close Tab",
+                        Command = new RelayCommand(() => CloseTab(captured)),
+                    },
+                },
+            };
+
             // Pointer handling: immediate pointer-capture on press (so PointerMoved fires even
             // when the cursor moves over other tabs).  Activation is deferred to PointerReleased
             // so that RebuildTabStrip is never called while a drag is in-flight.
@@ -224,29 +246,6 @@ public partial class MainWindow : Window
             tabBorder.PointerPressed += (_, args) =>
             {
                 var pt = args.GetCurrentPoint(tabBorder);
-                if (pt.Properties.IsRightButtonPressed)
-                {
-                    var menu = new ContextMenu
-                    {
-                        Items =
-                        {
-                            new MenuItem
-                            {
-                                Header = "Detach to New Window",
-                                Command = new RelayCommand(() => DetachTab(captured)),
-                            },
-                            new MenuItem
-                            {
-                                Header = "Close Tab",
-                                Command = new RelayCommand(() => CloseTab(captured)),
-                            },
-                        },
-                    };
-                    menu.Open(tabBorder);
-                    args.Handled = true;
-                    return;
-                }
-
                 if (pt.Properties.IsLeftButtonPressed)
                 {
                     // Skip close-button presses so Button.Click still fires normally.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabContextMenuTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression guard for issue #472: right-clicking a document tab must show a single,
+/// managed context menu — never stack a fresh menu on every press. The fix is to attach
+/// one <see cref="Control.ContextMenu"/> per tab (Avalonia light-dismisses and reuses it)
+/// instead of constructing and <c>Open()</c>-ing a new <see cref="ContextMenu"/> on each
+/// right-click. This test asserts each tab Border carries that managed menu with the
+/// expected items, which is impossible to stack by construction.
+/// </summary>
+public class TabContextMenuTests
+{
+    private static string WriteAchx(string dir, string fileName, string chainName)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = chainName + ".png", FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    [AvaloniaFact]
+    public async Task EachTab_HasManagedContextMenu_WithDetachAndCloseItems()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            // Two tabs so the tab strip is visible and populated.
+            await window.OpenFileAsTab(WriteAchx(dir, "a.achx", "Walk"));
+            Dispatcher.UIThread.RunJobs();
+            await window.OpenFileAsTab(WriteAchx(dir, "b.achx", "Run"));
+            Dispatcher.UIThread.RunJobs();
+
+            var tabStrip = window.FindControl<Panel>("TabStrip")!;
+            var tabBorders = tabStrip.Children.OfType<Border>().ToList();
+            Assert.Equal(2, tabBorders.Count);
+
+            foreach (var tabBorder in tabBorders)
+            {
+                // A managed ContextMenu means right-click reuses one menu instead of
+                // stacking a new one — the defect in #472.
+                Assert.NotNull(tabBorder.ContextMenu);
+                var headers = tabBorder.ContextMenu!.Items
+                    .OfType<MenuItem>()
+                    .Select(m => (string?)m.Header)
+                    .ToList();
+                Assert.Contains("Detach to New Window", headers);
+                Assert.Contains("Close Tab", headers);
+            }
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Right-clicking an Animation Editor document tab opened a context menu that didn't dismiss on the next right-click — instead a fresh menu stacked on top, accumulating with each press.

## Root cause

The tab `PointerPressed` handler constructed a **new** `ContextMenu` and called `menu.Open(tabBorder)` on every right-click, keeping no reference to close the previous one. `args.Handled = true` also prevented the press from light-dismissing the prior menu.

## Fix

Attach a single managed `ContextMenu` via the `tabBorder.ContextMenu` property — the same idiomatic pattern the tree view (`AnimTree.ContextMenu`) already uses. Avalonia owns the menu lifecycle, reusing one instance per tab and light-dismissing it on the next click, so stacking is impossible by construction. The manual right-button branch in `PointerPressed` is removed.

## Test

`TabContextMenuTests.EachTab_HasManagedContextMenu_WithDetachAndCloseItems` — opens two tabs and asserts each tab `Border` carries a managed `ContextMenu` with the *Detach to New Window* and *Close Tab* items. Failed before the change (menu was null / opened manually), passes after. Full App suite: 504/504 green.

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)