### PR TITLE
Fix grid snapping to only reposition, never resize or display-snap frames (#538)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -832,9 +832,7 @@ public class WireframeControl : Control
     {
         if (_bitmap is null || !_showGrid || _gridSize <= 0) return;
         var world = ScreenToTexture(screenX, screenY);
-        int gx = GridSnapper.Snap(world.X, _gridSize);
-        int gy = GridSnapper.Snap(world.Y, _gridSize);
-        ApplyRegionToSelectedFrame(gx, gy, gx + _gridSize, gy + _gridSize);
+        SnapSelectedFrameToGridCell(world.X, world.Y);
     }
 
     /// <summary>
@@ -1321,9 +1319,7 @@ public class WireframeControl : Control
         if (!isCtrl && !_isMagicWandMode && e.ClickCount == 2 && _showGrid && _gridSize > 0 && _bitmap != null)
         {
             var dblWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
-            int gx = GridSnapper.Snap(dblWorld.X, _gridSize);
-            int gy = GridSnapper.Snap(dblWorld.Y, _gridSize);
-            ApplyRegionToSelectedFrame(gx, gy, gx + _gridSize, gy + _gridSize);
+            SnapSelectedFrameToGridCell(dblWorld.X, dblWorld.Y);
             return;
         }
 
@@ -1401,15 +1397,18 @@ public class WireframeControl : Control
             return;
         }
 
-        // 3. Grid mode: Ctrl+click → create frame; plain click → set region of selected frame
+        // 3. Grid mode: Ctrl+click → create a new cell-sized frame; plain click →
+        //    reposition the selected frame's origin to the cell, preserving its size.
         if (_showGrid && _gridSize > 0)
         {
-            int gx = GridSnapper.Snap(world.X, _gridSize);
-            int gy = GridSnapper.Snap(world.Y, _gridSize);
             if (isCtrl)
+            {
+                int gx = GridSnapper.Snap(world.X, _gridSize);
+                int gy = GridSnapper.Snap(world.Y, _gridSize);
                 FrameCreatedFromRegion?.Invoke(gx, gy, gx + _gridSize, gy + _gridSize);
+            }
             else
-                ApplyRegionToSelectedFrame(gx, gy, gx + _gridSize, gy + _gridSize);
+                SnapSelectedFrameToGridCell(world.X, world.Y);
             return;
         }
 
@@ -1818,6 +1817,24 @@ public class WireframeControl : Control
     }
 
     /// <summary>
+    /// Grid click-to-place: snaps the selected frame's origin to the grid cell
+    /// containing (<paramref name="worldX"/>, <paramref name="worldY"/>) while
+    /// preserving its current pixel size. Grid must never resize an existing
+    /// frame — only reposition it (issue #538).
+    /// </summary>
+    private void SnapSelectedFrameToGridCell(float worldX, float worldY)
+    {
+        if (_selectedState!.SelectedFrame is null || _bitmap is null) return;
+        var frame = _selectedState!.SelectedFrame;
+        float w = _bitmap.Width, h = _bitmap.Height;
+        int frameW = (int)MathF.Round(frame.RightCoordinate  * w) - (int)MathF.Round(frame.LeftCoordinate * w);
+        int frameH = (int)MathF.Round(frame.BottomCoordinate * h) - (int)MathF.Round(frame.TopCoordinate  * h);
+        var (minX, minY, maxX, maxY) = GridPlacementCalculator.SnapOriginPreserveSize(
+            worldX, worldY, _gridSize, frameW, frameH);
+        ApplyRegionToSelectedFrame(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
     /// Applies the current hover-preview rect (<see cref="_previewRect"/>) to the selected frame.
     /// Used by Magic Wand double-click to commit the dashed-outline selection.
     /// No-op when no frame is selected, no bitmap is loaded, or no preview is active.
@@ -1885,24 +1902,13 @@ public class WireframeControl : Control
                 if (!fp.Equals(new FilePath(_loadedTexturePath))) continue;
             }
 
+            // Displayed bounds always reflect the frame's true UV pixel bounds.
+            // Grid must never snap or resize an existing frame's display — it only
+            // affects active drags and click-to-place (issue #538).
             float pixL = frame.LeftCoordinate   * w;
             float pixT = frame.TopCoordinate    * h;
             float pixR = frame.RightCoordinate  * w;
             float pixB = frame.BottomCoordinate * h;
-
-            if (_showGrid && _gridSize > 0)
-            {
-                // Snap the display coordinates to grid line intersections for
-                // visual feedback.  UV write-back is intentionally omitted —
-                // grid is a future-edit setting and must never modify existing frames.
-                static float Snap(float v, int g) => MathF.Round(v / g) * g;
-                pixL = Snap(pixL, _gridSize);
-                pixT = Snap(pixT, _gridSize);
-                pixR = Snap(pixR, _gridSize);
-                pixB = Snap(pixB, _gridSize);
-                if (pixR <= pixL) pixR = pixL + _gridSize;
-                if (pixB <= pixT) pixB = pixT + _gridSize;
-            }
 
             _frameRects.Add(new FrameRect
             {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/DragHandleApplier.cs
@@ -45,13 +45,33 @@ public static class DragHandleApplier
         if (handle == HandleKind.Move)
             return nb;
 
-        // Resize: enforce minimum 1-pixel size; frame may extend outside bitmap.
-        float l  = Math.Min(nb.Left,   nb.Right  - 1f);
-        float t  = Math.Min(nb.Top,    nb.Bottom - 1f);
-        float r  = Math.Max(nb.Right,  nb.Left   + 1f);
-        float bm = Math.Max(nb.Bottom, nb.Top    + 1f);
+        // Resize: enforce a 1-pixel minimum by clamping the dragged edge against the
+        // fixed opposite edge; frame may extend outside bitmap.
+        return ClampDraggedEdgesMinSize(nb, handle);
+    }
 
-        return new(l, t, r, bm);
+    /// <summary>Which of the four edges a resize handle moves (false for all with Move/None).</summary>
+    private static (bool Left, bool Right, bool Top, bool Bottom) DraggedEdges(HandleKind handle) => (
+        handle is HandleKind.TopLeft  or HandleKind.MidLeft   or HandleKind.BotLeft,
+        handle is HandleKind.TopRight or HandleKind.MidRight  or HandleKind.BotRight,
+        handle is HandleKind.TopLeft  or HandleKind.TopCenter or HandleKind.TopRight,
+        handle is HandleKind.BotLeft  or HandleKind.BotCenter or HandleKind.BotRight);
+
+    /// <summary>
+    /// Clamps each dragged edge so it stays at least 1 pixel from the fixed opposite
+    /// edge, keeping the fixed edge anchored. Dragging (or snapping) an edge past the
+    /// far side collapses the frame to 1 pixel instead of moving the fixed edge — which
+    /// would slide the frame sideways and/or invert it (handles rendering on the inside).
+    /// </summary>
+    private static BoundsRect ClampDraggedEdgesMinSize(BoundsRect b, HandleKind handle)
+    {
+        var (dl, dr, dt, db) = DraggedEdges(handle);
+        float l = b.Left, t = b.Top, r = b.Right, bm = b.Bottom;
+        if (dl) l  = MathF.Min(l,  r  - 1f);
+        if (dr) r  = MathF.Max(r,  l  + 1f);
+        if (dt) t  = MathF.Min(t,  bm - 1f);
+        if (db) bm = MathF.Max(bm, t  + 1f);
+        return new BoundsRect(l, t, r, bm);
     }
 
     /// <summary>
@@ -63,6 +83,10 @@ public static class DragHandleApplier
     /// <remarks>
     /// For <see cref="HandleKind.Move"/> the top-left corner is snapped and the
     /// original width/height is preserved so the frame does not drift in size.
+    /// For resize handles a snapped edge is clamped so it never crosses the fixed
+    /// opposite edge (minimum 1 pixel, matching <see cref="Apply"/>): otherwise,
+    /// when the fixed edge is off-grid, snapping the dragged edge could land it past
+    /// the fixed edge and invert the frame.
     /// </remarks>
     public static BoundsRect SnapEdges(BoundsRect bounds, HandleKind handle, int snapSize)
     {
@@ -71,21 +95,20 @@ public static class DragHandleApplier
         float Snap(float v) => MathF.Round(v / snapSize) * snapSize;
 
         float l = bounds.Left, t = bounds.Top, r = bounds.Right, b = bounds.Bottom;
-        return handle switch
-        {
-            HandleKind.Move =>
-                // Preserve size; snap top-left corner only.
-                new BoundsRect(Snap(l), Snap(t), Snap(l) + (r - l), Snap(t) + (b - t)),
-            HandleKind.TopLeft   => new BoundsRect(Snap(l), Snap(t), r, b),
-            HandleKind.TopCenter => new BoundsRect(l, Snap(t), r, b),
-            HandleKind.TopRight  => new BoundsRect(l, Snap(t), Snap(r), b),
-            HandleKind.MidLeft   => new BoundsRect(Snap(l), t, r, b),
-            HandleKind.MidRight  => new BoundsRect(l, t, Snap(r), b),
-            HandleKind.BotLeft   => new BoundsRect(Snap(l), t, r, Snap(b)),
-            HandleKind.BotCenter => new BoundsRect(l, t, r, Snap(b)),
-            HandleKind.BotRight  => new BoundsRect(l, t, Snap(r), Snap(b)),
-            _                    => bounds,
-        };
+
+        if (handle == HandleKind.Move)
+            // Preserve size; snap top-left corner only.
+            return new BoundsRect(Snap(l), Snap(t), Snap(l) + (r - l), Snap(t) + (b - t));
+
+        var (dl, dr, dt, db) = DraggedEdges(handle);
+        if (dl) l = Snap(l);
+        if (dr) r = Snap(r);
+        if (dt) t = Snap(t);
+        if (db) b = Snap(b);
+
+        // A snap can land the dragged edge past the (possibly off-grid) fixed edge —
+        // clamp it so the frame collapses to 1px instead of inverting.
+        return ClampDraggedEdgesMinSize(new BoundsRect(l, t, r, b), handle);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/GridPlacementCalculator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/GridPlacementCalculator.cs
@@ -1,0 +1,24 @@
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Computes the pixel region for placing an <em>existing</em> frame onto a grid cell.
+/// Grid placement snaps the frame's origin (top-left) to the grid but preserves its
+/// current size — clicking a cell must never resize a frame (issue #538). Contrast
+/// with new-frame creation, which is free to use a full grid cell as the frame size.
+/// </summary>
+public static class GridPlacementCalculator
+{
+    /// <summary>
+    /// Snaps (<paramref name="worldX"/>, <paramref name="worldY"/>) down to the grid
+    /// via <see cref="GridSnapper.Snap"/> and returns the region
+    /// (minX, minY, maxX, maxY) whose size equals the passed
+    /// <paramref name="frameWidth"/> × <paramref name="frameHeight"/> in pixels.
+    /// </summary>
+    public static (int minX, int minY, int maxX, int maxY) SnapOriginPreserveSize(
+        float worldX, float worldY, int gridSize, int frameWidth, int frameHeight)
+    {
+        int gx = GridSnapper.Snap(worldX, gridSize);
+        int gy = GridSnapper.Snap(worldY, gridSize);
+        return (gx, gy, gx + frameWidth, gy + frameHeight);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -2,6 +2,7 @@ using AnimationEditor.App.Controls;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
 using Avalonia.Headless.XUnit;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
@@ -452,14 +453,14 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// A frame whose pixel bounds are not aligned to the grid should have its
-    /// <em>displayed</em> bounds snapped to the nearest grid line when grid mode
-    /// is active.  The underlying UV coordinates must remain unchanged — the snap
-    /// is display-only so the wireframe gives visual grid alignment feedback
-    /// without destructively modifying animation data.
+    /// Issue #538: turning the grid on must never alter how an existing frame is
+    /// displayed. Grid only affects active drags in the editor — it must not snap
+    /// or resize a frame's displayed bounds just because it is on. A small,
+    /// off-grid frame must render at its true UV pixel bounds, not ballooned to a
+    /// grid cell.
     /// </summary>
     [AvaloniaFact]
-    public void GridEnabled_NonAlignedFrameBounds_DisplayBoundsSnapToNearestGridLine()
+    public void GridEnabled_SmallOffGridFrame_DisplayBoundsMatchRawUVAndPreserveSize()
     {
         var ctx = ResetSingletons();
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -471,11 +472,12 @@ public class GridRenderTests
         var frame = new AnimationFrameSave
         {
             TextureName      = System.IO.Path.GetFileName(png),
-            // Bounds in pixels: left=13, top=23, right=47, bottom=58 — none on the 10px grid.
+            // A tiny 4×4 frame at (13,23) — the issue #538 repro shape. None of the
+            // edges land on the 10px grid, so a display-snap would balloon it to a cell.
             LeftCoordinate   = 13f / 100f,
             TopCoordinate    = 23f / 100f,
-            RightCoordinate  = 47f / 100f,
-            BottomCoordinate = 58f / 100f,
+            RightCoordinate  = 17f / 100f,
+            BottomCoordinate = 27f / 100f,
         };
         chain.Frames.Add(frame);
         ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
@@ -497,17 +499,68 @@ public class GridRenderTests
             Assert.Single(rects);
             var bounds = rects[0].Bounds;
 
-            // Display bounds snapped to 10-pixel grid for visual feedback.
-            Assert.Equal(0, (int)bounds.Left   % 10);
-            Assert.Equal(0, (int)bounds.Top    % 10);
-            Assert.Equal(0, (int)bounds.Right  % 10);
-            Assert.Equal(0, (int)bounds.Bottom % 10);
+            // Display bounds equal raw UV pixels — no snapping, no resizing.
+            Assert.Equal(13f, bounds.Left,   precision: 2);
+            Assert.Equal(23f, bounds.Top,    precision: 2);
+            Assert.Equal(17f, bounds.Right,  precision: 2);
+            Assert.Equal(27f, bounds.Bottom, precision: 2);
+            // Size stays 4×4 — grid never resizes an existing frame.
+            Assert.Equal(4f, bounds.Right  - bounds.Left, precision: 2);
+            Assert.Equal(4f, bounds.Bottom - bounds.Top,  precision: 2);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 
-            // UV data on the frame itself must NOT be snapped.
-            Assert.Equal(13f / 100f, frame.LeftCoordinate);
-            Assert.Equal(23f / 100f, frame.TopCoordinate);
-            Assert.Equal(47f / 100f, frame.RightCoordinate);
-            Assert.Equal(58f / 100f, frame.BottomCoordinate);
+    /// <summary>
+    /// Bug from issue #538 discussion: changing a frame's coordinates through a
+    /// means other than a visual drag (e.g. typing a new Y in the property panel,
+    /// which calls <see cref="WireframeControl.RefreshFrames"/>) must not snap the
+    /// displayed bounds to the grid. The wireframe must reflect the exact value the
+    /// user typed while grid is on.
+    /// </summary>
+    [AvaloniaFact]
+    public void RefreshFrames_GridEnabled_CoordinateChange_DisplayBoundsMatchRawUV()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black, 100, 100);
+
+        var chain = new AnimationChainSave { Name = "C" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = System.IO.Path.GetFileName(png),
+            LeftCoordinate   = 10f / 100f,
+            TopCoordinate    = 20f / 100f,
+            RightCoordinate  = 30f / 100f,
+            BottomCoordinate = 40f / 100f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);
+
+        try
+        {
+            ctrl.SetGrid(true, 10);
+
+            // Simulate the property-panel edit: user types Y = 23 (off-grid).
+            frame.TopCoordinate    = 23f / 100f;
+            frame.BottomCoordinate = 43f / 100f;
+            ctrl.RefreshFrames();
+
+            var bounds = ctrl.GetFrameRects()[0].Bounds;
+
+            // Display must show the typed value, not a grid-snapped one.
+            Assert.Equal(23f, bounds.Top,    precision: 2);
+            Assert.Equal(43f, bounds.Bottom, precision: 2);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
@@ -616,11 +669,11 @@ public class GridRenderTests
     // ── Double-click: ApplyRegionToSelectedFrame ──────────────────────────────
 
     /// <summary>
-    /// Helper: loads a 64×64 texture, creates a single full-sheet frame (UV 0→1),
-    /// selects it, and returns both the control and the frame.
+    /// Helper: loads a 64×64 texture, creates a single frame of the given pixel size
+    /// at pixel origin (frameX, frameY), selects it, and returns the control and frame.
     /// </summary>
     private static (WireframeControl ctrl, AnimationFrameSave frame, string dir)
-        BuildCtrlWithFullSheetFrame(TestServices ctx)
+        BuildCtrlWithFrame(TestServices ctx, int frameX, int frameY, int frameW, int frameH)
     {
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         System.IO.Directory.CreateDirectory(dir);
@@ -630,10 +683,10 @@ public class GridRenderTests
         var frame = new AnimationFrameSave
         {
             TextureName      = System.IO.Path.GetFileName(png),
-            LeftCoordinate   = 0f,
-            TopCoordinate    = 0f,
-            RightCoordinate  = 1f,
-            BottomCoordinate = 1f,
+            LeftCoordinate   = frameX / 64f,
+            TopCoordinate    = frameY / 64f,
+            RightCoordinate  = (frameX + frameW) / 64f,
+            BottomCoordinate = (frameY + frameH) / 64f,
         };
         chain.Frames.Add(frame);
         ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
@@ -649,49 +702,53 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// Double-clicking at screen (20, 20) with cellSize=16, pan=(0,0), zoom=1 on a full-sheet
-    /// frame should update that frame's UV coordinates to the cell (16,16)→(32,32) (i.e. 0.25–0.5
-    /// on a 64×64 texture).
+    /// Issue #538: grid double-click relocates the frame's origin to the clicked
+    /// grid cell but must preserve its existing size. A 4×4 frame double-clicked at
+    /// screen (20,20) with cellSize=16 snaps its origin to (16,16) and stays 4×4 →
+    /// bounds (16,16,20,20), never (16,16,32,32).
     /// </summary>
     [AvaloniaFact]
-    public void GridSnapDoubleClick_WithFullSheetFrame_UpdatesFrameUVToClickedCell()
+    public void GridSnapDoubleClick_SmallFrame_SnapsOriginAndPreservesSize()
     {
         var ctx = ResetSingletons();
-        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        // 4×4 frame at pixel (5,5).
+        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 5, frameY: 5, frameW: 4, frameH: 4);
         try
         {
             ctrl.SetGrid(true, 16);
 
             ctrl.SimulateGridSnapDoubleClick(20f, 20f);
 
-            // Screen (20,20) → texture (20,20) → snap to 16 → cell (16,16,32,32) on 64×64
+            // Origin snaps to (16,16); size stays 4×4 → (16,16,20,20) on 64×64.
             Assert.Equal(16f / 64f, frame.LeftCoordinate,   precision: 5);
             Assert.Equal(16f / 64f, frame.TopCoordinate,    precision: 5);
-            Assert.Equal(32f / 64f, frame.RightCoordinate,  precision: 5);
-            Assert.Equal(32f / 64f, frame.BottomCoordinate, precision: 5);
+            Assert.Equal(20f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(20f / 64f, frame.BottomCoordinate, precision: 5);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
 
     /// <summary>
-    /// Verifies the grid-snap math: clicking at (0, 0) should map to the top-left cell (0,0,16,16).
+    /// Verifies the grid-snap math preserves size at the top-left cell: a 4×4 frame
+    /// double-clicked at (5,5) snaps its origin to (0,0) and stays 4×4 → (0,0,4,4).
     /// </summary>
     [AvaloniaFact]
-    public void GridSnapDoubleClick_SnapsToCorrectGridCell()
+    public void GridSnapDoubleClick_SnapsOriginToGridCell_PreservesSize()
     {
         var ctx = ResetSingletons();
-        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        // 4×4 frame at pixel (13,23) — deliberately off-grid.
+        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 13, frameY: 23, frameW: 4, frameH: 4);
         try
         {
             ctrl.SetGrid(true, 16);
 
             ctrl.SimulateGridSnapDoubleClick(5f, 5f);
 
-            // (5,5) snaps to (0,0,16,16) on 64×64 texture
-            Assert.Equal(0f,        frame.LeftCoordinate,   precision: 5);
-            Assert.Equal(0f,        frame.TopCoordinate,    precision: 5);
-            Assert.Equal(16f / 64f, frame.RightCoordinate,  precision: 5);
-            Assert.Equal(16f / 64f, frame.BottomCoordinate, precision: 5);
+            // (5,5) snaps origin to (0,0); size stays 4×4 → (0,0,4,4) on 64×64.
+            Assert.Equal(0f,       frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(0f,       frame.TopCoordinate,    precision: 5);
+            Assert.Equal(4f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(4f / 64f, frame.BottomCoordinate, precision: 5);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
@@ -703,7 +760,7 @@ public class GridRenderTests
     public void GridSnapDoubleClick_GridDisabled_IsNoOp()
     {
         var ctx = ResetSingletons();
-        var (ctrl, frame, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 0, frameY: 0, frameW: 64, frameH: 64);
         try
         {
             ctrl.SetGrid(false, 16);
@@ -726,7 +783,7 @@ public class GridRenderTests
     public void GridSnapDoubleClick_NoSelectedFrame_IsNoOp()
     {
         var ctx = ResetSingletons();
-        var (ctrl, _, dir) = BuildCtrlWithFullSheetFrame(ctx);
+        var (ctrl, _, dir) = BuildCtrlWithFrame(ctx, frameX: 0, frameY: 0, frameW: 64, frameH: 64);
         try
         {
             ctx.SelectedState.SelectedFrame = null;
@@ -735,6 +792,61 @@ public class GridRenderTests
             // Must not throw
             var ex = Record.Exception(() => ctrl.SimulateGridSnapDoubleClick(20f, 20f));
             Assert.Null(ex);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    // ── Resize: dragging a size handle must not snap position ──────────────────
+
+    /// <summary>
+    /// Resizing a frame with the grid on must snap only the dragged edges — the
+    /// opposite (position) edges must stay exactly where they were, even if they
+    /// are off-grid. Regression guard: before the display-snap removal the drag
+    /// started from the grid-snapped display rect, so resizing also yanked the
+    /// frame's position to the grid.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateHandleDrag_ResizeWithGridOn_PreservesOffGridPositionEdges()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black, 100, 100);
+
+        var chain = new AnimationChainSave { Name = "C" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = System.IO.Path.GetFileName(png),
+            // Off-grid origin at (13,23); 4×4 → bottom-right at (17,27).
+            LeftCoordinate   = 13f / 100f,
+            TopCoordinate    = 23f / 100f,
+            RightCoordinate  = 17f / 100f,
+            BottomCoordinate = 27f / 100f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);
+
+        try
+        {
+            ctrl.SetGrid(true, 16);
+
+            // Drag the bottom-right handle from (17,27) to (44,44): right/bottom snap
+            // to 48 (nearest 16); left/top must remain the off-grid 13/23.
+            ctrl.SimulateHandleDrag(HandleKind.BotRight, 17f, 27f, 44f, 44f);
+
+            Assert.Equal(13f / 100f, frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(23f / 100f, frame.TopCoordinate,    precision: 5);
+            Assert.Equal(48f / 100f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(48f / 100f, frame.BottomCoordinate, precision: 5);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -850,4 +850,54 @@ public class GridRenderTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    /// <summary>
+    /// Dragging the right handle left past an off-grid left edge with grid on must
+    /// not invert the frame (Right &lt; Left, handles rendering on the inside). The
+    /// right edge stays clamped to the left edge; the frame never flips.
+    /// </summary>
+    [AvaloniaFact]
+    public void SimulateHandleDrag_ResizeRightEdgePastOffGridLeftWithGridOn_DoesNotInvert()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black, 100, 100);
+
+        var chain = new AnimationChainSave { Name = "C" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = System.IO.Path.GetFileName(png),
+            // Off-grid X and width: left=21, right=45 (width 24).
+            LeftCoordinate   = 21f / 100f,
+            TopCoordinate    = 21f / 100f,
+            RightCoordinate  = 45f / 100f,
+            BottomCoordinate = 45f / 100f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);
+
+        try
+        {
+            ctrl.SetGrid(true, 16);
+
+            // Grab the right edge at x=45 and drag far left to x=5 (past left=21).
+            ctrl.SimulateHandleDrag(HandleKind.MidRight, 45f, 33f, 5f, 33f);
+
+            // Frame must stay non-inverted; left edge stays put at 21.
+            Assert.True(frame.RightCoordinate > frame.LeftCoordinate,
+                $"Frame inverted: Left={frame.LeftCoordinate}, Right={frame.RightCoordinate}");
+            Assert.Equal(21f / 100f, frame.LeftCoordinate, precision: 5);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DragHandleTests.cs
@@ -374,6 +374,43 @@ public class DragHandleApplierTests
         Assert.Equal(input, DragHandleApplier.SnapEdges(input, HandleKind.Move, -1));
     }
 
+    // ── SnapEdges – dragged edge must not cross the fixed opposite edge ────────
+    //
+    // When the fixed edge is off-grid, snapping the dragged edge to a grid line
+    // can land it past the fixed edge and invert the rect (right < left) — the
+    // handles then render on the inside. The dragged edge must stay clamped to the
+    // fixed edge (min 1px), matching Apply's minimum-size behaviour.
+
+    [Fact]
+    public void SnapEdges_MidRightSnappedPastOffGridLeftEdge_ClampsRightToLeftPlusOne()
+    {
+        // Left=20 is off the 16px grid. Right=22 snaps to 16 (< 20) → would invert.
+        var input = new BoundsRect(20f, 0f, 22f, 10f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.MidRight, 16);
+        Assert.Equal(20f, result.Left);   // fixed edge unchanged
+        Assert.Equal(21f, result.Right);  // clamped to Left+1, not snapped below Left
+    }
+
+    [Fact]
+    public void SnapEdges_MidLeftSnappedPastOffGridRightEdge_ClampsLeftToRightMinusOne()
+    {
+        // Right=12 is off-grid. Left=10 snaps to 16 (> 12) → would invert.
+        var input = new BoundsRect(10f, 0f, 12f, 10f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.MidLeft, 16);
+        Assert.Equal(11f, result.Left);   // clamped to Right-1
+        Assert.Equal(12f, result.Right);  // fixed edge unchanged
+    }
+
+    [Fact]
+    public void SnapEdges_BotCenterSnappedPastOffGridTopEdge_ClampsBottomToTopPlusOne()
+    {
+        // Top=20 is off-grid. Bottom=22 snaps to 16 (< 20) → would invert.
+        var input = new BoundsRect(0f, 20f, 10f, 22f);
+        var result = DragHandleApplier.SnapEdges(input, HandleKind.BotCenter, 16);
+        Assert.Equal(20f, result.Top);     // fixed edge unchanged
+        Assert.Equal(21f, result.Bottom);  // clamped to Top+1
+    }
+
     // ── Move handle boundary clamping bug ─────────────────────────────────────
     //
     // BUG: when a Move drag carries the entire frame past the right or left

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GridPlacementCalculatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GridPlacementCalculatorTests.cs
@@ -1,0 +1,31 @@
+using AnimationEditor.Core.Rendering;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class GridPlacementCalculatorTests
+{
+    [Fact]
+    public void SnapOriginPreserveSize_ClickInsideCell_SnapsOriginKeepsSize()
+    {
+        // Click at (20,20) with a 16px grid snaps origin to (16,16); a 4×4 frame
+        // stays 4×4 → (16,16,20,20).
+        var region = GridPlacementCalculator.SnapOriginPreserveSize(20f, 20f, 16, 4, 4);
+        Assert.Equal((16, 16, 20, 20), region);
+    }
+
+    [Fact]
+    public void SnapOriginPreserveSize_ClickAtCellBoundary_ReturnsCellOrigin()
+    {
+        var region = GridPlacementCalculator.SnapOriginPreserveSize(16f, 16f, 16, 4, 4);
+        Assert.Equal((16, 16, 20, 20), region);
+    }
+
+    [Fact]
+    public void SnapOriginPreserveSize_NonSquareFrame_PreservesBothDimensions()
+    {
+        // 8px grid: 33→32, 5→0. A 10×3 frame keeps 10 wide, 3 tall → (32,0,42,3).
+        var region = GridPlacementCalculator.SnapOriginPreserveSize(33f, 5f, 8, 10, 3);
+        Assert.Equal((32, 0, 42, 3), region);
+    }
+}


### PR DESCRIPTION
## Problem

**Issue #538:** Turning on grid snapping resized existing frames — a 4×4 frame ballooned to a full grid cell.

**Additional bugs (reported in discussion):**
- Changing a frame's Y (or any coordinate) in the property panel while grid was on made the frame's displayed bounds snap to the grid and jump. Grid should only apply to *drags in the visual editor*, never to items just because grid is on or when a frame is changed by other means.
- Dragging a resize handle (e.g. the right edge) toward/past the opposite edge with grid on **inverted the frame** — the handles rendered on the inside and the frame appeared to snap sideways.

## Root causes & fixes

### 1. Display-snap on every refresh (`RefreshFramesInternal`)
Snapped the *displayed* rect to grid lines whenever grid was on (with a `pixR <= pixL → pixL + gridSize` guard that ballooned small frames). Because it ran on every refresh it: resized a small frame's display on grid-toggle (#538), snapped the display on any property edit (the "Y behaves weird" bug), and made handle-drag resizes start from the *snapped* rect.
**Fix:** removed it — the wireframe always shows true UV pixel bounds; grid only affects active drags + click-to-place.

### 2. Click-to-place overwrote size
The three grid click-to-place sites called `ApplyRegionToSelectedFrame(gx, gy, gx+_gridSize, gy+_gridSize)`, forcing the frame to one cell.
**Fix:** grid click-to-place now snaps the origin and preserves the frame's existing pixel size via new pure `GridPlacementCalculator.SnapOriginPreserveSize` (mirrors `PlainClickFrameRegionCalculator`). New-frame creation (Ctrl+click) still defaults to one cell.

### 3. Resize inverted / slid the frame (`DragHandleApplier`)
Two interacting defects:
- `Apply` enforced the 1px minimum **symmetrically**, so dragging the right edge past the left moved the *left (fixed)* edge instead of clamping the dragged right edge — sliding the frame sideways.
- `SnapEdges` snapped the dragged edge to a grid line **without checking the fixed edge**, so with an off-grid fixed edge the snap could land past it and invert the frame.

**Fix:** both now clamp only the *dragged* edge against the fixed opposite edge (min 1px), keeping the fixed edge anchored, via a shared `ClampDraggedEdgesMinSize` helper. Dragging a handle past the far side now collapses the frame to 1px in place instead of flipping/sliding.

## Tests (TDD — all written failing first, then made green)

- `GridPlacementCalculatorTests` — pure origin-snap/size-preserve math.
- `DragHandleApplierTests.SnapEdges_*Past*Edge_*` — dragged edge never crosses the fixed edge (3 cases: right/left/bottom).
- `GridEnabled_SmallOffGridFrame_DisplayBoundsMatchRawUVAndPreserveSize` — grid on never resizes the display (#538 repro).
- `RefreshFrames_GridEnabled_CoordinateChange_DisplayBoundsMatchRawUV` — property-panel edit no longer snaps.
- `GridSnapDoubleClick_SmallFrame_SnapsOriginAndPreservesSize` / `GridSnapDoubleClick_SnapsOriginToGridCell_PreservesSize` — click-to-place preserves size.
- `SimulateHandleDrag_ResizeWithGridOn_PreservesOffGridPositionEdges` — resize never moves position edges.
- `SimulateHandleDrag_ResizeRightEdgePastOffGridLeftWithGridOn_DoesNotInvert` — end-to-end inversion guard.

App suite: 540/540. Core suite: 1412/1412.

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)