### PR TITLE
Animation Editor: working search/filter for the ANIMATIONS tree

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -309,12 +309,13 @@
                                             Width="20" Height="20"
                                             Padding="0"
                                             Margin="0,0,2,0"
+                                            Focusable="False"
                                             Background="Transparent"
                                             BorderThickness="0"
                                             Foreground="{DynamicResource InkMid}"
                                             HorizontalContentAlignment="Center"
                                             VerticalContentAlignment="Center"
-                                            ToolTip.Tip="Clear filter">
+                                            ToolTip.Tip="Clear filter (empties, then closes)">
                                         <TextBlock Text="&#x2715;" FontSize="10" />
                                     </Button>
                                 </TextBox.InnerRightContent>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -293,8 +293,18 @@
                     <DockPanel Margin="10,0">
                         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2"
                                     VerticalAlignment="Center">
-                            <!-- Search icon button (placeholder — no handler yet) -->
-                            <Button Width="24" Height="24"
+                            <!-- Inline search box: hidden until the search icon is clicked. -->
+                            <TextBox x:Name="SearchBox"
+                                     Width="140" Height="24"
+                                     Padding="6,2"
+                                     FontSize="11"
+                                     VerticalAlignment="Center"
+                                     VerticalContentAlignment="Center"
+                                     IsVisible="False"
+                                     PlaceholderText="Filter animations…" />
+                            <!-- Search icon button: toggles the inline search box. -->
+                            <Button x:Name="SearchToggleBtn"
+                                    Width="24" Height="24"
                                     Padding="0"
                                     Background="Transparent"
                                     BorderThickness="0"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -293,7 +293,9 @@
                     <DockPanel Margin="10,0">
                         <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2"
                                     VerticalAlignment="Center">
-                            <!-- Inline search box: hidden until the search icon is clicked. -->
+                            <!-- Inline search box: hidden until the search icon is clicked.
+                                 The trailing ✕ button is a discoverable way to clear the sticky
+                                 filter (Escape / toggling the icon also clear it). -->
                             <TextBox x:Name="SearchBox"
                                      Width="140" Height="24"
                                      Padding="6,2"
@@ -301,7 +303,22 @@
                                      VerticalAlignment="Center"
                                      VerticalContentAlignment="Center"
                                      IsVisible="False"
-                                     PlaceholderText="Filter animations…" />
+                                     PlaceholderText="Filter animations…">
+                                <TextBox.InnerRightContent>
+                                    <Button x:Name="SearchClearBtn"
+                                            Width="20" Height="20"
+                                            Padding="0"
+                                            Margin="0,0,2,0"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Foreground="{DynamicResource InkMid}"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center"
+                                            ToolTip.Tip="Clear filter">
+                                        <TextBlock Text="&#x2715;" FontSize="10" />
+                                    </Button>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
                             <!-- Search icon button: toggles the inline search box. -->
                             <Button x:Name="SearchToggleBtn"
                                     Width="24" Height="24"
@@ -352,6 +369,17 @@
                         <Style Selector="TreeViewItem">
                             <Setter Property="IsExpanded"
                                     Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
+                            <!-- Search filter: hide rows the filter excludes, but always keep the
+                                 selected row visible (safety net for off-filter programmatic selection). -->
+                            <Setter Property="IsVisible">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{x:Static BoolConverters.Or}">
+                                        <ReflectionBinding Path="PinnedVisible" />
+                                        <ReflectionBinding Path="IsSelected"
+                                                           RelativeSource="{RelativeSource Self}" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
                         </Style>
                         <!-- Expand chevron hit area to a full-height square; icon stays 12×12 centered. -->
                         <Style Selector="TreeViewItem /template/ Panel#PART_ExpandCollapseChevronContainer">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1881,14 +1881,19 @@ public partial class MainWindow : Window
             ApplyQueryFilter();
         };
 
-        // ✕ clears the filter but leaves the box open (discoverable exit affordance).
+        // Two-stage ✕: with text, clear it (box stays open); when already empty, collapse.
         SearchClearBtn.Click += (_, _) =>
         {
-            SearchBox.Text = string.Empty; // fires TextChanged → ApplyQueryFilter restores all
-            SearchBox.Focus();
+            if (TreeSearchBoxLogic.ClearShouldCollapse(SearchBox.Text))
+                CollapseSearchBox();
+            else
+            {
+                SearchBox.Text = string.Empty; // fires TextChanged → ApplyQueryFilter restores all
+                SearchBox.Focus();
+            }
         };
 
-        // Escape clears the filter and collapses the box; handled tunnel-phase so it
+        // Escape collapses the box (and clears the filter); handled tunnel-phase so it
         // doesn't reach the TreeView (which would otherwise steal the key).
         SearchBox.AddHandler(
             InputElement.KeyDownEvent,
@@ -1901,6 +1906,12 @@ public partial class MainWindow : Window
                 }
             },
             RoutingStrategies.Tunnel);
+
+        // Click-away collapses the box — EXCEPT when focus moves into the tree, so the
+        // sticky-filter workflow (filter, click a result, edit, click another) keeps the
+        // box and filter alive. Deferred to Background so the new focus target has settled.
+        SearchBox.LostFocus += (_, _) =>
+            Dispatcher.UIThread.Post(CollapseSearchBoxOnClickAway, DispatcherPriority.Background);
     }
 
     // Query-change path: the only place allowed to HIDE a chain (typing/refining shrinks
@@ -1911,21 +1922,39 @@ public partial class MainWindow : Window
 
     private void ToggleSearchBox()
     {
-        if (SearchBox.IsVisible)
-            CollapseSearchBox();
-        else
-        {
-            SearchBox.IsVisible = true;
-            Dispatcher.UIThread.Post(() => SearchBox.Focus(), DispatcherPriority.Background);
-        }
+        if (SearchBox.IsVisible) CollapseSearchBox();
+        else ExpandSearchBox();
     }
 
-    // Hides the box and clears the query, restoring the full tree. Clearing the text
-    // fires TextChanged, which rebuilds the tree unfiltered.
+    // Pattern B: the box replaces the 🔍 icon (they are never both visible) and takes focus.
+    private void ExpandSearchBox()
+    {
+        SearchToggleBtn.IsVisible = false;
+        SearchBox.IsVisible = true;
+        Dispatcher.UIThread.Post(() => SearchBox.Focus(), DispatcherPriority.Background);
+    }
+
+    // Hides the box, restores the 🔍 icon, and clears the query (restoring the full tree).
+    // Clearing the text fires TextChanged, which re-applies the empty filter.
     private void CollapseSearchBox()
     {
         SearchBox.IsVisible = false;
+        SearchToggleBtn.IsVisible = true;
         SearchBox.Text = string.Empty;
+    }
+
+    // Collapses the box when focus has left both the box and the tree. Keeping the box open
+    // while focus is in the tree is what preserves the sticky click-a-result workflow.
+    private void CollapseSearchBoxOnClickAway()
+    {
+        if (!SearchBox.IsVisible) return;
+        var focused = FocusManager?.GetFocusedElement() as Avalonia.Visual;
+        bool focusInBox  = focused is not null &&
+            (ReferenceEquals(focused, SearchBox) || focused.GetVisualAncestors().Contains(SearchBox));
+        bool focusInTree = focused is not null &&
+            (ReferenceEquals(focused, AnimTree) || focused.GetVisualAncestors().Contains(AnimTree));
+        if (!focusInBox && !focusInTree)
+            CollapseSearchBox();
     }
 
     private void AddAnimationChainAndBeginInlineRename()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1834,6 +1834,9 @@ public partial class MainWindow : Window
         ExpandAllBtn.Click  += (_, _) => SetAllExpanded(true);
         CollapseAllBtn.Click += (_, _) => SetAllExpanded(false);
 
+        // Search box: icon toggles the inline box; typing filters the tree by chain name.
+        WireTreeSearch();
+
         // Blank-space double-tap: expand / collapse the node
         AnimTree.DoubleTapped += OnAnimTreeDoubleTapped;
 
@@ -1859,6 +1862,54 @@ public partial class MainWindow : Window
     {
         foreach (var node in _treeRoots)
             TreeNodeVm.SetExpandedRecursive(node, expanded);
+    }
+
+    // Current ANIMATIONS tree filter text. Empty/whitespace = no filter (full tree).
+    // RebuildTreeView honours this so only matching chain nodes are shown.
+    private string _treeFilterQuery = string.Empty;
+
+    private void WireTreeSearch()
+    {
+        SearchToggleBtn.Click += (_, _) => ToggleSearchBox();
+
+        SearchBox.TextChanged += (_, _) =>
+        {
+            _treeFilterQuery = SearchBox.Text ?? string.Empty;
+            RebuildTreeView();
+        };
+
+        // Escape clears the filter and collapses the box; handled tunnel-phase so it
+        // doesn't reach the TreeView (which would otherwise steal the key).
+        SearchBox.AddHandler(
+            InputElement.KeyDownEvent,
+            (object? _, KeyEventArgs e) =>
+            {
+                if (e.Key == Key.Escape)
+                {
+                    CollapseSearchBox();
+                    e.Handled = true;
+                }
+            },
+            RoutingStrategies.Tunnel);
+    }
+
+    private void ToggleSearchBox()
+    {
+        if (SearchBox.IsVisible)
+            CollapseSearchBox();
+        else
+        {
+            SearchBox.IsVisible = true;
+            Dispatcher.UIThread.Post(() => SearchBox.Focus(), DispatcherPriority.Background);
+        }
+    }
+
+    // Hides the box and clears the query, restoring the full tree. Clearing the text
+    // fires TextChanged, which rebuilds the tree unfiltered.
+    private void CollapseSearchBox()
+    {
+        SearchBox.IsVisible = false;
+        SearchBox.Text = string.Empty;
     }
 
     private void AddAnimationChainAndBeginInlineRename()
@@ -2452,9 +2503,11 @@ public partial class MainWindow : Window
             }
 
             // Empty expandedChainNames (not null) collapses every chain; null would
-            // default them all to expanded.
+            // default them all to expanded. When a search filter is active, only chain
+            // nodes whose name matches the query are added (children stay intact).
             foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
-                _treeRoots.Add(node);
+                if (TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery))
+                    _treeRoots.Add(node);
             RefreshFilesPanel();
 
             RefreshTreeThumbnails();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1903,15 +1903,11 @@ public partial class MainWindow : Window
             RoutingStrategies.Tunnel);
     }
 
-    // Query-change path: hard-set each chain row's visibility to whether it matches the
-    // query. This is the only place allowed to HIDE a chain (typing/refining shrinks the
-    // set); an empty query shows all. The selected row stays visible via its IsVisible binding.
-    private void ApplyQueryFilter()
-    {
-        foreach (var node in _treeRoots)
-            if (node.Data is AnimationChainSave)
-                node.PinnedVisible = TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery);
-    }
+    // Query-change path: the only place allowed to HIDE a chain (typing/refining shrinks
+    // the set); an empty query shows all. The selected row stays visible via its IsVisible
+    // binding. Logic lives in the pure, unit-tested TreeBuilder.ApplyQueryFilter.
+    private void ApplyQueryFilter() =>
+        TreeBuilder.ApplyQueryFilter(_treeRoots, _treeFilterQuery);
 
     private void ToggleSearchBox()
     {
@@ -2489,6 +2485,10 @@ public partial class MainWindow : Window
             // Capture filter state BEFORE the diff mutates the tree: which chains are
             // currently visible, and which existing chains have nodes. Used for the
             // grow-only visibility recompute below.
+            // NOTE: this reads PinnedVisible only — a chain visible *solely* via the
+            // IsSelected half of the row's `PinnedVisible || IsSelected` binding is not
+            // captured here. That's benign: SyncTreeSelection re-applies the selection
+            // after the diff, so the selected row is re-shown regardless of PinnedVisible.
             var chains = acls.AnimationChains;
             var previouslyVisible = _treeRoots
                 .Where(n => n.Data is AnimationChainSave && n.PinnedVisible)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1865,17 +1865,27 @@ public partial class MainWindow : Window
     }
 
     // Current ANIMATIONS tree filter text. Empty/whitespace = no filter (full tree).
-    // RebuildTreeView honours this so only matching chain nodes are shown.
+    // The filter is *sticky*: it survives selection and model edits. Two triggers apply
+    // it differently — ApplyQueryFilter (typing) may hide rows; the model-change paths
+    // (RefreshTreeView/RefreshChainNode) are grow-only and never hide a visible row.
     private string _treeFilterQuery = string.Empty;
 
     private void WireTreeSearch()
     {
         SearchToggleBtn.Click += (_, _) => ToggleSearchBox();
 
+        // Typing recomputes visibility from scratch — this is the only path allowed to hide.
         SearchBox.TextChanged += (_, _) =>
         {
             _treeFilterQuery = SearchBox.Text ?? string.Empty;
-            RebuildTreeView();
+            ApplyQueryFilter();
+        };
+
+        // ✕ clears the filter but leaves the box open (discoverable exit affordance).
+        SearchClearBtn.Click += (_, _) =>
+        {
+            SearchBox.Text = string.Empty; // fires TextChanged → ApplyQueryFilter restores all
+            SearchBox.Focus();
         };
 
         // Escape clears the filter and collapses the box; handled tunnel-phase so it
@@ -1891,6 +1901,16 @@ public partial class MainWindow : Window
                 }
             },
             RoutingStrategies.Tunnel);
+    }
+
+    // Query-change path: hard-set each chain row's visibility to whether it matches the
+    // query. This is the only place allowed to HIDE a chain (typing/refining shrinks the
+    // set); an empty query shows all. The selected row stays visible via its IsVisible binding.
+    private void ApplyQueryFilter()
+    {
+        foreach (var node in _treeRoots)
+            if (node.Data is AnimationChainSave)
+                node.PinnedVisible = TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery);
     }
 
     private void ToggleSearchBox()
@@ -2466,10 +2486,31 @@ public partial class MainWindow : Window
             var acls = _projectManager.AnimationChainListSave;
             if (acls is null) { _treeRoots.Clear(); RefreshFilesPanel(); return; }
 
+            // Capture filter state BEFORE the diff mutates the tree: which chains are
+            // currently visible, and which existing chains have nodes. Used for the
+            // grow-only visibility recompute below.
+            var chains = acls.AnimationChains;
+            var previouslyVisible = _treeRoots
+                .Where(n => n.Data is AnimationChainSave && n.PinnedVisible)
+                .Select(n => (AnimationChainSave)n.Data!)
+                .ToList();
+            var existingChains = new HashSet<AnimationChainSave>(
+                _treeRoots.Where(n => n.Data is AnimationChainSave).Select(n => (AnimationChainSave)n.Data!),
+                ReferenceEqualityComparer.Instance);
+            var brandNew = chains.Where(c => !existingChains.Contains(c)).ToList();
+
             // Diff-update the root nodes instead of clearing and rebuilding, so each
             // chain's collapse state (and selection) survives copy/paste and reorder.
-            TreeBuilder.SyncChainsInto(_treeRoots, acls.AnimationChains);
+            TreeBuilder.SyncChainsInto(_treeRoots, chains);
             ApplyPendingPastedChainExpand();
+
+            // Grow-only: never hide a chain that was visible; add newly-relevant ones.
+            var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+                previouslyVisible, chains, _treeFilterQuery, brandNew);
+            foreach (var node in _treeRoots)
+                if (node.Data is AnimationChainSave c)
+                    node.PinnedVisible = visible.Contains(c);
+
             RefreshTreeThumbnails();
 
             // Re-select to keep visual state
@@ -2503,11 +2544,14 @@ public partial class MainWindow : Window
             }
 
             // Empty expandedChainNames (not null) collapses every chain; null would
-            // default them all to expanded. When a search filter is active, only chain
-            // nodes whose name matches the query are added (children stay intact).
+            // default them all to expanded. All nodes are added (membership always
+            // mirrors the model); an active filter is applied as per-node visibility so
+            // it persists across a full rebuild without dropping nodes from the tree.
             foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
-                if (TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery))
-                    _treeRoots.Add(node);
+            {
+                node.PinnedVisible = TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery);
+                _treeRoots.Add(node);
+            }
             RefreshFilesPanel();
 
             RefreshTreeThumbnails();
@@ -2527,6 +2571,7 @@ public partial class MainWindow : Window
             var node = FindChainNode(chain);
             if (node is null)
             {
+                // Brand-new node defaults to visible (never hide something just created).
                 _treeRoots.Add(TreeBuilder.BuildChainNode(chain));
             }
             else
@@ -2534,6 +2579,9 @@ public partial class MainWindow : Window
                 node.Header = chain.Name;
                 node.Meta   = $"{chain.Frames.Count} fr";
                 TreeBuilder.SyncFramesInto(node, chain.Frames);
+                // Grow-only: keep it visible if it already was, or if it now matches.
+                node.PinnedVisible = node.PinnedVisible
+                    || TreeBuilder.MatchesFilter(chain.Name, _treeFilterQuery);
             }
             RefreshTreeThumbnails();
             SyncTreeSelection();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -397,13 +397,23 @@ public static class TreeBuilder
     }
 
     /// <summary>
-    /// Returns the subset of <paramref name="chainNames"/> that match
-    /// <paramref name="query"/> under <see cref="MatchesFilter"/>, preserving input
-    /// order. An empty/whitespace query returns every name; a query matching nothing
-    /// returns an empty list. This is the query-change path: it may shrink the set.
+    /// Query-change path: sets each chain (root) node's
+    /// <see cref="TreeNodeVm.PinnedVisible"/> to whether its header matches
+    /// <paramref name="query"/> under <see cref="MatchesFilter"/>. This is the <b>only</b>
+    /// filter path allowed to hide a row — typing/refining the query shrinks the visible
+    /// set; an empty/whitespace query shows every chain. Non-chain nodes (frames, shapes)
+    /// are left untouched: they are hidden only when their parent chain is.
+    /// <para>
+    /// Contrast with <see cref="ComputeVisibleAfterModelChange"/>, the grow-only path used
+    /// when the model mutates but the query is unchanged.
+    /// </para>
     /// </summary>
-    public static List<string> FilterChainNames(IEnumerable<string> chainNames, string? query) =>
-        chainNames.Where(n => MatchesFilter(n, query)).ToList();
+    public static void ApplyQueryFilter(IEnumerable<TreeNodeVm> roots, string? query)
+    {
+        foreach (var node in roots)
+            if (node.Data is AnimationChainSave)
+                node.PinnedVisible = MatchesFilter(node.Header, query);
+    }
 
     /// <summary>
     /// Computes which chains should be visible after a <b>model mutation</b> while the

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -382,6 +382,29 @@ public static class TreeBuilder
         return null;
     }
 
+    // ── Search / filter ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Case-insensitive substring match of a single chain name against a search
+    /// <paramref name="query"/>. A <c>null</c>, empty, or whitespace-only query
+    /// matches every name (no filter active). Leading/trailing whitespace in the
+    /// query is ignored.
+    /// </summary>
+    public static bool MatchesFilter(string chainName, string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return true;
+        return chainName.Contains(query.Trim(), System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the subset of <paramref name="chainNames"/> that match
+    /// <paramref name="query"/> under <see cref="MatchesFilter"/>, preserving input
+    /// order. An empty/whitespace query returns every name; a query matching nothing
+    /// returns an empty list.
+    /// </summary>
+    public static List<string> FilterChainNames(IEnumerable<string> chainNames, string? query) =>
+        chainNames.Where(n => MatchesFilter(n, query)).ToList();
+
     // ── Node search ───────────────────────────────────────────────────────────
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -400,10 +400,41 @@ public static class TreeBuilder
     /// Returns the subset of <paramref name="chainNames"/> that match
     /// <paramref name="query"/> under <see cref="MatchesFilter"/>, preserving input
     /// order. An empty/whitespace query returns every name; a query matching nothing
-    /// returns an empty list.
+    /// returns an empty list. This is the query-change path: it may shrink the set.
     /// </summary>
     public static List<string> FilterChainNames(IEnumerable<string> chainNames, string? query) =>
         chainNames.Where(n => MatchesFilter(n, query)).ToList();
+
+    /// <summary>
+    /// Computes which chains should be visible after a <b>model mutation</b> while the
+    /// search <paramref name="query"/> is unchanged (rename, add, delete, undo/redo,
+    /// hot-reload). This is <b>grow-only</b>: it never hides a chain that was already
+    /// visible, so the chain the user is editing can't vanish out from under them.
+    /// A chain is visible when it was <paramref name="previouslyVisible"/>, is
+    /// <paramref name="brandNew"/> to the tree (just created or undo-restored), or its
+    /// current name matches <paramref name="query"/> (newly relevant, or no filter).
+    /// <para>
+    /// Identity is by reference — a renamed chain keeps the same object, so it stays
+    /// visible via <paramref name="previouslyVisible"/> even though its name changed.
+    /// The <b>selected</b> chain is intentionally not handled here (folding it in would
+    /// permanently pin every chain the user ever clicked); selection is kept visible
+    /// reactively at the view layer via a <c>PinnedVisible || IsSelected</c> binding.
+    /// </para>
+    /// </summary>
+    public static HashSet<AnimationChainSave> ComputeVisibleAfterModelChange(
+        IEnumerable<AnimationChainSave> previouslyVisible,
+        IReadOnlyList<AnimationChainSave> currentChains,
+        string? query,
+        IEnumerable<AnimationChainSave> brandNew)
+    {
+        var prev = new HashSet<AnimationChainSave>(previouslyVisible, ReferenceEqualityComparer.Instance);
+        var brand = new HashSet<AnimationChainSave>(brandNew, ReferenceEqualityComparer.Instance);
+        var result = new HashSet<AnimationChainSave>(ReferenceEqualityComparer.Instance);
+        foreach (var chain in currentChains)
+            if (prev.Contains(chain) || brand.Contains(chain) || MatchesFilter(chain.Name, query))
+                result.Add(chain);
+        return result;
+    }
 
     // ── Node search ───────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeNodeVm.cs
@@ -89,6 +89,20 @@ public class TreeNodeVm : INotifyPropertyChanged
     /// <summary>True when this node represents a CircleSave shape. Set once at construction time.</summary>
     public bool IsCircleNode { get; set; }
 
+    private bool _pinnedVisible = true;
+    /// <summary>
+    /// Whether this row is shown by the ANIMATIONS search filter. Defaults to
+    /// <c>true</c> (no filter). Only chain (root) nodes are toggled — frame/shape
+    /// nodes stay <c>true</c> and are hidden only when their parent chain is.
+    /// The tree row binds <c>IsVisible</c> to <c>PinnedVisible || IsSelected</c>, so
+    /// the currently-selected chain stays visible even when filtered out.
+    /// </summary>
+    public bool PinnedVisible
+    {
+        get => _pinnedVisible;
+        set { if (_pinnedVisible != value) { _pinnedVisible = value; Notify(); } }
+    }
+
     private bool _isPendingCut;
     /// <summary>True while this item is part of a pending cut (Ctrl+X, not yet pasted).</summary>
     public bool IsPendingCut

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeSearchBoxLogic.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeSearchBoxLogic.cs
@@ -1,0 +1,15 @@
+namespace AnimationEditor.Core.ViewModels;
+
+/// <summary>
+/// Pure decision logic for the ANIMATIONS search box's two-stage clear (✕) button.
+/// </summary>
+public static class TreeSearchBoxLogic
+{
+    /// <summary>
+    /// Decides what the in-field ✕ does: when the box already has no text it
+    /// <b>collapses</b> the box (returns <c>true</c>); otherwise it <b>clears</b> the
+    /// text and stays open (returns <c>false</c>). Whitespace counts as text — the user
+    /// can see it, so ✕ clears it first.
+    /// </summary>
+    public static bool ClearShouldCollapse(string? currentText) => string.IsNullOrEmpty(currentText);
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -85,6 +85,22 @@ public class HeadlessTreeViewTests
         method.Invoke(window, null);
     }
 
+    /// <summary>
+    /// Sets the private <c>_treeFilterQuery</c> field and invokes the private
+    /// <c>ApplyQueryFilter</c> method — mirroring exactly what the search box's
+    /// TextChanged handler does on a keystroke.
+    /// </summary>
+    private static void SetFilterAndApply(MainWindow window, string query)
+    {
+        typeof(MainWindow)
+            .GetField("_treeFilterQuery", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(window, query);
+        typeof(MainWindow)
+            .GetMethod("ApplyQueryFilter", BindingFlags.NonPublic | BindingFlags.Instance,
+                       null, Type.EmptyTypes, null)!
+            .Invoke(window, null);
+    }
+
     private static List<string?> ContextMenuHeaders(MainWindow window)
     {
         var tree = GetTree(window);
@@ -970,6 +986,43 @@ public class HeadlessTreeViewTests
             Assert.False(roots[0].IsExpanded);   // pre-existing chain stays collapsed
             Assert.Same(pasted, roots[1].Data);
             Assert.True(roots[1].IsExpanded);    // pasted chain defaults to expanded
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTreeView_GrowOnly_KeepsFilteredChainVisibleAfterRenamedOutOfFilter()
+    {
+        // Issue #517 (sticky filter): RefreshTreeView must capture which chains are visible
+        // BEFORE the diff mutates the tree, then apply grow-only visibility. The chain the
+        // user is editing must not vanish when a model change renames it out of the filter,
+        // and a chain that was never visible must not leak back in.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var walk = new AnimationChainSave { Name = "walkLeft" };
+            var idle = new AnimationChainSave { Name = "Idle" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(walk);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(idle);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            // Filter "walk": walkLeft visible, Idle hidden.
+            SetFilterAndApply(window, "walk");
+            var roots    = GetRoots(GetTree(window));
+            var walkNode = roots.First(n => ReferenceEquals(n.Data, walk));
+            var idleNode = roots.First(n => ReferenceEquals(n.Data, idle));
+            Assert.True(walkNode.PinnedVisible);
+            Assert.False(idleNode.PinnedVisible);
+
+            // Rename the visible chain OUT of the filter, then refresh via the diff path.
+            walk.Name = "sleeping";
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(walkNode.PinnedVisible);  // grow-only kept the edited chain visible
+            Assert.False(idleNode.PinnedVisible); // never-visible chain did not leak in
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
@@ -1,51 +1,92 @@
 using System.Collections.Generic;
+using System.Linq;
 using AnimationEditor.Core.ViewModels;
 using FlatRedBall2.Animation.Content;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
 
-// Pure tests for the ANIMATIONS tree search/filter predicate (issue #517).
+// Pure tests for the ANIMATIONS tree search/filter (issue #517). These exercise the same
+// functions production runs: ApplyQueryFilter on keystroke, ComputeVisibleAfterModelChange
+// on model mutation.
 public class TreeFilterTests
 {
-    private static readonly string[] Chains = { "walkLeft", "slowWalk", "Idle", "RunRight" };
+    private static readonly string[] Names = { "walkLeft", "slowWalk", "Idle", "RunRight" };
 
-    // ── Query-change path (can shrink) — FilterChainNames / MatchesFilter ──────
+    // Builds the root chain nodes exactly as the tree holds them: Header == chain name,
+    // Data == the chain (the guard ApplyQueryFilter keys on).
+    private static List<TreeNodeVm> ChainNodes(params string[] names) =>
+        names.Select(n => new TreeNodeVm
+        {
+            Header = n,
+            Data = new AnimationChainSave { Name = n },
+            IsChainNode = true,
+        }).ToList();
+
+    private static List<string> VisibleNames(IEnumerable<TreeNodeVm> roots) =>
+        roots.Where(n => n.PinnedVisible).Select(n => n.Header).ToList();
+
+    // ── Query-change path (can shrink) — ApplyQueryFilter ─────────────────────
 
     [Fact]
-    public void FilterChainNames_EmptyQuery_ReturnsAll()
+    public void ApplyQueryFilter_CaseInsensitive_MatchesRegardlessOfCase()
     {
-        var result = TreeBuilder.FilterChainNames(Chains, "");
-        Assert.Equal(Chains, result);
+        var roots = ChainNodes(Names);
+        TreeBuilder.ApplyQueryFilter(roots, "WALK");
+        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, VisibleNames(roots));
     }
 
     [Fact]
-    public void FilterChainNames_WhitespaceQuery_ReturnsAll()
+    public void ApplyQueryFilter_EmptyQuery_AllVisible()
     {
-        var result = TreeBuilder.FilterChainNames(Chains, "   ");
-        Assert.Equal(Chains, result);
+        var roots = ChainNodes(Names);
+        TreeBuilder.ApplyQueryFilter(roots, "");
+        Assert.Equal(Names, VisibleNames(roots));
     }
 
     [Fact]
-    public void FilterChainNames_CaseInsensitive_MatchesRegardlessOfCase()
-    {
-        var result = TreeBuilder.FilterChainNames(Chains, "WALK");
-        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, result);
-    }
-
-    [Fact]
-    public void FilterChainNames_MidStringSubstring_Matches()
+    public void ApplyQueryFilter_MidStringSubstring_Matches()
     {
         // "walk" appears mid-string in "slowWalk", not just as a prefix.
-        var result = TreeBuilder.FilterChainNames(Chains, "walk");
-        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, result);
+        var roots = ChainNodes(Names);
+        TreeBuilder.ApplyQueryFilter(roots, "walk");
+        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, VisibleNames(roots));
     }
 
     [Fact]
-    public void FilterChainNames_NoMatch_ReturnsEmpty()
+    public void ApplyQueryFilter_NoMatch_AllHidden()
     {
-        var result = TreeBuilder.FilterChainNames(Chains, "zzz");
-        Assert.Empty(result);
+        var roots = ChainNodes(Names);
+        TreeBuilder.ApplyQueryFilter(roots, "zzz");
+        Assert.Empty(VisibleNames(roots));
+    }
+
+    // The guard: a non-chain node (e.g. a frame) is never toggled by the query filter.
+    [Fact]
+    public void ApplyQueryFilter_NonChainNode_LeftVisible()
+    {
+        var frameNode = new TreeNodeVm { Header = "Frame 1", Data = new AnimationFrameSave(), IsFrameNode = true };
+        var roots = new List<TreeNodeVm> { frameNode };
+
+        TreeBuilder.ApplyQueryFilter(roots, "walk"); // frame header doesn't match
+
+        Assert.True(frameNode.PinnedVisible); // untouched, stays visible
+    }
+
+    [Fact]
+    public void ApplyQueryFilter_SurroundingWhitespace_TrimsAndMatches()
+    {
+        var roots = ChainNodes("walkLeft", "Idle");
+        TreeBuilder.ApplyQueryFilter(roots, "  walk  "); // trimmed to "walk"
+        Assert.Equal(new List<string> { "walkLeft" }, VisibleNames(roots));
+    }
+
+    [Fact]
+    public void ApplyQueryFilter_WhitespaceQuery_AllVisible()
+    {
+        var roots = ChainNodes(Names);
+        TreeBuilder.ApplyQueryFilter(roots, "   ");
+        Assert.Equal(Names, VisibleNames(roots));
     }
 
     // ── Sticky model-change path (grow-only) — ComputeVisibleAfterModelChange ──
@@ -69,6 +110,42 @@ public class TreeFilterTests
             brandNew: new List<AnimationChainSave> { newChain });
 
         Assert.Contains(newChain, visible);
+    }
+
+    // Two distinct chains share the name "Idle"; only the one that was visible stays so —
+    // reference identity, not name, drives the grow-only keep.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_DuplicateNames_ReferenceIdentityKeepsRightOne()
+    {
+        var visibleIdle = new AnimationChainSave { Name = "Idle" };
+        var hiddenIdle = new AnimationChainSave { Name = "Idle" };
+        var current = new List<AnimationChainSave> { visibleIdle, hiddenIdle };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave> { visibleIdle },
+            currentChains: current,
+            query: "walk", // neither name matches
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.Contains(visibleIdle, visible);
+        Assert.DoesNotContain(hiddenIdle, visible);
+    }
+
+    [Fact]
+    public void ComputeVisibleAfterModelChange_EmptyQuery_AllVisible()
+    {
+        var a = new AnimationChainSave { Name = "walkLeft" };
+        var b = new AnimationChainSave { Name = "Idle" };
+        var current = new List<AnimationChainSave> { a, b };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.Contains(a, visible);
+        Assert.Contains(b, visible);
     }
 
     // A hidden, non-matching chain must not reappear on an unrelated model change.
@@ -103,6 +180,25 @@ public class TreeFilterTests
         Assert.Contains(chain, visible);
     }
 
+    // A chain that was visible but has since been removed from the model must not survive
+    // in the result (result is scoped to currentChains).
+    [Fact]
+    public void ComputeVisibleAfterModelChange_PreviouslyVisibleButRemoved_NotInResult()
+    {
+        var kept = new AnimationChainSave { Name = "walkLeft" };
+        var deleted = new AnimationChainSave { Name = "walkRight" };
+        var current = new List<AnimationChainSave> { kept }; // deleted no longer present
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave> { kept, deleted },
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.DoesNotContain(deleted, visible);
+        Assert.Contains(kept, visible);
+    }
+
     // The chain being edited stays visible even after it's renamed out of the filter.
     [Fact]
     public void ComputeVisibleAfterModelChange_RenamedOutOfFilter_StaysVisible()
@@ -133,5 +229,22 @@ public class TreeFilterTests
             brandNew: new List<AnimationChainSave> { restored }); // restored == new to the tree
 
         Assert.Contains(restored, visible);
+    }
+
+    [Fact]
+    public void ComputeVisibleAfterModelChange_WhitespaceQuery_AllVisible()
+    {
+        var a = new AnimationChainSave { Name = "walkLeft" };
+        var b = new AnimationChainSave { Name = "Idle" };
+        var current = new List<AnimationChainSave> { a, b };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "   ",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.Contains(a, visible);
+        Assert.Contains(b, visible);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using AnimationEditor.Core.ViewModels;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Pure tests for the ANIMATIONS tree search/filter predicate (issue #517).
+public class TreeFilterTests
+{
+    private static readonly string[] Chains = { "walkLeft", "slowWalk", "Idle", "RunRight" };
+
+    [Fact]
+    public void FilterChainNames_EmptyQuery_ReturnsAll()
+    {
+        var result = TreeBuilder.FilterChainNames(Chains, "");
+        Assert.Equal(Chains, result);
+    }
+
+    [Fact]
+    public void FilterChainNames_WhitespaceQuery_ReturnsAll()
+    {
+        var result = TreeBuilder.FilterChainNames(Chains, "   ");
+        Assert.Equal(Chains, result);
+    }
+
+    [Fact]
+    public void FilterChainNames_CaseInsensitive_MatchesRegardlessOfCase()
+    {
+        var result = TreeBuilder.FilterChainNames(Chains, "WALK");
+        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, result);
+    }
+
+    [Fact]
+    public void FilterChainNames_MidStringSubstring_Matches()
+    {
+        // "walk" appears mid-string in "slowWalk", not just as a prefix.
+        var result = TreeBuilder.FilterChainNames(Chains, "walk");
+        Assert.Equal(new List<string> { "walkLeft", "slowWalk" }, result);
+    }
+
+    [Fact]
+    public void FilterChainNames_NoMatch_ReturnsEmpty()
+    {
+        var result = TreeBuilder.FilterChainNames(Chains, "zzz");
+        Assert.Empty(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using AnimationEditor.Core.ViewModels;
+using FlatRedBall2.Animation.Content;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -8,6 +9,8 @@ namespace AnimationEditor.Core.Tests;
 public class TreeFilterTests
 {
     private static readonly string[] Chains = { "walkLeft", "slowWalk", "Idle", "RunRight" };
+
+    // ── Query-change path (can shrink) — FilterChainNames / MatchesFilter ──────
 
     [Fact]
     public void FilterChainNames_EmptyQuery_ReturnsAll()
@@ -43,5 +46,92 @@ public class TreeFilterTests
     {
         var result = TreeBuilder.FilterChainNames(Chains, "zzz");
         Assert.Empty(result);
+    }
+
+    // ── Sticky model-change path (grow-only) — ComputeVisibleAfterModelChange ──
+    //
+    // While the query is unchanged, a model mutation must never HIDE a chain that
+    // was already visible, and must SHOW a chain that just became relevant
+    // (newly matches, brand-new, or undo-restored). It must not leak previously
+    // hidden non-matching chains back in.
+
+    // Brand-new chain (e.g. just created) appears even though its name doesn't match.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_BrandNewChain_IsVisible()
+    {
+        var newChain = new AnimationChainSave { Name = "NewAnimation" };
+        var current = new List<AnimationChainSave> { newChain };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave> { newChain });
+
+        Assert.Contains(newChain, visible);
+    }
+
+    // A hidden, non-matching chain must not reappear on an unrelated model change.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_HiddenNonMatching_StaysHidden()
+    {
+        var idle = new AnimationChainSave { Name = "Idle" };
+        var current = new List<AnimationChainSave> { idle };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.DoesNotContain(idle, visible);
+    }
+
+    // Renaming a hidden chain so it now matches the query makes it appear.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_NewlyMatchingRename_BecomesVisible()
+    {
+        var chain = new AnimationChainSave { Name = "walkIdle" }; // renamed from "Idle"
+        var current = new List<AnimationChainSave> { chain };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.Contains(chain, visible);
+    }
+
+    // The chain being edited stays visible even after it's renamed out of the filter.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_RenamedOutOfFilter_StaysVisible()
+    {
+        var chain = new AnimationChainSave { Name = "Idle" }; // was "walkLeft", now renamed out
+        var current = new List<AnimationChainSave> { chain };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave> { chain }, // was visible
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave>());
+
+        Assert.Contains(chain, visible);
+    }
+
+    // An undo-restored chain (brand-new to the current tree) reappears.
+    [Fact]
+    public void ComputeVisibleAfterModelChange_UndoRestoredChain_IsVisible()
+    {
+        var restored = new AnimationChainSave { Name = "Idle" };
+        var current = new List<AnimationChainSave> { restored };
+
+        var visible = TreeBuilder.ComputeVisibleAfterModelChange(
+            previouslyVisible: new List<AnimationChainSave>(),
+            currentChains: current,
+            query: "walk",
+            brandNew: new List<AnimationChainSave> { restored }); // restored == new to the tree
+
+        Assert.Contains(restored, visible);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeSearchBoxLogicTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeSearchBoxLogicTests.cs
@@ -1,0 +1,34 @@
+using AnimationEditor.Core.ViewModels;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// The ANIMATIONS search box's inner ✕ is two-stage: clear text while there is text,
+// collapse the box when it's already empty (issue #517).
+public class TreeSearchBoxLogicTests
+{
+    [Fact]
+    public void ClearShouldCollapse_EmptyText_ReturnsTrue()
+    {
+        Assert.True(TreeSearchBoxLogic.ClearShouldCollapse(""));
+    }
+
+    [Fact]
+    public void ClearShouldCollapse_NullText_ReturnsTrue()
+    {
+        Assert.True(TreeSearchBoxLogic.ClearShouldCollapse(null));
+    }
+
+    [Fact]
+    public void ClearShouldCollapse_WhitespaceText_ReturnsFalse()
+    {
+        // Whitespace is still text the user can see and clear, so ✕ clears it first.
+        Assert.False(TreeSearchBoxLogic.ClearShouldCollapse("   "));
+    }
+
+    [Fact]
+    public void ClearShouldCollapse_WithText_ReturnsFalse()
+    {
+        Assert.False(TreeSearchBoxLogic.ClearShouldCollapse("walk"));
+    }
+}


### PR DESCRIPTION
Closes #517

## What changed
The 🔍 button in the ANIMATIONS pane header was a placeholder with no click handler (a dead affordance). It now drives a real, **sticky** filter with a clean compact-toolbar UX.

### Search UX (Pattern B + two-stage clear)
- **🔍 → box replaces the icon.** Clicking 🔍 hides the icon and shows a focused inline TextBox in its place; collapsing restores the icon. The icon and the box are never both visible (their `IsVisible` is mutually exclusive).
- **Typing filters chains by name** — case-insensitive **substring** match ("walk" matches `walkLeft` and `slowWalk`). Top-level chains only (frame/shape search deferred — see below).
- **Two-stage ✕ (in-field clear):** with text, ✕ clears the text and the box stays open; when the box is already empty, ✕ collapses it back to the 🔍 icon.
- **Escape and click-away collapse** the box (restoring the icon). Any collapse clears the filter (full tree returns).
- **Sticky carve-out:** click-away does *not* collapse when focus moves into the tree, so the sticky workflow (filter → click a result → edit → click another result) keeps the box and filter alive. Clicking truly outside (e.g. the property panel) collapses.

### Sticky, grow-only semantics
The filter **persists** across selection and model edits, so *every* tree-repopulation path is filter-aware. Implementation uses a per-node `PinnedVisible` flag: `_treeRoots` always mirrors the full model, and each row binds `IsVisible` to `PinnedVisible || IsSelected`.

Two triggers, different rules:

1. **Query change (typing):** `TreeBuilder.ApplyQueryFilter` sets `PinnedVisible = MatchesFilter(name, query)` on every chain node — the **only** path allowed to hide a row (refining `a` → `walk` drops non-walk chains).
2. **Model mutation with query unchanged (rename / add / delete / undo-redo / hot-reload):** **grow-only** — never hides an already-visible row; adds a chain that just became relevant (newly matches, brand-new, or undo-restored).

Where each rule lives:
- `TreeBuilder.ComputeVisibleAfterModelChange` (grow-only) is consumed **only** by `RefreshTreeView` (the diff path), which captures `previouslyVisible` *before* `SyncChainsInto` mutates the tree.
- `RebuildTreeView` (full rebuild on load) applies the query directly via `MatchesFilter`.
- `RefreshChainNode` (single-chain refresh) inlines the same grow-only step (`PinnedVisible || MatchesFilter`); brand-new nodes default to visible.

Concrete behaviors covered: rename the chain you're editing out of the filter → stays; create a non-matching new chain → appears; delete a visible chain then Ctrl+Z → reappears; refine the query → non-matching chains disappear; unrelated model change while filtered → hidden non-matching chains do **not** leak back in.

## Design / testability
Pure, UI-free functions in `TreeBuilder` / `ViewModels`, each the exact code production runs:
- `MatchesFilter(name, query)` — case-insensitive substring; null/empty/whitespace matches all; trims surrounding whitespace.
- `ApplyQueryFilter(roots, query)` — query-change path (sets `PinnedVisible` on chain nodes; guards non-chain nodes). `MainWindow.ApplyQueryFilter` delegates to it.
- `ComputeVisibleAfterModelChange(previouslyVisible, currentChains, query, brandNew)` — grow-only model-change path; reference identity keeps a renamed chain visible.
- `TreeSearchBoxLogic.ClearShouldCollapse(text)` — the two-stage ✕ decision (empty/null → collapse; whitespace → clear).

Tests: `TreeFilterTests` (query-change + grow-only, incl. duplicate-name reference identity, previously-visible-but-removed, whitespace trim), `TreeSearchBoxLogicTests` (two-stage clear), and `HeadlessTreeViewTests.RefreshTreeView_GrowOnly_...` (E2E proof that `RefreshTreeView` captures `previouslyVisible` before the diff).

**Selection safety net:** the selected chain stays visible reactively via `|| IsSelected`, *not* the pure function — folding "keep selected" into `PinnedVisible` would permanently pin every chain ever clicked.

**Untested UI residue (b):** the search box's expand/collapse/blur wiring is thin UI toggling (visibility flip, focus, click-away focus check) with no extractable behavioral core beyond the trivial empty-check, which *is* covered by `TreeSearchBoxLogicTests`. The mutually-exclusive visibility and focus/blur behavior is left to manual verification.

**Known limitation (off-filter programmatic selection):** Avalonia may not realize/select a container whose row is collapsed by the filter, so `|| IsSelected` could fail to reveal a *hidden* chain selected purely in code. Assessed: **no current code path selects an off-filter chain** (undo-restore / paste / duplicate / add all produce brand-new chains grow-only makes visible before selection; delete clears selection rather than advancing). Documented for future changes; the fix would be forcing `PinnedVisible = true` when selecting programmatically.

## Deferred (intentional)
**Searching frame and shape names** is a deliberate future enhancement, per the agreed scope on the issue.

## Tests
- Full `AnimationEditor.Core.Tests` green (1372). `HeadlessTreeViewTests` green (39). App + App.Tests build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)