### PR TITLE
feat(animeditor): crash logging to log.txt + Help → View Log (#480)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -34,6 +34,10 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        // Catch UI-thread crashes (e.g. the SKImage.FromBitmap crash in #479, which came
+        // through the dispatcher). The background-thread handlers are installed in Program.Main.
+        Services.CrashLogging.InstallDispatcherHandler();
+
         var services = BuildServices();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
@@ -110,6 +114,7 @@ public partial class App : Application
         viewMenu.Add(new NativeMenuItem("Show History") { Command = Cmd(a.ShowHistory) });
 
         var helpMenu = new NativeMenu();
+        helpMenu.Add(new NativeMenuItem("View Log") { Command = Cmd(a.ViewLog) });
         helpMenu.Add(new NativeMenuItem("About Animation Editor") { Command = Cmd(a.About) });
 
         var appMenu = new NativeMenu();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -117,6 +117,7 @@
                         </MenuItem>
                     </MenuItem>
                     <MenuItem Header="_Help">
+                        <MenuItem Header="View _Log"      x:Name="MenuViewLog" />
                         <MenuItem Header="_About"         x:Name="MenuAbout" />
                     </MenuItem>
                 </Menu>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1250,6 +1250,7 @@ public partial class MainWindow : Window
         MenuSave.Click   += OnSaveClick;
         MenuSaveAs.Click += OnSaveAsClick;
         MenuAbout.Click  += OnAboutClick;
+        MenuViewLog.Click += OnViewLogClick;
         MenuCopy.Click          += (_, _) => _ = HandleCopyAsync();
         MenuPaste.Click         += (_, _) => _ = HandlePasteAsync();
         MenuDuplicate.Click     += (_, _) => HandleDuplicate();
@@ -1319,6 +1320,7 @@ public partial class MainWindow : Window
         ToggleHotReload: () => { _appCommands.HotReloadWatcher.IsEnabled = !_appCommands.HotReloadWatcher.IsEnabled; },
         ResizeTexture:   () => _ = DoResizeTextureAsync(),
         ShowHistory:     () => SetHistoryVisible(true),
+        ViewLog:         () => OnViewLogClick(null, null!),
         About:           () => _ = BuildAboutWindow().ShowDialog(this));
 
     private void RefreshRecentFiles()
@@ -1395,6 +1397,24 @@ public partial class MainWindow : Window
 
     private void OnAboutClick(object? sender, RoutedEventArgs e)
         => _ = BuildAboutWindow().ShowDialog(this);
+
+    private void OnViewLogClick(object? sender, RoutedEventArgs e)
+    {
+        var path = Services.CrashLogging.LogFilePath;
+        if (path == null || !File.Exists(path))
+        {
+            ShowStatusMessage("No log yet.");
+            return;
+        }
+        try
+        {
+            Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            ShowStatusMessage($"⚠ Could not open log: {ex.Message}", isError: true);
+        }
+    }
 
     /// <summary>
     /// Returns a fully-configured About window centered on its owner.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
@@ -22,4 +22,5 @@ internal sealed record NativeMenuActions(
     Action ToggleHotReload,
     Action ResizeTexture,
     Action ShowHistory,
+    Action ViewLog,
     Action About);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
@@ -13,6 +13,10 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Install crash logging first so even a failure during startup gets recorded.
+        CrashLogging.Install(AppContext.BaseDirectory,
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+
         string? fileArg = args.Length >= 1 && File.Exists(args[0]) ? args[0] : null;
 
         var singleInstance = new SingleInstanceServer();
@@ -34,9 +38,20 @@ class Program
         // calling setProcessName: afterwards has no visible effect on the Dock label.
         MacOSDockIcon.SetProcessName("Animation Editor");
         App.SingleInstance = singleInstance;
-        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
-
-        singleInstance.Dispose();
+        try
+        {
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
+        catch (Exception ex)
+        {
+            // Record main-thread startup/run crashes, then let the process die as before.
+            CrashLogging.LogCrash("Main", ex);
+            throw;
+        }
+        finally
+        {
+            singleInstance.Dispose();
+        }
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/CrashLogging.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/CrashLogging.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AnimationEditor.Core.Logging;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Installs process-wide unhandled-exception handlers that record crashes to <c>log.txt</c>
+/// before the process terminates. Crash-only for now, but built on <see cref="ILogger"/> so
+/// future warning/info/debug logging can flow through the same sink. Handlers record and
+/// re-let the crash propagate — they never swallow it.
+/// </summary>
+internal static class CrashLogging
+{
+    private static FileLogger? _logger;
+
+    /// <summary>Absolute path of the live log file, or null until <see cref="Install"/> runs.</summary>
+    public static string? LogFilePath { get; private set; }
+
+    /// <summary>
+    /// Resolves the log path (next to the exe, falling back to <c>%APPDATA%</c> when that
+    /// directory isn't writable), writes a session header, and subscribes the background-thread
+    /// and finalizer crash handlers. Call once, early in <c>Main</c>, before Avalonia starts.
+    /// </summary>
+    public static void Install(string baseDirectory, string applicationDataRoot)
+    {
+        var path = LogFileLocation.Resolve(baseDirectory, applicationDataRoot, IsDirectoryWritable);
+        LogFilePath = path.FullPath;
+        _logger = new FileLogger(path.FullPath);
+        _logger.LogInformation("=== Animation Editor session started ===");
+
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            LogCrash("AppDomain.UnhandledException", e.ExceptionObject as Exception);
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+            LogCrash("TaskScheduler.UnobservedTaskException", e.Exception);
+    }
+
+    /// <summary>
+    /// Subscribes the UI-thread crash handler. Call after the Avalonia dispatcher exists
+    /// (from <c>App.OnFrameworkInitializationCompleted</c>).
+    /// </summary>
+    public static void InstallDispatcherHandler() =>
+        Dispatcher.UIThread.UnhandledException += (_, e) =>
+            LogCrash("Dispatcher.UnhandledException", e.Exception);
+
+    /// <summary>Records a crash through the installed logger; no-op before <see cref="Install"/>.</summary>
+    public static void LogCrash(string source, Exception? exception)
+    {
+        if (_logger != null)
+            Log(_logger, source, exception);
+    }
+
+    /// <summary>
+    /// Pure wiring from an exception to a log line. Exposed so the handler behavior can be
+    /// exercised in tests with an injected sink and a synthetic exception.
+    /// </summary>
+    internal static void Log(ILogger logger, string source, Exception? exception) =>
+        logger.LogError(exception, "Unhandled exception ({Source})", source);
+
+    private static bool IsDirectoryWritable(string directory)
+    {
+        try
+        {
+            Directory.CreateDirectory(directory);
+            var probe = Path.Combine(directory, $".write-probe-{Guid.NewGuid():N}.tmp");
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>AnimationEditor.Core.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/FileLogger.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/FileLogger.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace AnimationEditor.Core.Logging;
+
+/// <summary>
+/// Minimal <see cref="ILogger"/> that appends formatted entries to a text file. Built for
+/// crash logging first, but accepts any level so future warning/info/debug calls flow through
+/// the same sink. Write failures are swallowed — logging must never itself crash the app.
+/// </summary>
+public sealed class FileLogger : ILogger
+{
+    private readonly string _filePath;
+    private readonly Func<DateTimeOffset> _clock;
+    private static readonly object _gate = new();
+
+    /// <param name="clock">Injected for deterministic timestamps in tests; defaults to local now.</param>
+    public FileLogger(string filePath, Func<DateTimeOffset>? clock = null)
+    {
+        _filePath = filePath;
+        _clock = clock ?? (() => DateTimeOffset.Now);
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+        Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+        Append(FormatEntry(_clock(), logLevel, formatter(state, exception), exception));
+    }
+
+    /// <summary>
+    /// Formats one entry as <c>[yyyy-MM-dd HH:mm:ss.fff] [Level] message</c>, followed by the
+    /// full exception (type, message, stack) on the next lines when present.
+    /// </summary>
+    public static string FormatEntry(DateTimeOffset timestamp, LogLevel level, string message, Exception? exception)
+    {
+        var sb = new StringBuilder();
+        sb.Append('[').Append(timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff")).Append("] [")
+          .Append(level).Append("] ").Append(message).AppendLine();
+        if (exception != null)
+            sb.AppendLine(exception.ToString());
+        return sb.ToString();
+    }
+
+    private void Append(string text)
+    {
+        try
+        {
+            lock (_gate)
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
+                File.AppendAllText(_filePath, text);
+            }
+        }
+        catch
+        {
+            // Logging must never crash the app — swallow IO failures.
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/FileLoggerProvider.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/FileLoggerProvider.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Logging;
+
+namespace AnimationEditor.Core.Logging;
+
+/// <summary>
+/// <see cref="ILoggerProvider"/> backing all categories with a single <see cref="FileLogger"/>.
+/// Register it via <c>ILoggingBuilder.AddProvider</c> so future code can inject
+/// <see cref="ILogger{T}"/> and have it flow to <c>log.txt</c> with no call-site changes.
+/// </summary>
+public sealed class FileLoggerProvider : ILoggerProvider
+{
+    private readonly FileLogger _logger;
+
+    public FileLoggerProvider(string filePath) => _logger = new FileLogger(filePath);
+
+    public ILogger CreateLogger(string categoryName) => _logger;
+
+    public void Dispose() { }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/LogFileLocation.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Logging/LogFileLocation.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using AnimationEditor.Core.IO;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Core.Logging;
+
+/// <summary>
+/// Resolves where the editor writes its <c>log.txt</c>. The default is next to the running
+/// executable so the user can find and share it without hunting through <c>%APPDATA%</c>;
+/// if that directory isn't writable (e.g. the editor is installed under <c>Program Files</c>)
+/// the location falls back to the per-user config dir that <see cref="AppSettingsLocation"/> uses.
+/// </summary>
+public static class LogFileLocation
+{
+    public const string FileName = "log.txt";
+
+    /// <param name="baseDirectory">
+    /// The directory containing the running executable — i.e. <c>AppContext.BaseDirectory</c>.
+    /// </param>
+    public static FilePath NextToExecutable(string baseDirectory) =>
+        new FilePath(Path.Combine(baseDirectory, FileName));
+
+    /// <param name="applicationDataRoot">
+    /// The platform's per-user application-data root — i.e.
+    /// <c>Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)</c>.
+    /// </param>
+    public static FilePath ForApplicationDataRoot(string applicationDataRoot) =>
+        new FilePath(Path.Combine(applicationDataRoot, AppSettingsLocation.FolderName, FileName));
+
+    /// <summary>
+    /// Picks <see cref="NextToExecutable"/> when its directory is writable, otherwise
+    /// <see cref="ForApplicationDataRoot"/>. The writability probe is injected so callers
+    /// (and tests) control the side effect.
+    /// </summary>
+    public static FilePath Resolve(string baseDirectory, string applicationDataRoot,
+        Func<string, bool> isDirectoryWritable) =>
+        isDirectoryWritable(baseDirectory)
+            ? NextToExecutable(baseDirectory)
+            : ForApplicationDataRoot(applicationDataRoot);
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CrashLoggingTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CrashLoggingTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using AnimationEditor.App.Services;
+using AnimationEditor.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies the handler-to-logger wiring (issue #480): invoking the crash-log delegate
+/// with a synthetic exception produces a log line. The actual event subscriptions and
+/// <c>Process.Start</c> remain the thin untested boundary.
+/// </summary>
+public class CrashLoggingTests
+{
+    [Fact]
+    public void Log_WithException_WritesSourceAndExceptionToSink()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"frb-crashlog-{Guid.NewGuid():N}.txt");
+        try
+        {
+            ILogger logger = new FileLogger(path);
+
+            CrashLogging.Log(logger, "Dispatcher.UnhandledException", new InvalidOperationException("ui-thread-boom"));
+
+            var contents = File.ReadAllText(path);
+            Assert.Contains("Dispatcher.UnhandledException", contents);
+            Assert.Contains("ui-thread-boom", contents);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/Logging/FileLoggerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/Logging/FileLoggerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using AnimationEditor.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests.Logging;
+
+public class FileLoggerTests
+{
+    [Fact]
+    public void FormatEntry_WithoutException_WritesTimestampLevelAndMessage()
+    {
+        var timestamp = new DateTimeOffset(2026, 6, 28, 9, 30, 15, 250, TimeSpan.Zero);
+
+        var line = FileLogger.FormatEntry(timestamp, LogLevel.Information, "App started", null);
+
+        Assert.Equal("[2026-06-28 09:30:15.250] [Information] App started" + Environment.NewLine, line);
+    }
+
+    [Fact]
+    public void FormatEntry_WithException_IncludesExceptionDetails()
+    {
+        var timestamp = new DateTimeOffset(2026, 6, 28, 9, 30, 15, 0, TimeSpan.Zero);
+        var exception = new InvalidOperationException("boom");
+
+        var line = FileLogger.FormatEntry(timestamp, LogLevel.Error, "Unhandled exception", exception);
+
+        Assert.Contains("[Error] Unhandled exception", line);
+        Assert.Contains("InvalidOperationException", line);
+        Assert.Contains("boom", line);
+    }
+
+    [Fact]
+    public void Log_AppendsFormattedEntryToFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"frb-logtest-{Guid.NewGuid():N}.txt");
+        try
+        {
+            ILogger logger = new FileLogger(path);
+
+            logger.LogError(new InvalidOperationException("kaboom"), "Crash in {Source}", "Main");
+
+            var contents = File.ReadAllText(path);
+            Assert.Contains("[Error]", contents);
+            Assert.Contains("Crash in Main", contents);
+            Assert.Contains("kaboom", contents);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Log_AppendsAcrossMultipleCalls()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"frb-logtest-{Guid.NewGuid():N}.txt");
+        try
+        {
+            ILogger logger = new FileLogger(path);
+
+            logger.LogInformation("first");
+            logger.LogInformation("second");
+
+            var contents = File.ReadAllText(path);
+            Assert.Contains("first", contents);
+            Assert.Contains("second", contents);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/Logging/LogFileLocationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/Logging/LogFileLocationTests.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.Logging;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests.Logging;
+
+public class LogFileLocationTests
+{
+    // FilePath normalizes directory separators to forward slashes, so expected values use '/'.
+    [Fact]
+    public void NextToExecutable_PlacesLogTxtInBaseDirectory()
+    {
+        var result = LogFileLocation.NextToExecutable(@"C:\Apps\AnimationEditor");
+
+        Assert.Equal("C:/Apps/AnimationEditor/log.txt", result.FullPath);
+    }
+
+    [Fact]
+    public void ForApplicationDataRoot_PlacesLogUnderAnimationEditorSubfolder()
+    {
+        var result = LogFileLocation.ForApplicationDataRoot(@"C:\Users\dev\AppData\Roaming");
+
+        Assert.Equal("C:/Users/dev/AppData/Roaming/AnimationEditor/log.txt", result.FullPath);
+    }
+
+    [Fact]
+    public void Resolve_WhenExeDirWritable_UsesNextToExecutable()
+    {
+        var result = LogFileLocation.Resolve(
+            @"C:\Apps\AnimationEditor", @"C:\Users\dev\AppData\Roaming",
+            isDirectoryWritable: _ => true);
+
+        Assert.Equal("C:/Apps/AnimationEditor/log.txt", result.FullPath);
+    }
+
+    [Fact]
+    public void Resolve_WhenExeDirNotWritable_FallsBackToApplicationData()
+    {
+        // Simulates install under a write-protected dir like Program Files.
+        var result = LogFileLocation.Resolve(
+            @"C:\Program Files\AnimationEditor", @"C:\Users\dev\AppData\Roaming",
+            isDirectoryWritable: _ => false);
+
+        Assert.Equal("C:/Users/dev/AppData/Roaming/AnimationEditor/log.txt", result.FullPath);
+    }
+}


### PR DESCRIPTION
## What

Adds crash logging to the Animation Editor, built on the .NET standard `ILogger` so it starts crash-only but future warning/debug/info logs can hook into the same pipe.

### Logging abstraction (`AnimationEditor.Core/Logging`)
- **`FileLogger : ILogger`** — appends formatted entries (`[timestamp] [Level] message` + full exception) to a file. Write failures are swallowed so logging never crashes the app.
- **`FileLoggerProvider : ILoggerProvider`** — backs all categories with one `FileLogger`; lets future code inject `ILogger<T>` and have it flow to `log.txt`.
- **`LogFileLocation`** — resolves the path: **next to the .exe** (`AppContext.BaseDirectory`) so it's easy to find/share, falling back to `%APPDATA%/AnimationEditor/log.txt` when the exe dir isn't writable (e.g. installed under `Program Files`).
- Package: `Microsoft.Extensions.Logging.Abstractions` (Option A from the issue).

### Global handlers (`App/Services/CrashLogging`)
- `Program.Main`: installs `AppDomain.UnhandledException` + `TaskScheduler.UnobservedTaskException`, and wraps `StartWithClassicDesktopLifetime` in try/catch.
- `App.OnFrameworkInitializationCompleted`: installs `Dispatcher.UIThread.UnhandledException` (catches the UI-thread crash class from #479).
- Handlers **record and re-let the crash propagate** — they don't hide it.

### Help → View Log
- New menu item (in-window Help menu + macOS native Help menu) opens `log.txt` in the OS default viewer via `Process.Start(UseShellExecute = true)`; shows "No log yet." when the file doesn't exist.

## Testing
- `LogFileLocationTests` — next-to-exe path, %APPDATA% fallback, and writable-probe branch selection.
- `FileLoggerTests` — line formatting (with/without exception) and append behavior.
- `CrashLoggingTests` — handler-to-logger wiring with a synthetic exception.
- Untested boundary: the actual event subscriptions and `Process.Start` (per the issue).

Full suites green: 1288 Core + 508 App.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)