### PR TITLE
Fix Animation Editor preview playback drifting ~20% slower than real time

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -33,6 +33,16 @@ public class PreviewControl : Control
     private readonly DispatcherTimer _timer;
     private readonly AnimationEditor.Core.CommandsAndState.PlaybackController _playback = new();
 
+    // Measures real wall-clock time between timer ticks so playback advances by true
+    // elapsed time, not the timer's nominal interval (a DispatcherTimer fires later than
+    // its Interval, which otherwise makes the animation run slow — see #526).
+    private readonly AnimationEditor.Core.CommandsAndState.TickClock _clock =
+        new(System.Diagnostics.Stopwatch.GetTimestamp, System.Diagnostics.Stopwatch.Frequency);
+
+    // A stall (window drag, GC pause) shouldn't fast-forward playback by the whole frozen
+    // span; cap a single tick's advance so one bad frame doesn't jump the animation.
+    private const double MaxTickSeconds = 0.25;
+
     // -- Camera ----------------------------------------------------------------
     private float _zoom = 1f;
     private float _panX, _panY;
@@ -396,9 +406,13 @@ public class PreviewControl : Control
 
     private void OnTimerTick(object? sender, EventArgs e)
     {
+        // Tick every time so the baseline stays current even while paused/pinned; this keeps
+        // a resume from crediting the whole paused span as one huge delta.
+        double delta = _clock.Tick();
+
         // Only advance when the whole chain is playing (no specific frame pinned)
         if (_selectedState!.SelectedFrame is not null) return;
-        _playback.Advance(0.016);
+        _playback.Advance(Math.Min(delta, MaxTickSeconds));
     }
 
     // -- State reset -----------------------------------------------------------

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TickClock.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TickClock.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Converts a monotonic timestamp source (e.g. <c>Stopwatch.GetTimestamp</c>) into the
+/// real seconds elapsed between successive <see cref="Tick"/> calls.
+/// <para>
+/// Playback must advance by true wall-clock time, not by an assumed fixed step: a UI
+/// timer set to "16 ms" actually fires later than that (OS timer resolution + UI-thread
+/// work), so crediting a hardcoded 16 ms per tick makes an animation run slow. Feeding
+/// <see cref="Tick"/>'s real delta into the playback controller keeps it stopwatch-accurate.
+/// </para>
+/// </summary>
+public class TickClock
+{
+    private readonly Func<long> _timestamp;
+    private readonly double _secondsPerTick;
+    private long _last;
+    private bool _hasBaseline;
+
+    /// <param name="timestamp">Monotonic tick counter, e.g. <c>Stopwatch.GetTimestamp</c>.</param>
+    /// <param name="frequency">Ticks per second for <paramref name="timestamp"/>, e.g. <c>Stopwatch.Frequency</c>.</param>
+    public TickClock(Func<long> timestamp, long frequency)
+    {
+        _timestamp = timestamp;
+        _secondsPerTick = 1.0 / frequency;
+    }
+
+    /// <summary>
+    /// Real seconds since the previous <see cref="Tick"/>. Returns 0 on the first call
+    /// after construction or <see cref="Reset"/>, since there is no prior baseline.
+    /// </summary>
+    public double Tick()
+    {
+        long now = _timestamp();
+        if (!_hasBaseline)
+        {
+            _last = now;
+            _hasBaseline = true;
+            return 0;
+        }
+
+        double delta = (now - _last) * _secondsPerTick;
+        _last = now;
+        return delta;
+    }
+
+    /// <summary>
+    /// Drops the baseline so the next <see cref="Tick"/> returns 0. Call when resuming
+    /// after a pause so the paused span is not credited as one huge delta.
+    /// </summary>
+    public void Reset() => _hasBaseline = false;
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TickClockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TickClockTests.cs
@@ -1,0 +1,49 @@
+using AnimationEditor.Core.CommandsAndState;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TickClockTests
+{
+    // A tick source where 1000 ticks == 1 second, so elapsed math is easy to read.
+    private const long Frequency = 1000;
+
+    [Fact]
+    public void Tick_FirstCall_ReturnsZero()
+    {
+        long now = 500;
+        var clock = new TickClock(() => now, Frequency);
+        Assert.Equal(0.0, clock.Tick());
+    }
+
+    [Fact]
+    public void Tick_SubsequentCalls_ReturnRealElapsedSeconds()
+    {
+        // Timestamps advance by an *uneven* amount each tick — 20 ms then 30 ms —
+        // proving the clock reports true elapsed time rather than a fixed step.
+        long now = 0;
+        var clock = new TickClock(() => now, Frequency);
+
+        clock.Tick();          // establishes baseline at 0, returns 0
+        now = 20;              // 20 ticks == 0.020 s
+        Assert.Equal(0.020, clock.Tick(), 6);
+        now = 50;              // +30 ticks == 0.030 s
+        Assert.Equal(0.030, clock.Tick(), 6);
+    }
+
+    [Fact]
+    public void Tick_AfterReset_ReturnsZeroThenResumesFromNewBaseline()
+    {
+        long now = 100;
+        var clock = new TickClock(() => now, Frequency);
+        clock.Tick();          // baseline at 100
+        now = 200;
+        clock.Tick();          // 0.100 s
+
+        clock.Reset();
+        now = 1000;            // large gap while "paused"
+        Assert.Equal(0.0, clock.Tick());   // discarded, no jump
+        now = 1010;
+        Assert.Equal(0.010, clock.Tick(), 6);
+    }
+}


### PR DESCRIPTION
## Problem

Playing an animation in the Animation Editor preview ran visibly slower than real time — a 10-frame × 0.1s clip (nominally 1.0s) fell ~20% behind a stopwatch.

## Cause

`PreviewControl.OnTimerTick` advanced playback by a hardcoded `0.016` per `DispatcherTimer` tick. A `DispatcherTimer` is a best-effort UI-thread timer that fires **later** than its `Interval` (Windows ~15.6ms timer resolution + layout/render work on the same thread). Crediting a fixed 16ms while real ticks take ~20ms runs playback at ~80% speed → the systematic ~20% drift.

`PlaybackController` itself accumulates time exactly; the bug was the fixed-timestep delta fed into it.

## Fix

Switch the preview to a **variable timestep**: new `TickClock` converts a monotonic timestamp source (`Stopwatch.GetTimestamp`) into the real seconds elapsed between ticks, and that true delta is passed to `Advance`. A single tick is clamped (`MaxTickSeconds = 0.25`) so a stall (window drag, GC pause) doesn't fast-forward the animation.

Runtime `Sprite`/`AnimationPlayer` were checked and are unaffected — they already accumulate the game loop's real `DeltaSeconds`.

## Tests

`TickClockTests` covers the delta measurement (first-call-zero, uneven real elapsed, reset). The thin residue — `Stopwatch` + `DispatcherTimer` wiring and the clamp — is untested UI glue. Full Core suite green (1378 tests).

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)