### PR TITLE
Fix Alt+Arrow reorder to move all multi-selected frames, preserving gaps

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -687,6 +687,50 @@ namespace AnimationEditor.Core.CommandsAndState
                 frames, sourceChain, targetChain, insertIndex, this, _events, _selectedState));
         }
 
+        /// <inheritdoc cref="IAppCommands.MoveFramesRelative"/>
+        public void MoveFramesRelative(IReadOnlyList<AnimationFrameSave> frames,
+            AnimationChainSave chain, int delta)
+        {
+            if (delta == 0 || frames.Count == 0) return;
+
+            var indices = frames
+                .Select(f => chain.Frames.IndexOf(f))
+                .Where(i => i >= 0)
+                .Distinct()
+                .OrderBy(i => i)
+                .ToList();
+            if (indices.Count == 0) return;
+
+            // Rigid group: if shifting either edge by delta would cross a boundary, no-op.
+            if (indices[0] + delta < 0) return;
+            if (indices[^1] + delta > chain.Frames.Count - 1) return;
+
+            var selected = new HashSet<int>(indices);
+
+            _undoManager.Execute(new ReorderCommand<AnimationFrameSave>(
+                chain.Frames,
+                () =>
+                {
+                    var reordered = new AnimationFrameSave[chain.Frames.Count];
+                    // Selected frames land at their shifted slots (gaps preserved)...
+                    foreach (int i in indices)
+                        reordered[i + delta] = chain.Frames[i];
+                    // ...and the rest slot into the remaining holes in original order.
+                    int cursor = 0;
+                    for (int i = 0; i < chain.Frames.Count; i++)
+                    {
+                        if (selected.Contains(i)) continue;
+                        while (reordered[cursor] is not null) cursor++;
+                        reordered[cursor] = chain.Frames[i];
+                    }
+                    chain.Frames.Clear();
+                    foreach (var frame in reordered)
+                        chain.Frames.Add(frame);
+                },
+                this, _events, () => RefreshTreeNode(chain),
+                delta > 0 ? "Move Frames Down" : "Move Frames Up"));
+        }
+
         public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {
             var shapes = frame.ShapesSave?.Shapes;
@@ -749,7 +793,17 @@ namespace AnimationEditor.Core.CommandsAndState
                 if (ownerFrame is not null) MoveShape(circle, ownerFrame, delta);
             }
             else if (frame is not null && chain is not null)
-                MoveFrame(frame, chain, delta);
+            {
+                // Reorder the whole multi-selection together (gaps preserved); fall back to
+                // the single-frame move when only the primary frame is selected.
+                var frames = _selectedState.SelectedFrames
+                    .Where(chain.Frames.Contains)
+                    .ToList();
+                if (frames.Count > 1)
+                    MoveFramesRelative(frames, chain, delta);
+                else
+                    MoveFrame(frame, chain, delta);
+            }
             else if (chain is not null)
                 MoveChain(chain, delta);
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -142,6 +142,17 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void MoveFrames(IReadOnlyList<AnimationFrameSave> frames,
             AnimationChainSave sourceChain, AnimationChainSave targetChain, int insertIndex);
+
+        /// <summary>
+        /// Shifts <paramref name="frames"/> within <paramref name="chain"/> by
+        /// <paramref name="delta"/> slots (−1 = up, +1 = down) as one rigid group, preserving
+        /// the gaps between non-contiguous frames, as a single undo step. The whole group is
+        /// clamped at the chain boundaries: if the shift would push any selected frame past an
+        /// end, nothing moves. Drives the Alt+Arrow keyboard reorder — unlike the drag-drop
+        /// <see cref="MoveFrames"/> path, it does not collapse the selection into a contiguous block.
+        /// </summary>
+        void MoveFramesRelative(IReadOnlyList<AnimationFrameSave> frames,
+            AnimationChainSave chain, int delta);
         void MoveShape(object shape, AnimationFrameSave frame, int delta);
         void MoveShapeToTop(object shape, AnimationFrameSave frame);
         void MoveShapeToBottom(object shape, AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -1,6 +1,8 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -97,6 +99,140 @@ public class AppCommandsReorderTests
         var ex = Record.Exception(() => ctx.AppCommands.HandleReorder(+1));
 
         Assert.Null(ex);
+    }
+
+    // ── HandleReorder — multiple frames selected ─────────────────────────────
+
+    [Fact]
+    public void HandleReorder_MultiFrameContiguous_DeltaPos1_MovesBlockDown()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[1] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // Block {f0,f1} shifts down one; f2 fills the vacated top slot.
+        Assert.Equal(new[] { f[2], f[0], f[1], f[3] }, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameContiguous_DeltaNeg1_MovesBlockUp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[2];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[2], f[3] };
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        Assert.Equal(new[] { f[0], f[2], f[3], f[1] }, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameNonContiguous_DeltaPos1_PreservesGaps()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 6);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[2], f[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // 0,2,4 → 1,3,5; gaps preserved, non-selected fill remaining slots in order.
+        Assert.Equal(new[] { f[1], f[0], f[3], f[2], f[5], f[4] }, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameNonContiguous_DeltaNeg1_PreservesGaps()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 6);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[1];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[1], f[3], f[5] };
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        // 1,3,5 → 0,2,4; gaps preserved.
+        Assert.Equal(new[] { f[1], f[0], f[3], f[2], f[5], f[4] }, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameAtBottom_DeltaPos1_IsNoOp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[2];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[2], f[3] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // Bottommost selected frame is already at the end — whole group is clamped.
+        Assert.Equal(f, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameAtTop_DeltaNeg1_IsNoOp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[1] };
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        Assert.Equal(f, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrameNonContiguousBlockedEdge_DeltaPos1_IsNoOp()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 5);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[2], f[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // f4 is already at the end, so the rigid group can't move; nothing shifts.
+        Assert.Equal(f, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrame_SingleUndo_RevertsWholeMove()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 6);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[2], f[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(f, chain.Frames.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiFrame_KeepsAllFramesSelected()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 6);
+        var f = chain.Frames.ToArray();
+        ctx.SelectedState.SelectedFrame = f[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { f[0], f[2], f[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(new[] { f[0], f[2], f[4] }, ctx.SelectedState.SelectedFrames.ToArray());
     }
 
     // ── HandleReorder — rectangle selected ───────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -78,6 +78,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrameToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrames)]                   = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveFramesRelative)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShape)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToBottom)]            = Category.MutatingUndoable,
@@ -234,6 +235,10 @@ public class UndoCoverageRosterTests
             // Within-chain drag move: frame 0 → end of Zebra (3 frames) reorders to 1,2,0.
             ctx => Sync(() => ctx.AppCommands.MoveFrames(
                 new[] { Zebra(ctx).Frames[0] }, Zebra(ctx), Zebra(ctx), insertIndex: 3)));
+        yield return Row(nameof(IAppCommands.MoveFramesRelative),
+            // Rigid multi-frame shift: frames 0 and 1 of Zebra (3 frames) move down → 2,0,1.
+            ctx => Sync(() => ctx.AppCommands.MoveFramesRelative(
+                new[] { Zebra(ctx).Frames[0], Zebra(ctx).Frames[1] }, Zebra(ctx), +1)));
         yield return Row(nameof(IAppCommands.MoveShape),
             ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.MoveShapeToTop),


### PR DESCRIPTION
## Summary

Alt+Up / Alt+Down reorder moved only the primary `SelectedFrame` when multiple frames were multi-selected. It now moves the whole selection together, preserving the gaps between non-contiguous frames.

## What changed

- `AppCommands.HandleReorder` now gathers `SelectedFrames` (filtered to the active chain). With >1 frame selected it routes through a new `MoveFramesRelative`; single-frame reorder still uses `MoveFrame` unchanged.
- New `MoveFramesRelative(frames, chain, delta)` shifts the selection by one slot as a **rigid group**: gaps between non-contiguous frames are preserved, and the whole group is clamped at the chain boundaries (if any selected frame would cross an end, nothing moves). One undo entry; all moved frames stay selected (instance identity preserved).
- Unlike the drag-drop `MoveFrames` path, this does **not** collapse the selection into a contiguous block.

## Tests (TDD — red first, then green)

Added multi-frame cases to `AppCommandsReorderTests`: contiguous block up/down, non-contiguous gap preservation up/down, clamp-at-both-ends no-ops (incl. a non-contiguous edge-blocked case), single-undo revert, and selection preservation. `MoveFramesRelative` is registered in the `UndoCoverageRosterTests` roster with a round-trip invocation.

All 1395 Core + 533 App tests pass.

## Acceptance

- [x] Multi-selected contiguous frames move together as a block on Alt+Arrow.
- [x] Multi-selected non-contiguous frames move together with gaps preserved.
- [x] Single-frame reorder still works unchanged.
- [x] Single undo reverts the entire multi-frame move.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)