### PR TITLE
Fix flanker value field overflowing onto −/+ buttons (#501)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -623,9 +623,12 @@
                                 <Button x:Name="GridSizePlusBtn" DockPanel.Dock="Right"
                                         Classes="flanker" Content="+" Width="22"
                                         BorderBrush="{DynamicResource LineBrush}" BorderThickness="1,0,0,0" />
+                                <!-- MinWidth/MinHeight 0 (#501): keep the field from overflowing its
+                                     center slot over the −/+ buttons; Fluent forces a min ~64×32. -->
                                 <TextBox x:Name="GridSizeInput" Text="16"
                                          HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                                          Background="Transparent" BorderThickness="0" Padding="4,0" FontSize="11"
+                                         MinWidth="0" MinHeight="0"
                                          Height="26" VerticalAlignment="Center"
                                          KeyDown="OnGridSizeInputKeyDown" />
                             </DockPanel>
@@ -659,6 +662,10 @@
                                             <Setter Property="TextAlignment" Value="Center"/>
                                             <Setter Property="VerticalContentAlignment" Value="Center"/>
                                             <Setter Property="Padding" Value="4,0"/>
+                                            <!-- MinWidth/MinHeight 0 (#501): keep the field within its
+                                                 center slot so its focus highlight cannot overflow the
+                                                 −/+ buttons; Fluent forces a min ~64×32. -->
+                                            <Setter Property="MinWidth" Value="0"/>
                                             <Setter Property="MinHeight" Value="0"/>
                                             <Setter Property="FontSize" Value="11"/>
                                         </Style>
@@ -840,9 +847,14 @@
                                         <Button x:Name="SpeedUpBtn" DockPanel.Dock="Right"
                                                 Classes="flanker" Content="+" Width="22"
                                                 BorderBrush="{DynamicResource LineBrush}" BorderThickness="1,0,0,0" />
+                                        <!-- MinWidth/MinHeight 0 (#501): Fluent forces a TextBox min size
+                                             (~64×32); in this fixed-width pill the center slot is narrower,
+                                             so without this the textbox overflows centered and its focus
+                                             highlight bleeds over the −/+ buttons. -->
                                         <TextBox x:Name="SpeedInput" Text="1.0"
                                                  HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                                                  Background="Transparent" BorderThickness="0" Padding="4,0" FontSize="11"
+                                                 MinWidth="0" MinHeight="0"
                                                  Height="26" VerticalAlignment="Center" />
                                     </DockPanel>
                                 </Border>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Flanker fields (a value <c>TextBox</c>/<c>AutoCompleteBox</c> flanked by −/+ buttons inside one
+/// bordered pill) must keep the value field confined to the center column (#501). Fluent's base
+/// TextBox style forces a <c>MinWidth</c>/<c>MinHeight</c> (~64×32). When the pill's fixed width
+/// makes the center slot narrower than that minimum, Avalonia arranges the oversized textbox
+/// centered in the slot, overflowing horizontally over the −/+ buttons — invisible until focus turns
+/// the textbox background/border opaque, at which point the focus highlight bleeds over the buttons.
+/// Each field sets MinWidth/MinHeight 0 so it shrinks to its slot. These tests assert the value field
+/// never horizontally overlaps either flanker button.
+/// </summary>
+public class FlankerFieldLayoutTests
+{
+    [AvaloniaTheory]
+    [InlineData("GridSizeInput", "GridSizeMinusBtn", "GridSizePlusBtn")]
+    [InlineData("SpeedInput", "SpeedDownBtn", "SpeedUpBtn")]
+    [InlineData("ZoomCombo", "ZoomMinusBtn", "ZoomPlusBtn")]
+    [InlineData("PreviewZoomCombo", "PreviewZoomMinusBtn", "PreviewZoomPlusBtn")]
+    public void FlankerField_StaysBetweenButtons(string fieldName, string minusName, string plusName)
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Width = 1400;
+        window.Height = 900;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            var field = window.FindControl<Control>(fieldName)
+                ?? throw new InvalidOperationException($"{fieldName} not found");
+            var minus = window.FindControl<Button>(minusName)
+                ?? throw new InvalidOperationException($"{minusName} not found");
+            var plus = window.FindControl<Button>(plusName)
+                ?? throw new InvalidOperationException($"{plusName} not found");
+
+            // The value field is either a TextBox directly (SpeedInput, GridSizeInput) or the inner
+            // TextBox of an AutoCompleteBox (ZoomCombo, PreviewZoomCombo). The inner TextBox is what
+            // carries the focus background/border, so measure its edges — not the outer control's.
+            var textBox = field as TextBox
+                ?? field.GetVisualDescendants().OfType<TextBox>().FirstOrDefault()
+                ?? throw new InvalidOperationException($"{fieldName} has no TextBox");
+
+            // Project everything into the shared DockPanel space so the edges are comparable.
+            var dock = (Control?)minus.Parent
+                ?? throw new InvalidOperationException("flanker button has no parent");
+            double fieldLeft = textBox.TranslatePoint(new Point(0, 0), dock)!.Value.X;
+            double fieldRight = textBox.TranslatePoint(new Point(textBox.Bounds.Width, 0), dock)!.Value.X;
+
+            const double eps = 0.5;
+            Assert.True(fieldLeft >= minus.Bounds.Right - eps,
+                $"{fieldName}: field left {fieldLeft} overlaps − button (right edge {minus.Bounds.Right})");
+            Assert.True(fieldRight <= plus.Bounds.Left + eps,
+                $"{fieldName}: field right {fieldRight} overlaps + button (left edge {plus.Bounds.Left})");
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
## Problem

In the flanker controls (a value `TextBox`/`AutoCompleteBox` flanked by `−`/`+` buttons inside one bordered pill), the focused **SpeedInput** field's background and red focus highlight bled horizontally over the adjacent `−` and `+` buttons.

## Root cause

Fluent's base `TextBox` style forces a `MinWidth`/`MinHeight` (~64×32) onto the control. When a pill's fixed width makes the center slot narrower than that minimum (SpeedInput: 92px pill → 46px slot < 64px min), Avalonia arranges the oversized textbox **centered** in the slot, overflowing ~9px over each button. The overflow is invisible until focus, when Fluent makes the textbox background/border opaque (red accent) — at which point it visibly covers the buttons.

GridSize/Zoom pills happen to be wide enough to avoid the overflow today, but share the same latent fragility.

## Fix

Set `MinWidth="0" MinHeight="0"` on each flanker value field so it shrinks to its slot instead of forcing a larger size. Applied to `SpeedInput`, `GridSizeInput`, and the inner-`TextBox` styles of `ZoomCombo` / `PreviewZoomCombo`.

## Test

Adds a headless (`[AvaloniaTheory]`) layout regression test asserting each of the four flanker fields stays between its two buttons (no horizontal overlap). Confirmed it fails before the fix (SpeedInput: field left 13 overlaps − button right edge 22) and passes after. Full App suite: 526/526 green.

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)