### PR TITLE
Set explicit AppUserModelID so the taskbar resolves the app icon (#550)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
@@ -37,6 +37,10 @@ class Program
         // (inside UsePlatformDetect). The Dock caches the process name at that point;
         // calling setProcessName: afterwards has no visible effect on the Dock label.
         MacOSDockIcon.SetProcessName("Animation Editor");
+
+        // Give the process a stable Windows shell identity before any window is created, so
+        // the (unpinned) taskbar button can resolve the exe's icon instead of a blank default.
+        WindowsTaskbarIdentity.Set();
         App.SingleInstance = singleInstance;
         try
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/WindowsTaskbarIdentity.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/WindowsTaskbarIdentity.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace AnimationEditor.App;
+
+/// <summary>
+/// Gives the running process a stable Windows shell identity (AppUserModelID) so the
+/// taskbar can associate the button with the executable's icon.
+///
+/// <para><b>Why</b> — an unpackaged .NET process with no explicit AppUserModelID gets a
+/// system-derived identity that carries no icon resource, so an <i>unpinned</i> taskbar
+/// button can fall back to the blank default icon. Pinning writes a shortcut that carries
+/// its own AppUserModelID + icon, which is why pinning appears to "fix" the icon and
+/// unpinning reverts it. Setting an explicit, stable id here gives every launch the same
+/// shell identity the taskbar can hang the <c>.exe</c>'s icon on, pinned or not.</para>
+///
+/// <para>The id is namespaced to match <c>WindowsFileAssociationService.ProgId</c>'s root
+/// so the taskbar identity and the <c>.achx</c> file-association identity stay consistent.
+/// It must be stable across launches and contain no spaces.</para>
+///
+/// <para>Call once at the very start of <c>Main()</c>, before Avalonia creates any window.
+/// Safe to call on non-Windows platforms (returns immediately).</para>
+/// </summary>
+internal static class WindowsTaskbarIdentity
+{
+    /// <summary>Stable AppUserModelID for the editor. Shares the <c>FlatRedBall.AnimationEditor</c>
+    /// root with <see cref="Services.WindowsFileAssociationService.ProgId"/>.</summary>
+    private const string AppUserModelId = "FlatRedBall.AnimationEditor";
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void SetCurrentProcessExplicitAppUserModelID(
+        [MarshalAs(UnmanagedType.LPWStr)] string appId);
+
+    /// <summary>
+    /// Assigns the stable AppUserModelID to the current process. No-op off Windows, and any
+    /// failure is swallowed — a missing shell identity only affects the taskbar icon, never
+    /// the app's ability to run.
+    /// </summary>
+    public static void Set()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        SetWindows();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void SetWindows()
+    {
+        try
+        {
+            SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+        }
+        catch (Exception e)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to set AppUserModelID: {e}");
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `WindowsTaskbarIdentity.Set()` — a small shell32 P/Invoke to `SetCurrentProcessExplicitAppUserModelID`, guarded by `OperatingSystem.IsWindows()` — called at the very start of `Main()` before any window is created. Mirrors the existing `MacOSDockIcon` early-identity pattern.

## Why

On Windows an unpackaged .NET process with no explicit **AppUserModelID (AUMID)** gets a system-derived shell identity that carries no icon resource, so the **unpinned** taskbar button falls back to the blank/white default. Pinning writes a shortcut carrying its own AUMID + icon resource — which is exactly why pinning appears to "fix" the icon and unpinning reverts it. Setting a stable, explicit AUMID gives every launch the same shell identity the taskbar can hang the exe's icon on.

The id reuses the `FlatRedBall.AnimationEditor` root already used by `WindowsFileAssociationService.ProgId`, so the taskbar identity and the `.achx` file-association identity stay consistent.

## ⚠️ UNVERIFIED

**Neither the issue author nor I can reproduce #550 locally.** This is the standard, well-established remedy for the symptom signature (pin fixes it → unpin reverts) — not a confirmed fix. It needs confirmation on a machine that actually shows the white icon. It is safe to land regardless: the call is a no-op off Windows, swallows failures, and a missing shell identity only affects the taskbar icon, never app execution.

Open question #1 from the issue remains possible: AUMID alone may be necessary but not sufficient — Avalonia 12's Win32 backend may also need the window's small-size HICON set from the `.ico` rather than only the 256px PNG. Can't tell without a repro.

## Testing

No unit test — written (b) exception per the repo test-first discipline:
1. **Blocked because** the behavior is pure Win32 shell icon rendering driven by `SetCurrentProcessExplicitAppUserModelID`; there is no observable in-process state to assert. It can only be confirmed visually on a machine that reproduces the white icon.
2. **Testable core extracted:** none of substance — the only logic is a stable AUMID constant.
3. **Left untested:** the single P/Invoke and its constant. Low risk (no-op off Windows, failures swallowed).

Closes #550