### PR TITLE
fix(animation-editor): cache tree/timeline thumbnails, drop PNG round-trip (#474)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -139,9 +139,9 @@ public partial class MainWindow : Window
             _appCommands.HotReloadWatcher.Dispose();
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
             PreviewCtrl.IsPlayingChanged -= UpdatePlayPauseIcon;
-            foreach (var vm in _timelineFrames)
-                (vm.Thumbnail as IDisposable)?.Dispose();
-            DisposeTreeThumbnails();
+            // The thumbnail service owns every cached chain/timeline icon; disposing it here
+            // releases them all (and the decoded source sheets) as the window tears down.
+            _thumbnailService.Dispose();
         };
     }
 
@@ -1936,7 +1936,7 @@ public partial class MainWindow : Window
         try
         {
             var acls = _projectManager.AnimationChainListSave;
-            if (acls is null) { DisposeTreeThumbnails(); _treeRoots.Clear(); return; }
+            if (acls is null) { _treeRoots.Clear(); return; }
 
             // Diff-update the root nodes instead of clearing and rebuilding, so each
             // chain's collapse state (and selection) survives copy/paste and reorder.
@@ -1964,7 +1964,6 @@ public partial class MainWindow : Window
         _suppressTreeSelectionHandling = true;
         try
         {
-            DisposeTreeThumbnails();
             _treeRoots.Clear();
 
             var acls = _projectManager.AnimationChainListSave;
@@ -2060,8 +2059,9 @@ public partial class MainWindow : Window
                 chain.Frames.Count > 0 &&
                 !string.IsNullOrEmpty(chain.Frames[0].TextureName))
             {
-                // Force thumbnail regeneration regardless of source equality
-                (node.Thumbnail as IDisposable)?.Dispose();
+                // Force thumbnail regeneration regardless of source equality. The cached bitmap
+                // was already dropped by InvalidatePath above; clearing the node fields makes the
+                // change-detection in RefreshTreeThumbnails re-render from the reloaded sheet.
                 node.Thumbnail = null;
                 node.ThumbnailSource = null;
             }
@@ -2106,21 +2106,13 @@ public partial class MainWindow : Window
             if (!needsRegen)
                 continue;
 
-            (node.Thumbnail as IDisposable)?.Dispose();
+            // The previous bitmap (if any) is cache-owned — drop the reference, don't dispose it.
             node.Thumbnail = source is null
                 ? null
                 : _thumbnailService.GetFrameThumbnail(
                     chain.Frames[0], TreeChainThumbnailPixelSize, TreeChainThumbnailPixelSize);
             node.ThumbnailSource = source;
         }
-    }
-
-    /// <summary>Releases every chain node's first-frame thumbnail bitmap. Call before clearing
-    /// <c>_treeRoots</c> or on window close so the cropped bitmaps are not leaked.</summary>
-    private void DisposeTreeThumbnails()
-    {
-        foreach (var node in _treeRoots)
-            (node.Thumbnail as IDisposable)?.Dispose();
     }
 
     private void SyncTreeSelection()
@@ -2180,12 +2172,9 @@ public partial class MainWindow : Window
 
     private void RebuildTimelineStripCells(AnimationChainSave? chain)
     {
-        // Capture old thumbnails before clearing so we dispose after the collection is empty
-        // (avoids briefly holding disposed Bitmaps in bound Image controls)
-        var oldThumbnails = _timelineFrames.Select(vm => vm.Thumbnail as IDisposable).ToList();
+        // Timeline thumbnails are cache-owned by the ThumbnailService, so just drop the cells —
+        // no per-cell dispose (that would invalidate a bitmap a later cache hit returns).
         _timelineFrames.Clear();
-        foreach (var d in oldThumbnails)
-            d?.Dispose();
 
         foreach (var item in TimelineBuilder.BuildFrameItems(chain))
             _timelineFrames.Add(item);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using AnimationEditor.Core;
+using Avalonia;
+using Avalonia.Platform;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
@@ -12,8 +14,14 @@ namespace AnimationEditor.App.Services;
 /// Decodes texture PNGs once, caches them, and crops frame-region thumbnails.
 /// Shared by the preview render path, the timeline strip, and the animation-tree
 /// first-frame chain icons so a sprite sheet is only decoded a single time.
+/// <para>
+/// Finished per-frame thumbnails are cached too (see <see cref="GetFrameThumbnail"/>),
+/// so switching back to a previously-viewed tab re-uses the existing icons instead of
+/// re-cropping every chain. The service owns those bitmaps; callers must not dispose
+/// the returned <see cref="Avalonia.Media.Imaging.Bitmap"/>.
+/// </para>
 /// </summary>
-public sealed class ThumbnailService
+public sealed class ThumbnailService : IDisposable
 {
     private readonly IProjectManager _projectManager;
 
@@ -24,16 +32,54 @@ public sealed class ThumbnailService
     public Dictionary<string, SKBitmap?> BitmapCache { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Cache signature for a finished thumbnail. Two equal keys produce a pixel-identical
+    /// bitmap, so a tab switch (or strip rebuild) re-uses the cached icon. The resolved
+    /// <em>absolute</em> texture path is part of the key — two tabs in different folders can
+    /// share the same relative <c>TextureName</c> yet must not collide on one cached crop.
+    /// </summary>
+    private readonly record struct ThumbnailKey(
+        string Path, float Left, float Right, float Top, float Bottom,
+        bool FlipHorizontal, bool FlipVertical, int MaxWidth, int MaxHeight);
+
+    /// <summary>
+    /// Finished-thumbnail cache. The service owns these bitmaps and is their sole disposer
+    /// (on eviction the reference is simply dropped — GC reclaims it once no UI control holds
+    /// it, which avoids disposing a bitmap a live <c>Image</c> is still bound to).
+    /// </summary>
+    private readonly Dictionary<ThumbnailKey, Avalonia.Media.Imaging.Bitmap> _thumbnailCache = new();
+
+    /// <summary>Insertion order for FIFO eviction once <see cref="MaxCachedThumbnails"/> is exceeded.
+    /// A key may linger here after <see cref="InvalidatePath"/> removed it from the cache; the
+    /// eviction loop tolerates that (the dictionary <c>Remove</c> simply reports it absent).</summary>
+    private readonly Queue<ThumbnailKey> _thumbnailOrder = new();
+
+    /// <summary>Caps finished-thumbnail memory so editing churn (e.g. dragging a UV slider, which
+    /// mints a new key per tick) can't grow the cache without bound. Each entry is tiny
+    /// (≤ 56×56×4 bytes), so this is a few MB worst case.</summary>
+    private const int MaxCachedThumbnails = 512;
+
     public ThumbnailService(IProjectManager projectManager) =>
         _projectManager = projectManager;
 
     /// <summary>Evict a specific path from the bitmap cache so it is re-decoded on next access.
     /// Normalises backslashes to forward slashes before lookup so FSW-reported paths (backslash
     /// on Windows) evict entries that were stored via <c>FilePath.FullPath</c> (forward slash).
+    /// Also drops every finished thumbnail cropped from this texture, so a hot-reloaded sheet
+    /// re-renders its chain/timeline icons instead of showing the stale crop.
     /// </summary>
     public void InvalidatePath(string absolutePath)
     {
-        BitmapCache.Remove(absolutePath.Replace('\\', '/'));
+        var key = absolutePath.Replace('\\', '/');
+        BitmapCache.Remove(key);
+
+        List<ThumbnailKey>? stale = null;
+        foreach (var k in _thumbnailCache.Keys)
+            if (string.Equals(k.Path, key, StringComparison.OrdinalIgnoreCase))
+                (stale ??= new()).Add(k);
+        if (stale is not null)
+            foreach (var k in stale)
+                _thumbnailCache.Remove(k);
     }
 
     /// <summary>
@@ -95,20 +141,78 @@ public sealed class ThumbnailService
     /// Returns an Avalonia Bitmap of the frame's texture region, scaled to fit within
     /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (preserving aspect ratio).
     /// Returns <c>null</c> if the texture cannot be resolved, is not loaded, or the frame
-    /// has no valid UV region. Caller owns the returned bitmap.
+    /// has no valid UV region.
+    /// <para>
+    /// The result is cached (keyed by resolved texture path + UV region + flips + target
+    /// size) and <em>owned by this service</em> — do not dispose it. Re-calling with the same
+    /// frame state returns the same cached instance, so a tab switch re-uses every unchanged
+    /// icon. The Skia crop is wrapped directly as a <see cref="Avalonia.Media.Imaging.WriteableBitmap"/>;
+    /// there is no PNG encode/decode round-trip.
+    /// </para>
     /// </summary>
     public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
     {
-        var bm = GetBitmap(ResolveTexturePath(frame));
+        var path = ResolveTexturePath(frame);
+        var bm   = GetBitmap(path);
         if (bm is null) return null;
+
+        var key = new ThumbnailKey(
+            path!.Replace('\\', '/'),
+            frame.LeftCoordinate, frame.RightCoordinate, frame.TopCoordinate, frame.BottomCoordinate,
+            frame.FlipHorizontal, frame.FlipVertical, maxWidth, maxHeight);
+        if (_thumbnailCache.TryGetValue(key, out var cachedBitmap))
+            return cachedBitmap;
 
         using var thumb = RenderFrameThumbnail(bm, frame, maxWidth, maxHeight);
         if (thumb is null) return null;
 
-        using var ms = new MemoryStream();
-        thumb.Encode(ms, SKEncodedImageFormat.Png, 100);
-        ms.Position = 0;
-        return new Avalonia.Media.Imaging.Bitmap(ms);
+        var bitmap = ToAvaloniaBitmap(thumb);
+        _thumbnailCache[key] = bitmap;
+        _thumbnailOrder.Enqueue(key);
+        EvictExcessThumbnails();
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Wraps a Skia bitmap as an Avalonia <see cref="Avalonia.Media.Imaging.WriteableBitmap"/> by
+    /// copying its pixels straight into the framebuffer — no PNG encode/decode. Skia converts to
+    /// the destination BGRA/premultiplied layout during <see cref="SKBitmap.ReadPixels(SKImageInfo,
+    /// IntPtr, int, int, int)"/>, so the source colour/alpha type does not matter.
+    /// </summary>
+    private static Avalonia.Media.Imaging.Bitmap ToAvaloniaBitmap(SKBitmap thumb)
+    {
+        var size   = new PixelSize(thumb.Width, thumb.Height);
+        var bitmap = new Avalonia.Media.Imaging.WriteableBitmap(
+            size, new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul);
+        using (var fb = bitmap.Lock())
+        using (var pixmap = thumb.PeekPixels())
+        {
+            var dstInfo = new SKImageInfo(thumb.Width, thumb.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+            pixmap.ReadPixels(dstInfo, fb.Address, fb.RowBytes, 0, 0);
+        }
+        return bitmap;
+    }
+
+    /// <summary>Drops the oldest finished thumbnails once the cache exceeds its cap. The reference
+    /// is released (not disposed) so a bitmap still bound to a live <c>Image</c> stays valid until
+    /// GC reclaims it after the control lets go.</summary>
+    private void EvictExcessThumbnails()
+    {
+        while (_thumbnailCache.Count > MaxCachedThumbnails && _thumbnailOrder.Count > 0)
+            _thumbnailCache.Remove(_thumbnailOrder.Dequeue());
+    }
+
+    /// <summary>Disposes every cached source sheet and finished thumbnail. Call on window close;
+    /// any bitmaps still bound to UI are released as the window tears down.</summary>
+    public void Dispose()
+    {
+        foreach (var bm in BitmapCache.Values)
+            bm?.Dispose();
+        BitmapCache.Clear();
+        foreach (var bitmap in _thumbnailCache.Values)
+            bitmap.Dispose();
+        _thumbnailCache.Clear();
+        _thumbnailOrder.Clear();
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -272,11 +272,9 @@ public static class TreeBuilder
         var chainSet = new HashSet<AnimationChainSave>(chains, ReferenceEqualityComparer.Instance);
         for (int i = roots.Count - 1; i >= 0; i--)
             if (roots[i].Data is AnimationChainSave c && !chainSet.Contains(c))
-            {
-                // Release the chain's first-frame thumbnail bitmap before dropping the node.
-                (roots[i].Thumbnail as System.IDisposable)?.Dispose();
+                // The thumbnail bitmap is owned by ThumbnailService's cache, not the node —
+                // drop the node without disposing it (a later cache hit may return it again).
                 roots.RemoveAt(i);
-            }
 
         // Build a lookup of surviving VMs keyed by chain reference.
         var existingByChain = new Dictionary<AnimationChainSave, TreeNodeVm>(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.IO;
 using AnimationEditor.App.Services;
 using AnimationEditor.Core.CommandsAndState;
+using Avalonia.Headless.XUnit;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using Xunit;
@@ -116,6 +119,80 @@ public class ThumbnailServiceTests
         var rightPx = thumb.GetPixel(thumb.Width - 1, 4);
         Assert.True(rightPx.Red > rightPx.Blue,
             $"Right edge pixel {rightPx} should be red after horizontal flip.");
+    }
+
+    // -- Finished-thumbnail cache tests (Issue #474) --------------------------
+    //
+    // GetFrameThumbnail caches the finished Avalonia Bitmap keyed by (resolved texture
+    // path + UV region + flips + target size) and wraps the Skia crop directly as a
+    // WriteableBitmap — no PNG encode/decode round-trip. These tests use [AvaloniaFact]
+    // because constructing an Avalonia Bitmap needs the headless platform's render
+    // interface. They write a real PNG to a temp file so ResolveTexturePath finds it.
+
+    /// <summary>Writes a solid-green PNG to a unique temp file and returns its absolute path.</summary>
+    private static string WriteTempPng(int width, int height)
+    {
+        var dir  = Path.Combine(Path.GetTempPath(), "AnimationEditorTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "sheet.png");
+        using var bm = new SKBitmap(width, height);
+        bm.Erase(SKColors.Green);
+        using var img  = SKImage.FromBitmap(bm);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        using var fs   = File.OpenWrite(path);
+        data.SaveTo(fs);
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_AfterInvalidatePath_ReturnsDifferentInstance()
+    {
+        var svc   = MakeSvc();
+        var path  = WriteTempPng(8, 8);
+        var frame = Frame();
+        frame.TextureName = path;
+
+        var first = svc.GetFrameThumbnail(frame, 56, 56);
+        svc.InvalidatePath(path);
+        var afterInvalidate = svc.GetFrameThumbnail(frame, 56, 56);
+
+        Assert.NotNull(first);
+        Assert.NotNull(afterInvalidate);
+        // Invalidation must drop the cached finished thumbnail so the next call re-renders.
+        Assert.NotSame(first, afterInvalidate);
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_CalledTwiceForSameFrame_ReturnsSameCachedInstance()
+    {
+        var svc   = MakeSvc();
+        var path  = WriteTempPng(8, 8);
+        var frame = Frame();
+        frame.TextureName = path;
+
+        var first  = svc.GetFrameThumbnail(frame, 56, 56);
+        var second = svc.GetFrameThumbnail(frame, 56, 56);
+
+        Assert.NotNull(first);
+        // Second call must hit the finished-thumbnail cache, not crop+wrap a fresh bitmap.
+        Assert.Same(first, second);
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_SquareSource_ReturnsBitmapAtRequestedSize()
+    {
+        // Exercises the WriteableBitmap conversion (no PNG round-trip): a 64×64 source
+        // asked for 56×56 must come back 56×56.
+        var svc   = MakeSvc();
+        var path  = WriteTempPng(64, 64);
+        var frame = Frame();
+        frame.TextureName = path;
+
+        var thumb = svc.GetFrameThumbnail(frame, 56, 56);
+
+        Assert.NotNull(thumb);
+        Assert.Equal(56, thumb!.PixelSize.Width);
+        Assert.Equal(56, thumb.PixelSize.Height);
     }
 
     // -- InvalidatePath path-normalization tests (Issue #310) -----------------

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineScrubberTests.cs
@@ -246,7 +246,8 @@ public class TimelineScrubberTests
                     ?? throw new InvalidOperationException("TimelineStrip not found");
                 var items = Assert.IsType<ObservableCollection<TimelineFrameVm>>(timeline.ItemsSource);
                 Assert.Single(items);
-                Assert.IsType<Bitmap>(items[0].Thumbnail);
+                // WriteableBitmap (a Bitmap subclass) since the crop is wrapped without a PNG round-trip.
+                Assert.IsAssignableFrom<Bitmap>(items[0].Thumbnail);
             }
             finally
             {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineStripRebuildTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineStripRebuildTests.cs
@@ -86,7 +86,7 @@ public class TimelineStripRebuildTests
                 // Capture identities before the scrub-like selection change.
                 var vm0 = items[0]; var vm1 = items[1]; var vm2 = items[2];
                 var thumb0 = items[0].Thumbnail;
-                Assert.IsType<Bitmap>(thumb0); // textures resolve, so thumbnails are real bitmaps
+                Assert.IsAssignableFrom<Bitmap>(thumb0); // textures resolve, so thumbnails are real bitmaps (WriteableBitmap)
 
                 // Crossing a frame boundary while scrubbing sets SelectedFrame — a non-structural
                 // selection change.


### PR DESCRIPTION
Closes #474

## Problem
Switching tabs with 2+ open froze the **treeview** for seconds while the **preview pane** updated instantly. `RebuildTreeView` does a full teardown and regenerates every chain icon, and each icon went through a **PNG encode + re-decode on the UI thread** in `ThumbnailService.GetFrameThumbnail` — O(N chains) of CPU work per switch.

## Fix (issue's recommended (1)+(3))
1. **Cache finished thumbnails.** `ThumbnailService` now caches the finished Avalonia `Bitmap` keyed by `(resolved absolute texture path, UV region, flips, target size)`. Re-viewing a tab is a cache hit (no crop/encode); the full-rebuild path no longer pays for unchanged chains. The *absolute* path is in the key so two tabs sharing a relative `TextureName` in different folders don't collide.
2. **Drop the PNG round-trip.** The Skia crop is wrapped directly as a `WriteableBitmap` via `PeekPixels` + `ReadPixels(Bgra8888)` — no encode/decode for genuine misses.

### Ownership
The service now **owns** the thumbnail bitmaps and is their sole disposer (in `Dispose()`, called on window close). All caller-side thumbnail disposal is removed (tree rebuild, timeline rebuild, hot-reload, `TreeBuilder.SyncChainsInto`) — disposing a shared cached bitmap would hand a later cache hit a disposed bitmap. Eviction (FIFO cap of 512 + `InvalidatePath` on hot-reload) only **drops references**; GC reclaims a bitmap once no `Image` is bound, so a live control never sees a disposed bitmap.

I did **not** also take fix (2) (reuse the diff path) — the cache makes the existing full rebuild cheap, so the extra change isn't needed.

## Tests
- `ThumbnailServiceTests` + 3 `[AvaloniaFact]`: cache hit returns the **same** instance; `InvalidatePath` forces a **fresh** instance; the `WriteableBitmap` path yields the requested `PixelSize`.
- Two timeline tests relaxed from `IsType<Bitmap>` to `IsAssignableFrom<Bitmap>` (the thumbnail is now a `WriteableBitmap` subclass).
- Full suites green: **506** App + **1280** Core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)