### PR TITLE
Animation Editor: cache tab models to fix tab-switch lag (#476)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -351,10 +351,13 @@ public partial class MainWindow : Window
     {
         if (tab == _tabManager.ActiveTab) return;
 
-        // Save the leaving tab's undo history before the editor reloads a different file.
+        // Save the leaving tab's undo history and in-memory model before the editor switches.
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab != null)
+        {
             leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
+            _appCommands.CaptureTabEditorState(leavingTab);
+        }
 
         SaveCompanionFile();
         _tabManager.Activate(tab.Path);
@@ -362,25 +365,39 @@ public partial class MainWindow : Window
         // the file load when the path is already the active tab.
         if (IsUntitledTab(tab))
         {
-            // Untitled tab — reset to a blank editor; there is no on-disk file to reload.
-            _projectManager.AnimationChainListSave = new AnimationChainListSave();
-            _projectManager.FileName = null;
-            _selectedState.Reset();
-            _undoManager.Clear();
-            if (tab.UndoSnapshot != null)
-                _undoManager.RestoreSnapshot(tab.UndoSnapshot);
-            RefreshTreeView();
-            UpdateTitle();
-            UpdateStatusBar();
+            ActivateUntitledTabContent(tab);
         }
         else
         {
-            await _appCommands.OpenAchxWorkflowAsync(tab.Path.FullPath);
+            await _appCommands.ActivateTabContentAsync(tab);
             // LoadAnimationChain cleared the stack — restore this tab's saved history.
             if (tab.UndoSnapshot != null)
                 _undoManager.RestoreSnapshot(tab.UndoSnapshot);
         }
         RebuildTabStrip();
+    }
+
+    private void ActivateUntitledTabContent(TabEntry tab)
+    {
+        _projectManager.AnimationChainListSave =
+            tab.CachedEditorModel ?? new AnimationChainListSave();
+        _projectManager.FileName = null;
+        _selectedState.Reset();
+        _undoManager.Clear();
+        if (tab.UndoSnapshot != null)
+            _undoManager.RestoreSnapshot(tab.UndoSnapshot);
+        RefreshTreeView();
+        UpdateTitle();
+        UpdateStatusBar();
+    }
+
+    private void SyncTabCacheFromEditor(string? path)
+    {
+        TabEntry? tab = path != null
+            ? _tabManager.Tabs.FirstOrDefault(t => t.Path == new FilePath(path))
+            : _tabManager.ActiveTab;
+        if (tab != null)
+            _appCommands.CaptureTabEditorState(tab);
     }
 
     /// <summary>
@@ -399,25 +416,10 @@ public partial class MainWindow : Window
             // Use OpenAchxWorkflowAsync directly — bypasses EnsureCurrentEditorContentHasTab
             // so the just-closed file is not accidentally re-registered as a background tab.
             if (!IsUntitledTab(next))
-                _ = _appCommands.OpenAchxWorkflowAsync(next.Path.FullPath)
-                    .ContinueWith(_ => Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        if (next.UndoSnapshot != null)
-                            _undoManager.RestoreSnapshot(next.UndoSnapshot);
-                        RebuildTabStrip();
-                    }));
+                _ = ActivateTabAfterCloseAsync(next);
             else
             {
-                // Switching to an Untitled tab — reset to a blank editor.
-                _projectManager.AnimationChainListSave = new AnimationChainListSave();
-                _projectManager.FileName = null;
-                _selectedState.Reset();
-                _undoManager.Clear();
-                if (next.UndoSnapshot != null)
-                    _undoManager.RestoreSnapshot(next.UndoSnapshot);
-                RefreshTreeView();
-                UpdateTitle();
-                UpdateStatusBar();
+                ActivateUntitledTabContent(next);
                 RebuildTabStrip();
             }
         }
@@ -432,6 +434,14 @@ public partial class MainWindow : Window
             UpdateTitle();
             UpdateStatusBar();
         }
+    }
+
+    private async Task ActivateTabAfterCloseAsync(TabEntry tab)
+    {
+        await _appCommands.ActivateTabContentAsync(tab);
+        if (tab.UndoSnapshot != null)
+            _undoManager.RestoreSnapshot(tab.UndoSnapshot);
+        RebuildTabStrip();
     }
 
     private void SaveTabsToSettings()
@@ -537,6 +547,9 @@ public partial class MainWindow : Window
         _appCommands.HotReloadFailed += (path, reason) =>
             Dispatcher.UIThread.InvokeAsync(() =>
                 ShowStatusMessage($"⚠ Reload skipped for '{Path.GetFileName(path)}': {reason}", isError: true));
+
+        _appCommands.EditorProjectModelChanged += path =>
+            Dispatcher.UIThread.InvokeAsync(() => SyncTabCacheFromEditor(path));
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
@@ -3081,10 +3094,13 @@ public partial class MainWindow : Window
     {
         if (string.IsNullOrEmpty(fileName)) return;
 
-        // Save the leaving tab's undo history before a different file takes over the editor.
+        // Save the leaving tab's undo history and in-memory model before a different file takes over.
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab != null)
+        {
             leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
+            _appCommands.CaptureTabEditorState(leavingTab);
+        }
 
         // If there is already a file open that hasn't been registered as a tab yet,
         // add it as a background tab so it appears as the first tab when the second
@@ -3105,7 +3121,7 @@ public partial class MainWindow : Window
                 StringComparison.OrdinalIgnoreCase);
             if (!alreadyShown && !string.IsNullOrEmpty(fileName))
             {
-                await _appCommands.OpenAchxWorkflowAsync(fileName);
+                await _appCommands.ActivateTabContentAsync(arrivedTab!);
                 if (arrivedTab?.UndoSnapshot != null)
                     _undoManager.RestoreSnapshot(arrivedTab.UndoSnapshot);
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1,6 +1,7 @@
 ﻿using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
@@ -130,6 +131,9 @@ namespace AnimationEditor.Core.CommandsAndState
         /// <inheritdoc cref="IAppCommands.HotReloadFailed"/>
         public event Action<string, string>? HotReloadFailed;
 
+        /// <inheritdoc cref="IAppCommands.EditorProjectModelChanged"/>
+        public event Action<string?>? EditorProjectModelChanged;
+
         // ── Open workflow ─────────────────────────────────────────────────────────
 
         /// <inheritdoc cref="IAppCommands.OpenAchxWorkflowAsync"/>
@@ -175,7 +179,7 @@ namespace AnimationEditor.Core.CommandsAndState
             bool failed = false;
             void OnFail(string _, Exception __) => failed = true;
             LoadFailed += OnFail;
-            try { LoadAnimationChain(path); }
+            try { LoadAnimationChainFromParsed(path, preview); }
             finally { LoadFailed -= OnFail; }
 
             if (failed) return;
@@ -202,6 +206,26 @@ namespace AnimationEditor.Core.CommandsAndState
                 return;
             }
 
+            FinishLoadIntoEditor(fileName);
+        }
+
+        private void LoadAnimationChainFromParsed(string fileName, AnimationChainListSave preParsed)
+        {
+            try
+            {
+                _pm.LoadAnimationChain(new AnimationEditor.Core.Paths.FilePath(fileName), preParsed);
+            }
+            catch (Exception ex)
+            {
+                LoadFailed?.Invoke(fileName, ex);
+                return;
+            }
+
+            FinishLoadIntoEditor(fileName);
+        }
+
+        private void FinishLoadIntoEditor(string fileName)
+        {
             _undoManager.Clear();
             _undoManager.MarkSaved();
             _selectedState.Reset();
@@ -217,6 +241,46 @@ namespace AnimationEditor.Core.CommandsAndState
             var achxDir = System.IO.Path.GetDirectoryName(fileName) ?? string.Empty;
             var pngPaths = GetReferencedAbsolutePngPaths(fileName, achxDir);
             HotReloadWatcher.StartWatching(fileName, pngPaths);
+
+            EditorProjectModelChanged?.Invoke(fileName);
+        }
+
+        /// <inheritdoc cref="IAppCommands.CaptureTabEditorState"/>
+        public void CaptureTabEditorState(TabEntry tab) =>
+            TabEditorCache.CaptureFromProject(tab, _pm);
+
+        /// <inheritdoc cref="IAppCommands.TryActivateTabFromCache"/>
+        public bool TryActivateTabFromCache(TabEntry tab)
+        {
+            if (!TabEditorCache.HasFreshCache(tab))
+            {
+                TabEditorCache.Invalidate(tab);
+                return false;
+            }
+
+            TabEditorCache.ApplyToProject(tab, _pm);
+
+            _selectedState.Reset();
+            _selectedState.SelectedChain = tab.CachedEditorModel?.AnimationChains.FirstOrDefault();
+            RebuildTreeViewRequested?.Invoke();
+            _ioManager.LoadAndApplyCompanionFileFor(tab.Path.FullPath);
+            RefreshWireframeRequested?.Invoke();
+            RefreshAnimationFrameDisplayRequested?.Invoke();
+            SyncHotReloadWatcher();
+
+            _events.RaiseCurrentFileChanged(tab.Path.FullPath);
+            _events.RaiseAvailableTexturesChanged();
+            return true;
+        }
+
+        /// <inheritdoc cref="IAppCommands.ActivateTabContentAsync"/>
+        public async Task ActivateTabContentAsync(TabEntry tab)
+        {
+            if (TryActivateTabFromCache(tab))
+                return;
+
+            await OpenAchxWorkflowAsync(tab.Path.FullPath);
+            CaptureTabEditorState(tab);
         }
 
         public void RefreshTreeNode(AnimationChainSave animationChain) =>
@@ -244,6 +308,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 {
                     _pm.SaveAnimationChainList(target);
                     _undoManager.MarkSaved();
+                    EditorProjectModelChanged?.Invoke(target);
                 }
                 catch
                 {
@@ -1245,6 +1310,7 @@ namespace AnimationEditor.Core.CommandsAndState
             RefreshAnimationFrameDisplayRequested?.Invoke();
 
             _events.RaiseAchxReloadedFromDisk(path);
+            EditorProjectModelChanged?.Invoke(path);
         }
 
         /// <inheritdoc cref="IAppCommands.ReloadPngFromDisk"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -1,5 +1,6 @@
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
@@ -77,6 +78,31 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         Task OpenAchxWorkflowAsync(string path);
         void LoadAnimationChain(string fileName);
+
+        /// <summary>
+        /// Stores the current project model on <paramref name="tab"/> for later tab switches.
+        /// </summary>
+        void CaptureTabEditorState(TabEntry tab);
+
+        /// <summary>
+        /// Swaps the editor to <paramref name="tab"/>'s cached in-memory model when the cache
+        /// is fresh. Does not clear or restore undo — the app layer handles that.
+        /// </summary>
+        /// <returns><c>true</c> when the cache was applied; <c>false</c> when a disk load is needed.</returns>
+        bool TryActivateTabFromCache(TabEntry tab);
+
+        /// <summary>
+        /// Activates <paramref name="tab"/>'s content from cache when possible; otherwise runs
+        /// <see cref="OpenAchxWorkflowAsync"/>. Does not restore undo.
+        /// </summary>
+        Task ActivateTabContentAsync(TabEntry tab);
+
+        /// <summary>
+        /// Raised after the in-memory project model is loaded or saved from disk so the app
+        /// layer can refresh per-tab caches. The argument is the affected <c>.achx</c> path,
+        /// or <c>null</c> for untitled projects.
+        /// </summary>
+        event Action<string?>? EditorProjectModelChanged;
 
         void RefreshTreeNode(AnimationChainSave animationChain);
         void RefreshTreeNode(AnimationFrameSave animationFrame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
@@ -12,7 +12,7 @@ namespace AnimationEditor.Core
         string? FileName { get; set; }
         TextureCoordinateType OnDiskCoordinateType { get; set; }
 
-        void LoadAnimationChain(FilePath fileName);
+        void LoadAnimationChain(FilePath fileName, AnimationChainListSave? preParsed = null);
         void SaveAnimationChainList(string targetPath);
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEditorCache.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEditorCache.cs
@@ -1,0 +1,73 @@
+using AnimationEditor.Core.Paths;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.IO;
+
+namespace AnimationEditor.Core.Models
+{
+    /// <summary>
+    /// Per-tab in-memory editor model cache so tab switches can swap project state
+    /// without re-reading and re-parsing the <c>.achx</c> from disk.
+    /// </summary>
+    public static class TabEditorCache
+    {
+        /// <summary>
+        /// Stores the current <see cref="IProjectManager"/> model on <paramref name="tab"/>.
+        /// The tab keeps the same object references so undo snapshots stay valid.
+        /// </summary>
+        public static void CaptureFromProject(TabEntry tab, IProjectManager pm)
+        {
+            tab.CachedEditorModel = pm.AnimationChainListSave;
+            tab.CachedOnDiskCoordinateType = pm.OnDiskCoordinateType;
+            tab.CachedDiskWriteTimeUtc = TryReadDiskWriteTimeUtc(tab.Path);
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when <paramref name="tab"/> has a cached model and the on-disk
+        /// file has not changed since the cache was captured.
+        /// </summary>
+        public static bool HasFreshCache(TabEntry tab)
+        {
+            if (tab.CachedEditorModel == null)
+                return false;
+
+            if (tab.CachedDiskWriteTimeUtc == null)
+                return true;
+
+            var diskTime = TryReadDiskWriteTimeUtc(tab.Path);
+            if (diskTime == null)
+                return true;
+
+            return diskTime.Value <= tab.CachedDiskWriteTimeUtc.Value;
+        }
+
+        /// <summary>Discards the cached model so the next activation reloads from disk.</summary>
+        public static void Invalidate(TabEntry tab)
+        {
+            tab.CachedEditorModel = null;
+            tab.CachedDiskWriteTimeUtc = null;
+        }
+
+        /// <summary>Refreshes only the on-disk timestamp after a save.</summary>
+        public static void RefreshDiskTimestamp(TabEntry tab)
+        {
+            tab.CachedDiskWriteTimeUtc = TryReadDiskWriteTimeUtc(tab.Path);
+        }
+
+        /// <summary>Copies cached editor state into <paramref name="pm"/>.</summary>
+        public static void ApplyToProject(TabEntry tab, IProjectManager pm)
+        {
+            pm.AnimationChainListSave = tab.CachedEditorModel;
+            pm.OnDiskCoordinateType = tab.CachedOnDiskCoordinateType;
+            pm.FileName = string.IsNullOrEmpty(tab.Path.Original) ? null : tab.Path.FullPath;
+        }
+
+        private static DateTime? TryReadDiskWriteTimeUtc(FilePath path)
+        {
+            if (string.IsNullOrEmpty(path.Original) || !path.Exists())
+                return null;
+
+            return File.GetLastWriteTimeUtc(path.FullPath);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
@@ -1,5 +1,7 @@
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Paths;
+using FlatRedBall2.Animation.Content;
+using System;
 
 namespace AnimationEditor.Core.Models
 {
@@ -32,6 +34,24 @@ namespace AnimationEditor.Core.Models
         /// edit history persists across tab switches.
         /// </summary>
         public UndoSnapshot? UndoSnapshot { get; set; }
+
+        /// <summary>
+        /// In-memory editor model for this tab. Populated when the tab is deactivated and
+        /// reused on re-activation when the on-disk file has not changed.
+        /// </summary>
+        public AnimationChainListSave? CachedEditorModel { get; set; }
+
+        /// <summary>
+        /// <see cref="IProjectManager.OnDiskCoordinateType"/> captured with
+        /// <see cref="CachedEditorModel"/>.
+        /// </summary>
+        public TextureCoordinateType CachedOnDiskCoordinateType { get; set; } = TextureCoordinateType.Pixel;
+
+        /// <summary>
+        /// UTC last-write time of <see cref="Path"/> when <see cref="CachedEditorModel"/> was
+        /// captured. Used to detect external edits while the tab was in the background.
+        /// </summary>
+        public DateTime? CachedDiskWriteTimeUtc { get; set; }
 
         /// <summary>
         /// The tab label. Returns <see cref="_displayNameOverride"/> when set;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -202,7 +202,13 @@ namespace AnimationEditor.Core.Models
             var tab = FindTab(oldPath);
             if (tab == null) return;
             int idx = _tabs.IndexOf(tab);
-            var replacement = new TabEntry(newPath);
+            var replacement = new TabEntry(newPath)
+            {
+                CachedEditorModel = tab.CachedEditorModel,
+                CachedOnDiskCoordinateType = tab.CachedOnDiskCoordinateType,
+                CachedDiskWriteTimeUtc = tab.CachedDiskWriteTimeUtc,
+                UndoSnapshot = tab.UndoSnapshot,
+            };
             _tabs[idx] = replacement;
             if (ActiveTab == tab)
                 ActiveTab = replacement;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -35,17 +35,25 @@ namespace AnimationEditor.Core
         /// </summary>
         public TextureCoordinateType OnDiskCoordinateType { get; set; } = TextureCoordinateType.Pixel;
 
-        public void LoadAnimationChain(FilePath fileName)
+        public void LoadAnimationChain(FilePath fileName, AnimationChainListSave? preParsed = null)
         {
             if (!fileName.Exists())
                 throw new FileNotFoundException($"Animation chain file not found: {fileName.FullPath}", fileName.FullPath);
 
-            var rawContent = File.ReadAllText(fileName.FullPath);
-            if (IO.AchxConflictMarkerDetector.HasConflictMarkers(rawContent))
-                throw new System.IO.InvalidDataException(
-                    $"{IO.AchxConflictMarkerDetector.ConflictMarkerMessage} ({fileName.FullPath})");
+            AnimationChainListSave acls;
+            if (preParsed != null)
+            {
+                acls = preParsed;
+            }
+            else
+            {
+                var rawContent = File.ReadAllText(fileName.FullPath);
+                if (IO.AchxConflictMarkerDetector.HasConflictMarkers(rawContent))
+                    throw new System.IO.InvalidDataException(
+                        $"{IO.AchxConflictMarkerDetector.ConflictMarkerMessage} ({fileName.FullPath})");
 
-            var acls = AnimationChainListSave.FromFile(fileName.FullPath);
+                acls = AnimationChainListSave.FromFile(fileName.FullPath);
+            }
 
             AddShapeCollectionsToFrames(acls);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
@@ -69,7 +69,7 @@ public class AppCommandsSaveFailTests
         public string? FileName { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
-        public void LoadAnimationChain(FilePath fileName) { }
+        public void LoadAnimationChain(FilePath fileName, AnimationChainListSave? preParsed = null) { }
 
         public void SaveAnimationChainList(string targetPath)
             => throw new InvalidOperationException("Simulated save failure");

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
@@ -1,0 +1,140 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies per-tab in-memory model caching avoids redundant disk loads on tab switch.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class TabSwitchCacheTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir = new();
+    private readonly CountingProjectManager _pm = new();
+    private readonly TestServices _ctx;
+
+    public TabSwitchCacheTests()
+    {
+        _ctx = new TestServices(_pm);
+    }
+
+    public void Dispose() => _dir.Dispose();
+
+    private string WriteAchx(string fileName, string chainName)
+    {
+        var path = Path.Combine(_dir.Path, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        acls.AnimationChains.Add(new AnimationChainSave { Name = chainName });
+        acls.Save(path);
+        return path;
+    }
+
+    [Fact]
+    public async Task TryActivateTabFromCache_AfterInitialLoad_DoesNotReloadFromDisk()
+    {
+        string pathA = WriteAchx("a.achx", "Walk");
+        string pathB = WriteAchx("b.achx", "Run");
+        var tabA = new TabEntry(new FilePath(pathA));
+        var tabB = new TabEntry(new FilePath(pathB));
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(pathA);
+        _ctx.AppCommands.CaptureTabEditorState(tabA);
+        Assert.Equal(1, _pm.LoadCallCount);
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(pathB);
+        _ctx.AppCommands.CaptureTabEditorState(tabB);
+        Assert.Equal(2, _pm.LoadCallCount);
+
+        Assert.True(_ctx.AppCommands.TryActivateTabFromCache(tabA));
+        Assert.Equal(2, _pm.LoadCallCount);
+        Assert.Equal("Walk", _ctx.SelectedState.SelectedChain!.Name);
+    }
+
+    [Fact]
+    public async Task TryActivateTabFromCache_WhenDiskFileIsNewer_ReturnsFalseAndReloads()
+    {
+        string path = WriteAchx("stale.achx", "Before");
+        var tab = new TabEntry(new FilePath(path));
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+        Assert.Equal(1, _pm.LoadCallCount);
+
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "After" });
+        acls.Save(path);
+
+        Assert.False(_ctx.AppCommands.TryActivateTabFromCache(tab));
+        Assert.Equal(1, _pm.LoadCallCount);
+
+        await _ctx.AppCommands.ActivateTabContentAsync(tab);
+        Assert.Equal(2, _pm.LoadCallCount);
+        Assert.Equal("After", _ctx.SelectedState.SelectedChain!.Name);
+    }
+
+    [Fact]
+    public void CaptureTabEditorState_PreservesEditsAcrossCacheRoundTrip()
+    {
+        string path = WriteAchx("edited.achx", "Idle");
+        var tab = new TabEntry(new FilePath(path));
+
+        _pm.LoadAnimationChain(new FilePath(path));
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+
+        _pm.AnimationChainListSave!.AnimationChains[0].Name = "Renamed";
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+
+        TabEditorCache.ApplyToProject(tab, _pm);
+        Assert.Equal("Renamed", _pm.AnimationChainListSave!.AnimationChains[0].Name);
+    }
+
+    private sealed class CountingProjectManager : IProjectManager
+    {
+        private readonly ProjectManager _inner = new();
+
+        public int LoadCallCount { get; private set; }
+
+        public AnimationChainListSave? AnimationChainListSave
+        {
+            get => _inner.AnimationChainListSave;
+            set => _inner.AnimationChainListSave = value;
+        }
+
+        public TileMapInformationList TileMapInformationList
+        {
+            get => _inner.TileMapInformationList;
+            set => _inner.TileMapInformationList = value;
+        }
+
+        public FilePath[] ReferencedPngs => _inner.ReferencedPngs;
+        public string? FileName { get => _inner.FileName; set => _inner.FileName = value; }
+        public TextureCoordinateType OnDiskCoordinateType
+        {
+            get => _inner.OnDiskCoordinateType;
+            set => _inner.OnDiskCoordinateType = value;
+        }
+
+        public void LoadAnimationChain(FilePath fileName, AnimationChainListSave? preParsed = null)
+        {
+            LoadCallCount++;
+            _inner.LoadAnimationChain(fileName, preParsed);
+        }
+
+        public void SaveAnimationChainList(string targetPath) =>
+            _inner.SaveAnimationChainList(targetPath);
+
+        public (int Width, int Height)? GetTextureSizeInPixels(string textureName) =>
+            _inner.GetTextureSizeInPixels(textureName);
+
+        public IReadOnlyList<string> FindMissingTextures(AnimationChainListSave acls, string achxDirectory) =>
+            _inner.FindMissingTextures(acls, achxDirectory);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
@@ -16,7 +16,7 @@ namespace AnimationEditor.Core.Tests;
 internal sealed class TestServices
 {
     public AnimationChainListSave Acls { get; }
-    public ProjectManager ProjectManager { get; }
+    public IProjectManager ProjectManager { get; }
     public ApplicationEvents ApplicationEvents { get; }
     public SelectedState SelectedState { get; }
     public AppState AppState { get; }
@@ -25,9 +25,11 @@ internal sealed class TestServices
     public UndoManager UndoManager { get; }
     public AppCommands AppCommands { get; }
 
-    public TestServices()
+    public TestServices() : this(new ProjectManager()) { }
+
+    public TestServices(IProjectManager projectManager)
     {
-        ProjectManager    = new ProjectManager();
+        ProjectManager    = projectManager;
         ApplicationEvents = new ApplicationEvents();
         SelectedState     = new SelectedState(ProjectManager);
         AppState          = new AppState(ApplicationEvents, SelectedState);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -41,6 +41,9 @@ public class UndoCoverageRosterTests
         // Mutating, deliberately NOT undoable -------------------------------------
         [nameof(IAppCommands.OpenAchxWorkflowAsync)]              = Category.MutatingNotUndoable, // loads a file; clears the undo stack
         [nameof(IAppCommands.LoadAnimationChain)]                 = Category.MutatingNotUndoable, // loads a file; clears the undo stack
+        [nameof(IAppCommands.CaptureTabEditorState)]              = Category.NonMutating,
+        [nameof(IAppCommands.TryActivateTabFromCache)]            = Category.MutatingNotUndoable, // swaps project model; undo restored by app layer
+        [nameof(IAppCommands.ActivateTabContentAsync)]            = Category.MutatingNotUndoable, // tab switch load or cache restore
         [nameof(IAppCommands.ReloadAchxFromDisk)]                 = Category.MutatingNotUndoable, // hot-reload; clears the undo stack on success
         [nameof(IAppCommands.NewFile)]                            = Category.MutatingNotUndoable, // resets the project; clears the undo stack
         [nameof(IAppCommands.SaveCurrentAnimationChainList)]      = Category.MutatingNotUndoable, // writes a file; no model change


### PR DESCRIPTION
## Summary
- Cache each open tab's in-memory \AnimationChainListSave\ on deactivate so re-activation swaps project state instead of re-reading/parsing the \.achx\ from disk.
- Invalidate cache when the on-disk file is newer than the cached timestamp (external edits while tab was in background).
- Reuse the UV-gate preview parse on first load to avoid a second \FromFile\ call; hot-reload and save paths refresh the tab cache via \EditorProjectModelChanged\.

## Test plan
- [x] \TabSwitchCacheTests\ — cache hit skips \LoadAnimationChain\, stale disk forces reload
- [x] Full \AnimationEditor.Core.Tests\ (1288 tests)
- [x] \TabSwitchUndoTests\ — undo history still preserved across tab switches
- [x] Manual: open two \.achx\ tabs, switch between them — treeview should update immediately with preview (no ~0.5s beat)
- [x] Manual: edit tab A, switch to B and back — unsaved edits and undo history intact
- [x] Manual: change tab A's \.achx\ on disk externally, switch to it — file reloads from disk

Closes #476