### PR TITLE
Drag-and-drop frame reorder within and across animations (#500)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2089,9 +2089,18 @@ public partial class MainWindow : Window
 
     private void SelectSingleFrame(AnimationFrameSave frame)
     {
-        _selectedState.SelectedNodes = new List<object> { frame };
-        _selectedState.SelectedFrame = frame;
-        SyncTreeSelection();
+        var vm = TreeBuilder.FindNodeForData(_treeRoots, frame);
+        if (vm is null) return;
+
+        // The tree still visually holds the whole multi-selection (the select-on-press was
+        // suppressed), and SyncTreeSelection won't collapse it because the clicked frame is
+        // already among SelectedItems. Drive the tree directly: clear the others silently,
+        // then set the single item so the normal selection cascade updates SelectedState.
+        bool prior = _suppressTreeSelectionHandling;
+        _suppressTreeSelectionHandling = true;
+        try { AnimTree.SelectedItems?.Clear(); }
+        finally { _suppressTreeSelectionHandling = prior; }
+        AnimTree.SelectedItem = vm;
     }
 
     private async void OnTreeFrameDragPointerMoved(object? sender, PointerEventArgs e)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -58,6 +58,20 @@ public partial class MainWindow : Window
     private double _dragStartX;
     private bool _isDragging;
     private Border? _ghostBorder;
+
+    // ── Frame drag-and-drop reorder state (issue #500) ──────────────────────────
+    // The DataTransfer only carries a marker token; the actual frames + source chain
+    // live in _pendingFrameDrag because the drag is always same-process.
+    private static readonly DataFormat<string> FrameDragDataFormat =
+        DataFormat.CreateStringApplicationFormat("animationeditor-frame-drag");
+    private const string FrameDragToken = "frame";
+    private FrameDragSource? _pendingFrameDrag;
+    private Avalonia.Point? _frameDragPressPoint;
+    private PointerPressedEventArgs? _frameDragPressArgs;
+    private AnimationFrameSave? _frameDragCandidate;
+    private List<object>? _frameDragSelectionSnapshot;
+    private bool _frameDragInProgress;
+    private Border? _frameDropLine;
     private int _untitledCounter;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
@@ -1795,6 +1809,17 @@ public partial class MainWindow : Window
             OnTreePointerPressed,
             RoutingStrategies.Tunnel);
 
+        // Frame drag-and-drop reorder: a press on a frame row arms a drag candidate, a
+        // pointer move past the threshold starts the Avalonia drag (issue #500).
+        AnimTree.AddHandler(
+            InputElement.PointerMovedEvent,
+            OnTreeFrameDragPointerMoved,
+            RoutingStrategies.Bubble);
+        AnimTree.AddHandler(
+            InputElement.PointerReleasedEvent,
+            OnTreeFrameDragPointerReleased,
+            RoutingStrategies.Bubble);
+
         // "Add Animation" button under the tree
         AddChainBtn.Click += (_, _) =>
         {
@@ -1872,6 +1897,24 @@ public partial class MainWindow : Window
 
     private void OnTreeDragOver(object? sender, DragEventArgs e)
     {
+        // Internal frame reorder drag — distinct from the external .png file drag below.
+        if (e.DataTransfer.Contains(FrameDragDataFormat) && _pendingFrameDrag is { IsValid: true } drag)
+        {
+            var target = ResolveFrameDrop(e, drag);
+            if (target.IsValid)
+            {
+                e.DragEffects = DragDropEffects.Move;
+                ShowFrameDropLine(e);
+            }
+            else
+            {
+                e.DragEffects = DragDropEffects.None;
+                RemoveFrameDropLine();
+            }
+            e.Handled = true;
+            return;
+        }
+
         string? firstFile = e.DataTransfer.TryGetFiles()?
             .FirstOrDefault()?.Path.LocalPath;
 
@@ -1905,6 +1948,18 @@ public partial class MainWindow : Window
 
     private void OnTreeDrop(object? sender, DragEventArgs e)
     {
+        // Internal frame reorder drop — perform the move and let the external .png path below
+        // stay untouched (external file drags never carry the frame marker format).
+        if (e.DataTransfer.Contains(FrameDragDataFormat) && _pendingFrameDrag is { IsValid: true } drag)
+        {
+            RemoveFrameDropLine();
+            var target = ResolveFrameDrop(e, drag);
+            if (target is { IsValid: true, Chain: not null } && drag.SourceChain is not null)
+                _appCommands.MoveFrames(drag.Frames, drag.SourceChain, target.Chain, target.InsertIndex);
+            e.Handled = true;
+            return;
+        }
+
         var firstFile = GetFirstDroppedFilePath(e);
         Trace.WriteLine($"[DragDrop] OnTreeDrop: firstFile={firstFile ?? "(null)"}, FileName={_projectManager.FileName ?? "(null)"}");
 
@@ -2018,6 +2073,184 @@ public partial class MainWindow : Window
         return TreePngDropTarget.FromNodeData(
             targetNode?.Data,
             frame => _objectFinder.GetAnimationChainContaining(frame));
+    }
+
+    // ── Internal frame drag-and-drop reorder (issue #500) ──────────────────────
+
+    private void ClearFrameDragCandidate()
+    {
+        _frameDragCandidate = null;
+        _frameDragPressPoint = null;
+        _frameDragPressArgs = null;
+        _frameDragSelectionSnapshot = null;
+    }
+
+    private async void OnTreeFrameDragPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_frameDragInProgress || _frameDragCandidate is null ||
+            _frameDragPressPoint is null || _frameDragPressArgs is null)
+            return;
+
+        if (!e.GetCurrentPoint(AnimTree).Properties.IsLeftButtonPressed)
+        {
+            ClearFrameDragCandidate();
+            return;
+        }
+
+        var pos = e.GetPosition(AnimTree);
+        if (Math.Abs(pos.X - _frameDragPressPoint.Value.X) <= 4 &&
+            Math.Abs(pos.Y - _frameDragPressPoint.Value.Y) <= 4)
+            return;
+
+        if (!TryBuildFrameDragSource(out var dragSource))
+        {
+            ClearFrameDragCandidate();
+            return;
+        }
+
+        _pendingFrameDrag = dragSource;
+        _frameDragInProgress = true;
+
+        var data = new DataTransfer();
+        data.Add(DataTransferItem.Create(FrameDragDataFormat, FrameDragToken));
+        try
+        {
+            // DoDragDropAsync needs the originating press args; the move past the threshold
+            // is what gates when we begin, so the platform drag never starts on a plain click.
+            await DragDrop.DoDragDropAsync(_frameDragPressArgs, data, DragDropEffects.Move);
+        }
+        finally
+        {
+            _pendingFrameDrag = null;
+            _frameDragInProgress = false;
+            RemoveFrameDropLine();
+            ClearFrameDragCandidate();
+        }
+    }
+
+    private void OnTreeFrameDragPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_frameDragInProgress)
+            ClearFrameDragCandidate();
+    }
+
+    /// <summary>
+    /// Decides which frames a drag moves. Dragging a frame that is part of a valid frame
+    /// multi-selection moves the whole set; a mixed or multi-chain selection that includes
+    /// the dragged frame is rejected with a toast; otherwise just the dragged frame moves.
+    /// </summary>
+    private bool TryBuildFrameDragSource(out FrameDragSource dragSource)
+    {
+        dragSource = default;
+        var candidate = _frameDragCandidate;
+        if (candidate is null) return false;
+
+        var snapshot = _frameDragSelectionSnapshot ?? new List<object>();
+        bool candidateInSnapshot = snapshot.Any(n => ReferenceEquals(n, candidate));
+        var classified = FrameDropResolver.ClassifySelection(
+            snapshot, f => _objectFinder.GetAnimationChainContaining(f));
+
+        if (candidateInSnapshot)
+        {
+            if (classified.IsValid)
+            {
+                dragSource = classified;
+                return true;
+            }
+            if (classified.Validity is FrameDragValidity.MixedTypes
+                or FrameDragValidity.MultipleSourceChains)
+            {
+                ShowFrameDragRejectedToast(classified.Validity);
+                return false;
+            }
+        }
+
+        // Drag just the single pressed frame.
+        var chain = _objectFinder.GetAnimationChainContaining(candidate);
+        if (chain is null) return false;
+        dragSource = new FrameDragSource(new[] { candidate }, chain, FrameDragValidity.Valid);
+        return true;
+    }
+
+    private void ShowFrameDragRejectedToast(FrameDragValidity validity)
+    {
+        string message = validity == FrameDragValidity.MultipleSourceChains
+            ? "Can't drag frames from multiple animations yet — select frames from one animation."
+            : "Can't reorder a mixed selection — select only frames.";
+        ShowStatusMessage(message, isError: true);
+    }
+
+    private FrameDropTarget ResolveFrameDrop(DragEventArgs e, FrameDragSource drag)
+    {
+        if (drag.SourceChain is null) return FrameDropTarget.None;
+        var (nodeData, half, _) = HitTestFrameRow(e.GetPosition(AnimTree));
+        return FrameDropResolver.Resolve(
+            nodeData, half, drag.Frames, drag.SourceChain,
+            f => _objectFinder.GetAnimationChainContaining(f));
+    }
+
+    /// <summary>
+    /// Maps a pointer position over the tree to the node under it, which half of that row
+    /// the pointer is in, and the realized container (used to place the drop indicator).
+    /// </summary>
+    private (object? NodeData, FrameRowHalf Half, TreeViewItem? Item) HitTestFrameRow(Avalonia.Point posInTree)
+    {
+        if (AnimTree.InputHitTest(posInTree) is not Control hit)
+            return (null, FrameRowHalf.Upper, null);
+
+        var tvi = hit.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        if (tvi?.DataContext is not TreeNodeVm vm)
+            return (null, FrameRowHalf.Upper, null);
+
+        // Frame rows are leaves, so the container height is the row height. The half only
+        // matters for frame targets; chain targets always append regardless.
+        var topLeft = Avalonia.VisualExtensions.TranslatePoint(tvi, new Avalonia.Point(0, 0), AnimTree) ?? posInTree;
+        double rowHeight = tvi.Bounds.Height;
+        var half = (posInTree.Y - topLeft.Y) < rowHeight / 2 ? FrameRowHalf.Upper : FrameRowHalf.Lower;
+        return (vm.Data, half, tvi);
+    }
+
+    private void ShowFrameDropLine(DragEventArgs e)
+    {
+        var (nodeData, half, tvi) = HitTestFrameRow(e.GetPosition(AnimTree));
+        if (tvi is null)
+        {
+            RemoveFrameDropLine();
+            return;
+        }
+
+        var topLeft = Avalonia.VisualExtensions.TranslatePoint(tvi, new Avalonia.Point(0, 0), DragOverlayCanvas);
+        var treeOrigin = Avalonia.VisualExtensions.TranslatePoint(AnimTree, new Avalonia.Point(0, 0), DragOverlayCanvas);
+        if (topLeft is null || treeOrigin is null)
+        {
+            RemoveFrameDropLine();
+            return;
+        }
+
+        // A chain target appends, so the line sits below the chain's whole subtree (after its
+        // last frame). A frame target lands at the top or bottom edge of that row.
+        double y = nodeData is AnimationChainSave
+            ? topLeft.Value.Y + tvi.Bounds.Height
+            : topLeft.Value.Y + (half == FrameRowHalf.Upper ? 0 : tvi.Bounds.Height);
+
+        _frameDropLine ??= new Border
+        {
+            Height = 2,
+            Background = new SolidColorBrush(Color.Parse("#4a90d9")),
+            IsHitTestVisible = false,
+        };
+        if (!DragOverlayCanvas.Children.Contains(_frameDropLine))
+            DragOverlayCanvas.Children.Add(_frameDropLine);
+
+        _frameDropLine.Width = AnimTree.Bounds.Width;
+        Canvas.SetLeft(_frameDropLine, treeOrigin.Value.X);
+        Canvas.SetTop(_frameDropLine, y - 1);
+    }
+
+    private void RemoveFrameDropLine()
+    {
+        if (_frameDropLine is not null)
+            DragOverlayCanvas.Children.Remove(_frameDropLine);
     }
 
     // ── Window-level OS file drop: open dropped .achx files as tabs ────────────
@@ -2442,6 +2675,25 @@ public partial class MainWindow : Window
             var tvi = src.FindAncestorOfType<TreeViewItem>(includeSelf: true);
             if (tvi?.DataContext is TreeNodeVm vm && !ReferenceEquals(AnimTree.SelectedItem, vm))
                 AnimTree.SelectedItem = vm;
+        }
+        else if (props.IsLeftButtonPressed && e.ClickCount == 1)
+        {
+            // Arm a frame-drag candidate. Snapshot the selection BEFORE the TreeView mutates
+            // it on press, so dragging a frame that is part of a multi-selection can move the
+            // whole set. Tunnel phase runs ahead of the TreeView's own selection handling.
+            if (e.Source is Control src &&
+                src.FindAncestorOfType<TreeViewItem>(includeSelf: true)?.DataContext
+                    is TreeNodeVm { Data: AnimationFrameSave frame })
+            {
+                _frameDragCandidate = frame;
+                _frameDragPressPoint = e.GetPosition(AnimTree);
+                _frameDragPressArgs = e;
+                _frameDragSelectionSnapshot = new List<object>(_selectedState.SelectedNodes);
+            }
+            else
+            {
+                ClearFrameDragCandidate();
+            }
         }
         else if (props.IsLeftButtonPressed && e.ClickCount == 2)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -73,6 +73,7 @@ public partial class MainWindow : Window
     private AnimationFrameSave? _pendingSingleSelectFrame;
     private bool _frameDragInProgress;
     private Border? _frameDropLine;
+    private Border? _frameDropBox;
     private int _untitledCounter;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
@@ -1905,12 +1906,12 @@ public partial class MainWindow : Window
             if (target.IsValid)
             {
                 e.DragEffects = DragDropEffects.Move;
-                ShowFrameDropLine(e);
+                ShowFrameDropIndicator(e);
             }
             else
             {
                 e.DragEffects = DragDropEffects.None;
-                RemoveFrameDropLine();
+                RemoveFrameDropIndicators();
             }
             e.Handled = true;
             return;
@@ -1953,7 +1954,7 @@ public partial class MainWindow : Window
         // stay untouched (external file drags never carry the frame marker format).
         if (e.DataTransfer.Contains(FrameDragDataFormat) && _pendingFrameDrag is { IsValid: true } drag)
         {
-            RemoveFrameDropLine();
+            RemoveFrameDropIndicators();
             var target = ResolveFrameDrop(e, drag);
             if (target is { IsValid: true, Chain: not null } && drag.SourceChain is not null)
                 _appCommands.MoveFrames(drag.Frames, drag.SourceChain, target.Chain, target.InsertIndex);
@@ -2144,7 +2145,7 @@ public partial class MainWindow : Window
         {
             _pendingFrameDrag = null;
             _frameDragInProgress = false;
-            RemoveFrameDropLine();
+            RemoveFrameDropIndicators();
             ClearFrameDragCandidate();
         }
     }
@@ -2240,12 +2241,12 @@ public partial class MainWindow : Window
         return (vm.Data, half, tvi);
     }
 
-    private void ShowFrameDropLine(DragEventArgs e)
+    private void ShowFrameDropIndicator(DragEventArgs e)
     {
         var (nodeData, half, tvi) = HitTestFrameRow(e.GetPosition(AnimTree));
         if (tvi is null)
         {
-            RemoveFrameDropLine();
+            RemoveFrameDropIndicators();
             return;
         }
 
@@ -2253,16 +2254,32 @@ public partial class MainWindow : Window
         var treeOrigin = Avalonia.VisualExtensions.TranslatePoint(AnimTree, new Avalonia.Point(0, 0), DragOverlayCanvas);
         if (topLeft is null || treeOrigin is null)
         {
-            RemoveFrameDropLine();
+            RemoveFrameDropIndicators();
             return;
         }
 
-        // A chain target appends, so the line sits below the chain's whole subtree (after its
-        // last frame). A frame target lands at the top or bottom edge of that row.
-        double y = nodeData is AnimationChainSave
-            ? topLeft.Value.Y + tvi.Bounds.Height
-            : topLeft.Value.Y + (half == FrameRowHalf.Upper ? 0 : tvi.Bounds.Height);
+        double treeRight = treeOrigin.Value.X + AnimTree.Bounds.Width;
 
+        if (nodeData is AnimationChainSave)
+        {
+            // Appending into an animation: outline the whole animation row/subtree so it reads as
+            // "drop inside this animation" — a box conveys containment in a way a line can't,
+            // which matters most for a collapsed chain where a line would look top-level.
+            RemoveDropLine();
+            ShowDropBox(topLeft.Value.X, topLeft.Value.Y, treeRight, tvi.Bounds.Height);
+            return;
+        }
+
+        // Reordering at a specific frame: a thin line at the precise insert position, indented to
+        // the frame content so it clearly belongs inside the animation rather than at the top level.
+        RemoveDropBox();
+        double y = topLeft.Value.Y + (half == FrameRowHalf.Upper ? 0 : tvi.Bounds.Height);
+        double left = HeaderContentLeft(tvi);
+        ShowDropLine(left, treeRight, y);
+    }
+
+    private void ShowDropLine(double left, double treeRight, double y)
+    {
         _frameDropLine ??= new Border
         {
             Height = 2,
@@ -2272,15 +2289,54 @@ public partial class MainWindow : Window
         if (!DragOverlayCanvas.Children.Contains(_frameDropLine))
             DragOverlayCanvas.Children.Add(_frameDropLine);
 
-        _frameDropLine.Width = AnimTree.Bounds.Width;
-        Canvas.SetLeft(_frameDropLine, treeOrigin.Value.X);
+        _frameDropLine.Width = Math.Max(0, treeRight - left);
+        Canvas.SetLeft(_frameDropLine, left);
         Canvas.SetTop(_frameDropLine, y - 1);
     }
 
-    private void RemoveFrameDropLine()
+    private void ShowDropBox(double left, double top, double treeRight, double height)
+    {
+        _frameDropBox ??= new Border
+        {
+            BorderBrush = new SolidColorBrush(Color.Parse("#4a90d9")),
+            BorderThickness = new Avalonia.Thickness(2),
+            CornerRadius = new Avalonia.CornerRadius(3),
+            Background = new SolidColorBrush(Color.Parse("#334a90d9")), // faint fill to suggest the target area
+            IsHitTestVisible = false,
+        };
+        if (!DragOverlayCanvas.Children.Contains(_frameDropBox))
+            DragOverlayCanvas.Children.Add(_frameDropBox);
+
+        _frameDropBox.Width = Math.Max(0, treeRight - left - 2);
+        _frameDropBox.Height = Math.Max(0, height);
+        Canvas.SetLeft(_frameDropBox, left);
+        Canvas.SetTop(_frameDropBox, top);
+    }
+
+    /// <summary>X of a tree row's header content (after the indent + chevron) in canvas coords.</summary>
+    private double HeaderContentLeft(TreeViewItem tvi)
+    {
+        Control anchor = tvi.GetVisualDescendants().OfType<Control>()
+            .FirstOrDefault(c => c.Name == "PART_HeaderPresenter") ?? tvi;
+        return Avalonia.VisualExtensions.TranslatePoint(anchor, new Avalonia.Point(0, 0), DragOverlayCanvas)?.X ?? 0;
+    }
+
+    private void RemoveDropLine()
     {
         if (_frameDropLine is not null)
             DragOverlayCanvas.Children.Remove(_frameDropLine);
+    }
+
+    private void RemoveDropBox()
+    {
+        if (_frameDropBox is not null)
+            DragOverlayCanvas.Children.Remove(_frameDropBox);
+    }
+
+    private void RemoveFrameDropIndicators()
+    {
+        RemoveDropLine();
+        RemoveDropBox();
     }
 
     // ── Window-level OS file drop: open dropped .achx files as tabs ────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -70,6 +70,7 @@ public partial class MainWindow : Window
     private PointerPressedEventArgs? _frameDragPressArgs;
     private AnimationFrameSave? _frameDragCandidate;
     private List<object>? _frameDragSelectionSnapshot;
+    private AnimationFrameSave? _pendingSingleSelectFrame;
     private bool _frameDragInProgress;
     private Border? _frameDropLine;
     private int _untitledCounter;
@@ -2083,6 +2084,14 @@ public partial class MainWindow : Window
         _frameDragPressPoint = null;
         _frameDragPressArgs = null;
         _frameDragSelectionSnapshot = null;
+        _pendingSingleSelectFrame = null;
+    }
+
+    private void SelectSingleFrame(AnimationFrameSave frame)
+    {
+        _selectedState.SelectedNodes = new List<object> { frame };
+        _selectedState.SelectedFrame = frame;
+        SyncTreeSelection();
     }
 
     private async void OnTreeFrameDragPointerMoved(object? sender, PointerEventArgs e)
@@ -2108,6 +2117,9 @@ public partial class MainWindow : Window
             return;
         }
 
+        // A drag is happening, so the deferred single-select must not fire on release.
+        _pendingSingleSelectFrame = null;
+        e.Pointer.Capture(null); // release our press-capture so the drag system can take over
         _pendingFrameDrag = dragSource;
         _frameDragInProgress = true;
 
@@ -2130,8 +2142,17 @@ public partial class MainWindow : Window
 
     private void OnTreeFrameDragPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        if (!_frameDragInProgress)
-            ClearFrameDragCandidate();
+        if (_frameDragInProgress) return;
+
+        // A press on an already-multi-selected frame that did not turn into a drag collapses
+        // the selection to that single frame now (the select-on-press was suppressed so the
+        // multi-selection could survive a potential drag).
+        if (_pendingSingleSelectFrame is { } frame)
+        {
+            e.Pointer.Capture(null);
+            SelectSingleFrame(frame);
+        }
+        ClearFrameDragCandidate();
     }
 
     /// <summary>
@@ -2689,6 +2710,24 @@ public partial class MainWindow : Window
                 _frameDragPressPoint = e.GetPosition(AnimTree);
                 _frameDragPressArgs = e;
                 _frameDragSelectionSnapshot = new List<object>(_selectedState.SelectedNodes);
+
+                // Pressing a frame that's part of a frame multi-selection (no modifiers) must
+                // not collapse the selection — otherwise a drag would only move one frame. Mark
+                // the press handled to suppress the TreeView's select-on-press, capture so the
+                // move/release still arrive here, and defer the single-select to release if no
+                // drag happens. Ctrl/Shift presses fall through to normal selection editing.
+                bool noModifiers = (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Shift)) == 0;
+                if (noModifiers &&
+                    FrameDropResolver.IsFrameMultiSelectionContaining(_frameDragSelectionSnapshot, frame))
+                {
+                    _pendingSingleSelectFrame = frame;
+                    e.Pointer.Capture(AnimTree);
+                    e.Handled = true;
+                }
+                else
+                {
+                    _pendingSingleSelectFrame = null;
+                }
             }
             else
             {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -678,6 +678,15 @@ namespace AnimationEditor.Core.CommandsAndState
                 "Move Frame to Bottom"));
         }
 
+        /// <inheritdoc cref="IAppCommands.MoveFrames"/>
+        public void MoveFrames(IReadOnlyList<AnimationFrameSave> frames,
+            AnimationChainSave sourceChain, AnimationChainSave targetChain, int insertIndex)
+        {
+            if (frames.Count == 0) return;
+            _undoManager.Execute(new MoveFramesCommand(
+                frames, sourceChain, targetChain, insertIndex, this, _events, _selectedState));
+        }
+
         public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {
             var shapes = frame.ShapesSave?.Shapes;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -131,6 +131,17 @@ namespace AnimationEditor.Core.CommandsAndState
         void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta);
         void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain);
         void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain);
+
+        /// <summary>
+        /// Moves <paramref name="frames"/> (the same instances, not clones) from
+        /// <paramref name="sourceChain"/> to <paramref name="targetChain"/> at
+        /// <paramref name="insertIndex"/> as one undo step. Drives drag-and-drop reorder
+        /// within a chain (source == target) and cross-animation moves. The frames are
+        /// sorted by source index and inserted as a contiguous block; <paramref name="insertIndex"/>
+        /// is interpreted against the target's current frame list before source removal.
+        /// </summary>
+        void MoveFrames(IReadOnlyList<AnimationFrameSave> frames,
+            AnimationChainSave sourceChain, AnimationChainSave targetChain, int insertIndex);
         void MoveShape(object shape, AnimationFrameSave frame, int delta);
         void MoveShapeToTop(object shape, AnimationFrameSave frame);
         void MoveShapeToBottom(object shape, AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFramesCommand.cs
@@ -1,0 +1,134 @@
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands;
+
+/// <summary>
+/// Moves the <em>same</em> frame instances (not clones) from a source chain to a target
+/// chain at a resolved insert index, as one undo step. Covers both within-chain reorder
+/// (source == target) and cross-animation moves. The moved frames are sorted by their
+/// source-chain index and become a contiguous, gap-squashed block at the destination, so
+/// a multi-select drag preserves relative order. Preserving instance identity is what lets
+/// the tree's frame VMs survive the move (see <c>TreeBuilder.SyncFramesInto</c>).
+/// </summary>
+internal sealed class MoveFramesCommand : IUndoableCommand
+{
+    private readonly IReadOnlyList<AnimationFrameSave> _frames;
+    private readonly AnimationChainSave _sourceChain;
+    private readonly AnimationChainSave _targetChain;
+    private readonly int _insertIndex;
+    private readonly IAppCommands _commands;
+    private readonly IApplicationEvents _events;
+    private readonly ISelectedState _selectedState;
+    private readonly List<object> _preSelection;
+
+    private AnimationFrameSave[] _moved = [];
+    private AnimationFrameSave[] _sourceBefore = [];
+    private AnimationFrameSave[] _targetBefore = [];
+
+    public string Description { get; }
+
+    /// <param name="insertIndex">Where the block lands in the target chain, interpreted
+    /// against the target's current frame list (before any source removal). For a same-chain
+    /// move the index is adjusted internally for the frames removed ahead of it.</param>
+    public MoveFramesCommand(
+        IReadOnlyList<AnimationFrameSave> frames,
+        AnimationChainSave sourceChain,
+        AnimationChainSave targetChain,
+        int insertIndex,
+        IAppCommands commands,
+        IApplicationEvents events,
+        ISelectedState selectedState)
+    {
+        _frames = frames;
+        _sourceChain = sourceChain;
+        _targetChain = targetChain;
+        _insertIndex = insertIndex;
+        _commands = commands;
+        _events = events;
+        _selectedState = selectedState;
+        _preSelection = new List<object>(selectedState.SelectedNodes);
+        bool sameChain = ReferenceEquals(sourceChain, targetChain);
+        Description = (frames.Count, sameChain) switch
+        {
+            (1, true) => "Move Frame",
+            (_, true) => $"Move {frames.Count} Frames",
+            (1, false) => $"Move Frame to '{targetChain.Name}'",
+            _ => $"Move {frames.Count} Frames to '{targetChain.Name}'",
+        };
+    }
+
+    public bool Do()
+    {
+        _sourceBefore = _sourceChain.Frames.ToArray();
+        _targetBefore = _targetChain.Frames.ToArray();
+
+        var movedIndices = _frames
+            .Select(f => _sourceChain.Frames.IndexOf(f))
+            .Where(i => i >= 0)
+            .OrderBy(i => i)
+            .ToArray();
+        if (movedIndices.Length == 0) return false;
+
+        _moved = movedIndices.Select(i => _sourceChain.Frames[i]).ToArray();
+
+        bool sameChain = ReferenceEquals(_sourceChain, _targetChain);
+
+        // Removing the selected frames from the target shifts the insert position left by
+        // however many of them sat ahead of it. Cross-chain moves don't touch the target.
+        int insertAt = _insertIndex;
+        if (sameChain)
+            insertAt -= movedIndices.Count(i => i < _insertIndex);
+
+        foreach (var frame in _moved)
+            _sourceChain.Frames.Remove(frame);
+
+        insertAt = Math.Clamp(insertAt, 0, _targetChain.Frames.Count);
+        for (int i = 0; i < _moved.Length; i++)
+            _targetChain.Frames.Insert(insertAt + i, _moved[i]);
+
+        if (sameChain && _targetChain.Frames.SequenceEqual(_targetBefore))
+            return false; // reorder produced an identical list — no undo entry
+
+        RaiseSideEffects();
+        SelectMoved();
+        return true;
+    }
+
+    public void Undo()
+    {
+        RestoreOrder(_sourceChain, _sourceBefore);
+        if (!ReferenceEquals(_sourceChain, _targetChain))
+            RestoreOrder(_targetChain, _targetBefore);
+        RaiseSideEffects();
+        _selectedState.SelectedNodes = _preSelection;
+        _selectedState.SelectedFrame = _preSelection.OfType<AnimationFrameSave>().LastOrDefault();
+    }
+
+    public void Redo() => Do();
+
+    private static void RestoreOrder(AnimationChainSave chain, AnimationFrameSave[] order)
+    {
+        chain.Frames.Clear();
+        foreach (var frame in order)
+            chain.Frames.Add(frame);
+    }
+
+    private void SelectMoved()
+    {
+        _selectedState.SelectedNodes = _moved.Cast<object>().ToList();
+        _selectedState.SelectedFrame = _moved[^1];
+    }
+
+    private void RaiseSideEffects()
+    {
+        _commands.RefreshTreeNode(_sourceChain);
+        if (!ReferenceEquals(_sourceChain, _targetChain))
+            _commands.RefreshTreeNode(_targetChain);
+        _commands.RefreshWireframe();
+        _events.RaiseAnimationChainsChanged();
+        _commands.SaveCurrentAnimationChainList();
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/FrameDropResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/FrameDropResolver.cs
@@ -1,0 +1,142 @@
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.DragDrop;
+
+/// <summary>Which half of a frame row the pointer is over during a frame drag.</summary>
+public enum FrameRowHalf { Upper, Lower }
+
+/// <summary>
+/// Why a frame drag may or may not be initiated from the current selection.
+/// <see cref="Valid"/> is the only state that starts a drag; <see cref="MixedTypes"/>
+/// and <see cref="MultipleSourceChains"/> warrant an error/info toast, while
+/// <see cref="Empty"/> and <see cref="NotFrames"/> silently suppress the drag.
+/// </summary>
+public enum FrameDragValidity { Valid, Empty, NotFrames, MixedTypes, MultipleSourceChains }
+
+/// <summary>
+/// The frames a drag would move plus where they come from. <see cref="SourceChain"/>
+/// is non-null only when <see cref="Validity"/> is <see cref="FrameDragValidity.Valid"/>.
+/// </summary>
+public readonly record struct FrameDragSource(
+    IReadOnlyList<AnimationFrameSave> Frames,
+    AnimationChainSave? SourceChain,
+    FrameDragValidity Validity)
+{
+    public bool IsValid => Validity == FrameDragValidity.Valid;
+}
+
+/// <summary>
+/// The resolved landing spot for a frame drag: the target chain and the index its
+/// frames will be inserted at (interpreted against the target chain's current frame
+/// list, before any source removal). <see cref="IsValid"/> is false when the drop
+/// must be rejected and no indicator line shown.
+/// </summary>
+public readonly record struct FrameDropTarget(
+    AnimationChainSave? Chain, int InsertIndex, bool IsValid)
+{
+    public static readonly FrameDropTarget None = new(null, -1, false);
+}
+
+/// <summary>
+/// Pure drag-and-drop logic for reordering / moving animation frames in the tree.
+/// Splits into two questions: <see cref="ClassifySelection"/> (can this selection be
+/// dragged, and from where) and <see cref="Resolve"/> (where would a drop land).
+/// Both are side-effect free so they can be unit-tested without Avalonia.
+/// </summary>
+public static class FrameDropResolver
+{
+    /// <summary>
+    /// Classifies the current tree selection for drag eligibility. A homogeneous set of
+    /// frames from a single source chain is <see cref="FrameDragValidity.Valid"/>; any
+    /// non-frame mixed in is <see cref="FrameDragValidity.MixedTypes"/>; frames spanning
+    /// more than one chain is <see cref="FrameDragValidity.MultipleSourceChains"/>
+    /// (deferred to a follow-up). Pure non-frame or empty selections do not drag.
+    /// </summary>
+    public static FrameDragSource ClassifySelection(
+        IReadOnlyList<object>? selectedNodes,
+        Func<AnimationFrameSave, AnimationChainSave?> getChainContainingFrame)
+    {
+        if (selectedNodes is null || selectedNodes.Count == 0)
+            return new(Array.Empty<AnimationFrameSave>(), null, FrameDragValidity.Empty);
+
+        var frames = selectedNodes.OfType<AnimationFrameSave>().ToList();
+
+        if (frames.Count == 0)
+            return new(frames, null, FrameDragValidity.NotFrames);
+
+        if (frames.Count != selectedNodes.Count)
+            return new(frames, null, FrameDragValidity.MixedTypes);
+
+        var chains = frames.Select(getChainContainingFrame).Distinct().ToList();
+        if (chains.Count != 1 || chains[0] is null)
+            return new(frames, null, FrameDragValidity.MultipleSourceChains);
+
+        return new(frames, chains[0], FrameDragValidity.Valid);
+    }
+
+    /// <summary>
+    /// Resolves where a frame drag would land given the tree node currently under the
+    /// pointer. <paramref name="nodeData"/> is the node's underlying model object: a frame
+    /// resolves to upper-half-before / lower-half-after that frame; a chain appends to the
+    /// end of its frame list; anything else is no drop.
+    /// </summary>
+    /// <param name="half">Which half of a frame row the pointer is over (ignored for chain targets).</param>
+    /// <param name="selectedFrames">The frames being dragged, in any order.</param>
+    /// <param name="sourceChain">The chain the dragged frames belong to.</param>
+    /// <param name="getChainContainingFrame">Maps the target frame to its owning chain.</param>
+    public static FrameDropTarget Resolve(
+        object? nodeData,
+        FrameRowHalf half,
+        IReadOnlyList<AnimationFrameSave> selectedFrames,
+        AnimationChainSave sourceChain,
+        Func<AnimationFrameSave, AnimationChainSave?> getChainContainingFrame)
+    {
+        if (selectedFrames is null || selectedFrames.Count == 0)
+            return FrameDropTarget.None;
+
+        AnimationChainSave? targetChain;
+        int insertIndex;
+
+        switch (nodeData)
+        {
+            case AnimationFrameSave frame:
+                targetChain = getChainContainingFrame(frame);
+                if (targetChain is null) return FrameDropTarget.None;
+                int frameIndex = targetChain.Frames.IndexOf(frame);
+                if (frameIndex < 0) return FrameDropTarget.None;
+                insertIndex = half == FrameRowHalf.Upper ? frameIndex : frameIndex + 1;
+                break;
+
+            case AnimationChainSave chain:
+                targetChain = chain;
+                insertIndex = chain.Frames.Count;
+                break;
+
+            default:
+                return FrameDropTarget.None;
+        }
+
+        // Same-chain accidental-squash guard: a drop landing strictly inside the index
+        // span of the selection would silently collapse the block. Only allow inserts at
+        // or before the first selected frame, or at/after the last selected frame.
+        if (ReferenceEquals(targetChain, sourceChain))
+        {
+            var indices = selectedFrames
+                .Select(f => targetChain.Frames.IndexOf(f))
+                .Where(i => i >= 0)
+                .OrderBy(i => i)
+                .ToList();
+            if (indices.Count == 0) return FrameDropTarget.None;
+
+            int minSel = indices[0];
+            int maxSel = indices[^1];
+            bool valid = insertIndex <= minSel || insertIndex >= maxSel + 1;
+            return new FrameDropTarget(targetChain, insertIndex, valid);
+        }
+
+        return new FrameDropTarget(targetChain, insertIndex, true);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/FrameDropResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/FrameDropResolver.cs
@@ -78,6 +78,20 @@ public static class FrameDropResolver
     }
 
     /// <summary>
+    /// True when <paramref name="candidate"/> is one of several frames in a homogeneous
+    /// frame multi-selection. Pressing such a frame must NOT collapse the selection (so a
+    /// drag can move the whole set); a plain click that never drags collapses on release
+    /// instead. Returns false for single selections or any selection containing a non-frame.
+    /// </summary>
+    public static bool IsFrameMultiSelectionContaining(
+        IReadOnlyList<object>? selection, AnimationFrameSave candidate)
+    {
+        if (selection is null || selection.Count < 2) return false;
+        if (!selection.All(n => n is AnimationFrameSave)) return false;
+        return selection.Any(n => ReferenceEquals(n, candidate));
+    }
+
+    /// <summary>
     /// Resolves where a frame drag would land given the tree node currently under the
     /// pointer. <paramref name="nodeData"/> is the node's underlying model object: a frame
     /// resolves to upper-half-before / lower-half-after that frame; a chain appends to the

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// End-to-end check that a drag-and-drop frame move (issue #500) flows through the real
+/// window tree: the chain node's frame children reorder and relabel, and one undo reverts.
+/// The pointer-driven drag itself (DoDragDropAsync) is exercised manually; here we drive the
+/// resolved move via AppCommands.MoveFrames, which is what the drop handler calls.
+/// </summary>
+public class FrameDragReorderHeadlessTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow)
+            .GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, null);
+    }
+
+    private static ObservableCollection<TreeNodeVm> Roots(MainWindow window)
+    {
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        return (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+    }
+
+    private static TreeNodeVm ChainNode(MainWindow window, AnimationChainSave chain)
+        => Roots(window).First(n => ReferenceEquals(n.Data, chain));
+
+    private static AnimationChainSave MakeChain(AnimationChainListSave acls, string name, int frameCount)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        for (int i = 0; i < frameCount; i++)
+            chain.Frames.Add(new AnimationFrameSave
+            {
+                TextureName = $"frame{i}.png",
+                LeftCoordinate = 0f, RightCoordinate = 1f,
+                TopCoordinate = 0f, BottomCoordinate = 1f,
+                FrameLength = 0.1f, ShapesSave = new ShapesSave(),
+            });
+        acls.AnimationChains.Add(chain);
+        return chain;
+    }
+
+    [AvaloniaFact]
+    public void MoveFrames_WithinChain_TreeChildrenReorderAndRelabel()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = MakeChain(ctx.ProjectManager.AnimationChainListSave!, "Walk", 4);
+            var original = chain.Frames.ToArray();
+            RebuildTree(window);
+
+            // Move the first frame to the end → expected order 1,2,3,0.
+            ctx.AppCommands.MoveFrames(new[] { original[0] }, chain, chain, insertIndex: 4);
+            Dispatcher.UIThread.RunJobs();
+
+            var children = ChainNode(window, chain).Children;
+            Assert.Equal(
+                new[] { original[1], original[2], original[3], original[0] },
+                children.Select(c => c.Data).ToArray());
+            // Positional "Frame N" labels follow the new order.
+            Assert.Equal(new[] { "Frame 1", "Frame 2", "Frame 3", "Frame 4" },
+                children.Select(c => c.Header).ToArray());
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void MoveFrames_MultiSelect_OneUndoRevertsEntireMove()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = MakeChain(ctx.ProjectManager.AnimationChainListSave!, "Walk", 5);
+            var original = chain.Frames.ToArray();
+            RebuildTree(window);
+
+            // Move frames 0 and 1 to the end as one block.
+            ctx.AppCommands.MoveFrames(new[] { original[0], original[1] }, chain, chain, insertIndex: 5);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(
+                new[] { original[2], original[3], original[4], original[0], original[1] },
+                chain.Frames.ToArray());
+
+            ctx.UndoManager.Undo();
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(original, chain.Frames.ToArray());
+            Assert.Equal(original, ChainNode(window, chain).Children.Select(c => c.Data).ToArray());
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
@@ -90,6 +90,36 @@ public class FrameDragReorderHeadlessTests
     }
 
     [AvaloniaFact]
+    public void SelectSingleFrame_FromMultiSelection_CollapsesTreeToThatFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = MakeChain(ctx.ProjectManager.AnimationChainListSave!, "Walk", 4);
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var frameNodes = ChainNode(window, chain).Children.ToList();
+            foreach (var node in frameNodes)
+                tree.SelectedItems!.Add(node);
+            Assert.Equal(4, tree.SelectedItems!.Count);
+
+            // A plain click on one already-selected frame collapses to just that frame —
+            // the bug was that the first click left the tree multi-selected.
+            var target = chain.Frames[1];
+            typeof(MainWindow)
+                .GetMethod("SelectSingleFrame", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, new object[] { target });
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(tree.SelectedItems!);
+            Assert.Same(target, ((TreeNodeVm)tree.SelectedItems![0]!).Data);
+            Assert.Same(target, ctx.SelectedState.SelectedFrame);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
     public void MoveFrames_MultiSelect_OneUndoRevertsEntireMove()
     {
         var (window, ctx) = CreateWindow();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FrameDropResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FrameDropResolverTests.cs
@@ -1,0 +1,151 @@
+using AnimationEditor.Core.DragDrop;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Pure drop-target and selection-classification logic for frame drag-and-drop (issue #500).
+/// </summary>
+public class FrameDropResolverTests
+{
+    private static AnimationChainSave ChainWithFrames(int count, out List<AnimationFrameSave> frames)
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        for (int i = 0; i < count; i++)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = $"f{i}.png" });
+        frames = chain.Frames.ToList();
+        return chain;
+    }
+
+    [Fact]
+    public void ClassifySelection_Empty_NoDrag()
+    {
+        var result = FrameDropResolver.ClassifySelection(new List<object>(), _ => null);
+        Assert.Equal(FrameDragValidity.Empty, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ClassifySelection_FramesFromOneChain_Valid()
+    {
+        var chain = ChainWithFrames(3, out var frames);
+        var selection = new List<object> { frames[0], frames[2] };
+
+        var result = FrameDropResolver.ClassifySelection(selection, _ => chain);
+
+        Assert.True(result.IsValid);
+        Assert.Same(chain, result.SourceChain);
+        Assert.Equal(2, result.Frames.Count);
+    }
+
+    [Fact]
+    public void ClassifySelection_FrameMixedWithChain_MixedTypes()
+    {
+        var chain = ChainWithFrames(2, out var frames);
+        var selection = new List<object> { frames[0], chain };
+
+        var result = FrameDropResolver.ClassifySelection(selection, _ => chain);
+
+        Assert.Equal(FrameDragValidity.MixedTypes, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ClassifySelection_FramesFromTwoChains_MultipleSourceChains()
+    {
+        var walk = ChainWithFrames(1, out var walkFrames);
+        var run = ChainWithFrames(1, out var runFrames);
+        var selection = new List<object> { walkFrames[0], runFrames[0] };
+
+        var result = FrameDropResolver.ClassifySelection(
+            selection,
+            f => walk.Frames.Contains(f) ? walk : run.Frames.Contains(f) ? run : null);
+
+        Assert.Equal(FrameDragValidity.MultipleSourceChains, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_ChainNode_AppendsToEnd()
+    {
+        var source = ChainWithFrames(2, out var srcFrames);
+        var target = ChainWithFrames(3, out _);
+
+        var result = FrameDropResolver.Resolve(
+            target, FrameRowHalf.Upper, new[] { srcFrames[0] }, source, _ => source);
+
+        Assert.Same(target, result.Chain);
+        Assert.Equal(3, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_FrameRowUpperHalf_InsertsBeforeThatFrame()
+    {
+        var source = ChainWithFrames(2, out var srcFrames);
+        var target = ChainWithFrames(3, out var targetFrames);
+
+        var result = FrameDropResolver.Resolve(
+            targetFrames[1], FrameRowHalf.Upper, new[] { srcFrames[0] }, source,
+            f => target.Frames.Contains(f) ? target : null);
+
+        Assert.Equal(1, result.InsertIndex);
+    }
+
+    [Fact]
+    public void Resolve_FrameRowLowerHalf_InsertsAfterThatFrame()
+    {
+        var source = ChainWithFrames(2, out var srcFrames);
+        var target = ChainWithFrames(3, out var targetFrames);
+
+        var result = FrameDropResolver.Resolve(
+            targetFrames[1], FrameRowHalf.Lower, new[] { srcFrames[0] }, source,
+            f => target.Frames.Contains(f) ? target : null);
+
+        Assert.Equal(2, result.InsertIndex);
+    }
+
+    [Fact]
+    public void Resolve_NonFrameNonChainNode_NoDrop()
+    {
+        var source = ChainWithFrames(1, out var srcFrames);
+
+        var result = FrameDropResolver.Resolve(
+            new AARectSave { Name = "Hit" }, FrameRowHalf.Upper, srcFrames, source, _ => source);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Chain);
+    }
+
+    [Fact]
+    public void Resolve_SameChainDropInsideSelectionSpan_Invalid()
+    {
+        // Frames 0..5; select indices 1,3,4. Span is [1,4]; dropping between 1 and 2
+        // (insert index 2) is inside the span and must be rejected.
+        var chain = ChainWithFrames(6, out var frames);
+        var selected = new[] { frames[1], frames[3], frames[4] };
+
+        var result = FrameDropResolver.Resolve(
+            frames[2], FrameRowHalf.Upper, selected, chain, _ => chain);
+
+        Assert.Equal(2, result.InsertIndex);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_SameChainDropAfterLastSelected_Valid()
+    {
+        // Same setup; dropping after the last frame (index 6) is outside the span → valid.
+        var chain = ChainWithFrames(6, out var frames);
+        var selected = new[] { frames[1], frames[3], frames[4] };
+
+        var result = FrameDropResolver.Resolve(
+            frames[5], FrameRowHalf.Lower, selected, chain, _ => chain);
+
+        Assert.Equal(6, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FrameDropResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FrameDropResolverTests.cs
@@ -69,6 +69,42 @@ public class FrameDropResolverTests
     }
 
     [Fact]
+    public void IsFrameMultiSelectionContaining_FrameInMultiFrameSelection_True()
+    {
+        var chain = ChainWithFrames(3, out var frames);
+        var selection = new List<object> { frames[0], frames[2] };
+
+        Assert.True(FrameDropResolver.IsFrameMultiSelectionContaining(selection, frames[0]));
+    }
+
+    [Fact]
+    public void IsFrameMultiSelectionContaining_SingleSelection_False()
+    {
+        var chain = ChainWithFrames(2, out var frames);
+        var selection = new List<object> { frames[0] };
+
+        Assert.False(FrameDropResolver.IsFrameMultiSelectionContaining(selection, frames[0]));
+    }
+
+    [Fact]
+    public void IsFrameMultiSelectionContaining_MixedSelection_False()
+    {
+        var chain = ChainWithFrames(2, out var frames);
+        var selection = new List<object> { frames[0], chain };
+
+        Assert.False(FrameDropResolver.IsFrameMultiSelectionContaining(selection, frames[0]));
+    }
+
+    [Fact]
+    public void IsFrameMultiSelectionContaining_CandidateNotInSelection_False()
+    {
+        var chain = ChainWithFrames(3, out var frames);
+        var selection = new List<object> { frames[0], frames[1] };
+
+        Assert.False(FrameDropResolver.IsFrameMultiSelectionContaining(selection, frames[2]));
+    }
+
+    [Fact]
     public void Resolve_ChainNode_AppendsToEnd()
     {
         var source = ChainWithFrames(2, out var srcFrames);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFramesCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFramesCommandTests.cs
@@ -1,0 +1,92 @@
+using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Drag-and-drop frame move command: within-chain reorder, cross-chain move, gap squash,
+/// and single-undo semantics (issue #500).
+/// </summary>
+[Collection("SequentialSingletons")]
+public class MoveFramesCommandTests
+{
+    [Fact]
+    public void MoveFrames_WithinChain_MultiSelectSquashesGapsAndPreservesOrder()
+    {
+        // Chain frames 0..5; move {1,3,4} to the end → 0,2,5,1,3,4 (block squashed, order kept).
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 6);
+        var f = chain.Frames.ToList();
+        var selected = new[] { f[1], f[3], f[4] };
+
+        ctx.AppCommands.MoveFrames(selected, chain, chain, insertIndex: 6);
+
+        Assert.Equal(new[] { f[0], f[2], f[5], f[1], f[3], f[4] }, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void MoveFrames_WithinChain_OneUndoRestoresOriginalOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var original = chain.Frames.ToArray();
+
+        // Move frame 0 to the end.
+        ctx.AppCommands.MoveFrames(new[] { original[0] }, chain, chain, insertIndex: 4);
+        Assert.Equal(new[] { original[1], original[2], original[3], original[0] }, chain.Frames.ToArray());
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(original, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void MoveFrames_CrossChain_RemovesFromSourceInsertsIntoTargetOneUndoRestoresBoth()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var run = TestHelpers.MakeChain(ctx.Acls, "Run", 2);
+        var walkOriginal = walk.Frames.ToArray();
+        var runOriginal = run.Frames.ToArray();
+        var moving = new[] { walkOriginal[0], walkOriginal[2] };
+
+        // Insert the two moved frames at the front of Run.
+        ctx.AppCommands.MoveFrames(moving, walk, run, insertIndex: 0);
+
+        Assert.Equal(new[] { walkOriginal[1] }, walk.Frames.ToArray());
+        Assert.Equal(new[] { walkOriginal[0], walkOriginal[2], runOriginal[0], runOriginal[1] }, run.Frames.ToArray());
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(walkOriginal, walk.Frames.ToArray());
+        Assert.Equal(runOriginal, run.Frames.ToArray());
+    }
+
+    [Fact]
+    public void MoveFrames_CrossChain_SelectsMovedFramesAfterMove()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var run = TestHelpers.MakeChain(ctx.Acls, "Run", 1);
+        var moving = walk.Frames.ToArray();
+
+        ctx.AppCommands.MoveFrames(moving, walk, run, insertIndex: 1);
+
+        Assert.Equal(moving.Cast<object>().ToList(), ctx.SelectedState.SelectedNodes);
+    }
+
+    [Fact]
+    public void MoveFrames_WithinChain_DropAtSamePosition_NoUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var f = chain.Frames.ToArray();
+
+        // Upper half of frame 1, moving frame 1 — lands in its own slot → no change.
+        ctx.AppCommands.MoveFrames(new[] { f[1] }, chain, chain, insertIndex: 1);
+
+        Assert.Equal(f, chain.Frames.ToArray());
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -77,6 +77,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveFrames)]                   = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShape)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToBottom)]            = Category.MutatingUndoable,
@@ -229,6 +230,10 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MoveFrameToTop(Zebra(ctx).Frames[2], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveFrameToBottom),
             ctx => Sync(() => ctx.AppCommands.MoveFrameToBottom(Zebra(ctx).Frames[0], Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.MoveFrames),
+            // Within-chain drag move: frame 0 → end of Zebra (3 frames) reorders to 1,2,0.
+            ctx => Sync(() => ctx.AppCommands.MoveFrames(
+                new[] { Zebra(ctx).Frames[0] }, Zebra(ctx), Zebra(ctx), insertIndex: 3)));
         yield return Row(nameof(IAppCommands.MoveShape),
             ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.MoveShapeToTop),


### PR DESCRIPTION
Closes #500.

Adds drag-and-drop frame reordering to the Animation Editor tree: drag frame rows to reorder within an animation chain or move them to another chain, with a drop-indicator line, multi-select, and single-undo semantics. Builds on the cut/paste/move plumbing from #498/#499.

## What's in scope (per the issue)
- DnD reorder **within** a chain and **across** chains (remove from source, insert at target).
- Single- and **multi-select** (homogeneous frames from one source chain).
- **One drag = one undo** (Ctrl+Z reverts the whole move).
- **Drop-indicator line** at the resolved insert position.
- **Post-drop:** all moved frames stay selected.
- **PNG drop unaffected** — external `.png` file drops onto the tree still apply textures.

## Design
- **`FrameDropResolver`** (Core, pure): selection classification (valid / mixed-type / multi-chain) + drop-target resolution (frame upper/lower half, chain-row → append) including the **accidental-squash guard** that rejects a drop landing strictly inside the selected index span.
- **`MoveFramesCommand`** (Core): moves the *same* `AnimationFrameSave` instances (not clones) so tree VM identity survives the move; sorts by source index and squashes gaps into a contiguous block; single undo snapshots both chains. `AppCommands.MoveFrames` runs it through the undo manager and is registered in the undo-coverage roster.
- **MainWindow wiring**: press arms a drag candidate (pre-press selection snapshot so dragging one frame of a multi-selection moves the set); move past a threshold starts an Avalonia drag carrying a marker `DataFormat`, payload held in-process. `OnTreeDragOver`/`OnTreeDrop` branch on that marker so the external `.png` path is untouched; the drop line is drawn in the overlay canvas.

Locked product decisions from the issue are implemented as specified, including the squash example (`1,2,3,4,5,6` select `2,4,5` → drop after `6` → `1,3,6,2,4,5`; drop between `2` and `3` rejected).

## Tests
- `FrameDropResolverTests`, `MoveFramesCommandTests` (gap-squash, span-guard, cross-chain undo, no-op guard).
- `FrameDragReorderHeadlessTests` (tree children reorder + relabel through the real window; multi-select one-undo).
- Existing `TreePngDropTargetTests` / `TextureDropProcessorTests` pass unchanged → PNG-drop regression covered.
- Full suite green: Core 1348, App 524.

**TDD residue (rule b):** the pointer-driven `DoDragDropAsync` gesture and the drop-line adorner geometry are thin Avalonia wiring that can't be exercised headlessly (`DragEventArgs`/`DataTransfer` aren't synthesizable in tests). The testable core — drop resolution, the move command, and the post-move tree refresh — is covered; the gesture/geometry residue is left for manual verification.

## Out of scope (per the issue)
- Animation-chain DnD reorder; shape DnD (fixed order for FRB1 compat); multi-select frames spanning multiple source chains in one drag (deferred follow-up, toasts today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)