### PR TITLE
Animation Editor: recoverable .achx file association + stale registry detection

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -103,6 +103,8 @@
                         <MenuItem Header="Enable Hot _Reload"   x:Name="MenuEnableHotReload" IsChecked="True" />
                         <Separator />
                         <MenuItem Header="Resize _Texture…" x:Name="MenuResizeTexture" />
+                        <Separator />
+                        <MenuItem Header="_Settings…" x:Name="MenuSettings" />
                     </MenuItem>
                     <MenuItem Header="_View">
                         <MenuItem Header="Wireframe _Zoom In"   InputGesture="Ctrl+OemPlus" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -507,12 +507,7 @@ public partial class MainWindow : Window
 
     private void WireDefaultHandlerBanner()
     {
-        MakeDefaultBtn.Click += (_, _) =>
-        {
-            _fileAssociation.RegisterAsDefault();
-            DefaultHandlerBanner.IsVisible = false;
-            ShowStatusMessage("Opened Windows settings — choose Animation Editor for .achx files.");
-        };
+        MakeDefaultBtn.Click += (_, _) => RegisterAsDefaultAchxHandler(hideBanner: true);
 
         DismissDefaultHandlerBtn.Click += (_, _) =>
         {
@@ -520,6 +515,14 @@ public partial class MainWindow : Window
             SaveSettingsFile();
             DefaultHandlerBanner.IsVisible = false;
         };
+    }
+
+    private void RegisterAsDefaultAchxHandler(bool hideBanner)
+    {
+        _fileAssociation.RegisterAsDefault();
+        if (hideBanner)
+            DefaultHandlerBanner.IsVisible = false;
+        ShowStatusMessage("Opened Windows settings — choose Animation Editor for .achx files.");
     }
 
     private void ShowDefaultHandlerBannerIfAppropriate()
@@ -1276,6 +1279,7 @@ public partial class MainWindow : Window
         MenuExportPixiJs.Click += OnExportPixiJsClick;
         MenuAbout.Click  += OnAboutClick;
         MenuViewLog.Click += OnViewLogClick;
+        MenuSettings.Click += OnSettingsClick;
         MenuCopy.Click          += (_, _) => _ = HandleCopyAsync();
         MenuPaste.Click         += (_, _) => _ = HandlePasteAsync();
         MenuDuplicate.Click     += (_, _) => HandleDuplicate();
@@ -1425,6 +1429,28 @@ public partial class MainWindow : Window
 
     private void OnAboutClick(object? sender, RoutedEventArgs e)
         => _ = BuildAboutWindow().ShowDialog(this);
+
+    private void OnSettingsClick(object? sender, RoutedEventArgs e)
+    {
+        var dialog = Settings.SettingsWindowBuilder.Build(
+            new Settings.SettingsWindowModel
+            {
+                FileAssociationSupported = _fileAssociation.IsSupported,
+                FileAssociationStatus = _fileAssociation.GetStatus(),
+                SuppressDefaultHandlerPrompt = _appSettings.SuppressDefaultHandlerPrompt,
+            },
+            new Settings.SettingsWindowCallbacks
+            {
+                OnSetDefaultAchx = () => RegisterAsDefaultAchxHandler(hideBanner: false),
+                OnSuppressDefaultHandlerPromptChanged = suppressed =>
+                {
+                    _appSettings.SuppressDefaultHandlerPrompt = suppressed;
+                    SaveSettingsFile();
+                    ShowDefaultHandlerBannerIfAppropriate();
+                },
+            });
+        _ = dialog.ShowDialog(this);
+    }
 
     private void OnViewLogClick(object? sender, RoutedEventArgs e)
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.Versioning;
 using AnimationEditor.Core.IO;
 using Microsoft.Win32;
@@ -33,12 +34,14 @@ internal sealed class WindowsFileAssociationService : IFileAssociationService
 
     public bool IsSupported => OperatingSystem.IsWindows();
 
-    public bool IsDefault()
+    public bool IsDefault() => GetStatus() == AchxFileAssociationStatus.AssociatedWithThisBuild;
+
+    public AchxFileAssociationStatus GetStatus()
     {
         if (!OperatingSystem.IsWindows())
-            return false;
+            return AchxFileAssociationStatus.NotSupported;
 
-        return IsDefaultWindows();
+        return GetStatusWindows();
     }
 
     public void RegisterAsDefault()
@@ -59,17 +62,35 @@ internal sealed class WindowsFileAssociationService : IFileAssociationService
         string.Equals(registeredProgId, ProgId, StringComparison.OrdinalIgnoreCase);
 
     [SupportedOSPlatform("windows")]
-    private static bool IsDefaultWindows()
+    private static AchxFileAssociationStatus GetStatusWindows()
     {
-        // An explicit per-user choice (set via the Windows "Open with" / default-apps UI) wins.
+        string? activeProgId = ReadActiveProgId();
+        bool isOurProgId = IsOurProgId(activeProgId);
+        string? registeredExe = isOurProgId ? ReadOpenCommandExe(activeProgId!) : null;
+        string? currentExe = Environment.ProcessPath;
+        bool registeredExeExists = !string.IsNullOrEmpty(registeredExe) && File.Exists(registeredExe);
+
+        return AchxFileAssociationEvaluator.Classify(
+            isOurProgId, registeredExe, currentExe, registeredExeExists);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? ReadActiveProgId()
+    {
         var userChoice = Registry.GetValue(
             $@"{ClassesRoot}\{Extension}\UserChoice", "ProgId", null) as string;
         if (!string.IsNullOrEmpty(userChoice))
-            return IsOurProgId(userChoice);
+            return userChoice;
 
-        // No explicit choice — fall back to the extension's default ProgId (what RegisterAsDefault sets).
-        var fallback = Registry.GetValue($@"{ClassesRoot}\{Extension}", null, null) as string;
-        return IsOurProgId(fallback);
+        return Registry.GetValue($@"{ClassesRoot}\{Extension}", null, null) as string;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? ReadOpenCommandExe(string progId)
+    {
+        var openCommand = Registry.GetValue(
+            $@"{ClassesRoot}\{progId}\shell\open\command", null, null) as string;
+        return FileAssociationCommandLine.TryParseExePath(openCommand);
     }
 
     [SupportedOSPlatform("windows")]

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
@@ -1,0 +1,129 @@
+using System;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace AnimationEditor.App.Settings;
+
+/// <summary>Snapshot of editor settings shown in <see cref="SettingsWindowBuilder"/>.</summary>
+public sealed class SettingsWindowModel
+{
+    public bool FileAssociationSupported { get; init; }
+
+    public AchxFileAssociationStatus FileAssociationStatus { get; init; }
+
+    public bool SuppressDefaultHandlerPrompt { get; init; }
+}
+
+/// <summary>Callbacks from the settings dialog back to <see cref="MainWindow"/>.</summary>
+public sealed class SettingsWindowCallbacks
+{
+    public Action? OnSetDefaultAchx { get; init; }
+
+    public Action<bool>? OnSuppressDefaultHandlerPromptChanged { get; init; }
+}
+
+/// <summary>Builds the editor settings window. New sections belong here as the dialog grows.</summary>
+public static class SettingsWindowBuilder
+{
+    public static Window Build(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
+    {
+        var closeBtn = new Button
+        {
+            Content = "Close",
+            HorizontalAlignment = HorizontalAlignment.Right,
+            MinWidth = 80,
+        };
+
+        var root = new DockPanel { Margin = new Thickness(20) };
+        DockPanel.SetDock(closeBtn, Dock.Bottom);
+        root.Children.Add(closeBtn);
+        root.Children.Add(new ScrollViewer
+        {
+            Content = BuildSections(model, callbacks),
+            VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+        });
+
+        var window = new Window
+        {
+            Title = "Settings",
+            Width = 480,
+            MinWidth = 400,
+            MinHeight = 200,
+            Height = 320,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = true,
+            Content = root,
+        };
+        closeBtn.Click += (_, _) => window.Close();
+        return window;
+    }
+
+    /// <summary>Section stack for the settings dialog. Extracted so layout can be unit-tested without a <see cref="Window"/>.</summary>
+    internal static StackPanel BuildSections(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
+    {
+        var sections = new StackPanel { Spacing = 20 };
+
+        if (model.FileAssociationSupported)
+            sections.Children.Add(BuildFileAssociationSection(model, callbacks));
+
+        if (sections.Children.Count == 0)
+        {
+            sections.Children.Add(new TextBlock
+            {
+                TextWrapping = TextWrapping.Wrap,
+                Text = "No settings are available on this platform yet.",
+            });
+        }
+
+        return sections;
+    }
+
+    private static Control BuildFileAssociationSection(
+        SettingsWindowModel model,
+        SettingsWindowCallbacks callbacks)
+    {
+        var statusText = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Text = AchxFileAssociationStatusFormatter.Describe(model.FileAssociationStatus),
+        };
+
+        var setDefaultBtn = new Button
+        {
+            Content = "Set as default for .achx files…",
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        setDefaultBtn.Click += (_, _) => callbacks.OnSetDefaultAchx?.Invoke();
+
+        var suppressCheck = new CheckBox
+        {
+            Content = "Don't show startup prompt for .achx association",
+            IsChecked = model.SuppressDefaultHandlerPrompt,
+        };
+        suppressCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (suppressCheck.IsChecked is bool value)
+                callbacks.OnSuppressDefaultHandlerPromptChanged?.Invoke(value);
+        };
+
+        return new StackPanel
+        {
+            Spacing = 10,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = "File association",
+                    FontWeight = FontWeight.SemiBold,
+                    FontSize = 14,
+                },
+                statusText,
+                setDefaultBtn,
+                suppressCheck,
+            },
+        };
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationEvaluator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationEvaluator.cs
@@ -1,0 +1,50 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Pure classification of whether the editor is the live default handler for
+/// <c>.achx</c> files. Keeps registry/UI wiring testable without touching the registry.
+/// </summary>
+public static class AchxFileAssociationEvaluator
+{
+    /// <summary>
+    /// Returns <c>true</c> only when our ProgId is registered and its open command targets
+    /// <paramref name="currentExePath"/> and that registered exe still exists.
+    /// </summary>
+    public static bool IsDefaultForCurrentBuild(
+        bool isOurProgId,
+        string? registeredExePath,
+        string? currentExePath,
+        bool registeredExeExists)
+    {
+        return Classify(isOurProgId, registeredExePath, currentExePath, registeredExeExists)
+            == AchxFileAssociationStatus.AssociatedWithThisBuild;
+    }
+
+    /// <summary>Classifies association state from registry facts and the running process path.</summary>
+    public static AchxFileAssociationStatus Classify(
+        bool isOurProgId,
+        string? registeredExePath,
+        string? currentExePath,
+        bool registeredExeExists)
+    {
+        if (!isOurProgId)
+            return AchxFileAssociationStatus.NotAssociated;
+
+        if (string.IsNullOrEmpty(registeredExePath) || string.IsNullOrEmpty(currentExePath))
+            return AchxFileAssociationStatus.Stale;
+
+        if (!registeredExeExists)
+            return AchxFileAssociationStatus.Stale;
+
+        if (!ExePathsMatch(registeredExePath, currentExePath))
+            return AchxFileAssociationStatus.Stale;
+
+        return AchxFileAssociationStatus.AssociatedWithThisBuild;
+    }
+
+    internal static bool ExePathsMatch(string registeredExePath, string currentExePath) =>
+        string.Equals(
+            Path.GetFullPath(registeredExePath),
+            Path.GetFullPath(currentExePath),
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationStatus.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationStatus.cs
@@ -1,0 +1,20 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// How the current process relates to the operating-system default handler for
+/// <c>.achx</c> files. Used by the startup banner and file-association settings UI.
+/// </summary>
+public enum AchxFileAssociationStatus
+{
+    /// <summary>File association is not implemented on this platform.</summary>
+    NotSupported,
+
+    /// <summary>Another app (or no handler) is registered for <c>.achx</c>.</summary>
+    NotAssociated,
+
+    /// <summary>Our ProgId is registered and its open command targets this build.</summary>
+    AssociatedWithThisBuild,
+
+    /// <summary>Our ProgId is registered but points at a missing or different exe path.</summary>
+    Stale,
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationStatusFormatter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFileAssociationStatusFormatter.cs
@@ -1,0 +1,17 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>User-visible labels for <see cref="AchxFileAssociationStatus"/> in settings UI.</summary>
+public static class AchxFileAssociationStatusFormatter
+{
+    public static string Describe(AchxFileAssociationStatus status) => status switch
+    {
+        AchxFileAssociationStatus.NotSupported => "File association is not available on this platform.",
+        AchxFileAssociationStatus.NotAssociated =>
+            "Animation Editor is not the default app for .achx files.",
+        AchxFileAssociationStatus.AssociatedWithThisBuild =>
+            "Animation Editor is the default app for .achx files (this build).",
+        AchxFileAssociationStatus.Stale =>
+            "A previous Animation Editor install is registered, but its executable is missing or different from this build.",
+        _ => string.Empty,
+    };
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FileAssociationCommandLine.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/FileAssociationCommandLine.cs
@@ -1,0 +1,27 @@
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Parses the quoted-exe portion of a Windows <c>shell\open\command</c> registry value.
+/// </summary>
+public static class FileAssociationCommandLine
+{
+    /// <summary>
+    /// Extracts the executable path from a value shaped like
+    /// <c>"C:\Path\App.exe" "%1"</c>. Returns <c>null</c> when the string is empty or malformed.
+    /// </summary>
+    public static string? TryParseExePath(string? openCommand)
+    {
+        if (string.IsNullOrWhiteSpace(openCommand))
+            return null;
+
+        string trimmed = openCommand.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '"')
+            return null;
+
+        int closingQuote = trimmed.IndexOf('"', 1);
+        if (closingQuote < 1)
+            return null;
+
+        return trimmed.Substring(1, closingQuote - 1);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileAssociationService.cs
@@ -16,10 +16,17 @@ public interface IFileAssociationService
     bool IsSupported { get; }
 
     /// <summary>
-    /// Whether this editor is the current default handler for <c>.achx</c> files. Only
+    /// Whether this editor is the current default handler for <c>.achx</c> files — i.e. our
+    /// ProgId is registered and its open command targets this build's executable. Only
     /// meaningful when <see cref="IsSupported"/> is true.
     /// </summary>
     bool IsDefault();
+
+    /// <summary>
+    /// Detailed association state for settings UI. Returns
+    /// <see cref="AchxFileAssociationStatus.NotSupported"/> when <see cref="IsSupported"/> is false.
+    /// </summary>
+    AchxFileAssociationStatus GetStatus();
 
     /// <summary>
     /// Registers the editor's file-type association and surfaces the OS confirmation UI.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileAssociationService.cs
@@ -11,5 +11,7 @@ public sealed class NullFileAssociationService : IFileAssociationService
 
     public bool IsDefault() => false;
 
+    public AchxFileAssociationStatus GetStatus() => AchxFileAssociationStatus.NotSupported;
+
     public void RegisterAsDefault() { }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
@@ -1,0 +1,26 @@
+using AnimationEditor.App.Settings;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class SettingsWindowBuilderTests
+{
+    [Fact]
+    public void BuildSections_WithFileAssociation_IncludesSectionHeader()
+    {
+        var sections = SettingsWindowBuilder.BuildSections(
+            new SettingsWindowModel
+            {
+                FileAssociationSupported = true,
+                FileAssociationStatus = AchxFileAssociationStatus.Stale,
+                SuppressDefaultHandlerPrompt = false,
+            },
+            new SettingsWindowCallbacks());
+
+        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[0]).Children[0]);
+
+        Assert.Equal("File association", header.Text);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFileAssociationEvaluatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFileAssociationEvaluatorTests.cs
@@ -1,0 +1,70 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class AchxFileAssociationEvaluatorTests
+{
+    private const string CurrentExe = @"C:\Build\AnimationEditor.exe";
+    private const string OtherExe = @"C:\OldWorktree\AnimationEditor.exe";
+
+    [Fact]
+    public void Classify_ForeignProgId_ReturnsNotAssociated()
+    {
+        var status = AchxFileAssociationEvaluator.Classify(
+            isOurProgId: false,
+            registeredExePath: OtherExe,
+            currentExePath: CurrentExe,
+            registeredExeExists: true);
+
+        Assert.Equal(AchxFileAssociationStatus.NotAssociated, status);
+    }
+
+    [Fact]
+    public void Classify_OurProgIdAndMatchingExe_ReturnsAssociatedWithThisBuild()
+    {
+        var status = AchxFileAssociationEvaluator.Classify(
+            isOurProgId: true,
+            registeredExePath: CurrentExe,
+            currentExePath: CurrentExe,
+            registeredExeExists: true);
+
+        Assert.Equal(AchxFileAssociationStatus.AssociatedWithThisBuild, status);
+    }
+
+    [Fact]
+    public void Classify_OurProgIdButDifferentExe_ReturnsStale()
+    {
+        var status = AchxFileAssociationEvaluator.Classify(
+            isOurProgId: true,
+            registeredExePath: OtherExe,
+            currentExePath: CurrentExe,
+            registeredExeExists: true);
+
+        Assert.Equal(AchxFileAssociationStatus.Stale, status);
+    }
+
+    [Fact]
+    public void Classify_OurProgIdButMissingExe_ReturnsStale()
+    {
+        var status = AchxFileAssociationEvaluator.Classify(
+            isOurProgId: true,
+            registeredExePath: OtherExe,
+            currentExePath: CurrentExe,
+            registeredExeExists: false);
+
+        Assert.Equal(AchxFileAssociationStatus.Stale, status);
+    }
+
+    [Fact]
+    public void IsDefaultForCurrentBuild_StaleAssociation_ReturnsFalse()
+    {
+        bool isDefault = AchxFileAssociationEvaluator.IsDefaultForCurrentBuild(
+            isOurProgId: true,
+            registeredExePath: OtherExe,
+            currentExePath: CurrentExe,
+            registeredExeExists: false);
+
+        Assert.False(isDefault);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFileAssociationStatusFormatterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFileAssociationStatusFormatterTests.cs
@@ -1,0 +1,15 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class AchxFileAssociationStatusFormatterTests
+{
+    [Fact]
+    public void Describe_Stale_MentionsPreviousInstall()
+    {
+        string text = AchxFileAssociationStatusFormatter.Describe(AchxFileAssociationStatus.Stale);
+
+        Assert.Contains("previous", text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileAssociationCommandLineTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FileAssociationCommandLineTests.cs
@@ -1,0 +1,28 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class FileAssociationCommandLineTests
+{
+    [Fact]
+    public void TryParseExePath_QuotedExeAndArg_ReturnsExePath()
+    {
+        string? exe = FileAssociationCommandLine.TryParseExePath(
+            "\"C:\\Program Files\\AnimationEditor\\AnimationEditor.exe\" \"%1\"");
+
+        Assert.Equal(@"C:\Program Files\AnimationEditor\AnimationEditor.exe", exe);
+    }
+
+    [Fact]
+    public void TryParseExePath_Null_ReturnsNull()
+    {
+        Assert.Null(FileAssociationCommandLine.TryParseExePath(null));
+    }
+
+    [Fact]
+    public void TryParseExePath_Unquoted_ReturnsNull()
+    {
+        Assert.Null(FileAssociationCommandLine.TryParseExePath(@"C:\App.exe %1"));
+    }
+}


### PR DESCRIPTION
## Summary

- Detect stale `.achx` file-association registry entries (missing exe or different path than the running build) so the startup banner reappears instead of silently hiding.
- Add **Edit -> Settings...** with a file-association section: status, set-default action, and don't show startup prompt toggle (SuppressDefaultHandlerPrompt in AESettings.json).
- Extend WindowsFileAssociationService with GetStatus() and pure evaluation helpers covered by unit tests.

**Note:** RegisterAsDefault() still opens Windows Default Apps, which does not list portable/uninstalled builds. A proper installer is tracked in #493 to make the in-app association flow actually completable.

Closes #492

## Test plan

- [ ] Run Animation Editor on Windows with a stale registry path - startup banner should appear
- [ ] Edit -> Settings - file association section shows status
- [ ] Toggle don't show startup prompt - banner respects setting across restart
- [ ] Set as default - registry ProgId updates to current exe
- [ ] dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/
- [ ] dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/