### PR TITLE
Fix Animation Editor toolbars clipping on narrow windows

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -608,6 +608,11 @@
                         BorderThickness="0,0,0,1"
                         Background="{DynamicResource BgRail}"
                         Padding="4,3">
+                    <!-- Horizontal scroll (not wrap/collapse) keeps every control reachable via a
+                         drag/wheel-scroll when the window is narrower than the toolbar's natural
+                         width (#510), without changing control order or hiding anything. -->
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                  VerticalScrollBarVisibility="Disabled">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="2">
                         <!-- Texture label + combo hidden for now — multi-texture support is planned for a future milestone.
                              Do not remove; set IsVisible="True" and re-enable when the multi-texture feature is implemented. -->
@@ -747,6 +752,7 @@
                                    Margin="4,0,0,0"
                                    IsVisible="False" />
                     </StackPanel>
+                    </ScrollViewer>
                 </Border>
 
                 <!-- Wireframe panel fills top. The control draws its texture under a manual
@@ -782,6 +788,11 @@
                             BorderThickness="0,0,0,1"
                             Background="{DynamicResource BgRail}"
                             Padding="4,3">
+                        <!-- Horizontal scroll (not wrap/collapse) keeps every control reachable via a
+                             drag/wheel-scroll when the window is narrower than the toolbar's natural
+                             width (#510), without changing control order or hiding anything. -->
+                        <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Disabled">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="2">
                             <ToggleButton x:Name="OnionSkinToggle"
                                           Height="26"
@@ -855,6 +866,7 @@
                                 </DockPanel>
                             </Border>
                         </StackPanel>
+                        </ScrollViewer>
                     </Border>
 
                     <!-- Preview panel fills remaining height of the block. Unlike the Wireframe

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -608,12 +608,11 @@
                         BorderThickness="0,0,0,1"
                         Background="{DynamicResource BgRail}"
                         Padding="4,3">
-                    <!-- Horizontal scroll (not wrap/collapse) keeps every control reachable via a
-                         drag/wheel-scroll when the window is narrower than the toolbar's natural
-                         width (#510), without changing control order or hiding anything. -->
-                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Disabled">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="2">
+                    <!-- WrapPanel (not scroll) reflows overflow controls onto a second row when the
+                         window is narrower than the toolbar's natural width (#510) — every control
+                         stays fully visible with no scroll gesture needed, matching the WrapPanel
+                         convention already used for the property panel's coordinate fields. -->
+                    <WrapPanel VerticalAlignment="Center">
                         <!-- Texture label + combo hidden for now — multi-texture support is planned for a future milestone.
                              Do not remove; set IsVisible="True" and re-enable when the multi-texture feature is implemented. -->
                         <TextBlock Text="Texture:" VerticalAlignment="Center" Margin="0,0,4,0"
@@ -709,7 +708,7 @@
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
                         <Border BorderBrush="{DynamicResource LineBrush}"
                                 BorderThickness="1" CornerRadius="4" ClipToBounds="True"
-                                Height="26" Width="130" VerticalAlignment="Center">
+                                Height="26" Width="130" Margin="0,0,2,0" VerticalAlignment="Center">
                             <DockPanel>
                                 <Button x:Name="ZoomMinusBtn" DockPanel.Dock="Left"
                                         Classes="flanker" Content="−" Width="22"
@@ -751,8 +750,7 @@
                                    Foreground="{DynamicResource InkMid}"
                                    Margin="4,0,0,0"
                                    IsVisible="False" />
-                    </StackPanel>
-                    </ScrollViewer>
+                    </WrapPanel>
                 </Border>
 
                 <!-- Wireframe panel fills top. The control draws its texture under a manual
@@ -788,12 +786,11 @@
                             BorderThickness="0,0,0,1"
                             Background="{DynamicResource BgRail}"
                             Padding="4,3">
-                        <!-- Horizontal scroll (not wrap/collapse) keeps every control reachable via a
-                             drag/wheel-scroll when the window is narrower than the toolbar's natural
-                             width (#510), without changing control order or hiding anything. -->
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                                      VerticalScrollBarVisibility="Disabled">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="2">
+                        <!-- WrapPanel (not scroll) reflows overflow controls onto a second row when the
+                             window is narrower than the toolbar's natural width (#510) — every control
+                             stays fully visible with no scroll gesture needed, matching the WrapPanel
+                             convention already used for the property panel's coordinate fields. -->
+                        <WrapPanel VerticalAlignment="Center">
                             <ToggleButton x:Name="OnionSkinToggle"
                                           Height="26"
                                           Foreground="{DynamicResource Ink}"
@@ -865,8 +862,7 @@
                                     </AutoCompleteBox>
                                 </DockPanel>
                             </Border>
-                        </StackPanel>
-                        </ScrollViewer>
+                        </WrapPanel>
                     </Border>
 
                     <!-- Preview panel fills remaining height of the block. Unlike the Wireframe


### PR DESCRIPTION
## Summary
- Both the wireframe toolbar and preview toolbar in `MainWindow.axaml` used a horizontal `StackPanel` with no overflow handling, so controls past the visible width (zoom stepper, texture name label, etc.) were clipped off-screen on narrow windows.
- Replaced the `StackPanel` in each toolbar with a `WrapPanel` so overflowing controls reflow onto a second row instead of being clipped or hidden — every control stays fully visible with no scroll gesture required. This matches the `WrapPanel` convention already used elsewhere in this file (the property panel's coordinate fields).
- (An earlier revision of this PR wrapped the toolbars in a horizontal `ScrollViewer` instead. That was reverted — a scrollbar eats a large fraction of a ~26-32px toolbar's height and requires a scroll gesture to reach controls that should be visible at a glance. `WrapPanel` avoids both problems.)

## Test plan
This is a pure XAML layout change with no logic to unit test (falls under the "genuinely untestable / cosmetic" exception in the coder agent guidelines). Verified with:
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` succeeds with no new warnings/errors.
- [x] Manual: resize the Animation Editor window to ~60% of a 1080p screen width and confirm all wireframe/preview toolbar controls remain visible (wrapping to a second row) instead of being clipped.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)