### PR TITLE
Animation Editor: suppress menu activation after Alt+Arrow reorder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -66,6 +66,7 @@ public partial class MainWindow : Window
     private bool _suppressTreeSelectionHandling;
     private bool _suppressCompanionSave;
     private bool _suppressInterpolateSync;
+    private readonly AltMenuActivationSuppressor _altMenuActivationSuppressor = new();
     private System.Threading.CancellationTokenSource? _toastCts;
 
     // The platform application-data root under which settings live. Injected (not read from
@@ -3609,6 +3610,7 @@ public partial class MainWindow : Window
                      e.KeyModifiers.HasFlag(KeyModifiers.Alt))
             {
                 e.Handled = true;
+                _altMenuActivationSuppressor.ArmFromAltArrowReorder();
                 int delta = e.Key == Key.Up ? -1 : +1;
                 _appCommands.HandleReorder(delta);
                 // Restore focus to the tree — reorder can cause Avalonia to shift focus
@@ -3616,6 +3618,18 @@ public partial class MainWindow : Window
                 Dispatcher.UIThread.Post(() => AnimTree.Focus(), DispatcherPriority.Background);
                 if (_selectedState.SelectedFrame is not null)
                     ShowStatusMessage("Frame labels updated to reflect new positions");
+            }
+        }), RoutingStrategies.Tunnel);
+
+        // Avalonia activates the title-bar menu on Alt KeyUp. Alt+Arrow reorder handles only
+        // the arrow KeyDown, so consume the matching Alt release when we armed suppression.
+        AddHandler(KeyUpEvent, (EventHandler<KeyEventArgs>)((_, e) =>
+        {
+            if (e.Handled) return;
+            if (e.Key is Key.LeftAlt or Key.RightAlt &&
+                _altMenuActivationSuppressor.TryConsumeIfArmed())
+            {
+                e.Handled = true;
             }
         }), RoutingStrategies.Tunnel);
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AltMenuActivationSuppressor.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AltMenuActivationSuppressor.cs
@@ -1,0 +1,23 @@
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Arms suppression of the next Alt KeyUp after an Alt+Arrow tree reorder so Avalonia's
+/// menu does not steal focus on Alt release (issue #488).
+/// </summary>
+public sealed class AltMenuActivationSuppressor
+{
+    private bool _suppressNextAltKeyUp;
+
+    public void ArmFromAltArrowReorder() => _suppressNextAltKeyUp = true;
+
+    /// <summary>
+    /// Returns true when the caller should mark the Alt KeyUp handled to block menu activation.
+    /// Clears the arm on consumption.
+    /// </summary>
+    public bool TryConsumeIfArmed()
+    {
+        if (!_suppressNextAltKeyUp) return false;
+        _suppressNextAltKeyUp = false;
+        return true;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AltMenuActivationSuppressorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AltMenuActivationSuppressorTests.cs
@@ -1,0 +1,40 @@
+using AnimationEditor.Core.CommandsAndState;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Issue #488: Alt+Arrow tree reorder arms suppression of the next Alt KeyUp so the
+/// title-bar menu is not activated when Alt is released.
+/// </summary>
+public class AltMenuActivationSuppressorTests
+{
+    [Fact]
+    public void TryConsumeIfArmed_AfterArm_ClearsArmAndReturnsTrue()
+    {
+        var suppressor = new AltMenuActivationSuppressor();
+        suppressor.ArmFromAltArrowReorder();
+
+        Assert.True(suppressor.TryConsumeIfArmed());
+        Assert.False(suppressor.TryConsumeIfArmed());
+    }
+
+    [Fact]
+    public void TryConsumeIfArmed_MultipleArmsBeforeRelease_ConsumesOnce()
+    {
+        var suppressor = new AltMenuActivationSuppressor();
+        suppressor.ArmFromAltArrowReorder();
+        suppressor.ArmFromAltArrowReorder();
+
+        Assert.True(suppressor.TryConsumeIfArmed());
+        Assert.False(suppressor.TryConsumeIfArmed());
+    }
+
+    [Fact]
+    public void TryConsumeIfArmed_NotArmed_ReturnsFalse()
+    {
+        var suppressor = new AltMenuActivationSuppressor();
+
+        Assert.False(suppressor.TryConsumeIfArmed());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AltMenuActivationSuppressor` in Core to arm on Alt+Arrow reorder and consume the next Alt KeyUp
- Wire tunnel-routed KeyUp handler in `MainWindow` so the title-bar menu does not steal focus after reordering
- Plain Alt-to-menu behavior is unchanged

Closes #488

## Test plan
- [x] `dotnet test` on `AltMenuActivationSuppressorTests` (3 tests)
- [x] `dotnet build` Animation Editor solution
- [ ] Manual: select a frame/chain in the tree, Alt+Up/Down to reorder, release Alt — menu bar should NOT activate; tree keeps focus
- [ ] Manual: tap Alt alone — File/Edit menu mnemonics still work
- [ ] Manual: hold Alt and press Up/Down multiple times before release — reorder works, single Alt release still does not activate menu

Made with [Cursor](https://cursor.com)