### PR TITLE
Fix timeline resume flake at the source (reset tick clock on timer restart)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -36,7 +36,8 @@ public class PreviewControl : Control
     // Measures real wall-clock time between timer ticks so playback advances by true
     // elapsed time, not the timer's nominal interval (a DispatcherTimer fires later than
     // its Interval, which otherwise makes the animation run slow — see #526).
-    private readonly AnimationEditor.Core.CommandsAndState.TickClock _clock =
+    // Not readonly: tests swap in a controllable clock via SetPlaybackClock for determinism.
+    private AnimationEditor.Core.CommandsAndState.TickClock _clock =
         new(System.Diagnostics.Stopwatch.GetTimestamp, System.Diagnostics.Stopwatch.Frequency);
 
     // A stall (window drag, GC pause) shouldn't fast-forward playback by the whole frozen
@@ -224,7 +225,7 @@ public class PreviewControl : Control
         if (_selectedState!.SelectedFrame is not null)
             _selectedState!.SelectedFrame = null;
         _playback.Play();
-        _timer.Start();
+        StartAutoTimer();
         InvalidateVisual();
     }
 
@@ -288,8 +289,27 @@ public class PreviewControl : Control
     public void ResumeAutoPlayback()
     {
         _playback.Play();
+        StartAutoTimer();
+    }
+
+    /// <summary>
+    /// (Re)starts the playback timer, first resetting the tick clock so the span during
+    /// which the timer was stopped is not credited as one huge delta on the first tick.
+    /// Without this, resuming after <see cref="PauseAutoPlayback"/> (which stops the timer,
+    /// letting the clock baseline go stale) fast-forwards the playhead by up to
+    /// <see cref="MaxTickSeconds"/> on the next tick — jumping a frame nondeterministically.
+    /// </summary>
+    private void StartAutoTimer()
+    {
+        _clock.Reset();
         _timer.Start();
     }
+
+    /// <summary>
+    /// Test hook: replaces the wall-clock tick source with a controllable one so playback
+    /// advancement is fully deterministic under test (no dependency on real elapsed time).
+    /// </summary>
+    internal void SetPlaybackClock(TickClock clock) => _clock = clock;
 
     /// <summary>
     /// Renders the current preview state to an off-screen bitmap of the given size.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelinePlaybackControlsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelinePlaybackControlsTests.cs
@@ -126,9 +126,13 @@ public class TimelinePlaybackControlsTests
             preview.ScrubToFrame(1, 0.5);         // paused, mid frame 1
             Dispatcher.UIThread.RunJobs();
 
-            preview.TogglePlayPause();            // resume
-            Dispatcher.UIThread.RunJobs();
-
+            preview.TogglePlayPause();            // resume — sets state synchronously
+            // Assert the resume state immediately. Do NOT pump the dispatcher here:
+            // ResumePlayback restarts the real 60 fps timer, and a pumped tick would
+            // credit up to MaxTickSeconds (0.25s) of elapsed time — far more than the
+            // 0.05s left in frame 1 — advancing the playhead to frame 2 and making the
+            // CurrentFrameIndex assertion flaky. IsPlaying, the un-pin, and the frame
+            // index are all set synchronously by ResumePlayback.
             Assert.True(preview.IsPlaying);
             Assert.Null(ctx.SelectedState.SelectedFrame);          // un-pinned
             Assert.Equal(1, preview.Playback.CurrentFrameIndex);   // resumed from playhead, not reset to 0

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelinePlaybackControlsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TimelinePlaybackControlsTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.Data;
 using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
@@ -126,16 +127,49 @@ public class TimelinePlaybackControlsTests
             preview.ScrubToFrame(1, 0.5);         // paused, mid frame 1
             Dispatcher.UIThread.RunJobs();
 
-            preview.TogglePlayPause();            // resume — sets state synchronously
-            // Assert the resume state immediately. Do NOT pump the dispatcher here:
-            // ResumePlayback restarts the real 60 fps timer, and a pumped tick would
-            // credit up to MaxTickSeconds (0.25s) of elapsed time — far more than the
-            // 0.05s left in frame 1 — advancing the playhead to frame 2 and making the
-            // CurrentFrameIndex assertion flaky. IsPlaying, the un-pin, and the frame
-            // index are all set synchronously by ResumePlayback.
+            preview.TogglePlayPause();            // resume
+            Dispatcher.UIThread.RunJobs();
+
             Assert.True(preview.IsPlaying);
             Assert.Null(ctx.SelectedState.SelectedFrame);          // un-pinned
             Assert.Equal(1, preview.Playback.CurrentFrameIndex);   // resumed from playhead, not reset to 0
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Root cause of the resume flake: PauseAutoPlayback stops the tick timer, so its clock
+    /// baseline goes stale. Resuming must reset that clock, otherwise the first tick credits
+    /// the entire paused span (capped at MaxTickSeconds) and fast-forwards the playhead.
+    /// This drives the clock deterministically (no dependency on real elapsed time): a 100s
+    /// simulated pause must NOT be credited on the first tick after resume.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResumePlayback_AfterAutoTimerStopped_ResetsClockSoStalePauseIsNotCredited()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var chain = MakeThreeFrameChain();
+        var (window, preview, _) = ShowWindowWithChain(ctx, chain);
+
+        try
+        {
+            // Controllable clock: frequency 1 → one timestamp unit == one second.
+            long fakeNow = 0;
+            var clock = new TickClock(() => fakeNow, 1);
+            preview.SetPlaybackClock(clock);
+            clock.Tick();                         // establish the baseline at t=0
+
+            preview.PauseAutoPlayback();          // stops the timer → baseline now stale
+            preview.ScrubToFrame(1, 0.5);
+            Dispatcher.UIThread.RunJobs();
+
+            fakeNow += 100;                        // 100 seconds "pass" while paused
+
+            preview.TogglePlayPause();            // resume — must reset the clock
+
+            // First tick after resume must credit ~0, not the 100s stale span. Without the
+            // reset this returns 100 (then Advance would cap it at MaxTickSeconds and jump a frame).
+            Assert.Equal(0.0, clock.Tick(), precision: 6);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
## Problem

`TimelinePlaybackControlsTests.TogglePlayPause_WhilePausedOnScrubbedFrame_ResumesFromPlayhead` fails intermittently in CI (most recently on #549, a docs-only change — GitHub runs PR checks on the branch merged into `main`, so unrelated PRs inherit this flake).

## Root cause (production bug, not just a test issue)

`PauseAutoPlayback()` **stops** the tick timer, so its `TickClock` baseline goes stale. `ResumePlayback()` / `ResumeAutoPlayback()` restarted the timer **without resetting the clock**, so the first `OnTimerTick` credited the entire stopped span — capped at `MaxTickSeconds = 0.25s` — as one delta, fast-forwarding the playhead by a frame.

- In the pause-**button** path (`PausePlayback`) the timer keeps running, so the baseline stays fresh and the bug is masked.
- The `PauseAutoPlayback`/`ResumeAutoPlayback` path (used by tests and automation) is exposed.

`TickClock.Reset()` exists for exactly this case — *"Call when resuming after a pause so the paused span is not credited as one huge delta"* — but was never called on resume.

The test then pumped the dispatcher; whether a timer tick fired in that window was pure timing, so `CurrentFrameIndex` came out 1 (fast machine) or 2 (loaded CI runner).

## Fix

Both resume paths now go through a single `StartAutoTimer()` that calls `_clock.Reset()` before `_timer.Start()`. The first tick after **any** resume credits ~0, so neither a test nor real playback can get a stale-span frame jump. This fixes the flake at the source — for every current and future test, not just the one that failed.

## Tests

- Restored `TogglePlayPause_WhilePausedOnScrubbedFrame_ResumesFromPlayhead` to its faithful form (it pumps the dispatcher after resume) — now **deterministic** because the first tick credits 0.
- Added `ResumePlayback_AfterAutoTimerStopped_ResetsClockSoStalePauseIsNotCredited`: injects a controllable clock via a new `internal SetPlaybackClock` hook, simulates a 100s pause, resumes, and asserts the stale span is not credited. **Verified red without the fix** (`Expected: 0, Actual: 100`), green with it — a deterministic regression guard, no dependency on real elapsed time.

App suite 544/544, Core 1414/1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)