### PR TITLE
Give the default-handler banner tier-2 actionable contrast

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
@@ -31,6 +31,9 @@
                     <SolidColorBrush x:Key="AccentSoft"  Color="#f0c674" />
                     <SolidColorBrush x:Key="AccentCool"  Color="#5fb6e8" />
                     <SolidColorBrush x:Key="Ok"          Color="#6dd28d" />
+                    <!-- Subtle cool-tinted fill for tier-2 "actionable info" banners:
+                         distinct from passive BgRail chrome, without the loud Accent red. -->
+                    <SolidColorBrush x:Key="InfoBannerBg" Color="#202d38" />
 
                     <!-- SVG icon CurrentColor tokens (Color, not Brush). -->
                     <Color x:Key="IconInk">#e6e8ec</Color>
@@ -65,6 +68,9 @@
                     <SolidColorBrush x:Key="AccentSoft"  Color="#b8860b" />
                     <SolidColorBrush x:Key="AccentCool"  Color="#2b7fc0" />
                     <SolidColorBrush x:Key="Ok"          Color="#2f9e54" />
+                    <!-- Subtle cool-tinted fill for tier-2 "actionable info" banners:
+                         distinct from passive BgRail chrome, without the loud Accent red. -->
+                    <SolidColorBrush x:Key="InfoBannerBg" Color="#dae5ee" />
 
                     <Color x:Key="IconInk">#2a2e35</Color>
                     <Color x:Key="IconInkMuted">#5a626e</Color>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -187,34 +187,53 @@
         </Border>
 
         <!-- ── Default-handler prompt: offers to register the editor for .achx files.
-             Shown on startup only when not already the default and not dismissed. ── -->
+             Shown on startup only when not already the default and not dismissed.
+             Tier-2 "actionable info" styling — cool-tinted background, a left accent
+             stripe, and a leading info icon — so it reads as a prompt the user can act
+             on, distinct from passive chrome (title bar) and from the loud red error
+             banner below. ── -->
         <Border x:Name="DefaultHandlerBanner"
                 DockPanel.Dock="Top"
                 IsVisible="False"
-                Background="{DynamicResource BgRail}"
+                Background="{DynamicResource InfoBannerBg}"
                 BorderBrush="{DynamicResource LineBrush}"
-                BorderThickness="0,0,0,1"
-                Padding="12,6">
+                BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel DockPanel.Dock="Right"
-                            Orientation="Horizontal"
-                            Spacing="8"
-                            VerticalAlignment="Center">
-                    <Button x:Name="MakeDefaultBtn"
-                            Content="Make default"
-                            Padding="10,3"
-                            FontSize="12" />
-                    <Button x:Name="DismissDefaultHandlerBtn"
-                            Content="Don't show again"
-                            Padding="10,3"
-                            FontSize="12"
-                            Background="Transparent"
-                            Foreground="{DynamicResource InkMid}" />
-                </StackPanel>
-                <TextBlock Text="Make the Animation Editor the default app for .achx files?"
-                           VerticalAlignment="Center"
-                           FontSize="12"
-                           Foreground="{DynamicResource Ink}" />
+                <!-- Accent stripe: signals "actionable" without borrowing the error red. -->
+                <Border DockPanel.Dock="Left"
+                        Width="3"
+                        Background="{DynamicResource AccentCool}" />
+                <DockPanel Margin="12,6">
+                    <StackPanel DockPanel.Dock="Right"
+                                Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                        <Button x:Name="MakeDefaultBtn"
+                                Content="Make default"
+                                Padding="10,3"
+                                FontSize="12" />
+                        <Button x:Name="DismissDefaultHandlerBtn"
+                                Content="Don't show again"
+                                Padding="10,3"
+                                FontSize="12"
+                                Background="Transparent"
+                                Foreground="{DynamicResource InkMid}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                        <Path Width="16"
+                              Height="16"
+                              VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource AccentCool}"
+                              Data="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+                        <TextBlock Text="Make the Animation Editor the default app for .achx files?"
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource Ink}" />
+                    </StackPanel>
+                </DockPanel>
             </DockPanel>
         </Border>
 


### PR DESCRIPTION
## What

The "Make the Animation Editor the default app for .achx files?" prompt (`DefaultHandlerBanner`, `MainWindow.axaml`) was styled with `BgRail` + a thin `LineBrush` border — identical to the passive title bar / chrome — so it read as inert furniture (banner blindness) despite being an actionable prompt.

This restyles it to the intended **tier-2 "actionable info"** look, distinct from both passive chrome (tier 1, title bar) and the loud red `ErrorBanner` (tier 3 — left untouched):

- Background now uses a new theme-aware **`InfoBannerBg`** brush (subtle cool tint: `#202d38` dark, `#dae5ee` light) instead of `BgRail`.
- Added a **3px left accent stripe** using the existing `AccentCool` brush.
- Added a **leading info icon** (MDI "information" `Path`) filled with `AccentCool`.
- Kept the **Make default** / **Don't show again** buttons unchanged.

All colors reference `DynamicResource` theme brushes, so the banner follows the active light/dark theme.

## Theme reasoning (both variants)

`AccentCool` is the cool-blue accent (`#5fb6e8` dark / `#2b7fc0` light) — the natural "info" hue, clearly separate from the red `Accent` used by the error banner. The new `InfoBannerBg` blends `AccentCool` lightly into the `BgRail` value on each ramp:
- **Dark** `#202d38`: slightly lighter and cooler than `BgRail` `#1f232a` — lifts off the chrome without glowing.
- **Light** `#dae5ee`: a soft blue tint below `BgRail` `#eef0f3` — reads as a distinct info surface against the light app background.

Both keep the existing bottom `LineBrush` separator and dark/light-appropriate `Ink` text, so contrast stays comfortable in either theme.

## Test policy (b) — no test written

1. **What blocked a test:** pure XAML styling change (brush references, a `Path` geometry, layout). No behavioral logic to assert against; the visible result is rendered pixels the headless test project cannot observe.
2. **Testable core extracted:** none applies — there is no pure mapping or state computation to lift out; every changed value is a static style token.
3. **Untested residue:** the styling itself. Acceptable because it carries no logic; correctness was verified by a successful build and by reasoning about the chosen theme brushes for both light and dark variants.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)