### PR TITLE
Enlarge inline Add-Frame button to 22px pointer target

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -468,11 +468,13 @@
                                            TextAlignment="Right"
                                            VerticalAlignment="Center"
                                            IsVisible="{Binding Meta, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                                <!-- Inline "Add Frame" button — only visible on chain nodes; shown on hover -->
+                                <!-- Inline "Add Frame" button — only visible on chain nodes; shown on hover.
+                                     22px pointer target (Fitts's Law); zero vertical margin keeps it under the
+                                     32px Fluent row height (TreeViewItemMinHeight) so the row never grows. -->
                                 <Button Grid.Column="2"
                                         Classes="add-frame-btn plus"
                                         IsVisible="{Binding IsChainNode}"
-                                        Width="18" Height="18"
+                                        Width="22" Height="22"
                                         Padding="0"
                                         Margin="4,0,4,0"
                                         HorizontalContentAlignment="Center"


### PR DESCRIPTION
## Summary

The inline "Add Frame" button on chain rows in the ANIMATIONS TreeView (`MainWindow.axaml`) was 18x18px — a small pointer target that's slower to acquire (Fitts's Law). Bumped to **22x22px**.

- **Hover-only reveal preserved**: `Opacity=0` until row `:pointerover` is untouched — no wall of always-visible buttons.
- **Row height unchanged**: zero vertical margin (`Margin="4,0,4,0"`) keeps the 22px button under the 32px Fluent row height (`TreeViewItemMinHeight`; chain icon is 28px), so rows don't grow.

Closes #518

## No-test justification (test-first policy)

1. **What blocked a test**: pure XAML sizing change — two literal attribute values (`Width`/`Height` 18 -> 22) on a control template. No behavioral logic, state computation, or mapping function to assert; the value only affects rendered layout, which Avalonia measures at runtime with no headless hook exposed here.
2. **Testable core extracted**: none applies — there is no logic to extract.
3. **Untested residue**: the sizing constant and the fact that it stays within the row height. Acceptable because it's a static layout value verified by a successful build and visual inspection; a regression would be an obvious visual change, not a silent logic defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)