### PR TITLE
Drag-and-drop reorder for animation chains in the tree

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -86,6 +86,6 @@ Both panels render through a SkiaSharp `ICustomDrawOperation` on Avalonia's rend
 
 Tests that exercise path logic **must** use Windows-style backslash literals (e.g. `@"C:\projects\MyAnim.achx"`) to prove the cross-platform handling works — not `Path.Combine`, which would only exercise the current OS's separator.
 
-## Tree reorder — frames only; shape order is fixed
+## Tree reorder — chains and frames; shape order is fixed
 
-Drag-and-drop tree reorder is **frames only** (see GitHub issues for frame DnD). **Do not add shape DnD reorder:** collision shapes in `.achx` keep a **fixed list order** for FRB1 runtime compatibility — order is meaningful to legacy consumers, not a cosmetic tree sort. Menu/Alt+Arrow shape reorder exists in `AppCommands.MoveShape` today; treat new reorder UX as frame-only unless an issue explicitly revisits shape ordering across runtimes.
+Drag-and-drop tree reorder covers **chains and frames** (pure resolvers `ChainDropResolver` / `FrameDropResolver`, wired in `MainWindow`). **Do not add shape DnD reorder:** collision shapes in `.achx` keep a **fixed list order** for FRB1 runtime compatibility — order is meaningful to legacy consumers, not a cosmetic tree sort. Menu/Alt+Arrow shape reorder exists in `AppCommands.MoveShape` today; treat new reorder UX as chain/frame-only unless an issue explicitly revisits shape ordering across runtimes.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -74,6 +74,18 @@ public partial class MainWindow : Window
     private bool _frameDragInProgress;
     private Border? _frameDropLine;
     private Border? _frameDropBox;
+
+    // ── Chain drag-and-drop reorder state ──────────────────────────────────────
+    // Mirrors the frame path above, but for top-level animation-chain nodes. Single-chain
+    // drag only; the dragged chain lives in _pendingChainDrag since the drag is same-process.
+    private static readonly DataFormat<string> ChainDragDataFormat =
+        DataFormat.CreateStringApplicationFormat("animationeditor-chain-drag");
+    private const string ChainDragToken = "chain";
+    private AnimationChainSave? _pendingChainDrag;
+    private AnimationChainSave? _chainDragCandidate;
+    private Avalonia.Point? _chainDragPressPoint;
+    private PointerPressedEventArgs? _chainDragPressArgs;
+    private bool _chainDragInProgress;
     private int _untitledCounter;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
@@ -1848,6 +1860,13 @@ public partial class MainWindow : Window
             OnTreeFrameDragPointerReleased,
             RoutingStrategies.Bubble);
 
+        // Chain drag-and-drop reorder: a press on a chain row arms a chain-drag candidate, a
+        // pointer move past the threshold starts the Avalonia drag (parallel to the frame path).
+        AnimTree.AddHandler(
+            InputElement.PointerMovedEvent,
+            OnTreeChainDragPointerMoved,
+            RoutingStrategies.Bubble);
+
         // "Add Animation" button under the tree
         AddChainBtn.Click += (_, _) =>
         {
@@ -2039,6 +2058,24 @@ public partial class MainWindow : Window
             return;
         }
 
+        // Internal chain reorder drag.
+        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { } draggedChain)
+        {
+            var target = ResolveChainDrop(e, draggedChain);
+            if (target.IsValid)
+            {
+                e.DragEffects = DragDropEffects.Move;
+                ShowChainDropIndicator(e);
+            }
+            else
+            {
+                e.DragEffects = DragDropEffects.None;
+                RemoveFrameDropIndicators();
+            }
+            e.Handled = true;
+            return;
+        }
+
         string? firstFile = e.DataTransfer.TryGetFiles()?
             .FirstOrDefault()?.Path.LocalPath;
 
@@ -2080,6 +2117,17 @@ public partial class MainWindow : Window
             var target = ResolveFrameDrop(e, drag);
             if (target is { IsValid: true, Chain: not null } && drag.SourceChain is not null)
                 _appCommands.MoveFrames(drag.Frames, drag.SourceChain, target.Chain, target.InsertIndex);
+            e.Handled = true;
+            return;
+        }
+
+        // Internal chain reorder drop.
+        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { } draggedChain)
+        {
+            RemoveFrameDropIndicators();
+            var target = ResolveChainDrop(e, draggedChain);
+            if (target.IsValid)
+                _appCommands.MoveChainToIndex(draggedChain, target.InsertIndex);
             e.Handled = true;
             return;
         }
@@ -2459,6 +2507,90 @@ public partial class MainWindow : Window
     {
         RemoveDropLine();
         RemoveDropBox();
+    }
+
+    // ── Internal chain drag-and-drop reorder ───────────────────────────────────
+
+    private void ClearChainDragCandidate()
+    {
+        _chainDragCandidate = null;
+        _chainDragPressPoint = null;
+        _chainDragPressArgs = null;
+    }
+
+    private async void OnTreeChainDragPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_chainDragInProgress || _chainDragCandidate is null ||
+            _chainDragPressPoint is null || _chainDragPressArgs is null)
+            return;
+
+        if (!e.GetCurrentPoint(AnimTree).Properties.IsLeftButtonPressed)
+        {
+            ClearChainDragCandidate();
+            return;
+        }
+
+        var pos = e.GetPosition(AnimTree);
+        if (Math.Abs(pos.X - _chainDragPressPoint.Value.X) <= 4 &&
+            Math.Abs(pos.Y - _chainDragPressPoint.Value.Y) <= 4)
+            return;
+
+        var chain = _chainDragCandidate;
+        e.Pointer.Capture(null); // release press-capture so the drag system can take over
+        _pendingChainDrag = chain;
+        _chainDragInProgress = true;
+
+        var data = new DataTransfer();
+        data.Add(DataTransferItem.Create(ChainDragDataFormat, ChainDragToken));
+        try
+        {
+            await DragDrop.DoDragDropAsync(_chainDragPressArgs, data, DragDropEffects.Move);
+        }
+        finally
+        {
+            _pendingChainDrag = null;
+            _chainDragInProgress = false;
+            RemoveFrameDropIndicators();
+            ClearChainDragCandidate();
+        }
+    }
+
+    private ChainDropTarget ResolveChainDrop(DragEventArgs e, AnimationChainSave draggedChain)
+    {
+        var chains = _projectManager.AnimationChainListSave?.AnimationChains;
+        if (chains is null) return ChainDropTarget.None;
+        var (nodeData, half, _) = HitTestFrameRow(e.GetPosition(AnimTree));
+        return ChainDropResolver.Resolve(
+            nodeData, half, draggedChain, chains,
+            f => _objectFinder.GetAnimationChainContaining(f));
+    }
+
+    /// <summary>
+    /// Draws a thin insert line at the resolved chain boundary. Chains are root nodes, so the
+    /// line spans the full tree width (no box — a box reads as "drop inside", which is the
+    /// frame-into-chain affordance, not a sibling reorder).
+    /// </summary>
+    private void ShowChainDropIndicator(DragEventArgs e)
+    {
+        var (_, half, tvi) = HitTestFrameRow(e.GetPosition(AnimTree));
+        if (tvi is null)
+        {
+            RemoveFrameDropIndicators();
+            return;
+        }
+
+        var topLeft = Avalonia.VisualExtensions.TranslatePoint(tvi, new Avalonia.Point(0, 0), DragOverlayCanvas);
+        var treeOrigin = Avalonia.VisualExtensions.TranslatePoint(AnimTree, new Avalonia.Point(0, 0), DragOverlayCanvas);
+        if (topLeft is null || treeOrigin is null)
+        {
+            RemoveFrameDropIndicators();
+            return;
+        }
+
+        double treeRight = treeOrigin.Value.X + AnimTree.Bounds.Width;
+        double y = topLeft.Value.Y + (half == FrameRowHalf.Upper ? 0 : tvi.Bounds.Height);
+        RemoveDropBox();
+        ShowDropLine(treeOrigin.Value.X, treeRight, y);
     }
 
     // ── Window-level OS file drop: open dropped .achx files as tabs ────────────
@@ -2935,6 +3067,7 @@ public partial class MainWindow : Window
                 src.FindAncestorOfType<TreeViewItem>(includeSelf: true)?.DataContext
                     is TreeNodeVm { Data: AnimationFrameSave frame })
             {
+                ClearChainDragCandidate();
                 _frameDragCandidate = frame;
                 _frameDragPressPoint = e.GetPosition(AnimTree);
                 _frameDragPressArgs = e;
@@ -2958,9 +3091,22 @@ public partial class MainWindow : Window
                     _pendingSingleSelectFrame = null;
                 }
             }
+            else if (e.Source is Control chainSrc &&
+                chainSrc.FindAncestorOfType<TreeViewItem>(includeSelf: true)?.DataContext
+                    is TreeNodeVm { Data: AnimationChainSave chain })
+            {
+                // Arm a chain-drag candidate. Do not handle/capture — normal selection and the
+                // context menu still run; the platform drag only begins once the pointer moves
+                // past the threshold, so a plain click never starts a drag.
+                ClearFrameDragCandidate();
+                _chainDragCandidate = chain;
+                _chainDragPressPoint = e.GetPosition(AnimTree);
+                _chainDragPressArgs = e;
+            }
             else
             {
                 ClearFrameDragCandidate();
+                ClearChainDragCandidate();
             }
         }
         else if (props.IsLeftButtonPressed && e.ClickCount == 2)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -632,6 +632,28 @@ namespace AnimationEditor.Core.CommandsAndState
                 delta > 0 ? "Move Animation Down" : "Move Animation Up"));
         }
 
+        /// <inheritdoc cref="IAppCommands.MoveChainToIndex"/>
+        public void MoveChainToIndex(AnimationChainSave chain, int insertIndex)
+        {
+            var chains = _pm.AnimationChainListSave?.AnimationChains;
+            if (chains is null) return;
+            int currentIndex = chains.IndexOf(chain);
+            if (currentIndex < 0) return;
+
+            // insertIndex is measured against the list before removal; removing the chain from
+            // ahead of the target shifts the landing spot left by one (mirrors MoveFramesCommand).
+            int insertAt = insertIndex;
+            if (insertIndex > currentIndex) insertAt--;
+            insertAt = Math.Clamp(insertAt, 0, chains.Count - 1);
+            if (insertAt == currentIndex) return;
+
+            _undoManager.Execute(new ReorderCommand<AnimationChainSave>(
+                chains,
+                () => { chains.RemoveAt(currentIndex); chains.Insert(insertAt, chain); },
+                this, _events, RefreshTreeView,
+                "Move Animation"));
+        }
+
         public void MoveChainToTop(AnimationChainSave chain)
         {
             var chains = _pm.AnimationChainListSave?.AnimationChains;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -130,6 +130,15 @@ namespace AnimationEditor.Core.CommandsAndState
         bool RenameChain(AnimationChainSave chain, string newName);
         void AddFrame(AnimationChainSave chain, string? textureName = null);
         void MoveChain(AnimationChainSave chain, int delta);
+
+        /// <summary>
+        /// Moves <paramref name="chain"/> to an absolute slot in the chain list as one undo
+        /// step — the drag-and-drop reorder entry point (parallel to <see cref="MoveFrames"/>
+        /// for frames). <paramref name="insertIndex"/> is interpreted against the current list
+        /// <em>before</em> the chain is removed, so it is adjusted internally for the removal;
+        /// an index landing on the chain's own slot is a no-op with no undo entry.
+        /// </summary>
+        void MoveChainToIndex(AnimationChainSave chain, int insertIndex);
         void MoveChainToTop(AnimationChainSave chain);
         void MoveChainToBottom(AnimationChainSave chain);
         void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/ChainDropResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/ChainDropResolver.cs
@@ -1,0 +1,79 @@
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.DragDrop;
+
+/// <summary>
+/// The resolved landing spot for an animation-chain drag: the index the chain will be
+/// inserted at in the chains list, interpreted against the current list before the dragged
+/// chain is removed. <see cref="IsValid"/> is false when the drop is a no-op (landing on the
+/// dragged chain's own slot) or has no valid target, in which case no indicator is shown.
+/// </summary>
+public readonly record struct ChainDropTarget(int InsertIndex, bool IsValid)
+{
+    public static readonly ChainDropTarget None = new(-1, false);
+}
+
+/// <summary>
+/// Pure drag-and-drop logic for reordering top-level animation chains in the tree. Mirrors
+/// <see cref="FrameDropResolver"/> but for chains; side-effect free so it can be unit-tested
+/// without Avalonia.
+/// </summary>
+public static class ChainDropResolver
+{
+    /// <summary>
+    /// Resolves where a single-chain drag would land given the tree node under the pointer.
+    /// A chain node resolves to before it (upper half) or after it (lower half); a frame node
+    /// resolves to just after its owning chain (so dropping over an expanded chain's frames
+    /// lands after that chain); anything else is no drop. Dropping onto the dragged chain's
+    /// own slot (its index or index+1) is a no-op and returns <see cref="ChainDropTarget.None"/>'s
+    /// invalidity with the computed index.
+    /// </summary>
+    /// <param name="half">Which half of a chain row the pointer is over (ignored for frame targets).</param>
+    /// <param name="draggedChain">The chain being dragged.</param>
+    /// <param name="chains">The current top-level chain list.</param>
+    /// <param name="getChainContainingFrame">Maps a target frame to its owning chain.</param>
+    public static ChainDropTarget Resolve(
+        object? nodeData,
+        FrameRowHalf half,
+        AnimationChainSave draggedChain,
+        IReadOnlyList<AnimationChainSave> chains,
+        Func<AnimationFrameSave, AnimationChainSave?> getChainContainingFrame)
+    {
+        int insertIndex;
+
+        switch (nodeData)
+        {
+            case AnimationChainSave chain:
+                int chainIndex = IndexOf(chains, chain);
+                if (chainIndex < 0) return ChainDropTarget.None;
+                insertIndex = half == FrameRowHalf.Upper ? chainIndex : chainIndex + 1;
+                break;
+
+            case AnimationFrameSave frame:
+                var owner = getChainContainingFrame(frame);
+                if (owner is null) return ChainDropTarget.None;
+                int ownerIndex = IndexOf(chains, owner);
+                if (ownerIndex < 0) return ChainDropTarget.None;
+                insertIndex = ownerIndex + 1;
+                break;
+
+            default:
+                return ChainDropTarget.None;
+        }
+
+        // Squash guard: an insert at the dragged chain's own index or index+1 leaves the list
+        // unchanged for a single-item move, so surface the index but mark it invalid.
+        int draggedIndex = IndexOf(chains, draggedChain);
+        bool valid = insertIndex != draggedIndex && insertIndex != draggedIndex + 1;
+        return new ChainDropTarget(insertIndex, valid);
+    }
+
+    private static int IndexOf(IReadOnlyList<AnimationChainSave> chains, AnimationChainSave chain)
+    {
+        for (int i = 0; i < chains.Count; i++)
+            if (ReferenceEquals(chains[i], chain)) return i;
+        return -1;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainDragReorderHeadlessTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainDragReorderHeadlessTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// End-to-end check that a drag-and-drop chain reorder flows through the real window tree:
+/// the top-level chain nodes reorder and one undo reverts. The pointer-driven drag itself
+/// (DoDragDropAsync) is exercised manually; here we drive the resolved move via
+/// AppCommands.MoveChainToIndex, which is what the drop handler calls.
+/// </summary>
+public class ChainDragReorderHeadlessTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow)
+            .GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object[] { Array.Empty<string>() });
+    }
+
+    private static ObservableCollection<TreeNodeVm> Roots(MainWindow window)
+    {
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        return (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+    }
+
+    private static AnimationChainSave MakeChain(AnimationChainListSave acls, string name)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        acls.AnimationChains.Add(chain);
+        return chain;
+    }
+
+    [AvaloniaFact]
+    public void MoveChainToIndex_ReordersRootTreeNodes_OneUndoReverts()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var acls = ctx.ProjectManager.AnimationChainListSave!;
+            var a = MakeChain(acls, "A");
+            var b = MakeChain(acls, "B");
+            var c = MakeChain(acls, "C");
+            RebuildTree(window);
+
+            // Drag C to the front (insert index 0).
+            ctx.AppCommands.MoveChainToIndex(c, 0);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(new[] { c, a, b },
+                Roots(window).Select(n => n.Data).ToArray());
+
+            ctx.UndoManager.Undo();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(new[] { a, b, c },
+                Roots(window).Select(n => n.Data).ToArray());
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -56,6 +56,85 @@ public class AppCommandsReorderTests
         Assert.Equal(walk, acls.AnimationChains[0]);
     }
 
+    // ── MoveChainToIndex ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveChainToIndex_EarlierPosition_MovesChainUp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var a = TestHelpers.MakeChain(acls, "A");
+        var b = TestHelpers.MakeChain(acls, "B");
+        var c = TestHelpers.MakeChain(acls, "C");
+
+        // Insert C before A (index 0).
+        ctx.AppCommands.MoveChainToIndex(c, 0);
+
+        Assert.Equal(new[] { c, a, b }, acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainToIndex_LaterPosition_AdjustsForRemoval()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var a = TestHelpers.MakeChain(acls, "A");
+        var b = TestHelpers.MakeChain(acls, "B");
+        var c = TestHelpers.MakeChain(acls, "C");
+
+        // insertIndex 3 (after C) is interpreted against the pre-removal list; removing A
+        // ahead of it shifts the landing spot left by one → A ends up last.
+        ctx.AppCommands.MoveChainToIndex(a, 3);
+
+        Assert.Equal(new[] { b, c, a }, acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainToIndex_OwnIndex_IsNoOp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var a = TestHelpers.MakeChain(acls, "A");
+        var b = TestHelpers.MakeChain(acls, "B");
+
+        ctx.AppCommands.MoveChainToIndex(a, 0);
+
+        Assert.Equal(new[] { a, b }, acls.AnimationChains.ToArray());
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void MoveChainToIndex_SingleUndo_RestoresOriginalOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var a = TestHelpers.MakeChain(acls, "A");
+        var b = TestHelpers.MakeChain(acls, "B");
+        var c = TestHelpers.MakeChain(acls, "C");
+
+        ctx.AppCommands.MoveChainToIndex(c, 0);
+        ctx.UndoManager.Undo();
+
+        // One undo step fully restores the prior order.
+        Assert.Equal(new[] { a, b, c }, acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainToIndex_Redo_ReappliesMove()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var a = TestHelpers.MakeChain(acls, "A");
+        var b = TestHelpers.MakeChain(acls, "B");
+        var c = TestHelpers.MakeChain(acls, "C");
+
+        ctx.AppCommands.MoveChainToIndex(c, 0);
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Equal(new[] { c, a, b }, acls.AnimationChains.ToArray());
+    }
+
     // ── HandleReorder — frame selected ───────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainDropResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainDropResolverTests.cs
@@ -1,0 +1,115 @@
+using AnimationEditor.Core.DragDrop;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Pure drop-target logic for animation-chain (top-level node) drag-and-drop reorder.
+/// </summary>
+public class ChainDropResolverTests
+{
+    private static List<AnimationChainSave> Chains(params string[] names)
+    {
+        var list = new List<AnimationChainSave>();
+        foreach (var name in names)
+            list.Add(new AnimationChainSave { Name = name });
+        return list;
+    }
+
+    [Fact]
+    public void Resolve_ChainNodeLowerHalf_InsertsAfterThatChain()
+    {
+        var chains = Chains("A", "B", "C");
+        var dragged = chains[0];
+
+        // Drop A onto the lower half of B (index 1) → insert after B.
+        var result = ChainDropResolver.Resolve(
+            chains[1], FrameRowHalf.Lower, dragged, chains, _ => null);
+
+        Assert.Equal(2, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_ChainNodeUpperHalf_InsertsBeforeThatChain()
+    {
+        var chains = Chains("A", "B", "C");
+        var dragged = chains[2];
+
+        // Drop C onto the upper half of B (index 1) → insert before B.
+        var result = ChainDropResolver.Resolve(
+            chains[1], FrameRowHalf.Upper, dragged, chains, _ => null);
+
+        Assert.Equal(1, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_FrameNode_MapsToAfterOwningChain()
+    {
+        var chains = Chains("A", "B", "C");
+        var dragged = chains[0];
+        var frame = new AnimationFrameSave { TextureName = "f.png" };
+        chains[1].Frames.Add(frame);
+
+        // Pointer over a frame owned by B (index 1) → land after B.
+        var result = ChainDropResolver.Resolve(
+            frame, FrameRowHalf.Lower, dragged, chains, _ => chains[1]);
+
+        Assert.Equal(2, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_NonChainNonFrameNode_None()
+    {
+        var chains = Chains("A", "B");
+
+        var result = ChainDropResolver.Resolve(
+            new AARectSave { Name = "Hit" }, FrameRowHalf.Upper, chains[0], chains, _ => null);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(-1, result.InsertIndex);
+    }
+
+    [Fact]
+    public void Resolve_NullNode_None()
+    {
+        var chains = Chains("A", "B");
+
+        var result = ChainDropResolver.Resolve(
+            null, FrameRowHalf.Upper, chains[0], chains, _ => null);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_OwnIndex_Invalid()
+    {
+        var chains = Chains("A", "B", "C");
+        var dragged = chains[1];
+
+        // Dropping B on its own upper half resolves to its own index → no-op.
+        var result = ChainDropResolver.Resolve(
+            chains[1], FrameRowHalf.Upper, dragged, chains, _ => null);
+
+        Assert.Equal(1, result.InsertIndex);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_OwnIndexPlusOne_Invalid()
+    {
+        var chains = Chains("A", "B", "C");
+        var dragged = chains[1];
+
+        // Dropping B on its own lower half resolves to index+1 → still a no-op.
+        var result = ChainDropResolver.Resolve(
+            chains[1], FrameRowHalf.Lower, dragged, chains, _ => null);
+
+        Assert.Equal(2, result.InsertIndex);
+        Assert.False(result.IsValid);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -72,6 +72,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.RenameChain)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.AddFrame)]                     = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChain)]                    = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChainToIndex)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
@@ -221,6 +222,9 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.AddFrame(Zebra(ctx))));
         yield return Row(nameof(IAppCommands.MoveChain),
             ctx => Sync(() => ctx.AppCommands.MoveChain(Zebra(ctx), +1)));
+        yield return Row(nameof(IAppCommands.MoveChainToIndex),
+            // Drag Alpha (index 1) to the front of the two-chain list.
+            ctx => Sync(() => ctx.AppCommands.MoveChainToIndex(Alpha(ctx), 0)));
         yield return Row(nameof(IAppCommands.MoveChainToTop),
             ctx => Sync(() => ctx.AppCommands.MoveChainToTop(Alpha(ctx))));
         yield return Row(nameof(IAppCommands.MoveChainToBottom),


### PR DESCRIPTION
## What changed

Animation **chains** (top-level tree nodes) can now be reordered by drag-and-drop, mirroring the existing **frame** DnD pipeline. Scope is **single-chain drag** (one animation at a time) — multi-chain drag is not implemented.

- **`ChainDropResolver`** (new, `AnimationEditor.Core/DragDrop`) — pure, Avalonia-free logic. `ChainDropTarget(int InsertIndex, bool IsValid)` record struct with `None`. `Resolve` maps: chain node under pointer → before it (upper half) / after it (lower half); frame node → after its owning chain; anything else → `None`. Squash guard: an insert at the dragged chain's own index or index+1 is a no-op (`IsValid=false`).
- **`AppCommands.MoveChainToIndex`** (new on `IAppCommands`) — the DnD entry point, parallel to `MoveFrames`. Reuses `ReorderCommand<AnimationChainSave>` so **the whole reorder is a single undo action** — one Ctrl+Z restores the prior order, one Ctrl+Y re-applies. `insertIndex` is interpreted against the pre-removal list and adjusted for the removal exactly like `MoveFramesCommand`; a no-op move records no undo entry.
- **`MainWindow`** wiring — a chain-drag path parallel to the frame path: own `ChainDragDataFormat`/token, `_chainDragCandidate`/press-point/press-args/in-progress fields, a dedicated `OnTreeChainDragPointerMoved` handler, and branches in `OnTreeDragOver`/`OnTreeDrop` that resolve via `ChainDropResolver` and call `MoveChainToIndex`. The chain indicator reuses `ShowDropLine` (a thin full-width insert line; no box, since a box reads as "drop inside this chain"). **Frame DnD is untouched** — I added dedicated chain fields rather than generalizing the frame ones, so the frame path is byte-for-byte intact (the two lines added inside the frame branch only clear the *chain* candidate).

Shapes remain **fixed-order** (FRB1 runtime compatibility) — unchanged. The `animation-editor` skill's "Tree reorder" section was corrected to say chains + frames reorder, shapes stay fixed.

## TDD coverage

Tests written first, confirmed red, then implemented to green.

- `ChainDropResolverTests` — before/after a chain, frame-node maps to owning chain, no-op guard on own index / index+1, non-chain and null → `None` (7 tests).
- `AppCommandsReorderTests` (extended) — `MoveChainToIndex` move earlier, move later (removal-adjustment math), no-op drops no undo entry, single undo restores order, redo re-applies (5 tests).
- `UndoCoverageRosterTests` — added `MoveChainToIndex` to the roster (`MutatingUndoable`) and a round-trip invocation, satisfying the repo's reflection guardrail that every undoable `IAppCommands` method serializes/undoes/redoes cleanly.
- `ChainDragReorderHeadlessTests` (new `[AvaloniaFact]`) — drives `MoveChainToIndex` through the real window tree; asserts the root chain nodes reorder and one undo reverts. Cheap and non-flaky (no `DoDragDropAsync`; drives the resolved move like the frame headless test does).

All green: **Core 1427 / App 545**, zero new build warnings.

Closes #? (no linked issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)