### PR TITLE
Show effective (sticky) frame color in Animation Editor preview and inspector

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -309,7 +309,8 @@ public class PreviewControl : Control
                                         _appState!.OffsetMultiplier,
                                         _hGuides.ToArray(), _vGuides.ToArray(),
                                         _draggedGuideIdx, _draggingHGuide,
-                                        BuildShapeInfos(), frameOffX, frameOffY);
+                                        BuildShapeInfos(), frameOffX, frameOffY,
+                                        ResolveColor(chain, displayFrame), ResolveColor(chain, onionFrame));
         UpdatePalette();
         var bitmap = new SKBitmap(width, height);
         using var canvas = new SKCanvas(bitmap);
@@ -906,7 +907,8 @@ public class PreviewControl : Control
                 _appState!.OffsetMultiplier,
                 _hGuides.ToArray(), _vGuides.ToArray(),
                 _draggedGuideIdx, _draggingHGuide,
-                BuildShapeInfos(), frameOffX, frameOffY),
+                BuildShapeInfos(), frameOffX, frameOffY,
+                ResolveColor(chain, displayFrame), ResolveColor(chain, onionFrame)),
             _thumbnailService.ImageCache, _palette, _showDiagnostics ? _drawTimes : null));
     }
 
@@ -1699,7 +1701,21 @@ public class PreviewControl : Control
         bool   DraggingHGuide,
         PreviewShapeInfo[] Shapes,
         // Display-frame offset, already resolved for snap vs interpolate (see ResolveFrameOffset).
-        float  FrameOffsetX, float FrameOffsetY);
+        float  FrameOffsetX, float FrameOffsetY,
+        // Sticky per-channel color for the live frame and onion frame — an omitted channel holds
+        // whatever an earlier frame last set, matching runtime, rather than resetting each frame.
+        ResolvedFrameColor FrameColor, ResolvedFrameColor OnionColor);
+
+    /// <summary>
+    /// Resolves a frame's sticky effective color within its chain. Returns an all-unset result
+    /// when the frame isn't part of <paramref name="chain"/> (e.g. no selection).
+    /// </summary>
+    private static ResolvedFrameColor ResolveColor(AnimationChainSave? chain, AnimationFrameSave? frame)
+    {
+        if (chain is null || frame is null) return default;
+        int idx = chain.Frames.IndexOf(frame);
+        return idx < 0 ? default : EffectiveFrameColor.Resolve(chain.Frames, idx);
+    }
 
     // -- Shared SkiaSharp rendering (used by both live and off-screen paths) --
 
@@ -1722,7 +1738,7 @@ public class PreviewControl : Control
         {
             float ocx = cx + s.OnionFrame.RelativeX * s.OffsetMultiplier * s.Zoom;
             float ocy = cy - s.OnionFrame.RelativeY * s.OffsetMultiplier * s.Zoom;
-            DrawFrameCore(canvas, s.OnionFrame, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f);
+            DrawFrameCore(canvas, s.OnionFrame, s.OnionColor, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f);
         }
 
         if (s.Frame is not null &&
@@ -1731,7 +1747,7 @@ public class PreviewControl : Control
         {
             float fcx = cx + s.FrameOffsetX * s.OffsetMultiplier * s.Zoom;
             float fcy = cy - s.FrameOffsetY * s.OffsetMultiplier * s.Zoom;
-            DrawFrameCore(canvas, s.Frame, img, fcx, fcy, s.Zoom, alpha: 1.0f);
+            DrawFrameCore(canvas, s.Frame, s.FrameColor, img, fcx, fcy, s.Zoom, alpha: 1.0f);
         }
 
         // Origin crosshair (toggled by ShowGuides)
@@ -1995,7 +2011,7 @@ public class PreviewControl : Control
     }
 
     private static void DrawFrameCore(
-        SKCanvas canvas, AnimationFrameSave frame, SKImage img,
+        SKCanvas canvas, AnimationFrameSave frame, ResolvedFrameColor color, SKImage img,
         float cx, float cy, float zoom, float alpha)
     {
         var (sx, sy, sw, sh) = ComputeSourceRect(frame, img.Width, img.Height);
@@ -2009,11 +2025,12 @@ public class PreviewControl : Control
 
         using var paint = new SKPaint
         {
-            // Per-frame Alpha previews as opacity (reference render); runtimes apply it however they choose.
-            Color = new SKColor(255, 255, 255, FramePreviewOpacity.Resolve(frame.Alpha, alpha))
+            // Sticky effective alpha previews as opacity (reference render); an omitted channel holds
+            // the last set value, matching runtime. Runtimes apply it however they choose.
+            Color = new SKColor(255, 255, 255, FramePreviewOpacity.Resolve(color.Alpha, alpha))
         };
-        // Reference render of the frame's color operation; runtimes apply it however they choose.
-        using var colorFilter = FrameColorFilter.Create(frame.ColorOperation, frame.Red, frame.Green, frame.Blue);
+        // Reference render of the frame's sticky effective color operation; runtimes apply it however they choose.
+        using var colorFilter = FrameColorFilter.Create(color.Operation, color.Red, color.Green, color.Blue);
         if (colorFilter is not null)
             paint.ColorFilter = colorFilter;
         var sampling = zoom >= 1

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3469,12 +3469,37 @@ public partial class MainWindow : Window
                 PropGreen.Value      = frame.Green.HasValue ? frame.Green.Value : (decimal?)null;
                 PropBlue.Value       = frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null;
                 PropAlpha.Value      = frame.Alpha.HasValue ? frame.Alpha.Value : (decimal?)null;
-                PropColorMode.SelectedIndex = frame.ColorOperation switch
+
+                // Ghost the sticky effective value in each blank field: an omitted channel holds
+                // whatever an earlier frame last set (climbing back), or the operation's identity
+                // (Add → 0, else 255) when nothing ever set it. This makes a blank field read as the
+                // value a runtime actually applies, instead of implying "reset to default".
+                var chain = _selectedState.SelectedChain;
+                int frameIndex = chain?.Frames.IndexOf(frame) ?? -1;
+                var effective = frameIndex >= 0
+                    ? EffectiveFrameColor.Resolve(chain!.Frames, frameIndex)
+                    : default;
+                int rgbDefault = EffectiveFrameColor.ChannelDefault(effective.Operation);
+                PropRed.PlaceholderText   = (effective.Red   ?? rgbDefault).ToString();
+                PropGreen.PlaceholderText = (effective.Green ?? rgbDefault).ToString();
+                PropBlue.PlaceholderText  = (effective.Blue  ?? rgbDefault).ToString();
+                PropAlpha.PlaceholderText = (effective.Alpha ?? 255).ToString();
+
+                if (frame.ColorOperation is ColorOperation op)
                 {
-                    ColorOperation.Multiply => 1,
-                    ColorOperation.Add      => 2,
-                    _                       => 0, // None / null
-                };
+                    PropColorMode.SelectedIndex = op == ColorOperation.Multiply ? 1 : 2;
+                }
+                else if (effective.Operation is ColorOperation inherited)
+                {
+                    // Unset here but inherited from an earlier frame — ghost it as a combo placeholder
+                    // (SelectedIndex -1 shows PlaceholderText) so the combo matches the sticky preview.
+                    PropColorMode.SelectedIndex = -1;
+                    PropColorMode.PlaceholderText = $"{inherited} (inherited)";
+                }
+                else
+                {
+                    PropColorMode.SelectedIndex = 0; // None
+                }
                 PropTextureName.Text = TexturePathHelper.ComputeDisplayPath(
                     frame.TextureName, _projectManager.FileName);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/EffectiveFrameColor.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/EffectiveFrameColor.cs
@@ -1,0 +1,57 @@
+using FlatRedBall2.Animation;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.Rendering
+{
+    /// <summary>
+    /// A frame's per-channel color after applying the runtime "unset = keep the last value"
+    /// (sticky) semantic. Each channel is the most recent explicitly-set value at or before the
+    /// resolved frame, or <c>null</c> if no frame ever set it. Channels resolve independently.
+    /// </summary>
+    public readonly record struct ResolvedFrameColor(
+        int? Red, int? Green, int? Blue, int? Alpha, ColorOperation? Operation);
+
+    /// <summary>
+    /// Resolves the <em>effective</em> color of a frame under the sticky semantic runtimes use:
+    /// an omitted channel doesn't reset, it holds whatever an earlier frame last set. The editor
+    /// climbs backward so its preview and inspector match that behavior instead of resetting every
+    /// frame. Where a channel is genuinely never set, the value stays <c>null</c> and each caller
+    /// supplies its own baseline (preview: per-operation identity; inspector: a display default).
+    /// </summary>
+    public static class EffectiveFrameColor
+    {
+        /// <summary>
+        /// Walks backward from <paramref name="frameIndex"/> through <paramref name="frames"/>,
+        /// taking each channel's first explicitly-set value. Out-of-range indices clamp; a negative
+        /// index yields an all-<c>null</c> result.
+        /// </summary>
+        public static ResolvedFrameColor Resolve(IReadOnlyList<AnimationFrameSave> frames, int frameIndex)
+        {
+            int? red = null, green = null, blue = null, alpha = null;
+            ColorOperation? operation = null;
+
+            int start = Math.Min(frameIndex, frames.Count - 1);
+            for (int i = start; i >= 0; i--)
+            {
+                var f = frames[i];
+                red       ??= f.Red;
+                green     ??= f.Green;
+                blue      ??= f.Blue;
+                alpha     ??= f.Alpha;
+                operation ??= f.ColorOperation;
+            }
+
+            return new ResolvedFrameColor(red, green, blue, alpha, operation);
+        }
+
+        /// <summary>
+        /// The R/G/B identity value for a color operation — what a channel contributes when unset:
+        /// black (0) for <see cref="ColorOperation.Add"/> (adds nothing), white (255) otherwise.
+        /// Used as the inspector's never-set placeholder so the ghost value matches the preview.
+        /// </summary>
+        public static int ChannelDefault(ColorOperation? operation)
+            => operation == ColorOperation.Add ? 0 : 255;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EffectiveFrameColorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EffectiveFrameColorTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using AnimationEditor.Core.Rendering;
+using FlatRedBall2.Animation;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="EffectiveFrameColor"/> — the sticky "unset = keep the last value"
+/// resolution the editor uses so its preview and inspector match runtime behavior.
+/// </summary>
+public class EffectiveFrameColorTests
+{
+    private static List<AnimationFrameSave> Chain(params AnimationFrameSave[] frames)
+        => new(frames);
+
+    [Fact]
+    public void Resolve_ChannelSetOnEarlierFrame_CarriesForward()
+    {
+        // Frame 0 sets Alpha=250; frames 1 and 2 omit it → should stay 250 (sticky), not reset.
+        var frames = Chain(
+            new AnimationFrameSave { Alpha = 250 },
+            new AnimationFrameSave(),
+            new AnimationFrameSave());
+
+        Assert.Equal(250, EffectiveFrameColor.Resolve(frames, 2).Alpha);
+    }
+
+    [Fact]
+    public void Resolve_ChannelNeverSet_ReturnsNull()
+    {
+        var frames = Chain(new AnimationFrameSave(), new AnimationFrameSave());
+
+        Assert.Null(EffectiveFrameColor.Resolve(frames, 1).Alpha);
+    }
+
+    [Fact]
+    public void Resolve_ChannelResetOnLaterFrame_ReturnsMostRecentValue()
+    {
+        // Alpha changes across frames; resolving at frame 2 returns the closest preceding set (100).
+        var frames = Chain(
+            new AnimationFrameSave { Alpha = 250 },
+            new AnimationFrameSave { Alpha = 100 },
+            new AnimationFrameSave());
+
+        Assert.Equal(100, EffectiveFrameColor.Resolve(frames, 2).Alpha);
+    }
+
+    [Fact]
+    public void Resolve_ChannelsSetOnDifferentFrames_ResolveIndependently()
+    {
+        // Red set on frame 0, Blue set on frame 1; frame 2 inherits both.
+        var frames = Chain(
+            new AnimationFrameSave { Red = 200 },
+            new AnimationFrameSave { Blue = 50 },
+            new AnimationFrameSave());
+
+        var resolved = EffectiveFrameColor.Resolve(frames, 2);
+        Assert.Equal(200, resolved.Red);
+        Assert.Equal(50, resolved.Blue);
+        Assert.Null(resolved.Green);
+    }
+
+    [Fact]
+    public void Resolve_OperationSetOnEarlierFrame_CarriesForward()
+    {
+        var frames = Chain(
+            new AnimationFrameSave { ColorOperation = ColorOperation.Add },
+            new AnimationFrameSave());
+
+        Assert.Equal(ColorOperation.Add, EffectiveFrameColor.Resolve(frames, 1).Operation);
+    }
+
+    [Fact]
+    public void ChannelDefault_Add_ReturnsZero()
+        => Assert.Equal(0, EffectiveFrameColor.ChannelDefault(ColorOperation.Add));
+
+    [Fact]
+    public void ChannelDefault_MultiplyOrNone_Returns255()
+    {
+        Assert.Equal(255, EffectiveFrameColor.ChannelDefault(ColorOperation.Multiply));
+        Assert.Equal(255, EffectiveFrameColor.ChannelDefault(null));
+    }
+}


### PR DESCRIPTION
## What

Makes the Animation Editor's preview and inspector reflect the **sticky** per-frame color semantic: an omitted `Red`/`Green`/`Blue`/`Alpha`/`ColorOperation` channel means "don't touch it," so at runtime it holds whatever an earlier frame last set. The editor previously reset every channel to its identity each frame, so it implied "unset = default" and diverged from what runtimes actually render.

## Changes

- **`EffectiveFrameColor` (Core, new)** — `Resolve(frames, index)` climbs backward per channel for the "unset = keep last value" semantic; `ChannelDefault(op)` gives the operation identity (Add → 0, else 255). Pure and unit-tested (7 tests).
- **Preview (`PreviewControl`)** — resolves each drawn/onion frame's sticky color at snapshot build and feeds it through the existing `FrameColorFilter` / `FramePreviewOpacity`, so playback carries omitted channels forward instead of resetting every frame.
- **Inspector (`MainWindow`)** — blank R/G/B/A fields ghost the effective inherited value via `PlaceholderText` (falling back to the operation identity when a channel is never set); the `ColorOperation` combo shows an inherited-operation placeholder when the current frame doesn't set one.

The **data model is untouched** — sparseness is preserved. This is a display-only change that makes the editor honest about the runtime's existing behavior, not a semantic change to the format.

## Notes

- `ColorOperation` has only `Multiply`/`Add` (no explicit `None`), so a null operation can only mean "inherit" — the combo placeholder is how the inherited operation is surfaced.
- Follow-up filed as #528 (tint timeline thumbnails with the same effective color, with caching requirements).

## Testing

- 7 new unit tests for `EffectiveFrameColor`; full AE suite green (1915 tests), zero build warnings.
- Manually verified in the editor against a real `.achx`: a flash frame shows its explicit values, the following omitting frames ghost the inherited value and the combo shows `Add (inherited)`, and playback carries the tint forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)