### PR TITLE
fix(animation-editor): make timing labels colored and slightly larger (#483)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -445,8 +445,8 @@
                                 </StackPanel>
                                 <TextBlock Grid.Column="1"
                                            Text="{Binding Meta}"
-                                           Foreground="{DynamicResource InkDim}"
-                                           FontSize="10"
+                                           Foreground="{DynamicResource AccentCool}"
+                                           FontSize="11"
                                            Margin="8,0,6,0"
                                            HorizontalAlignment="Right"
                                            TextAlignment="Right"


### PR DESCRIPTION
## Summary
The duration/frame-count metadata shown beside nodes in the Animations List tree used the dim gray `InkDim` brush at `FontSize="10"`, making it hard to read at a glance (per #483).

- **Color:** `InkDim` → `AccentCool` — a theme-aware blue defined for both light and dark themes, distinct from the red selection `Accent`, giving the timing info stronger contrast and visual emphasis.
- **Size:** `FontSize` 10 → 11 (just barely larger, as requested).

Single change in `MainWindow.axaml` (the `Meta` `TextBlock`).

## Testing
No automated test: markup-only visual change (a `DynamicResource` key + `FontSize` literal). No behavioral core to extract; verified by building (XAML compiles) and visual inspection in both themes.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)