### PR TITLE
Animation Editor: Cut (Ctrl+X) with pending-cut highlights

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -102,6 +102,7 @@ public partial class App : Application
         editMenu.Add(new NativeMenuItem("Redo")  { Command = Cmd(a.Redo),  Gesture = new KeyGesture(Key.Z, KeyModifiers.Meta | KeyModifiers.Shift) });
         editMenu.Add(new NativeMenuItemSeparator());
         editMenu.Add(new NativeMenuItem("Copy")  { Command = Cmd(a.Copy),  Gesture = new KeyGesture(Key.C, KeyModifiers.Meta) });
+        editMenu.Add(new NativeMenuItem("Cut")   { Command = Cmd(a.Cut),   Gesture = new KeyGesture(Key.X, KeyModifiers.Meta) });
         editMenu.Add(new NativeMenuItem("Paste") { Command = Cmd(a.Paste), Gesture = new KeyGesture(Key.V, KeyModifiers.Meta) });
         editMenu.Add(new NativeMenuItem("Duplicate") { Command = Cmd(a.Duplicate), Gesture = new KeyGesture(Key.D, KeyModifiers.Meta) });
         editMenu.Add(new NativeMenuItemSeparator());
@@ -166,6 +167,9 @@ public partial class App : Application
         sc.AddSingleton<UndoManager>();
         sc.AddSingleton<IUndoManager>(sp => sp.GetRequiredService<UndoManager>());
 
+        sc.AddSingleton<PendingCutState>();
+        sc.AddSingleton<IPendingCutState>(sp => sp.GetRequiredService<PendingCutState>());
+
         sc.AddSingleton<AppCommands>(sp =>
             new AppCommands(
                 sp.GetRequiredService<IProjectManager>(),
@@ -195,6 +199,7 @@ public partial class App : Application
             sp.GetRequiredService<IIoManager>(),
             sp.GetRequiredService<IObjectFinder>(),
             sp.GetRequiredService<IUndoManager>(),
+            sp.GetRequiredService<IPendingCutState>(),
             sp.GetRequiredService<ThumbnailService>(),
             sp.GetRequiredService<IFileAssociationService>(),
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -284,6 +284,9 @@ public class PreviewControl : Control
     private IProjectManager? _projectManager;
     private IUndoManager? _undoManager;
     private ThumbnailService? _thumbnailService;
+    private IPendingCutState? _pendingCutState;
+
+    private static readonly SKColor CutOutlineColor = new(224, 112, 48, 220);
 
     /// <summary>
     /// Called from MainWindow after DI container wires all services.
@@ -296,7 +299,8 @@ public class PreviewControl : Control
         IApplicationEvents events,
         IProjectManager projectManager,
         IUndoManager undoManager,
-        ThumbnailService thumbnailService)
+        ThumbnailService thumbnailService,
+        IPendingCutState pendingCutState)
     {
         _selectedState  = selectedState;
         _appState       = appState;
@@ -305,8 +309,10 @@ public class PreviewControl : Control
         _projectManager = projectManager;
         _undoManager    = undoManager;
         _thumbnailService = thumbnailService;
+        _pendingCutState  = pendingCutState;
 
         _selectedState.SelectionChanged                        += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
+        _pendingCutState.Changed                               += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
         // Content edits change the union extent, hence the scrollbar range — refresh alongside the repaint.
         _events.AnimationChainsChanged                         += () => Dispatcher.UIThread.InvokeAsync(() => { InvalidateVisual(); RaiseViewChanged(); });
         _events.AchxLoaded                                     += _ => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
@@ -1040,12 +1046,13 @@ public class PreviewControl : Control
         }
 
         var list = new List<PreviewShapeInfo>();
+        var pendingShapes = _pendingCutState?.WireframeShapes.ToHashSet() ?? [];
         foreach (var r in frame.ShapesSave!.AARectSaves)
             list.Add(new PreviewShapeInfo(PreviewShapeKind.Rect, r.X, r.Y, r.ScaleX, r.ScaleY,
-                selectedRects.Contains(r)));
+                selectedRects.Contains(r), pendingShapes.Contains(r)));
         foreach (var c in frame.ShapesSave!.CircleSaves)
             list.Add(new PreviewShapeInfo(PreviewShapeKind.Circle, c.X, c.Y, c.Radius, 0f,
-                selectedCircles.Contains(c)));
+                selectedCircles.Contains(c), pendingShapes.Contains(c)));
         return list.ToArray();
     }
 
@@ -1629,7 +1636,8 @@ public class PreviewControl : Control
         PreviewShapeKind Kind,
         float X, float Y,
         float Param1, float Param2,
-        bool IsSelected);
+        bool IsSelected,
+        bool IsPendingCut = false);
 
     private record RenderSnapshot(
         AnimationFrameSave? Frame,
@@ -1761,6 +1769,26 @@ public class PreviewControl : Control
                         canvas.DrawRect(new SKRect(sx - sr, sy - sr, sx + sr, sy + sr), boxPaint);
                     }
                     canvas.DrawCircle(sx, sy, sh.Param1 * om, paint);
+                }
+
+                if (sh.IsPendingCut)
+                {
+                    using var cutPaint = new SKPaint
+                    {
+                        Color = CutOutlineColor,
+                        Style = SKPaintStyle.Stroke,
+                        StrokeWidth = 2f,
+                        IsAntialias = true,
+                        PathEffect = SKPathEffect.CreateDash(new float[] { 6f, 4f }, 0f),
+                    };
+                    if (sh.Kind == PreviewShapeKind.Rect)
+                    {
+                        float hw = sh.Param1 * om;
+                        float hh = sh.Param2 * om;
+                        canvas.DrawRect(new SKRect(sx - hw, sy - hh, sx + hw, sy + hh), cutPaint);
+                    }
+                    else
+                        canvas.DrawCircle(sx, sy, sh.Param1 * om, cutPaint);
                 }
             }
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -69,7 +69,10 @@ public class WireframeControl : Control
         /// Null when no frame is selected or origin data is unavailable.
         /// </summary>
         public float? OriginTexX, OriginTexY;
+        public List<SKRect> PendingCutFrameBounds = new();
     }
+
+    private static readonly SKColor CutOutlineColor = new(224, 112, 48, 220);
 
     private sealed class DrawOp : ICustomDrawOperation
     {
@@ -143,6 +146,20 @@ public class WireframeControl : Control
                 }
                 canvas.DrawRect(sr, frameFill);
                 canvas.DrawRect(sr, frameStroke);
+            }
+
+            // Pending-cut frames: dashed orange overlay (distinct from selection blue).
+            if (s.PendingCutFrameBounds.Count > 0)
+            {
+                using var cutPaint = new SKPaint
+                {
+                    Color = CutOutlineColor,
+                    Style = SKPaintStyle.Stroke,
+                    StrokeWidth = 2f,
+                    PathEffect = SKPathEffect.CreateDash(new float[] { 6f, 4f }, 0f),
+                };
+                foreach (var bounds in s.PendingCutFrameBounds)
+                    canvas.DrawRect(ToScreen(bounds, s), cutPaint);
             }
 
             // Resize handles on selected frame
@@ -460,6 +477,7 @@ public class WireframeControl : Control
 
     private ISelectedState? _selectedState;
     private IAppState? _appState;
+    private IPendingCutState? _pendingCutState;
     private IAppCommands? _appCommands;
     private IApplicationEvents? _events;
     private IProjectManager? _projectManager;
@@ -475,16 +493,19 @@ public class WireframeControl : Control
         IAppCommands appCommands,
         IApplicationEvents events,
         IProjectManager projectManager,
-        IUndoManager undoManager)
+        IUndoManager undoManager,
+        IPendingCutState pendingCutState)
     {
         _selectedState   = selectedState;
         _appState        = appState;
+        _pendingCutState = pendingCutState;
         _appCommands     = appCommands;
         _events          = events;
         _projectManager  = projectManager;
         _undoManager     = undoManager;
 
         _selectedState.SelectionChanged     += () => Dispatcher.UIThread.InvokeAsync(RefreshAll);
+        _pendingCutState.Changed            += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
         _appCommands.RefreshWireframeRequested += () => Dispatcher.UIThread.InvokeAsync(RefreshAll);
         _events.AchxLoaded                  += _ => Dispatcher.UIThread.InvokeAsync(RefreshAll);
     }
@@ -1133,6 +1154,8 @@ public class WireframeControl : Control
 
         foreach (var fr in _frameRects)
             snap.Frames.Add((fr.Bounds, fr.IsSelected));
+
+        snap.PendingCutFrameBounds.AddRange(BuildPendingCutFrameBounds());
 
         var sel = _frameRects.FirstOrDefault(f => f.IsSelected);
         if (sel != null && !_isMagicWandMode)
@@ -1839,6 +1862,37 @@ public class WireframeControl : Control
         }
 
         InvalidateVisual();
+    }
+
+    private List<SKRect> BuildPendingCutFrameBounds()
+    {
+        var result = new List<SKRect>();
+        if (_pendingCutState is null || !_pendingCutState.IsActive || _bitmap is null)
+            return result;
+
+        string? achxFolder = string.IsNullOrEmpty(_projectManager!.FileName)
+            ? null
+            : (Path.GetDirectoryName(_projectManager!.FileName) ?? string.Empty);
+
+        float w = _bitmap.Width;
+        float h = _bitmap.Height;
+
+        foreach (var frame in _pendingCutState.WireframeFrames)
+        {
+            if (string.IsNullOrEmpty(frame.TextureName)) continue;
+            if (achxFolder != null && _loadedTexturePath != null)
+            {
+                var fp = new FilePath(Path.Combine(achxFolder, frame.TextureName));
+                if (!fp.Equals(new FilePath(_loadedTexturePath))) continue;
+            }
+
+            float pixL = frame.LeftCoordinate   * w;
+            float pixT = frame.TopCoordinate    * h;
+            float pixR = frame.RightCoordinate  * w;
+            float pixB = frame.BottomCoordinate * h;
+            result.Add(new SKRect(pixL, pixT, pixR, pixB));
+        }
+        return result;
     }
 
     private void CenterTexture()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -1145,8 +1145,8 @@ public class WireframeControl : Control
     {
         var snap = new RenderSnapshot
         {
-            // Snapshot so LoadTexture can dispose _image without racing the render thread.
-            Image        = _image?.Snapshot(),
+            // Per-draw-op clone so LoadTexture can dispose _image without racing the render thread.
+            Image        = CloneBitmapAsImage(_bitmap),
             ImageWidth   = _bitmap?.Width ?? 0,
             ImageHeight  = _bitmap?.Height ?? 0,
             PanX         = _panX,
@@ -1183,6 +1183,18 @@ public class WireframeControl : Control
         // Move-drag still works via HitTestHandle, which uses _frameRects directly.
 
         return snap;
+    }
+
+    /// <summary>
+    /// Builds an <see cref="SKImage"/> owned by a single <see cref="DrawOp"/> so the UI thread
+    /// can replace <see cref="_image"/> in <see cref="LoadTexture"/> without use-after-dispose on
+    /// the render thread.
+    /// </summary>
+    private static SKImage? CloneBitmapAsImage(SKBitmap? bitmap)
+    {
+        if (bitmap is null) return null;
+        var copy = bitmap.Copy();
+        return SKImage.FromBitmap(copy);
     }
 
     // ── Mouse input ───────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -84,7 +84,7 @@ public class WireframeControl : Control
         public Rect Bounds { get; }
         public bool HitTest(Point p) => true;
         public bool Equals(ICustomDrawOperation? other) => false;
-        public void Dispose() { }
+        public void Dispose() => _s.Image?.Dispose();
 
         public void Render(ImmediateDrawingContext ctx)
         {
@@ -1071,10 +1071,17 @@ public class WireframeControl : Control
     {
         UpdatePalette();
         var snap   = BuildSnapshot(width, height);
-        var bitmap = new SKBitmap(width, height);
-        using var canvas = new SKCanvas(bitmap);
-        DrawOp.RenderSk(canvas, snap, _palette);
-        return bitmap;
+        try
+        {
+            var bitmap = new SKBitmap(width, height);
+            using var canvas = new SKCanvas(bitmap);
+            DrawOp.RenderSk(canvas, snap, _palette);
+            return bitmap;
+        }
+        finally
+        {
+            snap.Image?.Dispose();
+        }
     }
 
     /// <summary>
@@ -1138,7 +1145,8 @@ public class WireframeControl : Control
     {
         var snap = new RenderSnapshot
         {
-            Image        = _image,
+            // Snapshot so LoadTexture can dispose _image without racing the render thread.
+            Image        = _image?.Snapshot(),
             ImageWidth   = _bitmap?.Width ?? 0,
             ImageHeight  = _bitmap?.Height ?? 0,
             PanX         = _panX,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -389,10 +389,18 @@
                             <Setter Property="IsHitTestVisible" Value="True" />
                             <Setter Property="Focusable" Value="True" />
                         </Style>
+                        <!-- Pending cut (Ctrl+X): light orange wash across the full row -->
+                        <Style Selector="Border.cut-pending">
+                            <Setter Property="Background" Value="#28E07030" />
+                            <Setter Property="CornerRadius" Value="2" />
+                            <Setter Property="Padding" Value="2,1" />
+                        </Style>
                     </TreeView.Styles>
                     <TreeView.ItemTemplate>
                         <TreeDataTemplate x:DataType="models:TreeNodeVm"
                                           ItemsSource="{Binding Children}">
+                            <Border Classes.cut-pending="{Binding IsPendingCut}"
+                                    HorizontalAlignment="Stretch">
                             <Grid ColumnDefinitions="*,Auto,Auto" HorizontalAlignment="Stretch">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                     <!-- Node kind icons: SVG files are the single source of truth for path data. -->
@@ -430,25 +438,12 @@
                                              Path="avares://AnimationEditor/Assets/icons/svg/IconCircle.svg"
                                              CurrentColor="{DynamicResource IconInkDim}" />
                                     <Panel>
-                                        <!-- Display mode -->
                                         <TextBlock Text="{Binding Header}"
                                                    Foreground="{DynamicResource Ink}"
                                                    Padding="2,1"
                                                    VerticalAlignment="Center"
-                                                   IsVisible="{Binding ShowDefaultHeader}"
+                                                   IsVisible="{Binding !IsEditing}"
                                                    DoubleTapped="OnHeaderTextDoubleTapped" />
-                                        <!-- Pending-cut indicator: orange left bar (distinct from selection) -->
-                                        <Border IsVisible="{Binding ShowCutHeader}"
-                                                BorderBrush="#E07030"
-                                                BorderThickness="2,0,0,0"
-                                                Padding="4,0,0,0"
-                                                VerticalAlignment="Stretch"
-                                                IsHitTestVisible="False">
-                                            <TextBlock Text="{Binding Header}"
-                                                       Foreground="#E07030"
-                                                       Padding="2,1"
-                                                       VerticalAlignment="Center" />
-                                        </Border>
                                         <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
                                         <TextBox Text="{Binding EditingText, Mode=TwoWay}"
                                                  IsVisible="{Binding IsEditing}"
@@ -486,6 +481,7 @@
                                         Click="OnAddFrameBtnClick"
                                         DoubleTapped="OnAddFrameBtnDoubleTapped" />
                             </Grid>
+                            </Border>
                         </TreeDataTemplate>
                     </TreeView.ItemTemplate>
                 </TreeView>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -96,6 +96,7 @@
                         <MenuItem Header="_Redo"            x:Name="MenuRedo"          InputGesture="Ctrl+Y" />
                         <Separator />
                         <MenuItem Header="_Copy"            x:Name="MenuCopy"          InputGesture="Ctrl+C" />
+                        <MenuItem Header="Cu_t"             x:Name="MenuCut"           InputGesture="Ctrl+X" />
                         <MenuItem Header="_Paste"           x:Name="MenuPaste"         InputGesture="Ctrl+V" />
                         <MenuItem Header="_Duplicate"       x:Name="MenuDuplicate"     InputGesture="Ctrl+D" />
                         <Separator />
@@ -434,8 +435,20 @@
                                                    Foreground="{DynamicResource Ink}"
                                                    Padding="2,1"
                                                    VerticalAlignment="Center"
-                                                   IsVisible="{Binding !IsEditing}"
+                                                   IsVisible="{Binding ShowDefaultHeader}"
                                                    DoubleTapped="OnHeaderTextDoubleTapped" />
+                                        <!-- Pending-cut indicator: orange left bar (distinct from selection) -->
+                                        <Border IsVisible="{Binding ShowCutHeader}"
+                                                BorderBrush="#E07030"
+                                                BorderThickness="2,0,0,0"
+                                                Padding="4,0,0,0"
+                                                VerticalAlignment="Stretch"
+                                                IsHitTestVisible="False">
+                                            <TextBlock Text="{Binding Header}"
+                                                       Foreground="#E07030"
+                                                       Padding="2,1"
+                                                       VerticalAlignment="Center" />
+                                        </Border>
                                         <!-- Inline-edit mode: match TextBlock font/padding so it sits in the same spot -->
                                         <TextBox Text="{Binding EditingText, Mode=TwoWay}"
                                                  IsVisible="{Binding IsEditing}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -394,6 +394,8 @@ public partial class MainWindow : Window
     {
         if (tab == _tabManager.ActiveTab) return;
 
+        ClearPendingCut();
+
         // Save the leaving tab's undo history and in-memory model before the editor switches.
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab != null)
@@ -422,6 +424,7 @@ public partial class MainWindow : Window
 
     private void ActivateUntitledTabContent(TabEntry tab)
     {
+        ClearPendingCut();
         _projectManager.AnimationChainListSave =
             tab.CachedEditorModel ?? new AnimationChainListSave();
         _projectManager.FileName = null;
@@ -599,8 +602,7 @@ public partial class MainWindow : Window
         _appCommands.EditorProjectModelChanged += path =>
             Dispatcher.UIThread.InvokeAsync(() =>
             {
-                _pendingCutState.Clear();
-                SyncPendingCutHighlights();
+                ClearPendingCut();
                 SyncTabCacheFromEditor(path);
             });
 
@@ -3889,6 +3891,12 @@ public partial class MainWindow : Window
 
         var selectedData = SelectedData;
         bool completingCut = _pendingCutState.IsActive;
+        if (completingCut && !_pendingCutState.SourcesBelongToProject(acls, _objectFinder))
+        {
+            _pendingCutState.Clear();
+            SyncPendingCutHighlights();
+            completingCut = false;
+        }
 
         if (chains is { Count: > 0 })
         {
@@ -3962,6 +3970,13 @@ public partial class MainWindow : Window
             Walk(root);
         WireframeCtrl.InvalidateVisual();
         PreviewCtrl.InvalidateVisual();
+    }
+
+    private void ClearPendingCut()
+    {
+        if (!_pendingCutState.IsActive) return;
+        _pendingCutState.Clear();
+        SyncPendingCutHighlights();
     }
 
     private bool TreeMultiSelectionAlreadySynced(IReadOnlyList<object> dataObjects)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -45,6 +45,7 @@ public partial class MainWindow : Window
     private readonly IIoManager _ioManager;
     private readonly IObjectFinder _objectFinder;
     private readonly IUndoManager _undoManager;
+    private readonly IPendingCutState _pendingCutState;
     private readonly Services.ThumbnailService _thumbnailService;
     private readonly IFileAssociationService _fileAssociation;
     private readonly PngFolderWatcher _pngFolderWatcher = new();
@@ -124,6 +125,7 @@ public partial class MainWindow : Window
         IIoManager ioManager,
         IObjectFinder objectFinder,
         IUndoManager undoManager,
+        IPendingCutState pendingCutState,
         Services.ThumbnailService thumbnailService,
         IFileAssociationService fileAssociation,
         string applicationDataRoot)
@@ -138,6 +140,7 @@ public partial class MainWindow : Window
         _ioManager = ioManager;
         _objectFinder = objectFinder;
         _undoManager = undoManager;
+        _pendingCutState = pendingCutState;
         _thumbnailService = thumbnailService;
         _fileAssociation = fileAssociation;
 
@@ -166,8 +169,8 @@ public partial class MainWindow : Window
         WireTabBar();
         WireDefaultHandlerBanner();
 
-        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager);
-        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService);
+        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState);
+        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState);
         FilesPanel.Initialize(_thumbnailService, this, msg => ShowStatusMessage(msg, isError: true));
         _pngFolderWatcher.FolderContentsChanged += () =>
             Dispatcher.UIThread.InvokeAsync(RefreshFilesPanel);
@@ -594,7 +597,15 @@ public partial class MainWindow : Window
                 ShowStatusMessage($"⚠ Reload skipped for '{Path.GetFileName(path)}': {reason}", isError: true));
 
         _appCommands.EditorProjectModelChanged += path =>
-            Dispatcher.UIThread.InvokeAsync(() => SyncTabCacheFromEditor(path));
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                _pendingCutState.Clear();
+                SyncPendingCutHighlights();
+                SyncTabCacheFromEditor(path);
+            });
+
+        _pendingCutState.Changed += () =>
+            Dispatcher.UIThread.InvokeAsync(SyncPendingCutHighlights);
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
@@ -1323,6 +1334,7 @@ public partial class MainWindow : Window
         MenuViewLog.Click += OnViewLogClick;
         MenuSettings.Click += OnSettingsClick;
         MenuCopy.Click          += (_, _) => _ = HandleCopyAsync();
+        MenuCut.Click           += (_, _) => _ = HandleCutAsync();
         MenuPaste.Click         += (_, _) => _ = HandlePasteAsync();
         MenuDuplicate.Click     += (_, _) => HandleDuplicate();
         MenuResizeTexture.Click += (_, _) => _ = DoResizeTextureAsync();
@@ -1385,6 +1397,7 @@ public partial class MainWindow : Window
         Undo:            () => _undoManager.Undo(),
         Redo:            () => _undoManager.Redo(),
         Copy:            () => _ = HandleCopyAsync(),
+        Cut:             () => _ = HandleCutAsync(),
         Paste:           () => _ = HandlePasteAsync(),
         Duplicate:       () => HandleDuplicate(),
         ReloadFromDisk:  () => { if (!string.IsNullOrEmpty(_projectManager.FileName)) _appCommands.ReloadAchxFromDisk(_projectManager.FileName); },
@@ -2466,6 +2479,7 @@ public partial class MainWindow : Window
             });
             AddSeparator();
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(rect));
             AddSeparator();
@@ -2482,6 +2496,7 @@ public partial class MainWindow : Window
         {
             AddShapeReorderItems(circle, _objectFinder.GetAnimationFrameContaining(circle));
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(circle));
             AddSeparator();
@@ -2512,6 +2527,7 @@ public partial class MainWindow : Window
             AddMenuItem("Add Circle",               () => _appCommands.AddCircle(frame2));
             AddSeparator();
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             if (chain2 is not null)
                 AddMenuItem("Duplicate", () => _appCommands.DuplicateFrame(frame2, chain2));
@@ -2545,6 +2561,7 @@ public partial class MainWindow : Window
             AddMenuItem("Add Multiple Frames…", () => _ = AskAddMultipleFramesAsync(chain));
             AddSeparator();
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
+            AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddSubMenu("Duplicate",
                 ("Original",        () => _appCommands.DuplicateChain(chain)),
@@ -3667,6 +3684,12 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 _ = HandleCopyAsync();
             }
+            else if (e.Key == Key.X && HasCommandModifier(e.KeyModifiers))
+            {
+                if (IsTextInputFocused()) return;
+                e.Handled = true;
+                _ = HandleCutAsync();
+            }
             else if (e.Key == Key.V && HasCommandModifier(e.KeyModifiers))
             {
                 if (IsTextInputFocused()) return;
@@ -3799,6 +3822,7 @@ public partial class MainWindow : Window
     }
 
     private Task HandleCopyAsync()  => RunGuardedAsync(HandleCopyCoreAsync,  "Copy");
+    private Task HandleCutAsync()   => RunGuardedAsync(HandleCutCoreAsync,   "Cut");
     private Task HandlePasteAsync() => RunGuardedAsync(HandlePasteCoreAsync, "Paste");
 
     private async Task HandleCopyCoreAsync()
@@ -3820,6 +3844,31 @@ public partial class MainWindow : Window
         }
 
         await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
+        _pendingCutState.Clear();
+        SyncPendingCutHighlights();
+    }
+
+    private async Task HandleCutCoreAsync()
+    {
+        if (IsTextInputFocused()) return;
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is null) return;
+
+        if (!SelectionCopyContext.TryGet(
+                _selectedState, _objectFinder, _projectManager.AnimationChainListSave,
+                out var payload, out var failureMessage))
+        {
+            if (failureMessage is not null)
+            {
+                ShowStatusMessage(failureMessage, isError: true);
+                await clipboard.SetTextAsync(string.Empty);
+            }
+            return;
+        }
+
+        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
+        _pendingCutState.Set(payload);
+        SyncPendingCutHighlights();
     }
 
     private async Task HandlePasteCoreAsync()
@@ -3839,14 +3888,20 @@ public partial class MainWindow : Window
         if (acls is null) return;
 
         var selectedData = SelectedData;
+        bool completingCut = _pendingCutState.IsActive;
 
         if (chains is { Count: > 0 })
         {
+            if (completingCut && _pendingCutState.Kind != CopySelectionKind.Chain) return;
             QueuePastedChainExpandFromSources(chains, chains);
-            _appCommands.PasteChains(chains);
+            if (completingCut)
+                _appCommands.PasteChainsCut(chains, _pendingCutState.Chains);
+            else
+                _appCommands.PasteChains(chains);
         }
         else if (frames is { Count: > 0 })
         {
+            if (completingCut && _pendingCutState.Kind != CopySelectionKind.Frame) return;
             var (targetChain, insertIndex) = PastePlacementLogic.ResolveFramePasteTarget(
                 acls, selectedData, _objectFinder, _selectedState);
             if (targetChain is null) return;
@@ -3854,20 +3909,59 @@ public partial class MainWindow : Window
             foreach (var pasted in frames)
                 pasted.ShapesSave ??= new ShapesSave();
 
-            _appCommands.PasteFrames(targetChain, frames, insertIndex);
-            // Refresh synchronously so SyncTreeSelection can resolve new frame nodes.
+            if (completingCut)
+                _appCommands.PasteFramesCut(targetChain, frames, insertIndex, _pendingCutState.Frames);
+            else
+                _appCommands.PasteFrames(targetChain, frames, insertIndex);
             RefreshChainNode(targetChain);
             _appCommands.RefreshWireframe();
             SyncTreeSelection();
         }
         else if (rectangles is { Count: > 0 } || circles is { Count: > 0 })
         {
+            if (completingCut && _pendingCutState.Kind != CopySelectionKind.Shape) return;
             var frame = _selectedState.SelectedFrame;
             if (frame is null) return;
-            _appCommands.PasteShapes(frame, rectangles ?? [], circles ?? []);
+
+            if (completingCut)
+            {
+                var sourceFrame = _pendingCutState.Shapes[0] switch
+                {
+                    AARectSave r => _objectFinder.GetAnimationFrameContaining(r),
+                    CircleSave c => _objectFinder.GetAnimationFrameContaining(c),
+                    _ => null,
+                };
+                if (sourceFrame is null) return;
+                _appCommands.PasteShapesCut(
+                    frame, rectangles ?? [], circles ?? [], _pendingCutState.Shapes, sourceFrame);
+            }
+            else
+            {
+                _appCommands.PasteShapes(frame, rectangles ?? [], circles ?? []);
+            }
             RefreshFrameNode(frame);
             SyncTreeSelection();
         }
+
+        if (completingCut)
+        {
+            _pendingCutState.Clear();
+            SyncPendingCutHighlights();
+        }
+    }
+
+    private void SyncPendingCutHighlights()
+    {
+        void Walk(TreeNodeVm node)
+        {
+            node.IsPendingCut = node.Data is not null && _pendingCutState.Contains(node.Data);
+            foreach (var child in node.Children)
+                Walk(child);
+        }
+        foreach (var root in _treeRoots)
+            Walk(root);
+        WireframeCtrl.InvalidateVisual();
+        PreviewCtrl.InvalidateVisual();
     }
 
     private bool TreeMultiSelectionAlreadySynced(IReadOnlyList<object> dataObjects)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/NativeMenuActions.cs
@@ -16,6 +16,7 @@ internal sealed record NativeMenuActions(
     Action Undo,
     Action Redo,
     Action Copy,
+    Action Cut,
     Action Paste,
     Action Duplicate,
     Action ReloadFromDisk,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -270,6 +270,7 @@ namespace AnimationEditor.Core.CommandsAndState
 
             _events.RaiseCurrentFileChanged(tab.Path.FullPath);
             _events.RaiseAvailableTexturesChanged();
+            EditorProjectModelChanged?.Invoke(tab.Path.FullPath);
             return true;
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1312,6 +1312,87 @@ namespace AnimationEditor.Core.CommandsAndState
         public void PasteShapes(AnimationFrameSave frame, IReadOnlyList<AARectSave> rectangles,
             IReadOnlyList<CircleSave> circles)
         {
+            var clones = BuildShapeClones(frame, rectangles, circles);
+            if (clones.Count == 0) return;
+            _undoManager.Execute(new PasteShapesCommand(frame, clones, this, _events, _selectedState));
+        }
+
+        /// <inheritdoc cref="IAppCommands.PasteChainsCut"/>
+        public void PasteChainsCut(IReadOnlyList<AnimationChainSave> chains,
+            IReadOnlyList<AnimationChainSave> sourcesToRemove)
+        {
+            var acls = _pm.AnimationChainListSave;
+            if (acls is null || chains.Count == 0) return;
+
+            var cmds = new List<IUndoableCommand>
+            {
+                new PasteChainsCommand(acls, chains, this, _events, _selectedState),
+                new DeleteChainsCommand(sourcesToRemove, acls, this, _events, _selectedState),
+            };
+            string desc = chains.Count == 1 ? "Cut Animation" : $"Cut {chains.Count} Animations";
+            _undoManager.Execute(new CompositeCommand(cmds, desc));
+        }
+
+        /// <inheritdoc cref="IAppCommands.PasteFramesCut"/>
+        public void PasteFramesCut(AnimationChainSave targetChain,
+            IReadOnlyList<AnimationFrameSave> frames, int? insertIndex,
+            IReadOnlyList<AnimationFrameSave> sourcesToRemove)
+        {
+            if (frames.Count == 0) return;
+            var clones = frames.Select(AnimationCloneHelper.CloneFrame).ToArray();
+            var cmds = new List<IUndoableCommand>
+            {
+                new AddFramesCommand(clones, targetChain, this, _events, _selectedState, insertIndex),
+            };
+            foreach (var group in sourcesToRemove
+                         .Select(f => (Frame: f, Chain: _objectFinder.GetAnimationChainContaining(f)))
+                         .Where(x => x.Chain is not null)
+                         .GroupBy(x => x.Chain!))
+            {
+                cmds.Add(new DeleteFramesCommand(
+                    group.Select(x => x.Frame).ToList(), group.Key, this, _events, _selectedState));
+            }
+            string desc = frames.Count == 1 ? "Cut Frame" : $"Cut {frames.Count} Frames";
+            _undoManager.Execute(new CompositeCommand(cmds, desc));
+        }
+
+        /// <inheritdoc cref="IAppCommands.PasteShapesCut"/>
+        public void PasteShapesCut(AnimationFrameSave targetFrame,
+            IReadOnlyList<AARectSave> rectangles, IReadOnlyList<CircleSave> circles,
+            IReadOnlyList<object> sourcesToRemove, AnimationFrameSave sourceFrame)
+        {
+            var clones = BuildShapeClones(targetFrame, rectangles, circles);
+            if (clones.Count == 0) return;
+
+            var deleteCmds = new List<IUndoableCommand>();
+            foreach (var shape in sourcesToRemove)
+            {
+                switch (shape)
+                {
+                    case AARectSave r:
+                        deleteCmds.Add(new DeleteAxisAlignedRectangleCommand(
+                            r, sourceFrame, this, _events, _selectedState));
+                        break;
+                    case CircleSave c:
+                        deleteCmds.Add(new DeleteCircleCommand(
+                            c, sourceFrame, this, _events, _selectedState));
+                        break;
+                }
+            }
+            if (deleteCmds.Count == 0) return;
+
+            var cmds = new List<IUndoableCommand>
+            {
+                new PasteShapesCommand(targetFrame, clones, this, _events, _selectedState),
+            };
+            cmds.AddRange(deleteCmds);
+            string desc = clones.Count == 1 ? "Cut Shape" : $"Cut {clones.Count} Shapes";
+            _undoManager.Execute(new CompositeCommand(cmds, desc));
+        }
+
+        private List<object> BuildShapeClones(AnimationFrameSave frame,
+            IReadOnlyList<AARectSave> rectangles, IReadOnlyList<CircleSave> circles)
+        {
             frame.ShapesSave ??= new ShapesSave();
             var existingNames = GetShapeNames(frame);
             var clones = new List<object>();
@@ -1329,8 +1410,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 existingNames.Add(copy.Name);
                 clones.Add(copy);
             }
-            if (clones.Count == 0) return;
-            _undoManager.Execute(new PasteShapesCommand(frame, clones, this, _events, _selectedState));
+            return clones;
         }
 
         // ── Hot Reload ────────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -235,6 +235,19 @@ namespace AnimationEditor.Core.CommandsAndState
         void PasteShapes(AnimationFrameSave frame, IReadOnlyList<AARectSave> rectangles,
             IReadOnlyList<CircleSave> circles);
 
+        /// <summary>Paste chains then remove <paramref name="sourcesToRemove"/> in one undo step.</summary>
+        void PasteChainsCut(IReadOnlyList<AnimationChainSave> chains,
+            IReadOnlyList<AnimationChainSave> sourcesToRemove);
+
+        /// <summary>Paste frames then remove <paramref name="sourcesToRemove"/> in one undo step.</summary>
+        void PasteFramesCut(AnimationChainSave targetChain, IReadOnlyList<AnimationFrameSave> frames,
+            int? insertIndex, IReadOnlyList<AnimationFrameSave> sourcesToRemove);
+
+        /// <summary>Paste shapes then remove <paramref name="sourcesToRemove"/> in one undo step.</summary>
+        void PasteShapesCut(AnimationFrameSave targetFrame,
+            IReadOnlyList<AARectSave> rectangles, IReadOnlyList<CircleSave> circles,
+            IReadOnlyList<object> sourcesToRemove, AnimationFrameSave sourceFrame);
+
         /// <summary>Duplicates the homogeneous multi-selection as one undo step.</summary>
         void DuplicateSelection(CopySelectionPayload payload);
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
@@ -28,6 +28,9 @@ public interface IPendingCutState
 
     /// <summary>Shapes that should show a cut outline in the preview panel.</summary>
     IReadOnlyList<object> WireframeShapes { get; }
+
+    /// <summary>True when every pending-cut source still lives in <paramref name="acls"/>.</summary>
+    bool SourcesBelongToProject(AnimationChainListSave? acls, IObjectFinder finder);
 }
 
 public sealed class PendingCutState : IPendingCutState
@@ -74,4 +77,25 @@ public sealed class PendingCutState : IPendingCutState
             CopySelectionKind.Shape => _payload.Shapes.Contains(data),
             _ => false,
         };
+
+    public bool SourcesBelongToProject(AnimationChainListSave? acls, IObjectFinder finder)
+    {
+        if (_payload is null || acls is null) return false;
+        return _payload.Kind switch
+        {
+            CopySelectionKind.Chain => _payload.Chains.All(acls.AnimationChains.Contains),
+            CopySelectionKind.Frame => _payload.Frames.All(f =>
+                acls.AnimationChains.Any(c => c.Frames.Contains(f))),
+            CopySelectionKind.Shape => _payload.Shapes.All(s => s switch
+            {
+                AARectSave r => BelongsToProject(finder.GetAnimationFrameContaining(r), acls),
+                CircleSave c => BelongsToProject(finder.GetAnimationFrameContaining(c), acls),
+                _ => false,
+            }),
+            _ => false,
+        };
+    }
+
+    private static bool BelongsToProject(AnimationFrameSave? frame, AnimationChainListSave acls) =>
+        frame is not null && acls.AnimationChains.Any(c => c.Frames.Contains(frame));
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
@@ -1,0 +1,77 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core;
+
+/// <summary>
+/// Tracks animation items cut to the clipboard that remain in the project until paste completes.
+/// </summary>
+public interface IPendingCutState
+{
+    event Action? Changed;
+
+    bool IsActive { get; }
+    CopySelectionKind? Kind { get; }
+    IReadOnlyList<AnimationChainSave> Chains { get; }
+    IReadOnlyList<AnimationFrameSave> Frames { get; }
+    IReadOnlyList<object> Shapes { get; }
+
+    void Set(CopySelectionPayload payload);
+    void Clear();
+    bool Contains(object data);
+
+    /// <summary>Frames that should show a cut outline on the wireframe.</summary>
+    IReadOnlyList<AnimationFrameSave> WireframeFrames { get; }
+
+    /// <summary>Shapes that should show a cut outline in the preview panel.</summary>
+    IReadOnlyList<object> WireframeShapes { get; }
+}
+
+public sealed class PendingCutState : IPendingCutState
+{
+    private CopySelectionPayload? _payload;
+
+    public event Action? Changed;
+
+    public bool IsActive => _payload is not null;
+    public CopySelectionKind? Kind => _payload?.Kind;
+    public IReadOnlyList<AnimationChainSave> Chains => _payload?.Chains ?? [];
+    public IReadOnlyList<AnimationFrameSave> Frames => _payload?.Frames ?? [];
+    public IReadOnlyList<object> Shapes => _payload?.Shapes ?? [];
+
+    public IReadOnlyList<AnimationFrameSave> WireframeFrames =>
+        _payload?.Kind switch
+        {
+            CopySelectionKind.Chain => _payload.Chains.SelectMany(c => c.Frames).ToList(),
+            CopySelectionKind.Frame => _payload.Frames,
+            _ => [],
+        };
+
+    public IReadOnlyList<object> WireframeShapes =>
+        _payload?.Kind == CopySelectionKind.Shape ? _payload.Shapes : [];
+
+    public void Set(CopySelectionPayload payload)
+    {
+        _payload = payload;
+        Changed?.Invoke();
+    }
+
+    public void Clear()
+    {
+        if (_payload is null) return;
+        _payload = null;
+        Changed?.Invoke();
+    }
+
+    public bool Contains(object data) =>
+        _payload?.Kind switch
+        {
+            CopySelectionKind.Chain => data is AnimationChainSave c && _payload.Chains.Contains(c),
+            CopySelectionKind.Frame => data is AnimationFrameSave f && _payload.Frames.Contains(f),
+            CopySelectionKind.Shape => _payload.Shapes.Contains(data),
+            _ => false,
+        };
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -41,16 +41,7 @@ public class TreeNodeVm : INotifyPropertyChanged
     public bool IsEditing
     {
         get => _isEditing;
-        set
-        {
-            if (_isEditing != value)
-            {
-                _isEditing = value;
-                Notify();
-                Notify(nameof(ShowDefaultHeader));
-                Notify(nameof(ShowCutHeader));
-            }
-        }
+        set { if (_isEditing != value) { _isEditing = value; Notify(); } }
     }
 
     private string _editingText = string.Empty;
@@ -103,23 +94,8 @@ public class TreeNodeVm : INotifyPropertyChanged
     public bool IsPendingCut
     {
         get => _isPendingCut;
-        set
-        {
-            if (_isPendingCut != value)
-            {
-                _isPendingCut = value;
-                Notify();
-                Notify(nameof(ShowDefaultHeader));
-                Notify(nameof(ShowCutHeader));
-            }
-        }
+        set { if (_isPendingCut != value) { _isPendingCut = value; Notify(); } }
     }
-
-    /// <summary>Default header label when not pending cut and not inline-editing.</summary>
-    public bool ShowDefaultHeader => !_isPendingCut && !_isEditing;
-
-    /// <summary>Cut-pending header label (orange accent).</summary>
-    public bool ShowCutHeader => _isPendingCut && !_isEditing;
 
     /// <summary>
     /// True when this is a frame node that currently has no shape children.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -41,7 +41,16 @@ public class TreeNodeVm : INotifyPropertyChanged
     public bool IsEditing
     {
         get => _isEditing;
-        set { if (_isEditing != value) { _isEditing = value; Notify(); } }
+        set
+        {
+            if (_isEditing != value)
+            {
+                _isEditing = value;
+                Notify();
+                Notify(nameof(ShowDefaultHeader));
+                Notify(nameof(ShowCutHeader));
+            }
+        }
     }
 
     private string _editingText = string.Empty;
@@ -88,6 +97,29 @@ public class TreeNodeVm : INotifyPropertyChanged
     public bool IsRectNode   { get; set; }
     /// <summary>True when this node represents a CircleSave shape. Set once at construction time.</summary>
     public bool IsCircleNode { get; set; }
+
+    private bool _isPendingCut;
+    /// <summary>True while this item is part of a pending cut (Ctrl+X, not yet pasted).</summary>
+    public bool IsPendingCut
+    {
+        get => _isPendingCut;
+        set
+        {
+            if (_isPendingCut != value)
+            {
+                _isPendingCut = value;
+                Notify();
+                Notify(nameof(ShowDefaultHeader));
+                Notify(nameof(ShowCutHeader));
+            }
+        }
+    }
+
+    /// <summary>Default header label when not pending cut and not inline-editing.</summary>
+    public bool ShowDefaultHeader => !_isPendingCut && !_isEditing;
+
+    /// <summary>Cut-pending header label (orange accent).</summary>
+    public bool ShowCutHeader => _isPendingCut && !_isEditing;
 
     /// <summary>
     /// True when this is a frame node that currently has no shape children.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -22,6 +22,7 @@ internal sealed class TestServices
     public ObjectFinder ObjectFinder { get; }
     public UndoManager UndoManager { get; }
     public AppCommands AppCommands { get; }
+    public PendingCutState PendingCutState { get; }
     public ThumbnailService ThumbnailService { get; }
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
 
@@ -42,6 +43,7 @@ internal sealed class TestServices
         IoManager         = new IoManager(AppState);
         ObjectFinder      = new ObjectFinder(ProjectManager);
         UndoManager       = new UndoManager();
+        PendingCutState   = new PendingCutState();
         AppCommands       = new AppCommands(ProjectManager, SelectedState, ApplicationEvents,
                                             IoManager, ObjectFinder, UndoManager);
         ThumbnailService  = new ThumbnailService(ProjectManager);
@@ -50,20 +52,20 @@ internal sealed class TestServices
     public MainWindow CreateMainWindow() =>
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
-            ApplicationEvents, IoManager, ObjectFinder, UndoManager, ThumbnailService,
-            FileAssociationService, SettingsRoot);
+            ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
+            ThumbnailService, FileAssociationService, SettingsRoot);
 
     public WireframeControl CreateWireframeControl()
     {
         var ctrl = new WireframeControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, PendingCutState);
         return ctrl;
     }
 
     public PreviewControl CreatePreviewControl()
     {
         var ctrl = new PreviewControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, ThumbnailService);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, ThumbnailService, PendingCutState);
         return ctrl;
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeContextMenuTests.cs
@@ -89,8 +89,9 @@ public class TreeContextMenuTests
 
             int copy = IndexOfItem(items, "Copy");
             Assert.True(copy >= 0);
-            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
-            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.Equal(copy + 1, IndexOfItem(items, "Cut"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 3, IndexOfItem(items, "Duplicate"));
         }
         finally { window.Close(); }
     }
@@ -109,8 +110,9 @@ public class TreeContextMenuTests
 
             int copy = IndexOfItem(items, "Copy");
             Assert.True(copy >= 0);
-            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
-            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.Equal(copy + 1, IndexOfItem(items, "Cut"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 3, IndexOfItem(items, "Duplicate"));
         }
         finally { window.Close(); }
     }
@@ -144,8 +146,9 @@ public class TreeContextMenuTests
 
             int copy = IndexOfItem(items, "Copy");
             Assert.True(copy >= 0);
-            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
-            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.Equal(copy + 1, IndexOfItem(items, "Cut"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 3, IndexOfItem(items, "Duplicate"));
             Assert.True(IndexOfItem(items, "Rename…")        >= 0);
             Assert.True(IndexOfItem(items, "Match Frame Size") >= 0);
             Assert.True(IndexOfItem(items, "Delete Rectangle") >= 0);
@@ -182,8 +185,9 @@ public class TreeContextMenuTests
 
             int copy = IndexOfItem(items, "Copy");
             Assert.True(copy >= 0);
-            Assert.Equal(copy + 1, IndexOfItem(items, "Paste"));
-            Assert.Equal(copy + 2, IndexOfItem(items, "Duplicate"));
+            Assert.Equal(copy + 1, IndexOfItem(items, "Cut"));
+            Assert.Equal(copy + 2, IndexOfItem(items, "Paste"));
+            Assert.Equal(copy + 3, IndexOfItem(items, "Duplicate"));
             Assert.True(IndexOfItem(items, "Rename…")      >= 0);
             Assert.True(IndexOfItem(items, "Delete Circle") >= 0);
             // Match Frame Size is rect-only.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeChainDragTests.cs
@@ -83,7 +83,6 @@ public class WireframeChainDragTests
         ctx.SelectedState.SelectedChain = chain;
 
         var ctrl = ctx.CreateWireframeControl();
-        ctrl.InitializeServices(ctx.SelectedState, ctx.AppState, ctx.AppCommands, ctx.ApplicationEvents, ctx.ProjectManager, ctx.UndoManager);
         ctrl.LoadTexture(png);
         ctrl.SetCamera(0f, 0f, 1f);
         ctrl.RefreshFrames();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
@@ -153,4 +153,17 @@ public class CutPasteTests
         Assert.Same(walkF0, walk.Frames[0]);
         Assert.Same(runF1, run.Frames[1]);
     }
+
+    [Fact]
+    public void SourcesBelongToProject_FalseWhenSourceFromOtherAcls()
+    {
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var ctxB = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 1);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } });
+
+        Assert.True(cut.SourcesBelongToProject(ctxA.Acls, ctxA.ObjectFinder));
+        Assert.False(cut.SourcesBelongToProject(ctxB.Acls, ctxB.ObjectFinder));
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
@@ -1,0 +1,156 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Cut (Ctrl+X) clipboard semantics for issue #499.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class CutPasteTests
+{
+    [Fact]
+    public void PendingCutState_SetClearAndContains()
+    {
+        var cut = new PendingCutState();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var payload = new CopySelectionPayload
+        {
+            Kind = CopySelectionKind.Chain,
+            Chains = new[] { chain },
+        };
+
+        cut.Set(payload);
+        Assert.True(cut.IsActive);
+        Assert.Equal(CopySelectionKind.Chain, cut.Kind);
+        Assert.True(cut.Contains(chain));
+        Assert.False(cut.Contains(new AnimationChainSave { Name = "Other" }));
+
+        cut.Clear();
+        Assert.False(cut.IsActive);
+        Assert.False(cut.Contains(chain));
+    }
+
+    [Fact]
+    public void PendingCutState_NewCutReplacesPrevious()
+    {
+        var cut = new PendingCutState();
+        var c1 = new AnimationChainSave { Name = "A" };
+        var c2 = new AnimationChainSave { Name = "B" };
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c1 } });
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c2 } });
+
+        Assert.False(cut.Contains(c1));
+        Assert.True(cut.Contains(c2));
+    }
+
+    [Fact]
+    public void PendingCutState_WireframeFrames_IncludesChainChildren()
+    {
+        var cut = new PendingCutState();
+        var chain = TestHelpers.MakeChain(new AnimationChainListSave(), "Walk", 2);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } });
+
+        Assert.Equal(2, cut.WireframeFrames.Count);
+        Assert.Contains(chain.Frames[0], cut.WireframeFrames);
+        Assert.Contains(chain.Frames[1], cut.WireframeFrames);
+    }
+
+    [Fact]
+    public void PasteChainsCut_OneUndoRestoresSourcesAndRemovesPasted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c1 = TestHelpers.MakeChain(ctx.Acls, "Chain1");
+        var c2 = TestHelpers.MakeChain(ctx.Acls, "Chain2");
+        TestHelpers.MakeChain(ctx.Acls, "Chain3");
+        ctx.SelectedState.SelectedNodes = new List<object> { c1, c2 };
+
+        var pasted = new List<AnimationChainSave>
+        {
+            AnimationCloneHelper.CloneChain(c1),
+            AnimationCloneHelper.CloneChain(c2),
+        };
+
+        ctx.AppCommands.PasteChainsCut(pasted, new[] { c1, c2 });
+
+        Assert.Equal(3, ctx.Acls.AnimationChains.Count);
+        Assert.DoesNotContain(c1, ctx.Acls.AnimationChains);
+        Assert.DoesNotContain(c2, ctx.Acls.AnimationChains);
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(3, ctx.Acls.AnimationChains.Count);
+        Assert.Contains(c1, ctx.Acls.AnimationChains);
+        Assert.Contains(c2, ctx.Acls.AnimationChains);
+    }
+
+    [Fact]
+    public void PasteFramesCut_OneUndoRestoresSourcesAndRemovesPasted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var f1 = chain.Frames[1];
+        var pasted = new[] { AnimationCloneHelper.CloneFrame(f1) };
+
+        ctx.AppCommands.PasteFramesCut(chain, pasted, insertIndex: 2, sourcesToRemove: new[] { f1 });
+
+        Assert.Equal(3, chain.Frames.Count);
+        Assert.DoesNotContain(f1, chain.Frames);
+        Assert.Equal("frame1.png", chain.Frames[1].TextureName);
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(3, chain.Frames.Count);
+        Assert.Same(f1, chain.Frames[1]);
+    }
+
+    [Fact]
+    public void PasteShapesCut_OneUndoRestoresSourcesAndRemovesPasted()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hit" };
+        frame.ShapesSave!.Shapes.Add(rect);
+
+        var pastedRect = (AARectSave)AnimationCloneHelper.CloneShape(rect)!;
+        ctx.AppCommands.PasteShapesCut(frame, new[] { pastedRect }, [], new[] { rect }, frame);
+
+        Assert.Single(frame.ShapesSave.Shapes);
+        Assert.DoesNotContain(rect, frame.ShapesSave.Shapes);
+
+        ctx.UndoManager.Undo();
+        Assert.Single(frame.ShapesSave.Shapes);
+        Assert.Same(rect, frame.ShapesSave.Shapes[0]);
+    }
+
+    [Fact]
+    public void PasteFramesCut_CrossChainDelete_OneUndo()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var run  = TestHelpers.MakeChain(ctx.Acls, "Run", 2);
+        var walkF0 = walk.Frames[0];
+        var runF1  = run.Frames[1];
+        var pasted = new[]
+        {
+            AnimationCloneHelper.CloneFrame(walkF0),
+            AnimationCloneHelper.CloneFrame(runF1),
+        };
+
+        ctx.AppCommands.PasteFramesCut(walk, pasted, insertIndex: null,
+            sourcesToRemove: new[] { walkF0, runF1 });
+
+        Assert.Equal(3, walk.Frames.Count);
+        Assert.Single(run.Frames);
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(2, walk.Frames.Count);
+        Assert.Equal(2, run.Frames.Count);
+        Assert.Same(walkF0, walk.Frames[0]);
+        Assert.Same(runF1, run.Frames[1]);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -113,6 +113,9 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.PasteRectangle)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteCircle)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteShapes)]                  = Category.MutatingUndoable,
+        [nameof(IAppCommands.PasteChainsCut)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.PasteFramesCut)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.PasteShapesCut)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.DuplicateSelection)]           = Category.MutatingUndoable,
 
         // Hot reload — mutates the project but deliberately not undoable (reloads from disk)
@@ -309,6 +312,37 @@ public class UndoCoverageRosterTests
                 Zebra(ctx).Frames[1],
                 new List<AARectSave> { new() { Name = "P1" } },
                 new List<CircleSave> { new() { Name = "C1" } })));
+        yield return Row(nameof(IAppCommands.PasteChainsCut),
+            ctx => Sync(() =>
+            {
+                var source = Zebra(ctx);
+                ctx.AppCommands.PasteChainsCut(
+                    new List<AnimationChainSave> { new() { Name = "PastedCut" } },
+                    new List<AnimationChainSave> { source });
+            }));
+        yield return Row(nameof(IAppCommands.PasteFramesCut),
+            ctx => Sync(() =>
+            {
+                var chain = Zebra(ctx);
+                var source = chain.Frames[1];
+                ctx.AppCommands.PasteFramesCut(
+                    chain,
+                    new List<AnimationFrameSave> { new() { ShapesSave = new ShapesSave() } },
+                    insertIndex: 2,
+                    sourcesToRemove: new List<AnimationFrameSave> { source });
+            }));
+        yield return Row(nameof(IAppCommands.PasteShapesCut),
+            ctx => Sync(() =>
+            {
+                var frame = Zebra(ctx).Frames[1];
+                var source = Rect(ctx);
+                ctx.AppCommands.PasteShapesCut(
+                    frame,
+                    new List<AARectSave> { new() { Name = "PastedCut" } },
+                    new List<CircleSave>(),
+                    new List<object> { source },
+                    frame);
+            }));
         yield return Row(nameof(IAppCommands.DuplicateSelection),
             ctx => Sync(() => ctx.AppCommands.DuplicateSelection(new CopySelectionPayload
             {


### PR DESCRIPTION
## Summary
- Adds Cut (Ctrl+X) for chains, frames, and shapes using the same selection rules and clipboard payloads as #498 multi-copy/paste.
- Introduces `PendingCutState`: items stay in the project until paste; copy or a new cut clears pending state; project reload clears it.
- Paste after cut runs paste + source removal as one undo step via `PasteChainsCut` / `PasteFramesCut` / `PasteShapesCut`.
- Pending-cut visual: orange left bar in the tree; dashed orange overlay on wireframe frame regions and preview shapes.

## Cut outline style
Dashed orange (#E07030 / SK 224,112,48) — readable on light and dark themes and distinct from selection blue (wireframe) / gold (preview shapes).

## Cancel cut
Copy, Cut, and project reload clear pending cut. Escape / click-away not implemented (minimum from issue).

## Test plan
- [x] `CutPasteTests` (Core): pending state, single/multi cut-paste, one-undo revert, cross-chain frame cut
- [x] `TreeContextMenuTests` updated for Cut menu item
- [x] Full Animation Editor solution builds
- [ ] Manual: Cut chain/frame/shape → orange highlight, item still in project
- [ ] Manual: Paste after cut → moved copy, sources gone, one Undo restores all
- [ ] Manual: Copy after cut → highlight cleared, paste does not delete
- [ ] Manual: Mixed selection Cut → error toast, no cut state
- [ ] Manual: Load different file → pending cut cleared

Closes #499

Made with [Cursor](https://cursor.com)