### PR TITLE
Animation Editor: FILES panel for drag-to-assign PNG textures

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconFolder.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconFolder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.5a2 2 0 0 1-1-1l-2-2H4a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2z"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconFolderOpen.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/svg/IconFolderOpen.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.axaml
@@ -1,0 +1,106 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AnimationEditor.App.Controls"
+             xmlns:svg="clr-namespace:Avalonia.Svg.Skia;assembly=Svg.Controls.Skia.Avalonia"
+             x:Class="AnimationEditor.App.Controls.FilesPanelControl"
+             x:DataType="local:FilesPanelControl">
+    <UserControl.Resources>
+        <x:Double x:Key="FilesTreeThumbSize">28</x:Double>
+    </UserControl.Resources>
+    <Grid RowDefinitions="*,Auto">
+        <TreeView x:Name="FilesTree"
+                  Grid.Row="0"
+                  ItemsSource="{Binding TreeRoots}"
+                  Background="Transparent"
+                  Focusable="False"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                  ScrollViewer.AllowAutoHide="False">
+            <TreeView.Styles>
+                <Style Selector="TreeViewItem">
+                    <Setter Property="IsExpanded"
+                            Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
+                    <Setter Property="Focusable" Value="False" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="MinHeight" Value="24" />
+                </Style>
+                <Style Selector="TreeViewItem:selected">
+                    <Setter Property="Background" Value="Transparent" />
+                </Style>
+                <Style Selector="TreeViewItem:pointerover">
+                    <Setter Property="Background" Value="Transparent" />
+                </Style>
+                <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
+                    <Setter Property="Background" Value="Transparent" />
+                </Style>
+                <Style Selector="TreeViewItem:pointerover /template/ Border#PART_LayoutRoot">
+                    <Setter Property="Background" Value="Transparent" />
+                </Style>
+                <!-- No separate chevron — folder icon toggles expand/collapse (VS Code style). -->
+                <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">
+                    <Setter Property="Width" Value="0" />
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+                <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
+                    <Setter Property="Width" Value="0" />
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+            </TreeView.Styles>
+            <TreeView.ItemTemplate>
+                <TreeDataTemplate DataType="local:PngFilesTreeNodeVm"
+                                  ItemsSource="{Binding Children}">
+                    <Border CornerRadius="3"
+                            Padding="0,1"
+                            Classes.dragging="{Binding IsDragging}">
+                        <Border.Styles>
+                            <Style Selector="Border.dragging">
+                                <Setter Property="Background"
+                                        Value="{DynamicResource BgActive}" />
+                            </Style>
+                        </Border.Styles>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="4">
+                            <Panel x:Name="FolderExpander"
+                                   IsVisible="{Binding IsFolder}"
+                                   Width="16" Height="16"
+                                   Cursor="Hand"
+                                   PointerPressed="OnFolderExpanderPressed">
+                                <svg:Svg IsVisible="{Binding IsFolderOpen}"
+                                         Width="16" Height="16"
+                                         Path="avares://AnimationEditor/Assets/icons/svg/IconFolderOpen.svg"
+                                         CurrentColor="{DynamicResource IconInkDim}" />
+                                <svg:Svg IsVisible="{Binding IsFolderClosed}"
+                                         Width="16" Height="16"
+                                         Path="avares://AnimationEditor/Assets/icons/svg/IconFolder.svg"
+                                         CurrentColor="{DynamicResource IconInkDim}" />
+                            </Panel>
+                            <Image IsVisible="{Binding IsFile}"
+                                   Width="{StaticResource FilesTreeThumbSize}"
+                                   Height="{StaticResource FilesTreeThumbSize}"
+                                   Source="{Binding Thumbnail}"
+                                   Stretch="Uniform"
+                                   VerticalAlignment="Center" />
+                            <StackPanel VerticalAlignment="Center" Spacing="1">
+                                <TextBlock Text="{Binding Name}"
+                                           FontSize="11"
+                                           TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{Binding PathHint}"
+                                           IsVisible="{Binding ShowPathHint}"
+                                           FontSize="9"
+                                           Foreground="{DynamicResource InkDim}"
+                                           TextTrimming="CharacterEllipsis" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+        </TreeView>
+
+        <TextBlock x:Name="EmptyMessage"
+                   Grid.Row="1"
+                   Margin="8,4"
+                   TextWrapping="Wrap"
+                   FontSize="11"
+                   Foreground="{DynamicResource InkDim}"
+                   IsVisible="False" />
+    </Grid>
+</UserControl>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
@@ -1,0 +1,298 @@
+using AnimationEditor.App.Services;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace AnimationEditor.App.Controls;
+
+/// <summary>
+/// Tree of PNG thumbnails from the .achx folder for drag-to-assign and reveal-in-explorer.
+/// </summary>
+public partial class FilesPanelControl : UserControl
+{
+    private const int ThumbnailSize = 28;
+    private const double DragThreshold = 4;
+
+    private ThumbnailService? _thumbnailService;
+    private Window? _ownerWindow;
+    private Action<string>? _showError;
+    private PointerPressedEventArgs? _dragPressEvent;
+    private string? _dragPath;
+    private PngFilesTreeNodeVm? _dragSourceNode;
+    private PngFilesTreeNodeVm? _contextNode;
+
+    public ObservableCollection<PngFilesTreeNodeVm> TreeRoots { get; } = new();
+
+    public FilesPanelControl()
+    {
+        InitializeComponent();
+        DataContext = this;
+
+        FilesTree.AddHandler(InputElement.PointerPressedEvent, OnTreePointerPressed,
+            RoutingStrategies.Tunnel);
+        FilesTree.AddHandler(InputElement.PointerMovedEvent, OnTreePointerMoved,
+            RoutingStrategies.Tunnel);
+        FilesTree.AddHandler(InputElement.PointerReleasedEvent, OnTreePointerReleased,
+            RoutingStrategies.Tunnel);
+        FilesTree.SelectionChanged += (_, _) => ClearTreeSelection();
+
+        var contextMenu = new ContextMenu();
+        contextMenu.Opening += OnTreeContextMenuOpening;
+        FilesTree.ContextMenu = contextMenu;
+    }
+
+    public void Initialize(ThumbnailService thumbnailService, Window ownerWindow, Action<string>? showError = null)
+    {
+        _thumbnailService = thumbnailService;
+        _ownerWindow = ownerWindow;
+        _showError = showError;
+    }
+
+    public void Refresh(string? achxFolder)
+    {
+        TreeRoots.Clear();
+
+        if (_thumbnailService is null)
+        {
+            SetEmptyMessage(null, visible: false);
+            return;
+        }
+
+        var files = PngFolderScanner.ListFiles(achxFolder);
+        if (files.Count == 0)
+        {
+            SetEmptyMessage(
+                string.IsNullOrEmpty(achxFolder)
+                    ? "Save the .achx to browse folder PNGs."
+                    : "No PNG files in this folder.",
+                visible: true);
+            return;
+        }
+
+        SetEmptyMessage(null, visible: false);
+        foreach (var node in PngFolderTreeBuilder.Build(files))
+            TreeRoots.Add(PngFilesTreeNodeVm.FromNode(node, _thumbnailService, ThumbnailSize));
+    }
+
+    private void SetEmptyMessage(string? text, bool visible)
+    {
+        EmptyMessage.Text = text ?? string.Empty;
+        EmptyMessage.IsVisible = visible;
+        FilesTree.IsVisible = !visible;
+    }
+
+    private void ClearTreeSelection()
+    {
+        if (FilesTree.SelectedItems.Count == 0)
+            return;
+
+        FilesTree.SelectedItems.Clear();
+    }
+
+    private void OnFolderExpanderPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(sender as Control).Properties.IsLeftButtonPressed)
+            return;
+
+        if (GetNodeVmFromSource(sender) is not { IsFolder: true } node)
+            return;
+
+        node.IsExpanded = !node.IsExpanded;
+        e.Handled = true;
+        ClearTreeSelection();
+    }
+
+    private void OnTreeContextMenuOpening(object? sender, CancelEventArgs e)
+    {
+        if (FilesTree.ContextMenu is null)
+            return;
+
+        FilesTree.ContextMenu.Items.Clear();
+
+        if (_contextNode is not { IsFile: true, AbsolutePath: { } path })
+            return;
+
+        var revealItem = new MenuItem { Header = "View in Explorer" };
+        revealItem.Click += (_, _) => RevealInExplorer(path);
+        FilesTree.ContextMenu.Items.Add(revealItem);
+    }
+
+    private void OnTreePointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var props = e.GetCurrentPoint(FilesTree).Properties;
+
+        if (props.IsRightButtonPressed)
+        {
+            _contextNode = GetNodeVmFromSource(e.Source);
+            return;
+        }
+
+        if (!props.IsLeftButtonPressed)
+            return;
+
+        if (GetNodeVmFromSource(e.Source) is not { IsFile: true, AbsolutePath: { } path } sourceNode)
+            return;
+
+        _dragSourceNode = sourceNode;
+        _dragPressEvent = e;
+        _dragPath = path;
+        e.Pointer.Capture(FilesTree);
+    }
+
+    private async void OnTreePointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_dragPressEvent is null || _dragPath is null || _dragSourceNode is null)
+            return;
+        if (!e.GetCurrentPoint(FilesTree).Properties.IsLeftButtonPressed)
+            return;
+
+        var start = _dragPressEvent.GetPosition(FilesTree);
+        var current = e.GetPosition(FilesTree);
+        if (Math.Abs(current.X - start.X) < DragThreshold &&
+            Math.Abs(current.Y - start.Y) < DragThreshold)
+            return;
+
+        var path = _dragPath;
+        var pressEvent = _dragPressEvent;
+        var sourceNode = _dragSourceNode;
+        ClearPendingDrag();
+        e.Pointer.Capture(null);
+
+        if (_ownerWindow is null)
+            return;
+
+        sourceNode.IsDragging = true;
+        try
+        {
+            var storageItem = await _ownerWindow.StorageProvider.TryGetFileFromPathAsync(path);
+            if (storageItem is null)
+                return;
+
+            var data = new DataTransfer();
+            data.Add(DataTransferItem.CreateFile(storageItem));
+            await DragDrop.DoDragDropAsync(pressEvent, data, DragDropEffects.Copy);
+        }
+        finally
+        {
+            sourceNode.IsDragging = false;
+            if (ReferenceEquals(_dragSourceNode, sourceNode))
+                _dragSourceNode = null;
+        }
+    }
+
+    private void OnTreePointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_dragSourceNode?.IsDragging == true)
+            return;
+
+        _dragSourceNode = null;
+        ClearPendingDrag();
+    }
+
+    private static PngFilesTreeNodeVm? GetNodeVmFromSource(object? source)
+    {
+        if (source is not Control control)
+            return null;
+
+        var item = control.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        return item?.DataContext as PngFilesTreeNodeVm;
+    }
+
+    private void ClearPendingDrag()
+    {
+        _dragPressEvent = null;
+        _dragPath = null;
+    }
+
+    private void RevealInExplorer(string absolutePath)
+    {
+        var error = ShellExplorer.RevealFile(absolutePath);
+        if (error is not null)
+            _showError?.Invoke(error);
+    }
+}
+
+public sealed class PngFilesTreeNodeVm : INotifyPropertyChanged
+{
+    private bool _isExpanded = true;
+    private bool _isDragging;
+
+    public string Name { get; }
+    public string? AbsolutePath { get; }
+    public string? PathHint { get; }
+    public bool ShowPathHint => !string.IsNullOrEmpty(PathHint);
+    public bool IsFolder => AbsolutePath is null;
+    public bool IsFile => AbsolutePath is not null;
+    public Bitmap? Thumbnail { get; }
+    public ObservableCollection<PngFilesTreeNodeVm> Children { get; } = new();
+
+    public bool IsFolderOpen => _isExpanded;
+    public bool IsFolderClosed => !_isExpanded;
+
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (_isExpanded == value) return;
+            _isExpanded = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsFolderOpen));
+            OnPropertyChanged(nameof(IsFolderClosed));
+        }
+    }
+
+    public bool IsDragging
+    {
+        get => _isDragging;
+        set
+        {
+            if (_isDragging == value) return;
+            _isDragging = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private PngFilesTreeNodeVm(string name, string? absolutePath, string? pathHint, Bitmap? thumbnail)
+    {
+        Name = name;
+        AbsolutePath = absolutePath;
+        PathHint = pathHint;
+        Thumbnail = thumbnail;
+    }
+
+    public static PngFilesTreeNodeVm FromNode(PngFilesTreeNode node, ThumbnailService thumbnails, int thumbSize)
+    {
+        Bitmap? bitmap = node.IsFolder
+            ? null
+            : thumbnails.GetFullImageThumbnail(node.AbsolutePath, thumbSize, thumbSize);
+
+        string? pathHint = null;
+        if (!node.IsFolder && !string.IsNullOrEmpty(node.RelativePath))
+        {
+            int slash = node.RelativePath.LastIndexOf('/');
+            if (slash >= 0)
+                pathHint = node.RelativePath[..slash].Replace("/", " › ");
+        }
+
+        var vm = new PngFilesTreeNodeVm(node.Name, node.AbsolutePath, pathHint, bitmap);
+        foreach (var child in node.Children)
+            vm.Children.Add(FromNode(child, thumbnails, thumbSize));
+
+        return vm;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -274,9 +274,12 @@
         <!-- ── Main content: TreeView | Property Panel | [Wireframe / Preview] ── -->
         <Grid x:Name="MainContentGrid" ColumnDefinitions="280,4,240,4,*">
 
-            <!-- ── Left: Animation tree ── -->
-            <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto"
+            <!-- ── Left: Animation tree + Files panel ── -->
+            <Grid Grid.Column="0" RowDefinitions="*,4,*"
                   Background="{DynamicResource BgCanvas}">
+
+                <!-- Animations block: header + tree + add button stay grouped -->
+                <Grid Grid.Row="0" RowDefinitions="Auto,*,Auto">
 
                 <!-- ── Tree pane header ── -->
                 <Border Grid.Row="0"
@@ -484,6 +487,37 @@
                             Height="30"
                             Foreground="{DynamicResource Ink}" />
                 </Border>
+
+                </Grid>
+
+                <!-- Splitter between animations block and files block -->
+                <GridSplitter Grid.Row="1"
+                              ResizeDirection="Rows"
+                              Background="{DynamicResource LineStrong}"
+                              HorizontalAlignment="Stretch" />
+
+                <!-- Files block -->
+                <Grid Grid.Row="2" RowDefinitions="Auto,*" MinHeight="80">
+
+                <!-- ── Files pane header ── -->
+                <Border Grid.Row="0"
+                        Background="{DynamicResource BgRail}"
+                        BorderBrush="{DynamicResource LineBrush}"
+                        BorderThickness="0,1,0,0"
+                        Height="36">
+                    <DockPanel Margin="10,0">
+                        <TextBlock Text="FILES"
+                                   FontSize="11"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource InkMid}"
+                                   VerticalAlignment="Center" />
+                    </DockPanel>
+                </Border>
+
+                <controls:FilesPanelControl x:Name="FilesPanel"
+                                            Grid.Row="1" />
+
+                </Grid>
             </Grid>
 
             <!-- ── Splitter (left | middle) ── -->

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -47,6 +47,7 @@ public partial class MainWindow : Window
     private readonly IUndoManager _undoManager;
     private readonly Services.ThumbnailService _thumbnailService;
     private readonly IFileAssociationService _fileAssociation;
+    private readonly PngFolderWatcher _pngFolderWatcher = new();
 
     private AppSettingsModel _appSettings = new();
     private readonly TabManager _tabManager = new();
@@ -133,6 +134,9 @@ public partial class MainWindow : Window
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService);
+        FilesPanel.Initialize(_thumbnailService, this, msg => ShowStatusMessage(msg, isError: true));
+        _pngFolderWatcher.FolderContentsChanged += () =>
+            Dispatcher.UIThread.InvokeAsync(RefreshFilesPanel);
 
         Opened += OnOpened;
         Closed += (_, _) =>
@@ -144,6 +148,7 @@ public partial class MainWindow : Window
             // The thumbnail service owns every cached chain/timeline icon; disposing it here
             // releases them all (and the decoded source sheets) as the window tears down.
             _thumbnailService.Dispose();
+            _pngFolderWatcher.Dispose();
         };
     }
 
@@ -432,6 +437,7 @@ public partial class MainWindow : Window
             _selectedState.Reset();
             _undoManager.Clear();
             RefreshTreeView();
+            RefreshFilesPanel();
             UpdateTitle();
             UpdateStatusBar();
         }
@@ -500,6 +506,7 @@ public partial class MainWindow : Window
                 new AnimationChainListSave();
         }
 
+        RefreshFilesPanel();
         ShowDefaultHandlerBannerIfAppropriate();
     }
 
@@ -567,6 +574,7 @@ public partial class MainWindow : Window
             RefreshRecentFiles();
             UpdateTitle();
             UpdateStatusBar();
+            RefreshFilesPanel();
 
             // If the active tab was an Untitled sentinel, promote it to the real file path.
             var active = _tabManager.ActiveTab;
@@ -1789,11 +1797,9 @@ public partial class MainWindow : Window
 
     private void OnTreeDragOver(object? sender, DragEventArgs e)
     {
-        // Use TryGetFiles() — the correct Avalonia 12 API for OS file drops
-        string? firstFile = e.DataTransfer.TryGetFiles()?                  
+        string? firstFile = e.DataTransfer.TryGetFiles()?
             .FirstOrDefault()?.Path.LocalPath;
 
-        // Fallback for internal drag sources that use the Items API
         if (firstFile is null)
         {
             firstFile = e.DataTransfer.Items?
@@ -1801,16 +1807,24 @@ public partial class MainWindow : Window
                 .FirstOrDefault(f => f is not null)?.Path.LocalPath;
         }
 
-        if (!string.IsNullOrEmpty(firstFile) &&
-            string.Equals(Path.GetExtension(firstFile), ".png", StringComparison.OrdinalIgnoreCase))
-        {
-            e.DragEffects = DragDropEffects.Copy;
-        }
-        else
+        if (string.IsNullOrEmpty(firstFile) ||
+            !string.Equals(Path.GetExtension(firstFile), ".png", StringComparison.OrdinalIgnoreCase))
         {
             e.DragEffects = DragDropEffects.None;
+            e.Handled = true;
+            return;
         }
 
+        var (targetChain, targetFrame) = ResolveTreePngDropTarget(e);
+        var wouldApply = TextureDropProcessor.ComputePngDrop(
+            targetChain,
+            targetFrame,
+            firstFile,
+            _projectManager.FileName,
+            e.KeyModifiers.HasFlag(KeyModifiers.Control)).Result
+            != TextureDropResult.NotApplied;
+
+        e.DragEffects = wouldApply ? DragDropEffects.Copy : DragDropEffects.None;
         e.Handled = true;
     }
 
@@ -1832,15 +1846,7 @@ public partial class MainWindow : Window
             Trace.WriteLine("[DragDrop] Warning: no ACHX file saved yet — texture path will be absolute");
         }
 
-        var targetNode = AnimTree.SelectedItem as TreeNodeVm;
-
-        var targetFrame = targetNode?.Data as AnimationFrameSave;
-        var targetChain = targetNode?.Data as AnimationChainSave;
-
-        if (targetFrame is not null)
-        {
-            targetChain = _objectFinder.GetAnimationChainContaining(targetFrame);
-        }
+        var (targetChain, targetFrame) = ResolveTreePngDropTarget(e);
 
         Trace.WriteLine($"[DragDrop] targetChain={targetChain?.Name ?? "(null)"}, targetFrame={targetFrame?.TextureName ?? "(null)"}, ctrl={e.KeyModifiers.HasFlag(KeyModifiers.Control)}");
 
@@ -1920,6 +1926,25 @@ public partial class MainWindow : Window
         return fallback?.Path.LocalPath;
     }
 
+    private TreeNodeVm? GetTreeNodeAtDropPosition(DragEventArgs e)
+    {
+        var position = e.GetPosition(AnimTree);
+        var hit = AnimTree.InputHitTest(position);
+        if (hit is not Control src)
+            return null;
+
+        var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        return tvi?.DataContext as TreeNodeVm;
+    }
+
+    private (AnimationChainSave? Chain, AnimationFrameSave? Frame) ResolveTreePngDropTarget(DragEventArgs e)
+    {
+        var targetNode = GetTreeNodeAtDropPosition(e);
+        return TreePngDropTarget.FromNodeData(
+            targetNode?.Data,
+            frame => _objectFinder.GetAnimationChainContaining(frame));
+    }
+
     // ── Window-level OS file drop: open dropped .achx files as tabs ────────────
     //
     // Registered on the whole window (handledEventsToo) so an .achx dropped anywhere —
@@ -1975,6 +2000,17 @@ public partial class MainWindow : Window
         TreeBuilder.RouteNodeSelection(vm.Data, _selectedState, _projectManager.AnimationChainListSave);
     }
 
+    // ── Files panel ───────────────────────────────────────────────────────────
+
+    private void RefreshFilesPanel()
+    {
+        string? achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
+            ? null
+            : Path.GetDirectoryName(_projectManager.FileName);
+        FilesPanel.Refresh(achxFolder);
+        _pngFolderWatcher.Watch(achxFolder);
+    }
+
     // ── Tree refresh ──────────────────────────────────────────────────────────
 
     private void RefreshTreeView()
@@ -1983,7 +2019,7 @@ public partial class MainWindow : Window
         try
         {
             var acls = _projectManager.AnimationChainListSave;
-            if (acls is null) { _treeRoots.Clear(); return; }
+            if (acls is null) { _treeRoots.Clear(); RefreshFilesPanel(); return; }
 
             // Diff-update the root nodes instead of clearing and rebuilding, so each
             // chain's collapse state (and selection) survives copy/paste and reorder.
@@ -2014,12 +2050,17 @@ public partial class MainWindow : Window
             _treeRoots.Clear();
 
             var acls = _projectManager.AnimationChainListSave;
-            if (acls is null) return;
+            if (acls is null)
+            {
+                RefreshFilesPanel();
+                return;
+            }
 
             // Empty expandedChainNames (not null) collapses every chain; null would
             // default them all to expanded.
             foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
                 _treeRoots.Add(node);
+            RefreshFilesPanel();
 
             RefreshTreeThumbnails();
             SyncTreeSelection();
@@ -2120,6 +2161,7 @@ public partial class MainWindow : Window
         _timelineSignature = null;
         RefreshTimelineStrip();
         _appCommands.RefreshAnimationFrameDisplay();
+        RefreshFilesPanel();
         ShowToast($"Reloaded {System.IO.Path.GetFileName(absolutePath)}");
     }
 
@@ -4411,14 +4453,9 @@ public partial class MainWindow : Window
             return;
         }
 
-        try
-        {
-            Process.Start("explorer.exe", $"/select,\"{absPath}\"");
-        }
-        catch (Exception ex)
-        {
-            ShowStatusMessage($"⚠ Could not open Explorer: {ex.Message}", isError: true);
-        }
+        var error = Services.ShellExplorer.RevealFile(absPath);
+        if (error is not null)
+            ShowStatusMessage($"⚠ {error}", isError: true);
     }
 }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ShellExplorer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ShellExplorer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Opens the host file manager with a file selected (or its folder revealed).
+/// </summary>
+public static class ShellExplorer
+{
+    /// <summary>
+    /// Reveals <paramref name="absolutePath"/> in the system file manager.
+    /// Returns <c>null</c> on success, or an error message when the file is missing
+    /// or the shell command fails.
+    /// </summary>
+    public static string? RevealFile(string absolutePath)
+    {
+        if (string.IsNullOrEmpty(absolutePath))
+            return "No file path was provided.";
+
+        if (!File.Exists(absolutePath))
+            return $"File not found: {absolutePath}";
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    Arguments = $"/select,\"{absolutePath}\"",
+                    UseShellExecute = true,
+                });
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "open",
+                    Arguments = $"-R \"{absolutePath}\"",
+                    UseShellExecute = false,
+                });
+            }
+            else
+            {
+                var folder = Path.GetDirectoryName(absolutePath);
+                if (string.IsNullOrEmpty(folder))
+                    return $"Could not determine folder for: {absolutePath}";
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "xdg-open",
+                    Arguments = $"\"{folder}\"",
+                    UseShellExecute = false,
+                });
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"Could not open file manager: {ex.Message}";
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -138,6 +138,29 @@ public sealed class ThumbnailService : IDisposable
     }
 
     /// <summary>
+    /// Returns a downscaled Avalonia bitmap of the full PNG at <paramref name="path"/>.
+    /// Used by the Files panel; the result is owned by the caller.
+    /// </summary>
+    public Avalonia.Media.Imaging.Bitmap? GetFullImageThumbnail(string? path, int maxWidth, int maxHeight)
+    {
+        var bm = GetBitmap(path);
+        if (bm is null) return null;
+
+        float scale = Math.Min((float)maxWidth / bm.Width, (float)maxHeight / bm.Height);
+        scale = Math.Min(scale, 1f);
+        int finalW = Math.Max(1, (int)(bm.Width * scale));
+        int finalH = Math.Max(1, (int)(bm.Height * scale));
+
+        using var thumb = new SKBitmap(finalW, finalH);
+        using var canvas = new SKCanvas(thumb);
+        canvas.Clear(SKColors.Transparent);
+        using var img = SKImage.FromBitmap(bm);
+        canvas.DrawImage(img, SKRect.Create(0, 0, finalW, finalH),
+            new SKSamplingOptions(SKFilterMode.Linear));
+        return ToAvaloniaBitmap(thumb);
+    }
+
+    /// <summary>
     /// Returns an Avalonia Bitmap of the frame's texture region, scaled to fit within
     /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (preserving aspect ratio).
     /// Returns <c>null</c> if the texture cannot be resolved, is not loaded, or the frame

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TreePngDropTarget.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TreePngDropTarget.cs
@@ -1,0 +1,27 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.DragDrop;
+
+/// <summary>
+/// Resolves the animation-tree drop target from the node under the pointer.
+/// </summary>
+public static class TreePngDropTarget
+{
+    /// <summary>
+    /// Maps a tree node's <see cref="ViewModels.TreeNodeVm.Data"/> to the chain/frame
+    /// pair passed to <see cref="TextureDropProcessor.ComputePngDrop"/>. Returns
+    /// <c>(null, null)</c> when the pointer is not over a chain or frame node —
+    /// blank tree chrome must not fall back to the current selection.
+    /// </summary>
+    public static (AnimationChainSave? Chain, AnimationFrameSave? Frame) FromNodeData(
+        object? nodeData,
+        Func<AnimationFrameSave, AnimationChainSave?> getChainContainingFrame)
+    {
+        return nodeData switch
+        {
+            AnimationFrameSave frame => (getChainContainingFrame(frame), frame),
+            AnimationChainSave chain => (chain, null),
+            _ => (null, null),
+        };
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderScanner.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderScanner.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AnimationEditor.Core.Paths;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Recursively enumerates PNG files under a folder, grouped by immediate subfolder path.
+/// </summary>
+public static class PngFolderScanner
+{
+    /// <summary>
+    /// Scans <paramref name="rootFolder"/> and its subfolders for <c>.png</c> files
+    /// (case-insensitive extension match). Returns an empty list when the folder is
+    /// missing or null.
+    /// </summary>
+    /// <summary>
+    /// Returns every PNG under <paramref name="rootFolder"/>, recursively.
+    /// </summary>
+    public static IReadOnlyList<PngFileEntry> ListFiles(string? rootFolder)
+    {
+        if (string.IsNullOrEmpty(rootFolder) || !Directory.Exists(rootFolder))
+            return Array.Empty<PngFileEntry>();
+
+        var normalizedRoot = Path.GetFullPath(rootFolder);
+        var files = new List<PngFileEntry>();
+
+        foreach (var file in Directory.EnumerateFiles(normalizedRoot, "*", SearchOption.AllDirectories))
+        {
+            if (!Path.GetExtension(file).Equals(".png", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            string relative = Path.GetRelativePath(normalizedRoot, file).Replace('\\', '/');
+            files.Add(new PngFileEntry(file, relative));
+        }
+
+        return files;
+    }
+
+    public static IReadOnlyList<PngFolderGroup> Scan(string? rootFolder)
+    {
+        var groups = new Dictionary<string, List<PngFileEntry>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in ListFiles(rootFolder))
+        {
+            int slash = file.RelativePath.LastIndexOf('/');
+            string subfolder = slash < 0 ? string.Empty : file.RelativePath[..slash];
+
+            if (!groups.TryGetValue(subfolder, out var list))
+                groups[subfolder] = list = new List<PngFileEntry>();
+
+            list.Add(file);
+        }
+
+        return groups
+            .OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kv => new PngFolderGroup(
+                FormatGroupLabel(kv.Key),
+                kv.Value
+                    .OrderBy(f => f.FileName, StringComparer.OrdinalIgnoreCase)
+                    .ToList()))
+            .ToList();
+    }
+
+    private static string FormatGroupLabel(string subfolderPath)
+    {
+        if (string.IsNullOrEmpty(subfolderPath))
+            return "(root)";
+
+        return subfolderPath;
+    }
+
+    internal static bool IsPngPath(string path) =>
+        Path.GetExtension(path).Equals(".png", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record PngFileEntry(string AbsolutePath, string RelativePath)
+{
+    public string FileName => new FilePath(AbsolutePath).NoPath;
+}
+
+public sealed record PngFolderGroup(string Label, IReadOnlyList<PngFileEntry> Files);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderTreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderTreeBuilder.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Builds a hierarchical folder tree from flat PNG file entries.
+/// </summary>
+public static class PngFolderTreeBuilder
+{
+    public static IReadOnlyList<PngFilesTreeNode> Build(IReadOnlyList<PngFileEntry> files)
+    {
+        var root = new BuilderNode();
+        foreach (var file in files)
+        {
+            var parts = file.RelativePath.Replace('\\', '/').Split('/');
+            root.Insert(parts, file);
+        }
+
+        return root.ToSortedNodes();
+    }
+
+    private sealed class BuilderNode
+    {
+        private readonly Dictionary<string, BuilderNode> _folders =
+            new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<PngFileEntry> _files = new();
+
+        public void Insert(string[] pathParts, PngFileEntry file)
+        {
+            if (pathParts.Length == 1)
+            {
+                _files.Add(file);
+                return;
+            }
+
+            string folderName = pathParts[0];
+            if (!_folders.TryGetValue(folderName, out var child))
+                _folders[folderName] = child = new BuilderNode();
+
+            var remaining = pathParts.Length == 2
+                ? new[] { pathParts[1] }
+                : pathParts.Skip(1).ToArray();
+            child.Insert(remaining, file);
+        }
+
+        public List<PngFilesTreeNode> ToSortedNodes()
+        {
+            var nodes = new List<PngFilesTreeNode>();
+
+            foreach (var (name, folder) in _folders.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                nodes.Add(new PngFilesTreeNode
+                {
+                    Name = name,
+                    AbsolutePath = null,
+                    Children = folder.ToSortedNodes(),
+                });
+            }
+
+            foreach (var file in _files.OrderBy(f => f.FileName, StringComparer.OrdinalIgnoreCase))
+            {
+                nodes.Add(new PngFilesTreeNode
+                {
+                    Name = file.FileName,
+                    AbsolutePath = file.AbsolutePath,
+                    RelativePath = file.RelativePath,
+                    Children = Array.Empty<PngFilesTreeNode>(),
+                });
+            }
+
+            return nodes;
+        }
+    }
+}
+
+/// <summary>
+/// A folder or PNG file node in the files-panel tree. Folders have a null
+/// <see cref="AbsolutePath"/>; file nodes carry the on-disk path for drag/reveal.
+/// </summary>
+public sealed class PngFilesTreeNode
+{
+    public required string Name { get; init; }
+    public string? AbsolutePath { get; init; }
+    public string? RelativePath { get; init; }
+    public IReadOnlyList<PngFilesTreeNode> Children { get; init; } = Array.Empty<PngFilesTreeNode>();
+    public bool IsFolder => AbsolutePath is null;
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderWatcher.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderWatcher.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Watches an .achx folder (recursively) for PNG file changes and raises a debounced
+/// <see cref="FolderContentsChanged"/> event suitable for refreshing a file browser panel.
+/// </summary>
+public sealed class PngFolderWatcher : IDisposable
+{
+    private static readonly TimeSpan DebounceInterval = TimeSpan.FromMilliseconds(300);
+
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private readonly object _lock = new();
+
+    public event Action? FolderContentsChanged;
+
+    public void Watch(string? folder)
+    {
+        lock (_lock)
+        {
+            StopWatcherLocked();
+
+            if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+                return;
+
+            _watcher = new FileSystemWatcher(folder)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                EnableRaisingEvents = true,
+            };
+
+            _watcher.Created += OnFileSystemEvent;
+            _watcher.Deleted += OnFileSystemEvent;
+            _watcher.Renamed += OnRenamed;
+            _watcher.Changed += OnFileSystemEvent;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            StopWatcherLocked();
+            _debounceTimer?.Dispose();
+            _debounceTimer = null;
+        }
+    }
+
+    private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
+    {
+        if (!PngFolderScanner.IsPngPath(e.FullPath))
+            return;
+
+        ScheduleNotify();
+    }
+
+    private void OnRenamed(object sender, RenamedEventArgs e)
+    {
+        if (!PngFolderScanner.IsPngPath(e.FullPath) && !PngFolderScanner.IsPngPath(e.OldFullPath))
+            return;
+
+        ScheduleNotify();
+    }
+
+    private void ScheduleNotify()
+    {
+        lock (_lock)
+        {
+            _debounceTimer ??= new Timer(_ =>
+            {
+                FolderContentsChanged?.Invoke();
+            }, null, Timeout.Infinite, Timeout.Infinite);
+
+            _debounceTimer.Change(DebounceInterval, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private void StopWatcherLocked()
+    {
+        if (_watcher is null)
+            return;
+
+        _watcher.EnableRaisingEvents = false;
+        _watcher.Created -= OnFileSystemEvent;
+        _watcher.Deleted -= OnFileSystemEvent;
+        _watcher.Renamed -= OnRenamed;
+        _watcher.Changed -= OnFileSystemEvent;
+        _watcher.Dispose();
+        _watcher = null;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderScannerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderScannerTests.cs
@@ -1,0 +1,66 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class PngFolderScannerTests
+{
+    [Fact]
+    public void Scan_EmptyFolder_ReturnsEmpty()
+    {
+        using var dir = new TempDirectory();
+        Assert.Empty(PngFolderScanner.Scan(dir.Path));
+    }
+
+    [Fact]
+    public void Scan_MixedExtensions_ReturnsOnlyPngCaseInsensitive()
+    {
+        using var dir = new TempDirectory();
+        File.WriteAllText(Path.Combine(dir.Path, "hero.png"), "png");
+        File.WriteAllText(Path.Combine(dir.Path, "enemy.PNG"), "png");
+        File.WriteAllText(Path.Combine(dir.Path, "notes.txt"), "txt");
+        File.WriteAllText(Path.Combine(dir.Path, "photo.jpg"), "jpg");
+
+        var groups = PngFolderScanner.Scan(dir.Path);
+
+        Assert.Single(groups);
+        Assert.Equal("(root)", groups[0].Label);
+        Assert.Equal(2, groups[0].Files.Count);
+        Assert.Equal(["enemy.PNG", "hero.png"], groups[0].Files.Select(f => f.FileName).OrderBy(n => n).ToArray());
+    }
+
+    [Fact]
+    public void Scan_NestedSubfolders_GroupsBySubfolder()
+    {
+        using var dir = new TempDirectory();
+        var spritesDir = Path.Combine(dir.Path, "Sprites");
+        Directory.CreateDirectory(spritesDir);
+        File.WriteAllText(Path.Combine(dir.Path, "root.png"), "png");
+        File.WriteAllText(Path.Combine(spritesDir, "hero.png"), "png");
+
+        var groups = PngFolderScanner.Scan(dir.Path);
+
+        Assert.Equal(2, groups.Count);
+        Assert.Equal("(root)", groups[0].Label);
+        Assert.Equal("root.png", groups[0].Files.Single().FileName);
+        Assert.Equal("Sprites", groups[1].Label);
+        Assert.Equal("hero.png", groups[1].Files.Single().FileName);
+    }
+
+    [Fact]
+    public void Scan_NullFolder_ReturnsEmpty()
+    {
+        Assert.Empty(PngFolderScanner.Scan(null));
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "ae-png-scan-" + Guid.NewGuid().ToString("N"));
+
+        public TempDirectory() => Directory.CreateDirectory(Path);
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
@@ -1,0 +1,49 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class PngFolderTreeBuilderTests
+{
+    [Fact]
+    public void Build_RootFile_ReturnsSingleFileNode()
+    {
+        var files = new[] { new PngFileEntry(@"C:\proj\hero.png", "hero.png") };
+
+        var tree = PngFolderTreeBuilder.Build(files);
+
+        Assert.Single(tree);
+        Assert.False(tree[0].IsFolder);
+        Assert.Equal("hero.png", tree[0].Name);
+        Assert.Equal(@"C:\proj\hero.png", tree[0].AbsolutePath);
+    }
+
+    [Fact]
+    public void Build_NestedFolders_BuildsCollapsibleHierarchy()
+    {
+        var files = new[]
+        {
+            new PngFileEntry(@"C:\proj\root.png", "root.png"),
+            new PngFileEntry(@"C:\proj\Sprites\hero.png", "Sprites/hero.png"),
+            new PngFileEntry(@"C:\proj\Sprites\Enemies\goblin.png", "Sprites/Enemies/goblin.png"),
+        };
+
+        var tree = PngFolderTreeBuilder.Build(files);
+
+        Assert.Equal(2, tree.Count);
+        Assert.True(tree[0].IsFolder);
+        Assert.Equal("Sprites", tree[0].Name);
+        Assert.True(tree[0].Children[0].IsFolder);
+        Assert.Equal("Enemies", tree[0].Children[0].Name);
+        Assert.Equal("goblin.png", tree[0].Children[0].Children[0].Name);
+        Assert.Equal("hero.png", tree[0].Children[1].Name);
+        Assert.False(tree[1].IsFolder);
+        Assert.Equal("root.png", tree[1].Name);
+    }
+
+    [Fact]
+    public void Build_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(PngFolderTreeBuilder.Build(Array.Empty<PngFileEntry>()));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreePngDropTargetTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreePngDropTargetTests.cs
@@ -1,0 +1,86 @@
+using AnimationEditor.Core.DragDrop;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TreePngDropTargetTests
+{
+    [Fact]
+    public void FromNodeData_FrameNode_ReturnsFrameAndParentChain()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "old.png" };
+        chain.Frames.Add(frame);
+
+        var (resolvedChain, resolvedFrame) = TreePngDropTarget.FromNodeData(
+            frame,
+            f => ReferenceEquals(f, frame) ? chain : null);
+
+        Assert.Same(chain, resolvedChain);
+        Assert.Same(frame, resolvedFrame);
+    }
+
+    [Fact]
+    public void FromNodeData_ChainNode_ReturnsChainWithoutFrame()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave());
+
+        var (resolvedChain, resolvedFrame) = TreePngDropTarget.FromNodeData(
+            chain,
+            _ => null);
+
+        Assert.Same(chain, resolvedChain);
+        Assert.Null(resolvedFrame);
+    }
+
+    [Fact]
+    public void FromNodeData_BlankTreeChrome_ReturnsNullTargets()
+    {
+        var selectedChain = new AnimationChainSave { Name = "Selected" };
+        selectedChain.Frames.Add(new AnimationFrameSave { TextureName = "keep.png" });
+
+        var (resolvedChain, resolvedFrame) = TreePngDropTarget.FromNodeData(
+            null,
+            _ => selectedChain);
+
+        Assert.Null(resolvedChain);
+        Assert.Null(resolvedFrame);
+    }
+
+    [Fact]
+    public void FromNodeData_BlankTreeChrome_ComputePngDropDoesNotUpdateSelectedChain()
+    {
+        var selectedChain = new AnimationChainSave { Name = "Selected" };
+        var frame = new AnimationFrameSave { TextureName = "keep.png" };
+        selectedChain.Frames.Add(frame);
+        string png = TestPaths.Abs("Project", "Content", "NewTex.png");
+        string achx = TestPaths.Abs("Project", "Animations", "Player.achx");
+
+        var (chain, targetFrame) = TreePngDropTarget.FromNodeData(null, _ => selectedChain);
+
+        var (result, _) = TextureDropProcessor.ComputePngDrop(
+            chain,
+            targetFrame,
+            png,
+            achx,
+            createFrameOnCtrl: false);
+
+        Assert.Equal(TextureDropResult.NotApplied, result);
+        Assert.Equal("keep.png", frame.TextureName);
+    }
+
+    [Fact]
+    public void FromNodeData_ShapeNode_ReturnsNullTargets()
+    {
+        var rect = new AARectSave { Name = "Hitbox" };
+
+        var (resolvedChain, resolvedFrame) = TreePngDropTarget.FromNodeData(
+            rect,
+            _ => throw new InvalidOperationException("Should not resolve chain for shapes"));
+
+        Assert.Null(resolvedChain);
+        Assert.Null(resolvedFrame);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a FILES panel below ANIMATIONS (vertical splitter) listing PNGs from the .achx folder recursively, grouped in a folder tree with thumbnails.
- Drag a PNG onto a frame to assign its texture via the existing drop/copy path; drop targets the node under the pointer (not selected item).
- Auto-refresh on PNG create/delete/rename in the achx folder; right-click View in Explorer on file rows.

## Scope note
This PR implements **achx-folder-only** browsing (issue section B/C/D core). \AssociatedFolders\ / \.aeproperties\ custom folders are deferred to a follow-up.

## Test plan
- [x] \dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/\ (1303 passed)
- [ ] Open an .achx with nested PNG folders; expand/collapse via folder icon
- [ ] Drag PNG from FILES onto a frame; verify texture assigns
- [ ] Drop on blank tree area does not assign
- [ ] Add/delete/rename a PNG on disk; panel refreshes
- [ ] Right-click PNG row -> View in Explorer

Closes #482

Made with [Cursor](https://cursor.com)