### PR TITLE
Add user-controllable canvas background to Animation Editor

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
     <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml
@@ -156,6 +156,10 @@
 
     <Application.Styles>
         <FluentTheme />
+        <!-- ColorView/ColorPicker (Avalonia.Controls.ColorPicker) ships its control templates
+             in a separate theme dictionary; without this include the controls have no template
+             and render at zero size. Must match the FluentTheme above. -->
+        <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <!-- Compact buttons: override FluentTheme MinHeight so small +/- buttons aren't stretched -->
         <Style Selector="Button.compact">
             <Setter Property="MinHeight" Value="0"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -117,6 +117,25 @@ public class PreviewControl : Control
     // Neutral canvas/ruler colors for the active theme variant. Refreshed from
     // ActualThemeVariant on every render and whenever the variant changes.
     private CanvasPalette _palette = CanvasPalette.Dark;
+
+    private uint? _canvasBackgroundOverride;
+
+    /// <summary>
+    /// Optional user-chosen canvas background as a packed <c>0xAARRGGBB</c> value; <c>null</c>
+    /// follows the theme. Setting it re-resolves the palette and repaints. Chrome (rulers, guides)
+    /// stays theme-driven.
+    /// </summary>
+    public uint? CanvasBackgroundOverride
+    {
+        get => _canvasBackgroundOverride;
+        set
+        {
+            if (_canvasBackgroundOverride == value) return;
+            _canvasBackgroundOverride = value;
+            UpdatePalette();
+            InvalidateVisual();
+        }
+    }
     private readonly List<float> _hGuides = new(); // world-Y values (positive = down on screen)
     private readonly List<float> _vGuides = new(); // world-X values (positive = right on screen)
     private int  _draggedGuideIdx = -1;
@@ -928,7 +947,8 @@ public class PreviewControl : Control
 
     // ActualThemeVariant resolves Default to the concrete platform variant, so a simple
     // "is it Light?" check correctly handles the follow-system case.
-    private void UpdatePalette() => _palette = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light);
+    private void UpdatePalette() =>
+        _palette = CanvasPalette.Resolve(ActualThemeVariant != ThemeVariant.Light, _canvasBackgroundOverride);
 
     // -- Guide helpers ---------------------------------------------------------
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -342,6 +342,25 @@ public class WireframeControl : Control
     // ActualThemeVariant on every render and whenever the variant changes.
     private CanvasPalette _palette = CanvasPalette.Dark;
 
+    private uint? _canvasBackgroundOverride;
+
+    /// <summary>
+    /// Optional user-chosen canvas background as a packed <c>0xAARRGGBB</c> value; <c>null</c>
+    /// follows the theme. Setting it re-resolves the palette and repaints. Chrome (grid, rulers,
+    /// outline) stays theme-driven.
+    /// </summary>
+    public uint? CanvasBackgroundOverride
+    {
+        get => _canvasBackgroundOverride;
+        set
+        {
+            if (_canvasBackgroundOverride == value) return;
+            _canvasBackgroundOverride = value;
+            UpdatePalette();
+            InvalidateVisual();
+        }
+    }
+
     /// <summary>
     /// Shows/hides the render-diagnostics overlay (draw-time readout + camera stats). Toggled at
     /// runtime from MainWindow (F3 and the Help ▸ Show Render Diagnostics menu item).
@@ -1100,7 +1119,8 @@ public class WireframeControl : Control
 
     // ActualThemeVariant resolves Default to the concrete platform variant, so a simple
     // "is it Light?" check correctly handles the follow-system case.
-    private void UpdatePalette() => _palette = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light);
+    private void UpdatePalette() =>
+        _palette = CanvasPalette.Resolve(ActualThemeVariant != ThemeVariant.Light, _canvasBackgroundOverride);
 
     /// <summary>
     /// Renders the current wireframe state to an off-screen bitmap of the given size.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -121,6 +121,14 @@
                             <MenuItem Header="_Dark"          x:Name="MenuThemeDark"   ToggleType="Radio" />
                             <MenuItem Header="Follow _System" x:Name="MenuThemeSystem" ToggleType="Radio" />
                         </MenuItem>
+                        <MenuItem Header="Canvas _Background">
+                            <MenuItem Header="Theme _Default" x:Name="MenuBgThemeDefault" ToggleType="Radio" GroupName="CanvasBg" />
+                            <MenuItem Header="_Black"         x:Name="MenuBgBlack"        ToggleType="Radio" GroupName="CanvasBg" />
+                            <MenuItem Header="_White"         x:Name="MenuBgWhite"        ToggleType="Radio" GroupName="CanvasBg" />
+                            <MenuItem Header="Mid _Gray"      x:Name="MenuBgMidGray"      ToggleType="Radio" GroupName="CanvasBg" />
+                            <Separator />
+                            <MenuItem Header="_Custom…"       x:Name="MenuBgCustom"       ToggleType="Radio" GroupName="CanvasBg" />
+                        </MenuItem>
                     </MenuItem>
                     <MenuItem Header="_Help">
                         <MenuItem Header="Show _Render Diagnostics" x:Name="MenuShowDiagnostics"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -172,6 +172,7 @@ public partial class MainWindow : Window
         WireAppCommands();
         LoadSettingsFile();
         ApplyPersistedTheme();
+        ApplyPersistedCanvasBackground();
         WireMenuEvents();
         WireWireframeToolbar();
         WireWireframeControl();
@@ -1392,6 +1393,12 @@ public partial class MainWindow : Window
         MenuThemeLight.Click  += (_, _) => SetTheme(AppTheme.Light);
         MenuThemeDark.Click   += (_, _) => SetTheme(AppTheme.Dark);
         MenuThemeSystem.Click += (_, _) => SetTheme(AppTheme.System);
+
+        MenuBgThemeDefault.Click += (_, _) => SetCanvasBackground(null);
+        MenuBgBlack.Click        += (_, _) => SetCanvasBackground(CanvasBgBlack);
+        MenuBgWhite.Click        += (_, _) => SetCanvasBackground(CanvasBgWhite);
+        MenuBgMidGray.Click      += (_, _) => SetCanvasBackground(CanvasBgMidGray);
+        MenuBgCustom.Click       += async (_, _) => await PickCustomCanvasBackgroundAsync();
         // C#-built surfaces (tab strip, history rows) hold static brush snapshots, so
         // rebuild them when the variant changes. XAML surfaces follow via DynamicResource.
         ActualThemeVariantChanged += (_, _) => { RebuildTabStrip(); RefreshHistoryPanel(); };
@@ -3916,6 +3923,94 @@ public partial class MainWindow : Window
         MenuThemeLight.IsChecked  = _appSettings.Theme == AppTheme.Light;
         MenuThemeDark.IsChecked   = _appSettings.Theme == AppTheme.Dark;
         MenuThemeSystem.IsChecked = _appSettings.Theme == AppTheme.System;
+    }
+
+    // ── Canvas background ──────────────────────────────────────────────────────
+    // Preset backgrounds for the View → Canvas Background menu (packed 0xAARRGGBB, opaque).
+    private const uint CanvasBgBlack   = 0xFF000000;
+    private const uint CanvasBgWhite   = 0xFFFFFFFF;
+    private const uint CanvasBgMidGray = 0xFF808080;
+
+    /// <summary>Pushes the persisted canvas-background override onto both canvases and syncs the menu.</summary>
+    private void ApplyPersistedCanvasBackground()
+    {
+        WireframeCtrl.CanvasBackgroundOverride = _appSettings.CanvasBackgroundArgb;
+        PreviewCtrl.CanvasBackgroundOverride   = _appSettings.CanvasBackgroundArgb;
+        SyncCanvasBackgroundMenuChecks();
+    }
+
+    private void SetCanvasBackground(uint? argb)
+    {
+        _appSettings.CanvasBackgroundArgb = argb;
+        WireframeCtrl.CanvasBackgroundOverride = argb;
+        PreviewCtrl.CanvasBackgroundOverride   = argb;
+        SyncCanvasBackgroundMenuChecks();
+        SaveSettingsFile();
+    }
+
+    private void SyncCanvasBackgroundMenuChecks()
+    {
+        var argb = _appSettings.CanvasBackgroundArgb;
+        MenuBgThemeDefault.IsChecked = argb is null;
+        MenuBgBlack.IsChecked        = argb == CanvasBgBlack;
+        MenuBgWhite.IsChecked        = argb == CanvasBgWhite;
+        MenuBgMidGray.IsChecked      = argb == CanvasBgMidGray;
+        // "Custom" covers any opaque color that isn't one of the named presets.
+        MenuBgCustom.IsChecked =
+            argb is uint v && v != CanvasBgBlack && v != CanvasBgWhite && v != CanvasBgMidGray;
+    }
+
+    /// <summary>
+    /// Opens a color picker seeded with the current background, and on OK stores the chosen
+    /// color (forced opaque) as the custom canvas background.
+    /// </summary>
+    private async Task PickCustomCanvasBackgroundAsync()
+    {
+        var themed = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light).Background;
+        var seed = _appSettings.CanvasBackgroundArgb is uint v
+            ? Color.FromUInt32(v)
+            : Color.FromArgb(themed.Alpha, themed.Red, themed.Green, themed.Blue);
+
+        var colorView = new ColorView { Color = seed };
+
+        var okBtn     = new Button { Content = "OK",     MinWidth = 80 };
+        var cancelBtn = new Button { Content = "Cancel", MinWidth = 80 };
+        var buttons = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+            Spacing = 8,
+            Margin = new Avalonia.Thickness(0, 12, 0, 0),
+            Children = { okBtn, cancelBtn },
+        };
+
+        var root = new DockPanel { Margin = new Avalonia.Thickness(12) };
+        DockPanel.SetDock(buttons, Dock.Bottom);
+        root.Children.Add(buttons);
+        root.Children.Add(colorView);
+
+        var dialog = new Window
+        {
+            Title = "Canvas Background",
+            SizeToContent = SizeToContent.WidthAndHeight,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Content = root,
+        };
+        okBtn.Click     += (_, _) => dialog.Close(true);
+        cancelBtn.Click += (_, _) => dialog.Close(false);
+
+        if (await dialog.ShowDialog<bool>(this))
+        {
+            // Force opaque — a translucent canvas fill would composite unpredictably.
+            uint argb = 0xFF000000u | (colorView.Color.ToUInt32() & 0x00FFFFFFu);
+            SetCanvasBackground(argb);
+        }
+        else
+        {
+            // Re-sync so the "Custom…" radio doesn't stay selected after a cancel.
+            SyncCanvasBackgroundMenuChecks();
+        }
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Theming/CanvasPalette.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Theming/CanvasPalette.cs
@@ -50,4 +50,23 @@ internal readonly record struct CanvasPalette(
         GuideLine:       new SKColor(0, 105, 180));
 
     public static CanvasPalette For(bool isDark) => isDark ? Dark : Light;
+
+    /// <summary>
+    /// Returns a copy with <see cref="Background"/> replaced by <paramref name="background"/>.
+    /// Chrome colors (grid, rulers, outline, guides) are intentionally left untouched — they
+    /// stay theme-driven, so a user-chosen background that is very close to the theme's chrome
+    /// can reduce their contrast. See the canvas-background feature caveat.
+    /// </summary>
+    public CanvasPalette WithBackground(SKColor background) => this with { Background = background };
+
+    /// <summary>
+    /// Resolves the palette for a theme variant, applying an optional user background override
+    /// (packed <c>0xAARRGGBB</c>). <c>null</c> keeps the theme background; a value replaces only
+    /// the background via <see cref="WithBackground"/>, leaving chrome theme-driven.
+    /// </summary>
+    public static CanvasPalette Resolve(bool isDark, uint? overrideArgb)
+    {
+        var palette = For(isDark);
+        return overrideArgb is uint argb ? palette.WithBackground(new SKColor(argb)) : palette;
+    }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -27,6 +27,13 @@ namespace AnimationEditor.Core.Models
         public AppTheme Theme { get; set; } = AppTheme.Dark;
 
         /// <summary>
+        /// Optional override for the canvas background behind both editor panels, as a packed
+        /// <c>0xAARRGGBB</c> value. <c>null</c> follows the theme default. This is a per-user
+        /// viewing preference only — it is never written into the <c>.achx</c>.
+        /// </summary>
+        public uint? CanvasBackgroundArgb { get; set; }
+
+        /// <summary>
         /// When <c>true</c>, the editor never offers to register itself as the default
         /// application for <c>.achx</c> files. Set when the user clicks "Don't show again"
         /// on the file-association prompt. Defaults to <c>false</c> so the prompt can appear

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CanvasPaletteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CanvasPaletteTests.cs
@@ -41,6 +41,42 @@ public class CanvasPaletteTests
     }
 
     [Fact]
+    public void Resolve_NullOverride_UsesThemeBackground()
+    {
+        var expected = CanvasPalette.For(isDark: true).Background;
+
+        Assert.Equal(expected, CanvasPalette.Resolve(isDark: true, overrideArgb: null).Background);
+    }
+
+    [Fact]
+    public void Resolve_WithOverride_UsesOverrideBackgroundAndKeepsChrome()
+    {
+        // Opaque steel blue as a packed 0xAARRGGBB value.
+        uint argb = 0xFF4080C0;
+        var themed = CanvasPalette.For(isDark: true);
+
+        var result = CanvasPalette.Resolve(isDark: true, overrideArgb: argb);
+
+        Assert.Equal(new SKColor(argb), result.Background);
+        // Chrome stays theme-driven — only the background is overridden.
+        Assert.Equal(themed.GridLine, result.GridLine);
+        Assert.Equal(themed.GuideLine, result.GuideLine);
+    }
+
+    [Fact]
+    public void WithBackground_ReplacesBackgroundAndKeepsChrome()
+    {
+        var basePalette = CanvasPalette.For(isDark: true);
+        var custom = new SKColor(0x40, 0x80, 0xC0);
+
+        var result = basePalette.WithBackground(custom);
+
+        Assert.Equal(custom, result.Background);
+        Assert.Equal(basePalette.GridLine, result.GridLine);
+        Assert.Equal(basePalette.RulerBackground, result.RulerBackground);
+    }
+
+    [Fact]
     public void For_LightGuideLine_IsDarkerThanDarkGuideLine()
     {
         // The dark-theme guide is bright cyan; on a light canvas that washes out, so the

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -129,6 +129,26 @@ public class AppSettingsModelTests
     }
 
     [Fact]
+    public void CanvasBackgroundArgb_DefaultsToNull()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.Null(model.CanvasBackgroundArgb);
+    }
+
+    [Fact]
+    public void CanvasBackgroundArgb_SurvivesJsonRoundTrip()
+    {
+        // Packed 0xAARRGGBB — opaque dark slate.
+        var model = new AppSettingsModel { CanvasBackgroundArgb = 0xFF102030 };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.Equal(0xFF102030u, restored!.CanvasBackgroundArgb);
+    }
+
+    [Fact]
     public void SuppressDefaultHandlerPrompt_DefaultsToFalse()
     {
         var model = new AppSettingsModel();


### PR DESCRIPTION
Closes #552

## What

Adds a **View → Canvas Background** menu to the Animation Editor so the user can change the fill behind both Skia canvases (`WireframeControl`, `PreviewControl`) instead of the fixed theme color. This lets you judge sprite art against the color it will actually sit on in-game.

Options: **Theme Default · Black · White · Mid Gray** presets, plus **Custom…** (opens a color picker).

## Design decisions (from the issue's open questions)

1. **Where the setting lives** — a per-user viewing preference in `AppSettingsModel.CanvasBackgroundArgb` (packed `0xAARRGGBB`, `null` = follow theme). **Never** written into the `.achx`, which stays a general-purpose runtime-interpreted format.
2. **Contrast with chrome** — first pass is *background-only*: grid/rulers/outline/guides stay theme-driven. A custom background very close to the theme's chrome can reduce its contrast; documented on `CanvasPalette.WithBackground`. Auto-deriving chrome contrast is deferred.
3. **UI surface** — a View-menu submenu (radio items + checkmark reflecting the current choice). Custom color is forced opaque (a translucent canvas fill would composite unpredictably).

Scope kept lean: **shared** across both panels, **solid colors only** — checkerboard/alpha inspection is a natural follow-up once this plumbing exists.

## Testing

New tests (all green; full suite 1948 pass, 0 warnings):
- `CanvasPaletteTests` — `Resolve` with/without override, `WithBackground` replaces background but keeps chrome.
- `AppSettingsModelTests` — `CanvasBackgroundArgb` default + JSON round-trip.

Untested residue is thin UI wiring (menu Click handlers, the color-picker dialog, pushing the value onto the two controls) — no logic beyond delegating to the covered core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)