### PR TITLE
Animation Editor: fix Inspector X/Y/W/H labels reusing R/G/B/A accent colors

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1055,13 +1055,13 @@
                                             <WrapPanel>
                                                 <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                     <TextBlock Text="X" VerticalAlignment="Center"
-                                                               Foreground="{DynamicResource Accent}" FontSize="11" FontWeight="SemiBold" />
+                                                               Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
                                                     <NumericUpDown x:Name="PropPixelX" Grid.Column="1" MinWidth="66"
                                                                    Minimum="-16384" Maximum="16384" Increment="1" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                     <TextBlock Text="Y" VerticalAlignment="Center"
-                                                               Foreground="{DynamicResource AccentCool}" FontSize="11" FontWeight="SemiBold" />
+                                                               Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
                                                     <NumericUpDown x:Name="PropPixelY" Grid.Column="1" MinWidth="66"
                                                                    Minimum="-16384" Maximum="16384" Increment="1" />
                                                 </Grid>
@@ -1069,13 +1069,13 @@
                                             <WrapPanel>
                                                 <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                     <TextBlock Text="W" VerticalAlignment="Center"
-                                                               Foreground="{DynamicResource AccentSoft}" FontSize="11" FontWeight="SemiBold" />
+                                                               Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
                                                     <NumericUpDown x:Name="PropPixelW" Grid.Column="1" MinWidth="66"
                                                                    Minimum="1" Maximum="16384" Increment="1" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                     <TextBlock Text="H" VerticalAlignment="Center"
-                                                               Foreground="{DynamicResource Ok}" FontSize="11" FontWeight="SemiBold" />
+                                                               Foreground="{DynamicResource InkMid}" FontSize="11" FontWeight="SemiBold" />
                                                     <NumericUpDown x:Name="PropPixelH" Grid.Column="1" MinWidth="66"
                                                                    Minimum="1" Maximum="16384" Increment="1" />
                                                 </Grid>


### PR DESCRIPTION
## Summary
- COORDINATES section (X/Y/W/H) reused the same accent brushes (`Accent`/`AccentCool`/`AccentSoft`/`Ok`) as the COLOR section's R/G/B/A channel labels, where color legitimately encodes meaning
- X/Y/W/H labels now use `InkMid`, matching every other Inspector section (TIMING, TRANSFORM, RECTANGLE, CIRCLE)
- R/G/B/A accent colors untouched — that's the correct use of color-as-data

## Test plan
- [x] `dotnet build` of the Animation Editor App succeeds
- [x] Open Inspector with a frame selected, confirm X/Y/W/H labels are muted gray, consistent with other sections
- [x] Confirm COLOR section R/G/B/A labels are unchanged

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)