### PR TITLE
Fix ANIMATIONS tree collapse/expand flicker on tab switch

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -627,7 +627,7 @@ public partial class MainWindow : Window
 
         // Tree events — fully wired (WireTreeView connects these after tree is constructed)
         _appCommands.RefreshTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RefreshTreeView);
-        _appCommands.RebuildTreeViewRequested           += () => Dispatcher.UIThread.InvokeAsync(RebuildTreeView);
+        _appCommands.RebuildTreeViewRequested           += expandedChainNames => Dispatcher.UIThread.InvokeAsync(() => RebuildTreeView(expandedChainNames));
         _appCommands.RefreshChainNodeRequested          += c  => Dispatcher.UIThread.InvokeAsync(() => RefreshChainNode(c));
         _appCommands.RefreshFrameNodeRequested          += f  => Dispatcher.UIThread.InvokeAsync(() => RefreshFrameNode(f));
         _appCommands.RefreshAnimationFrameDisplayRequested += () => PreviewCtrl.InvalidateVisual();
@@ -2571,13 +2571,16 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Fully rebuilds the tree from scratch with every chain collapsed. Used on
-    /// .achx load (File &gt; Open, recent files, drag-drop, startup reopen) so a
-    /// freshly-opened file presents a scannable, collapsed overview. Contrast with
-    /// <see cref="RefreshTreeView"/>, which diff-updates and preserves each chain's
-    /// collapse state across edits.
+    /// Fully rebuilds the tree from scratch, expanding only the chains named in
+    /// <paramref name="expandedChainNames"/> (empty for a fresh, never-before-seen file,
+    /// so it presents a scannable, collapsed overview). Used on .achx load (File &gt; Open,
+    /// recent files, drag-drop, startup reopen, tab switch). Building the correct expand
+    /// state up front — rather than collapsing here and correcting it once companion-file
+    /// settings load — avoids a collapse-then-expand flicker on tab switch, since those two
+    /// steps land in separate dispatcher jobs. Contrast with <see cref="RefreshTreeView"/>,
+    /// which diff-updates and preserves each chain's collapse state across edits.
     /// </summary>
-    private void RebuildTreeView()
+    private void RebuildTreeView(IReadOnlyList<string> expandedChainNames)
     {
         _suppressTreeSelectionHandling = true;
         try
@@ -2591,11 +2594,10 @@ public partial class MainWindow : Window
                 return;
             }
 
-            // Empty expandedChainNames (not null) collapses every chain; null would
-            // default them all to expanded. All nodes are added (membership always
-            // mirrors the model); an active filter is applied as per-node visibility so
-            // it persists across a full rebuild without dropping nodes from the tree.
-            foreach (var node in TreeBuilder.BuildTree(acls, System.Array.Empty<string>()))
+            // All nodes are added (membership always mirrors the model); an active filter
+            // is applied as per-node visibility so it persists across a full rebuild
+            // without dropping nodes from the tree.
+            foreach (var node in TreeBuilder.BuildTree(acls, expandedChainNames))
             {
                 node.PinnedVisible = TreeBuilder.MatchesFilter(node.Header, _treeFilterQuery);
                 _treeRoots.Add(node);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -78,7 +78,7 @@ namespace AnimationEditor.Core.CommandsAndState
         public event Action? RefreshTreeViewRequested;
 
         /// <inheritdoc cref="IAppCommands.RebuildTreeViewRequested"/>
-        public event Action? RebuildTreeViewRequested;
+        public event Action<IReadOnlyList<string>>? RebuildTreeViewRequested;
 
         /// <summary>
         /// Request a single chain's tree node to refresh.
@@ -231,8 +231,12 @@ namespace AnimationEditor.Core.CommandsAndState
             _selectedState.Reset();
             _selectedState.SelectedChain = _pm.AnimationChainListSave?.AnimationChains.FirstOrDefault();
             // Rebuild (not refresh): a freshly-opened file should present a collapsed,
-            // scannable overview rather than every chain's frames expanded.
-            RebuildTreeViewRequested?.Invoke();
+            // scannable overview rather than every chain's frames expanded — unless a
+            // companion file already recorded which chains were expanded, in which case
+            // build the tree pre-expanded to that state in one pass. Building collapsed
+            // and correcting it once LoadAndApplyCompanionFileFor's settings land would
+            // flicker (two separately-dispatched UI updates).
+            RebuildTreeViewRequested?.Invoke((IReadOnlyList<string>?)_ioManager.TryLoadCompanionSettings(fileName)?.ExpandedNodes ?? Array.Empty<string>());
             _ioManager.LoadAndApplyCompanionFileFor(fileName);
             RefreshWireframeRequested?.Invoke();
             RefreshAnimationFrameDisplayRequested?.Invoke();
@@ -262,7 +266,9 @@ namespace AnimationEditor.Core.CommandsAndState
 
             _selectedState.Reset();
             _selectedState.SelectedChain = tab.CachedEditorModel?.AnimationChains.FirstOrDefault();
-            RebuildTreeViewRequested?.Invoke();
+            // See the comment in FinishLoadIntoEditor: build already-expanded from the
+            // companion file so reactivating a tab doesn't flicker collapsed-then-expanded.
+            RebuildTreeViewRequested?.Invoke((IReadOnlyList<string>?)_ioManager.TryLoadCompanionSettings(tab.Path.FullPath)?.ExpandedNodes ?? Array.Empty<string>());
             _ioManager.LoadAndApplyCompanionFileFor(tab.Path.FullPath);
             RefreshWireframeRequested?.Invoke();
             RefreshAnimationFrameDisplayRequested?.Invoke();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -24,12 +24,16 @@ namespace AnimationEditor.Core.CommandsAndState
         event Action RefreshTreeViewRequested;
 
         /// <summary>
-        /// Request a full tree-view rebuild from scratch with every chain collapsed.
-        /// Raised on .achx load (File &gt; Open, recent files, drag-drop, startup reopen).
-        /// Differs from <see cref="RefreshTreeViewRequested"/>, which diff-updates the
-        /// existing tree and preserves each chain's collapse state across edits.
+        /// Request a full tree-view rebuild from scratch. Raised on .achx load (File &gt; Open,
+        /// recent files, drag-drop, startup reopen, tab switch). The argument is the set of
+        /// chain names to expand — the saved companion-file expand state when one exists, or
+        /// empty for a genuinely new file, so the tree is built already in its final state
+        /// instead of collapsing first and correcting itself once settings load (which flickers
+        /// on tab switch since the two steps land in separate dispatcher jobs). Differs from
+        /// <see cref="RefreshTreeViewRequested"/>, which diff-updates the existing tree and
+        /// preserves each chain's collapse state across edits.
         /// </summary>
-        event Action RebuildTreeViewRequested;
+        event Action<IReadOnlyList<string>> RebuildTreeViewRequested;
 
         event Action<AnimationChainSave> RefreshChainNodeRequested;
         event Action<AnimationFrameSave> RefreshFrameNodeRequested;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IIoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IIoManager.cs
@@ -13,6 +13,15 @@ namespace AnimationEditor.Core.IO
 
         void SaveCompanionFileFor(FilePath fileName, AESettingsSave settings);
         void LoadAndApplyCompanionFileFor(string achxFile);
+
+        /// <summary>
+        /// Synchronously reads the companion settings for <paramref name="achxFile"/> without
+        /// raising <see cref="SettingsLoaded"/>. Returns null when no companion file exists or
+        /// it fails to deserialize. Callers that need to know the saved expand state (or other
+        /// settings) before the first tree build — e.g. to avoid a collapse-then-restore flicker
+        /// on tab switch — should use this instead of <see cref="LoadAndApplyCompanionFileFor"/>.
+        /// </summary>
+        AESettingsSave? TryLoadCompanionSettings(string achxFile);
         void WriteRecoveryFile(AnimationChainListSave? animationChainListSave);
         void DeleteRecoveryFile();
         bool RecoveryFileExists();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
@@ -40,23 +40,26 @@ namespace AnimationEditor.Core.IO
 
         public void LoadAndApplyCompanionFileFor(string achxFile)
         {
-            var fileToLoad = GetCompanionFileFor(new FilePath(achxFile));
-
-            if (!fileToLoad.Exists()) return;
-
-            AESettingsSave? loadedInstance = null;
-            try
-            {
-                loadedInstance = XmlFile.Deserialize<AESettingsSave>(fileToLoad.FullPath);
-            }
-            catch
-            {
-                return;
-            }
-
+            var loadedInstance = TryLoadCompanionSettings(achxFile);
             if (loadedInstance != null)
             {
                 ApplySettings(loadedInstance);
+            }
+        }
+
+        public AESettingsSave? TryLoadCompanionSettings(string achxFile)
+        {
+            var fileToLoad = GetCompanionFileFor(new FilePath(achxFile));
+
+            if (!fileToLoad.Exists()) return null;
+
+            try
+            {
+                return XmlFile.Deserialize<AESettingsSave>(fileToLoad.FullPath);
+            }
+            catch
+            {
+                return null;
             }
         }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameDragReorderHeadlessTests.cs
@@ -37,7 +37,7 @@ public class FrameDragReorderHeadlessTests
     {
         typeof(MainWindow)
             .GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(window, null);
+            .Invoke(window, new object[] { Array.Empty<string>() });
     }
 
     private static ObservableCollection<TreeNodeVm> Roots(MainWindow window)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiCopyPasteAppTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiCopyPasteAppTests.cs
@@ -34,7 +34,7 @@ public class MultiCopyPasteAppTests
     private static void RebuildTree(MainWindow window)
     {
         typeof(MainWindow).GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(window, null);
+            .Invoke(window, new object[] { Array.Empty<string>() });
         FlushUi();
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineStripRebuildTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelineStripRebuildTests.cs
@@ -49,7 +49,7 @@ public class TimelineStripRebuildTests
         ctx.ProjectManager.AnimationChainListSave = acls;
         typeof(MainWindow)
             .GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(window, null);
+            .Invoke(window, new object[] { Array.Empty<string>() });
         Dispatcher.UIThread.RunJobs();
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadFailureTests.cs
@@ -46,7 +46,7 @@ public class AppCommandsLoadFailureTests : IDisposable
     {
         var ctx = TestHelpers.SetupFreshAcls();
         bool fired = false;
-        ctx.AppCommands.RebuildTreeViewRequested += () => fired = true;
+        ctx.AppCommands.RebuildTreeViewRequested += _ => fired = true;
 
         ctx.AppCommands.LoadAnimationChain(TestPaths.Abs("does", "not", "exist.achx"));
 
@@ -100,7 +100,7 @@ public class AppCommandsLoadFailureTests : IDisposable
         var badFile = Path.Combine(_dir.Path, "bad2.achx");
         File.WriteAllText(badFile, "this is not valid xml");
         bool fired = false;
-        ctx.AppCommands.RebuildTreeViewRequested += () => fired = true;
+        ctx.AppCommands.RebuildTreeViewRequested += _ => fired = true;
 
         ctx.AppCommands.LoadAnimationChain(badFile);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsLoadTests.cs
@@ -133,7 +133,7 @@ public class AppCommandsLoadTests : IDisposable
     {
         var path = WriteAchx("Walk");
         AnimationChainSave? observedDuringRebuild = null;
-        _ctx.AppCommands.RebuildTreeViewRequested += () =>
+        _ctx.AppCommands.RebuildTreeViewRequested += _ =>
             observedDuringRebuild = _ctx.SelectedState.SelectedChain;
 
         _ctx.AppCommands.LoadAnimationChain(path);
@@ -155,7 +155,7 @@ public class AppCommandsLoadTests : IDisposable
     {
         var path = WriteAchx("Walk");
         bool rebuildFired = false;
-        _ctx.AppCommands.RebuildTreeViewRequested += () => rebuildFired = true;
+        _ctx.AppCommands.RebuildTreeViewRequested += _ => rebuildFired = true;
 
         _ctx.AppCommands.LoadAnimationChain(path);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsTreeExpandStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsTreeExpandStateTests.cs
@@ -1,0 +1,82 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies <see cref="IAppCommands.RebuildTreeViewRequested"/> is raised with the companion
+/// file's saved expand state already applied, instead of always empty (collapsed) and relying
+/// on a later <see cref="AnimationEditor.Core.IO.IIoManager.SettingsLoaded"/> pass to correct it.
+/// The two-pass version flickers on tab switch because the collapse and the re-expand are two
+/// separately-dispatched UI updates (issue #547).
+/// </summary>
+[Collection("SequentialSingletons")]
+public class AppCommandsTreeExpandStateTests : IDisposable
+{
+    private readonly TestHelpers.TempDir _dir = new();
+    private readonly TestServices _ctx = TestHelpers.SetupFreshAcls();
+
+    public void Dispose() => _dir.Dispose();
+
+    private string WriteAchx(string fileName, params string[] chainNames)
+    {
+        var path = Path.Combine(_dir.Path, fileName);
+        var acls = new AnimationChainListSave();
+        foreach (var name in chainNames)
+            acls.AnimationChains.Add(new AnimationChainSave { Name = name });
+        acls.Save(path);
+        return path;
+    }
+
+    [Fact]
+    public void LoadAnimationChain_WithNoCompanionFile_FiresRebuildTreeViewRequestedWithEmptyExpandedSet()
+    {
+        var path = WriteAchx("fresh.achx", "Walk", "Run");
+        IReadOnlyList<string>? observed = null;
+        _ctx.AppCommands.RebuildTreeViewRequested += names => observed = names;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(observed);
+        Assert.Empty(observed!);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_WithSavedExpandedChain_FiresRebuildTreeViewRequestedWithThatChainExpanded()
+    {
+        var path = WriteAchx("saved.achx", "Walk", "Run");
+        _ctx.IoManager.SaveCompanionFileFor(new FilePath(path), new AESettingsSave { ExpandedNodes = new List<string> { "Walk" } });
+        IReadOnlyList<string>? observed = null;
+        _ctx.AppCommands.RebuildTreeViewRequested += names => observed = names;
+
+        _ctx.AppCommands.LoadAnimationChain(path);
+
+        Assert.NotNull(observed);
+        Assert.Equal(new[] { "Walk" }, observed!.ToArray());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task TryActivateTabFromCache_WithSavedExpandedChain_FiresRebuildTreeViewRequestedWithThatChainExpanded()
+    {
+        var path = WriteAchx("cached.achx", "Walk", "Run");
+        _ctx.IoManager.SaveCompanionFileFor(new FilePath(path), new AESettingsSave { ExpandedNodes = new List<string> { "Walk" } });
+        var tab = new TabEntry(new FilePath(path));
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+
+        IReadOnlyList<string>? observed = null;
+        _ctx.AppCommands.RebuildTreeViewRequested += names => observed = names;
+        Assert.True(_ctx.AppCommands.TryActivateTabFromCache(tab));
+
+        Assert.NotNull(observed);
+        Assert.Equal(new[] { "Walk" }, observed!.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary

- Tab activation (`OpenAchxWorkflowAsync` / `TryActivateTabFromCache`) always rebuilt the ANIMATIONS tree fully collapsed, then relied on a separately-dispatched `SettingsLoaded` handler to re-expand chains from the companion `.aeproperties` file. Because those two UI updates land in separate dispatcher jobs, the render/compositor could paint the transient all-collapsed state before the re-expand landed — a visible flicker on tab switch. Timing-dependent, so it didn't reproduce every time.
- `RebuildTreeViewRequested` now carries the expand state to build with. `AppCommands` peeks the companion file's saved `ExpandedNodes` (via new `IIoManager.TryLoadCompanionSettings`) *before* firing the rebuild, so the tree is built already-correct in one pass instead of collapse-then-correct.
- Genuinely new files (no companion file yet) still build fully collapsed — unchanged behavior.

## Test plan

- [x] New tests in `AppCommandsTreeExpandStateTests.cs` verify `RebuildTreeViewRequested` fires with the companion file's saved expanded chains (or empty when none exists) for both `LoadAnimationChain` and `TryActivateTabFromCache`.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1406 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 537 passed

Closes #547