### PR TITLE
Tint timeline and tree thumbnails with effective (sticky) frame color

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2740,10 +2740,13 @@ public partial class MainWindow : Window
                 continue;
 
             // The previous bitmap (if any) is cache-owned — drop the reference, don't dispose it.
+            // Tint by frame 0's effective color (nothing precedes it, so this is just its own set
+            // channels) so the tree icon renders the frame the same way the preview/timeline does.
             node.Thumbnail = source is null
                 ? null
                 : _thumbnailService.GetFrameThumbnail(
-                    chain.Frames[0], TreeChainThumbnailPixelSize, TreeChainThumbnailPixelSize);
+                    chain.Frames[0], EffectiveFrameColor.Resolve(chain.Frames, 0),
+                    TreeChainThumbnailPixelSize, TreeChainThumbnailPixelSize);
             node.ThumbnailSource = source;
         }
     }
@@ -2822,11 +2825,14 @@ public partial class MainWindow : Window
             _timelineFrames.Add(item);
         _timelineEffectivePps = TimelineBuilder.ComputeEffectivePixelsPerSecond(chain);
 
-        // Populate frame thumbnails (texture crop, no shapes)
+        // Populate frame thumbnails (texture crop tinted by the frame's effective color, no shapes).
+        // Resolve all effective colors in one O(n) pass here — on data change, never in the playback
+        // loop. Cells whose effective color is unchanged hit the ThumbnailService cache and skip re-render.
         if (chain is not null)
         {
+            var colors = EffectiveFrameColor.ResolveAll(chain.Frames);
             for (int i = 0; i < chain.Frames.Count && i < _timelineFrames.Count; i++)
-                _timelineFrames[i].Thumbnail = _thumbnailService.GetFrameThumbnail(chain.Frames[i], 22, 18);
+                _timelineFrames[i].Thumbnail = _thumbnailService.GetFrameThumbnail(chain.Frames[i], colors[i], 22, 18);
         }
 
         // Cells were just recreated, so no frame is current until UpdateTimelineScrubber runs.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ThumbnailService.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using AnimationEditor.Core;
+using AnimationEditor.Core.Rendering;
 using Avalonia;
 using Avalonia.Platform;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
@@ -49,10 +51,16 @@ public sealed class ThumbnailService : IDisposable
     /// bitmap, so a tab switch (or strip rebuild) re-uses the cached icon. The resolved
     /// <em>absolute</em> texture path is part of the key — two tabs in different folders can
     /// share the same relative <c>TextureName</c> yet must not collide on one cached crop.
+    /// <para>
+    /// The effective color/alpha/operation are part of the key too: two frames with the same crop
+    /// but a different tint must not collide on one cached bitmap, and a tinted thumbnail is rendered
+    /// once and reused until its (crop or color) inputs change.
+    /// </para>
     /// </summary>
     private readonly record struct ThumbnailKey(
         string Path, float Left, float Right, float Top, float Bottom,
-        bool FlipHorizontal, bool FlipVertical, int MaxWidth, int MaxHeight);
+        bool FlipHorizontal, bool FlipVertical, int MaxWidth, int MaxHeight,
+        int? Red, int? Green, int? Blue, int? Alpha, ColorOperation? Operation);
 
     /// <summary>
     /// Finished-thumbnail cache. The service owns these bitmaps and is their sole disposer
@@ -200,14 +208,20 @@ public sealed class ThumbnailService : IDisposable
     /// Returns <c>null</c> if the texture cannot be resolved, is not loaded, or the frame
     /// has no valid UV region.
     /// <para>
-    /// The result is cached (keyed by resolved texture path + UV region + flips + target
-    /// size) and <em>owned by this service</em> — do not dispose it. Re-calling with the same
-    /// frame state returns the same cached instance, so a tab switch re-uses every unchanged
-    /// icon. The Skia crop is wrapped directly as a <see cref="Avalonia.Media.Imaging.WriteableBitmap"/>;
-    /// there is no PNG encode/decode round-trip.
+    /// The result is cached (keyed by resolved texture path + UV region + flips + effective
+    /// color/alpha + target size) and <em>owned by this service</em> — do not dispose it. Re-calling
+    /// with the same frame state returns the same cached instance, so a tab switch re-uses every
+    /// unchanged icon and playback never re-renders a cell. The Skia crop is wrapped directly as a
+    /// <see cref="Avalonia.Media.Imaging.WriteableBitmap"/>; there is no PNG encode/decode round-trip.
+    /// </para>
+    /// <para>
+    /// <paramref name="color"/> is the frame's <em>effective</em> (sticky) color — resolve it once per
+    /// data change via <see cref="EffectiveFrameColor.ResolveAll"/> and pass it in; do not resolve
+    /// inside the playback render loop. <c>default</c> means no tint / full opacity.
     /// </para>
     /// </summary>
-    public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(AnimationFrameSave frame, int maxWidth, int maxHeight)
+    public Avalonia.Media.Imaging.Bitmap? GetFrameThumbnail(
+        AnimationFrameSave frame, ResolvedFrameColor color, int maxWidth, int maxHeight)
     {
         var path = ResolveTexturePath(frame);
         var bm   = GetBitmap(path);
@@ -216,11 +230,12 @@ public sealed class ThumbnailService : IDisposable
         var key = new ThumbnailKey(
             path!.Replace('\\', '/'),
             frame.LeftCoordinate, frame.RightCoordinate, frame.TopCoordinate, frame.BottomCoordinate,
-            frame.FlipHorizontal, frame.FlipVertical, maxWidth, maxHeight);
+            frame.FlipHorizontal, frame.FlipVertical, maxWidth, maxHeight,
+            color.Red, color.Green, color.Blue, color.Alpha, color.Operation);
         if (_thumbnailCache.TryGetValue(key, out var cachedBitmap))
             return cachedBitmap;
 
-        using var thumb = RenderFrameThumbnail(bm, frame, maxWidth, maxHeight);
+        using var thumb = RenderFrameThumbnail(bm, frame, color, maxWidth, maxHeight);
         if (thumb is null) return null;
 
         var bitmap = ToAvaloniaBitmap(thumb);
@@ -277,13 +292,20 @@ public sealed class ThumbnailService : IDisposable
 
     /// <summary>
     /// Pure SkiaSharp core of <see cref="GetFrameThumbnail"/>: crops <paramref name="frame"/>'s
-    /// UV region out of <paramref name="source"/> and scales it to fit within
-    /// <paramref name="maxWidth"/> × <paramref name="maxHeight"/> (aspect-preserving).
-    /// Returns <c>null</c> for a degenerate UV region. Exposed (internal) so tests can verify
-    /// crop/scale/sampling behaviour without going through file decode or Avalonia bitmap wrapping.
+    /// UV region out of <paramref name="source"/>, applies the effective (sticky) <paramref name="color"/>
+    /// and alpha, and scales it to fit within <paramref name="maxWidth"/> × <paramref name="maxHeight"/>
+    /// (aspect-preserving). Returns <c>null</c> for a degenerate UV region. Exposed (internal) so tests
+    /// can verify crop/scale/sampling/tint behaviour without going through file decode or Avalonia
+    /// bitmap wrapping.
+    /// <para>
+    /// The tint reuses <see cref="FrameColorFilter"/> + <see cref="FramePreviewOpacity"/> — the same
+    /// reference interpretation the preview panel applies — so a timeline/tree thumbnail and the
+    /// preview render a given frame identically. A <c>default</c> color leaves the crop untinted at
+    /// full opacity.
+    /// </para>
     /// </summary>
     internal static SKBitmap? RenderFrameThumbnail(
-        SKBitmap source, AnimationFrameSave frame, int maxWidth, int maxHeight)
+        SKBitmap source, AnimationFrameSave frame, ResolvedFrameColor color, int maxWidth, int maxHeight)
     {
         float uvW = frame.RightCoordinate  - frame.LeftCoordinate;
         float uvH = frame.BottomCoordinate - frame.TopCoordinate;
@@ -310,7 +332,17 @@ public sealed class ThumbnailService : IDisposable
         var thumb = new SKBitmap(finalW, finalH);
         using var canvas = new SKCanvas(thumb);
         canvas.Clear(SKColors.Transparent);
-        using var paint  = new SKPaint { Color = SKColors.White };
+
+        // Same reference interpretation the preview panel uses (PreviewControl.DrawFrameCore): the
+        // sticky effective alpha previews as opacity, and the effective color operation as a filter.
+        // A default color yields alpha 255 + a null filter, i.e. the untinted crop.
+        using var paint  = new SKPaint
+        {
+            Color = new SKColor(255, 255, 255, FramePreviewOpacity.Resolve(color.Alpha, 1f)),
+        };
+        using var colorFilter = FrameColorFilter.Create(color.Operation, color.Red, color.Green, color.Blue);
+        if (colorFilter is not null)
+            paint.ColorFilter = colorFilter;
 
         bool anyFlip = frame.FlipHorizontal || frame.FlipVertical;
         if (anyFlip)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1247,7 +1247,8 @@ namespace AnimationEditor.Core.CommandsAndState
 
         public void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue)
         {
-            // Color is game-consumed and not previewed, so no wireframe refresh is needed.
+            // Color tints the preview and the timeline/tree thumbnails but not the wireframe, so no
+            // wireframe refresh is needed. The AnimationChainsChanged raised here rebuilds those.
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => { frame.Red = red; frame.Green = green; frame.Blue = blue; },
                 this, _events, false, "Set Frame Color"));
@@ -1255,7 +1256,8 @@ namespace AnimationEditor.Core.CommandsAndState
 
         public void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation)
         {
-            // Mode is game-consumed; not previewed by the engine, so no wireframe refresh is needed.
+            // Mode drives how the preview + timeline/tree thumbnails tint; it doesn't touch the
+            // wireframe, so no wireframe refresh is needed.
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => frame.ColorOperation = operation,
                 this, _events, false, "Set Frame Color Mode"));
@@ -1263,7 +1265,8 @@ namespace AnimationEditor.Core.CommandsAndState
 
         public void SetFrameAlpha(AnimationFrameSave frame, int? alpha)
         {
-            // Alpha is straight transparency, game-consumed and not previewed, so no wireframe refresh is needed.
+            // Alpha is straight transparency; it fades the preview + timeline/tree thumbnails but not
+            // the wireframe, so no wireframe refresh is needed.
             _undoManager.Execute(new BulkFrameEditCommand(
                 [frame], () => frame.Alpha = alpha,
                 this, _events, false, "Set Frame Alpha"));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/EffectiveFrameColor.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/EffectiveFrameColor.cs
@@ -47,6 +47,34 @@ namespace AnimationEditor.Core.Rendering
         }
 
         /// <summary>
+        /// Resolves the effective color of <em>every</em> frame in one forward O(n) pass, so callers
+        /// that tint a whole timeline strip don't pay a per-frame backward <see cref="Resolve"/> walk
+        /// (O(n²) overall). Result <c>[i]</c> equals <c>Resolve(frames, i)</c>. Returns an empty array
+        /// for an empty list.
+        /// </summary>
+        public static ResolvedFrameColor[] ResolveAll(IReadOnlyList<AnimationFrameSave> frames)
+        {
+            var result = new ResolvedFrameColor[frames.Count];
+            int? red = null, green = null, blue = null, alpha = null;
+            ColorOperation? operation = null;
+
+            for (int i = 0; i < frames.Count; i++)
+            {
+                var f = frames[i];
+                // Sticky: a frame that explicitly sets a channel overrides the running value; an omitted
+                // channel keeps the most recent set value. (`??=` would freeze on the first set — wrong.)
+                red       = f.Red           ?? red;
+                green     = f.Green         ?? green;
+                blue      = f.Blue          ?? blue;
+                alpha     = f.Alpha         ?? alpha;
+                operation = f.ColorOperation ?? operation;
+                result[i] = new ResolvedFrameColor(red, green, blue, alpha, operation);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// The R/G/B identity value for a color operation — what a channel contributes when unset:
         /// black (0) for <see cref="ColorOperation.Add"/> (adds nothing), white (255) otherwise.
         /// Used as the inspector's never-set placeholder so the ghost value matches the preview.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ThumbnailSource.cs
@@ -1,3 +1,5 @@
+using AnimationEditor.Core.Rendering;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 
 namespace AnimationEditor.Core.ViewModels;
@@ -7,7 +9,13 @@ namespace AnimationEditor.Core.ViewModels;
 /// Two equal <see cref="ThumbnailSource"/> values produce an identical thumbnail, so the
 /// animation tree only regenerates a chain icon when this changes — which happens on a
 /// frame reorder, a first-frame texture swap, a first-frame region edit, a first-frame
-/// flip toggle, or a first-frame delete.
+/// flip toggle, a first-frame color/alpha edit, or a first-frame delete.
+/// <para>
+/// The color fields carry the frame's <em>effective</em> (sticky) color — the value a runtime
+/// would apply — not just what the frame explicitly sets. That's why editing an earlier frame's
+/// color changes the signature of every later frame it tints, so the timeline strip rebuilds
+/// those downstream cells too.
+/// </para>
 /// </summary>
 public readonly record struct ThumbnailSource(
     string? TextureName,
@@ -16,22 +24,41 @@ public readonly record struct ThumbnailSource(
     float Top,
     float Bottom,
     bool FlipHorizontal,
-    bool FlipVertical)
+    bool FlipVertical,
+    int? Red,
+    int? Green,
+    int? Blue,
+    int? Alpha,
+    ColorOperation? Operation)
 {
-    /// <summary>Returns the signature of a single frame's thumbnail-relevant visual state.</summary>
-    public static ThumbnailSource FromFrame(AnimationFrameSave frame) =>
+    /// <summary>
+    /// Returns the signature of a single frame's thumbnail-relevant visual state, given the
+    /// frame's pre-resolved effective <paramref name="color"/> (from
+    /// <see cref="EffectiveFrameColor.Resolve"/> / <see cref="EffectiveFrameColor.ResolveAll"/>).
+    /// Requiring the resolved color as a parameter keeps callers that build a whole-strip signature
+    /// on the O(n) <see cref="EffectiveFrameColor.ResolveAll"/> path instead of an O(n²) per-frame walk.
+    /// </summary>
+    public static ThumbnailSource FromFrame(AnimationFrameSave frame, ResolvedFrameColor color) =>
         new(frame.TextureName,
             frame.LeftCoordinate,
             frame.RightCoordinate,
             frame.TopCoordinate,
             frame.BottomCoordinate,
             frame.FlipHorizontal,
-            frame.FlipVertical);
+            frame.FlipVertical,
+            color.Red,
+            color.Green,
+            color.Blue,
+            color.Alpha,
+            color.Operation);
 
     /// <summary>
     /// Returns the signature of <paramref name="chain"/>'s first frame, or <c>null</c>
-    /// when the chain has no frames (the tree falls back to the generic chain icon).
+    /// when the chain has no frames (the tree falls back to the generic chain icon). Frame 0's
+    /// effective color is just its own set channels (nothing precedes it), so this is a cheap resolve.
     /// </summary>
     public static ThumbnailSource? FromChain(AnimationChainSave chain) =>
-        chain.Frames.Count == 0 ? null : FromFrame(chain.Frames[0]);
+        chain.Frames.Count == 0
+            ? null
+            : FromFrame(chain.Frames[0], EffectiveFrameColor.Resolve(chain.Frames, 0));
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineStripSignature.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineStripSignature.cs
@@ -1,4 +1,5 @@
 using System;
+using AnimationEditor.Core.Rendering;
 using FlatRedBall2.Animation.Content;
 
 namespace AnimationEditor.Core.ViewModels;
@@ -30,11 +31,15 @@ public sealed class TimelineStripSignature : IEquatable<TimelineStripSignature>
         if (chain is null)
             return new TimelineStripSignature(null, Array.Empty<(float, ThumbnailSource)>());
 
+        // Resolve every frame's effective (sticky) color in one O(n) pass so a color edit on frame
+        // N shows up in the signature of frames N…(next frame that re-sets that channel) — that's how
+        // the strip knows to rebuild the downstream cells the edit re-tints, not just the edited one.
+        var colors = EffectiveFrameColor.ResolveAll(chain.Frames);
         var frames = new (float, ThumbnailSource)[chain.Frames.Count];
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var frame = chain.Frames[i];
-            frames[i] = (frame.FrameLength, ThumbnailSource.FromFrame(frame));
+            frames[i] = (frame.FrameLength, ThumbnailSource.FromFrame(frame, colors[i]));
         }
         return new TimelineStripSignature(chain, frames);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using AnimationEditor.App.Services;
 using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Rendering;
 using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using Xunit;
@@ -50,7 +52,7 @@ public class ThumbnailServiceTests
         using var source = new SKBitmap(64, 64);
         source.Erase(SKColors.Red);
 
-        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), 56, 56);
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 56, 56);
 
         Assert.NotNull(thumb);
         Assert.Equal(56, thumb!.Width);
@@ -65,7 +67,7 @@ public class ThumbnailServiceTests
         using var source = SplitSheet(16, 8, SKColors.Red, SKColors.Blue);
 
         using var thumb = ThumbnailService.RenderFrameThumbnail(
-            source, Frame(right: 0.5f), 56, 56);
+            source, Frame(right: 0.5f), default, 56, 56);
 
         Assert.NotNull(thumb);
         for (int y = 0; y < thumb!.Height; y++)
@@ -85,7 +87,7 @@ public class ThumbnailServiceTests
         // would smear a band of blended pixels across the middle.
         using var source = SplitSheet(2, 1, SKColors.Red, SKColors.Blue);
 
-        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), 40, 40);
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 40, 40);
 
         Assert.NotNull(thumb);
         for (int y = 0; y < thumb!.Height; y++)
@@ -108,7 +110,7 @@ public class ThumbnailServiceTests
         using var source = SplitSheet(16, 8, SKColors.Red, SKColors.Blue);
 
         using var thumb = ThumbnailService.RenderFrameThumbnail(
-            source, Frame(flipH: true), 16, 8);
+            source, Frame(flipH: true), default, 16, 8);
 
         Assert.NotNull(thumb);
         // Leftmost pixel should be blue (was originally on the right).
@@ -119,6 +121,81 @@ public class ThumbnailServiceTests
         var rightPx = thumb.GetPixel(thumb.Width - 1, 4);
         Assert.True(rightPx.Red > rightPx.Blue,
             $"Right edge pixel {rightPx} should be red after horizontal flip.");
+    }
+
+    // -- Effective-color tint tests (Issue #528) ------------------------------
+    //
+    // RenderFrameThumbnail applies the frame's effective (sticky) color/alpha via the same
+    // FrameColorFilter + FramePreviewOpacity the preview panel uses, so a timeline/tree cell
+    // renders a tinted frame identically to the preview.
+
+    [Fact]
+    public void RenderFrameThumbnail_MultiplyColor_TintsTheCrop()
+    {
+        // A white source multiplied by (0,0,255) must come back pure blue — red/green zeroed out.
+        using var source = new SKBitmap(8, 8);
+        source.Erase(SKColors.White);
+        var blue = new ResolvedFrameColor(0, 0, 255, null, ColorOperation.Multiply);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), blue, 8, 8);
+
+        Assert.NotNull(thumb);
+        var p = thumb!.GetPixel(4, 4);
+        Assert.True(p.Blue > 200 && p.Red < 55 && p.Green < 55,
+            $"Center pixel {p} — a Multiply-blue tint should zero red/green and keep blue.");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_EffectiveAlpha_ReducesOpacity()
+    {
+        // An opaque source drawn at effective alpha 64 must come back semi-transparent, matching
+        // FramePreviewOpacity's reference interpretation.
+        using var source = new SKBitmap(8, 8);
+        source.Erase(SKColors.White);
+        var faded = new ResolvedFrameColor(null, null, null, 64, null);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), faded, 8, 8);
+
+        Assert.NotNull(thumb);
+        var p = thumb!.GetPixel(4, 4);
+        Assert.True(p.Alpha is > 20 and < 128,
+            $"Center pixel alpha {p.Alpha} — effective alpha 64 should render roughly 64, not opaque.");
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_DifferentEffectiveColor_ProducesDifferentCachedInstance()
+    {
+        // The cache key must include the effective color: two calls for the same crop but different
+        // tints must not collide on one cached bitmap (that would show a stale/wrong color).
+        var svc   = MakeSvc();
+        var path  = WriteTempPng(8, 8);
+        var frame = Frame();
+        frame.TextureName = path;
+
+        var plain = svc.GetFrameThumbnail(frame, default, 56, 56);
+        var tinted = svc.GetFrameThumbnail(
+            frame, new ResolvedFrameColor(255, 0, 0, null, ColorOperation.Multiply), 56, 56);
+
+        Assert.NotNull(plain);
+        Assert.NotNull(tinted);
+        Assert.NotSame(plain, tinted);
+    }
+
+    [AvaloniaFact]
+    public void GetFrameThumbnail_SameEffectiveColor_ReturnsSameCachedInstance()
+    {
+        // A tinted thumbnail must be rendered once and reused (no per-playback-frame re-render).
+        var svc   = MakeSvc();
+        var path  = WriteTempPng(8, 8);
+        var frame = Frame();
+        frame.TextureName = path;
+        var color = new ResolvedFrameColor(255, 0, 0, null, ColorOperation.Multiply);
+
+        var first  = svc.GetFrameThumbnail(frame, color, 56, 56);
+        var second = svc.GetFrameThumbnail(frame, color, 56, 56);
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
     }
 
     // -- Finished-thumbnail cache tests (Issue #474) --------------------------
@@ -152,9 +229,9 @@ public class ThumbnailServiceTests
         var frame = Frame();
         frame.TextureName = path;
 
-        var first = svc.GetFrameThumbnail(frame, 56, 56);
+        var first = svc.GetFrameThumbnail(frame, default, 56, 56);
         svc.InvalidatePath(path);
-        var afterInvalidate = svc.GetFrameThumbnail(frame, 56, 56);
+        var afterInvalidate = svc.GetFrameThumbnail(frame, default, 56, 56);
 
         Assert.NotNull(first);
         Assert.NotNull(afterInvalidate);
@@ -170,8 +247,8 @@ public class ThumbnailServiceTests
         var frame = Frame();
         frame.TextureName = path;
 
-        var first  = svc.GetFrameThumbnail(frame, 56, 56);
-        var second = svc.GetFrameThumbnail(frame, 56, 56);
+        var first  = svc.GetFrameThumbnail(frame, default, 56, 56);
+        var second = svc.GetFrameThumbnail(frame, default, 56, 56);
 
         Assert.NotNull(first);
         // Second call must hit the finished-thumbnail cache, not crop+wrap a fresh bitmap.
@@ -188,7 +265,7 @@ public class ThumbnailServiceTests
         var frame = Frame();
         frame.TextureName = path;
 
-        var thumb = svc.GetFrameThumbnail(frame, 56, 56);
+        var thumb = svc.GetFrameThumbnail(frame, default, 56, 56);
 
         Assert.NotNull(thumb);
         Assert.Equal(56, thumb!.PixelSize.Width);
@@ -351,7 +428,7 @@ public class ThumbnailServiceTests
                 source.SetPixel(x, y, y < 8 ? SKColors.Red : SKColors.Blue);
 
         using var thumb = ThumbnailService.RenderFrameThumbnail(
-            source, Frame(flipV: true), 8, 16);
+            source, Frame(flipV: true), default, 8, 16);
 
         Assert.NotNull(thumb);
         // Top pixel should be blue (was originally at the bottom).

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EffectiveFrameColorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EffectiveFrameColorTests.cs
@@ -72,6 +72,70 @@ public class EffectiveFrameColorTests
         Assert.Equal(ColorOperation.Add, EffectiveFrameColor.Resolve(frames, 1).Operation);
     }
 
+    // ── ResolveAll (O(n) whole-strip resolution) ──────────────────────────────
+
+    [Fact]
+    public void ResolveAll_MatchesPerFrameResolve_ForEveryIndex()
+    {
+        // ResolveAll's forward pass must agree with the backward Resolve at every index, including
+        // channels set on different frames and channels re-set mid-chain.
+        var frames = Chain(
+            new AnimationFrameSave { Red = 200, ColorOperation = ColorOperation.Multiply },
+            new AnimationFrameSave { Blue = 50 },
+            new AnimationFrameSave { Red = 10 },
+            new AnimationFrameSave());
+
+        var all = EffectiveFrameColor.ResolveAll(frames);
+
+        Assert.Equal(frames.Count, all.Length);
+        for (int i = 0; i < frames.Count; i++)
+            Assert.Equal(EffectiveFrameColor.Resolve(frames, i), all[i]);
+    }
+
+    [Fact]
+    public void ResolveAll_LaterFrameReSetsChannel_OverridesRunningValue()
+    {
+        // Guards against a `??=` regression that would freeze the first set value: frame 2 sets Red=10
+        // and every later frame must inherit 10, not the earlier 200.
+        var frames = Chain(
+            new AnimationFrameSave { Red = 200 },
+            new AnimationFrameSave(),
+            new AnimationFrameSave { Red = 10 },
+            new AnimationFrameSave());
+
+        var all = EffectiveFrameColor.ResolveAll(frames);
+
+        Assert.Equal(200, all[0].Red);
+        Assert.Equal(200, all[1].Red);
+        Assert.Equal(10, all[2].Red);
+        Assert.Equal(10, all[3].Red);
+    }
+
+    [Fact]
+    public void ResolveAll_EditingEarlierFrame_ChangesDownstreamButNotUpstream()
+    {
+        // The sticky-invalidation contract: changing frame 1's color changes the effective color of
+        // frames 1 onward (until a frame re-sets that channel), and leaves frame 0 untouched.
+        var frames = Chain(
+            new AnimationFrameSave { Alpha = 255 },
+            new AnimationFrameSave { Alpha = 128 },
+            new AnimationFrameSave(),
+            new AnimationFrameSave { Alpha = 64 });
+
+        var before = EffectiveFrameColor.ResolveAll(frames);
+        frames[1].Alpha = 100;
+        var after = EffectiveFrameColor.ResolveAll(frames);
+
+        Assert.Equal(before[0], after[0]);      // upstream unchanged
+        Assert.NotEqual(before[1], after[1]);   // edited frame
+        Assert.NotEqual(before[2], after[2]);   // downstream inherits the edit
+        Assert.Equal(before[3], after[3]);      // frame 3 re-sets alpha, so it's shielded
+    }
+
+    [Fact]
+    public void ResolveAll_EmptyList_ReturnsEmptyArray()
+        => Assert.Empty(EffectiveFrameColor.ResolveAll(new System.Collections.Generic.List<AnimationFrameSave>()));
+
     [Fact]
     public void ChannelDefault_Add_ReturnsZero()
         => Assert.Equal(0, EffectiveFrameColor.ChannelDefault(ColorOperation.Add));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ThumbnailSourceTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.ViewModels;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using Xunit;
 
@@ -31,7 +32,48 @@ public class ThumbnailSourceTests
 
         var source = ThumbnailSource.FromChain(chain);
 
-        Assert.Equal(new ThumbnailSource("sheet.png", 0f, 0.5f, 0f, 1f, false, false), source);
+        // An uncolored first frame resolves to all-null color channels.
+        Assert.Equal(
+            new ThumbnailSource("sheet.png", 0f, 0.5f, 0f, 1f, false, false, null, null, null, null, null),
+            source);
+    }
+
+    [Fact]
+    public void FromChain_FirstFrameColorChange_ProducesUnequalSignature()
+    {
+        // A color/alpha edit on the first frame must invalidate the cached chain icon so the tree
+        // re-tints it. (Untinted vs Multiply-red.)
+        var plain = new AnimationChainSave { Name = "Plain" };
+        plain.Frames.Add(new AnimationFrameSave { TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f });
+        var tinted = new AnimationChainSave { Name = "Tinted" };
+        tinted.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f,
+            ColorOperation = ColorOperation.Multiply, Red = 255, Green = 0, Blue = 0,
+        });
+
+        Assert.NotEqual(ThumbnailSource.FromChain(plain), ThumbnailSource.FromChain(tinted));
+    }
+
+    // ── FromFrame effective (sticky) color ─────────────────────────────────────
+
+    [Fact]
+    public void FromFrame_CapturesEffectiveStickyColor_NotJustTheFramesOwnChannels()
+    {
+        // Frame 0 sets Multiply red; frame 1 sets nothing. Frame 1's signature must carry the
+        // inherited (sticky) red so the timeline cell it tints rebuilds when frame 0's color changes.
+        var frames = new System.Collections.Generic.List<AnimationFrameSave>
+        {
+            new() { TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f,
+                    ColorOperation = ColorOperation.Multiply, Red = 200 },
+            new() { TextureName = "sheet.png", RightCoordinate = 1f, BottomCoordinate = 1f },
+        };
+        var colors = Rendering.EffectiveFrameColor.ResolveAll(frames);
+
+        var frame1Source = ThumbnailSource.FromFrame(frames[1], colors[1]);
+
+        Assert.Equal(200, frame1Source.Red);
+        Assert.Equal(ColorOperation.Multiply, frame1Source.Operation);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineStripSignatureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineStripSignatureTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.ViewModels;
+using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using Xunit;
 
@@ -83,6 +84,41 @@ public class TimelineStripSignatureTests
         var before = TimelineStripSignature.From(chain);
 
         (chain.Frames[0], chain.Frames[1]) = (chain.Frames[1], chain.Frames[0]);
+        var after = TimelineStripSignature.From(chain);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void From_FrameColorChanged_AreNotEqual()
+    {
+        // A color edit changes the tinted thumbnail even though width is unchanged, so the strip
+        // must rebuild — otherwise the cell would show the old color.
+        var chain = new AnimationChainSave { Name = "Run" };
+        var frame = Frame(0.1f);
+        chain.Frames.Add(frame);
+        var before = TimelineStripSignature.From(chain);
+
+        frame.ColorOperation = ColorOperation.Multiply;
+        frame.Red = 255; frame.Green = 0; frame.Blue = 0;
+        var after = TimelineStripSignature.From(chain);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void From_EarlierFrameColorChanged_ChangesDownstreamSignature()
+    {
+        // Sticky color: editing frame 0's color must change frame 1's effective color too, so the
+        // whole-strip signature differs and RefreshTimelineStrip rebuilds the downstream cell.
+        var chain = new AnimationChainSave { Name = "Run" };
+        var frame0 = Frame(0.1f);
+        chain.Frames.Add(frame0);
+        chain.Frames.Add(Frame(0.1f));   // frame 1 sets no color → inherits frame 0's
+        var before = TimelineStripSignature.From(chain);
+
+        frame0.ColorOperation = ColorOperation.Multiply;
+        frame0.Red = 128;
         var after = TimelineStripSignature.From(chain);
 
         Assert.NotEqual(before, after);


### PR DESCRIPTION
## What

Timeline strip cells and animation-tree chain icons rendered a raw texture crop, ignoring each frame's color/`ColorOperation` and `Alpha` — a tinted or faded frame looked identical to an untinted one, even though the wireframe/preview panels already show the effective color.

Thumbnails now apply the frame's **effective (sticky) color**: an omitted channel holds whatever an earlier frame last set, matching runtime and the preview panel. The tint reuses `FrameColorFilter` + `FramePreviewOpacity` — the same reference interpretation the preview uses — so timeline, tree, and preview render a given frame identically.

Per the issue's open question: **all** thumbnails are tinted, tree chain icons included (the honest choice — every surface shows the frame the same way).

## Caching & invalidation (the hard requirement)

- **Extended cache key.** `ThumbnailKey` now includes effective R/G/B/A/`ColorOperation`, so a tinted thumbnail is rendered once and reused until its crop *or* color changes; two frames with the same crop but different color no longer collide on one bitmap.
- **Sticky-aware, whole-strip invalidation.** `TimelineStripSignature` and `ThumbnailSource` capture the *effective* color, so editing frame N's color rebuilds cell N **and** every downstream cell it re-tints (sticky propagation). UV/flip edits stay local.
- **Resolve once per data change, not per render.** `EffectiveFrameColor.ResolveAll` resolves the whole strip in one O(n) forward pass. Resolution runs only on strip rebuild / tree refresh (data change), never in the 60fps playback loop — `RefreshTimelineStrip`/signature-building is not on the per-frame playhead path (`OnPlaybackTicked` moves the scrubber directly).
- **No #514 regression.** The cached decoded `SKImage` is untouched; the tint is a paint-level color filter on the existing image.

## Tests

- `EffectiveFrameColorTests` — `ResolveAll` matches per-frame `Resolve` at every index, later-frame re-set overrides the running value (guards a `??=` freeze regression), and the upstream/edited/downstream/shielded cascade contract.
- `ThumbnailSourceTests` / `TimelineStripSignatureTests` — a color/alpha edit (and an *earlier*-frame sticky edit) produces an unequal signature so the strip rebuilds.
- `ThumbnailServiceTests` — Multiply tint and effective-alpha render correctly; the cache key distinguishes colors (different color → different instance, same color → same instance).

Full AE suite green: 1390 Core + 537 App.

## Note on the diff

This branch is stacked on the (previously unpushed) sticky-color commit `b604c78`, so this PR includes **two commits**: the earlier "Show effective (sticky) frame color in AE preview and inspector" and this timeline/tree work. They form one cohesive feature line. Happy to split into stacked PRs if you'd prefer separate reviews.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)