### PR TITLE
Cross-link gumcli skill to content-boundary

### DIFF
--- a/frb-skills/gumcli/SKILL.md
+++ b/frb-skills/gumcli/SKILL.md
@@ -5,6 +5,8 @@ description: "Gum CLI tool for FlatRedBall2. Trigger at game/sample START — be
 
 # Gum CLI Setup
 
+> **This skill is the mechanical setup only.** `gumcli` scaffolds the project and flat named controls; the user owns visual layout and composition in the Gum editor afterward — see the `content-boundary` skill for that AI/human split.
+
 **Ask the Gum mode question at game-start time** — before any code is written, not when Gum UI is about to be implemented. This affects project structure and cannot be changed easily mid-build.
 
 When starting any new game or sample, ask:


### PR DESCRIPTION
## What

Adds a one-line back-link at the top of the `gumcli` skill pointing to the `content-boundary` skill.

## Why

`gumcli/SKILL.md` covered only the mechanical Gum project setup (install → `new` → csproj → codegen → fonts → check) with no pointer to the AI/human content boundary. The `content-boundary` skill already referenced `gumcli`, but not the reverse — so an agent that loads `gumcli` alone at game-start (as the skill instructs) was never reminded that it only scaffolds flat named controls and the **user** owns visual layout/composition in the Gum editor. This closes that one-directional link.

`gum-integration` already cross-links `content-boundary`, so no change was needed there. The cross-referencing is now bidirectional across all three Gum skills.

## Change

One blockquote line added under the `# Gum CLI Setup` heading; nothing removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
