### PR TITLE
animation-editor skill: frame-only DnD reorder landmine

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -75,3 +75,7 @@ Both panels have their own zoom combo box wired in `MainWindow.axaml.cs` (`ZoomC
 | Equality / comparison | `new FilePath(a) == new FilePath(b)` |
 
 Tests that exercise path logic **must** use Windows-style backslash literals (e.g. `@"C:\projects\MyAnim.achx"`) to prove the cross-platform handling works — not `Path.Combine`, which would only exercise the current OS's separator.
+
+## Tree reorder — frames only; shape order is fixed
+
+Drag-and-drop tree reorder is **frames only** (see GitHub issues for frame DnD). **Do not add shape DnD reorder:** collision shapes in `.achx` keep a **fixed list order** for FRB1 runtime compatibility — order is meaningful to legacy consumers, not a cosmetic tree sort. Menu/Alt+Arrow shape reorder exists in `AppCommands.MoveShape` today; treat new reorder UX as frame-only unless an issue explicitly revisits shape ordering across runtimes.


### PR DESCRIPTION
## Summary

- Adds a short landmine to the \nimation-editor\ skill: tree drag-and-drop reorder is **frames only** (#500).
- Documents that \.achx\ collision-shape list order is fixed for FRB1 runtime compatibility — do not add shape DnD reorder.

## Test plan

- [ ] N/A — docs/skill only

Made with [Cursor](https://cursor.com)