### PR TITLE
Files panel browses the linked project's Content folder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2520,11 +2520,9 @@ public partial class MainWindow : Window
 
     private void RefreshFilesPanel()
     {
-        string? achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
-            ? null
-            : Path.GetDirectoryName(_projectManager.FileName);
-        FilesPanel.Refresh(achxFolder);
-        _pngFolderWatcher.Watch(achxFolder);
+        string? filesRoot = _projectManager.ResolveFilesPanelRoot();
+        FilesPanel.Refresh(filesRoot);
+        _pngFolderWatcher.Watch(filesRoot);
     }
 
     // ── Tree refresh ──────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
@@ -16,6 +16,12 @@ namespace AnimationEditor.Core
         void SaveAnimationChainList(string targetPath);
 
         /// <summary>
+        /// Root folder the Files panel should browse: the linked project's Content folder
+        /// when it resolves, otherwise the folder containing the loaded .achx.
+        /// </summary>
+        string? ResolveFilesPanelRoot();
+
+        /// <summary>
         /// Resolves a frame's texture name to its pixel size (PNG header read), relative to the
         /// loaded .achx directory. Returns <c>null</c> when the name is empty or unreadable.
         /// </summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
@@ -16,8 +16,10 @@ namespace AnimationEditor.Core
         void SaveAnimationChainList(string targetPath);
 
         /// <summary>
-        /// Root folder the Files panel should browse: the linked project's Content folder
-        /// when it resolves, otherwise the folder containing the loaded .achx.
+        /// Root folder the Files panel should browse: the linked project's folder (if the
+        /// <c>ProjectFile</c> reference resolves to an existing directory) or its <c>Content</c>
+        /// subfolder, then the nearest ancestor named <c>Content</c> walking up from the .achx's
+        /// folder, then the .achx's own folder.
         /// </summary>
         string? ResolveFilesPanelRoot();
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -259,7 +259,11 @@ namespace AnimationEditor.Core
 
         private static string? FindContentAncestor(string folderFullPath)
         {
-            var segments = folderFullPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            // Deliberately no StringSplitOptions.RemoveEmptyEntries: a Unix-style absolute
+            // path ("/tmp/...") splits with a leading empty entry, and dropping it would
+            // make the reconstructed join lose its leading '/' — turning an absolute path
+            // into a relative one that FilePath then resolves against the current directory.
+            var segments = folderFullPath.Split('/');
 
             for (int i = segments.Length - 1; i >= 0; i--)
             {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -224,6 +224,35 @@ namespace AnimationEditor.Core
             }
         }
 
+        /// <summary>
+        /// Root folder the Files panel should browse: the linked project's Content folder
+        /// when <see cref="AnimationChainListSave.ProjectFile"/> resolves to an existing
+        /// file, otherwise the folder containing the loaded .achx. Only the project file's
+        /// *location* on disk is used here — never its internal format — so this keeps
+        /// working for project file formats other than the FRB1 .gluj this repo currently
+        /// supports. Returns <c>null</c> when no .achx is loaded/saved yet.
+        /// </summary>
+        public string? ResolveFilesPanelRoot()
+        {
+            if (string.IsNullOrEmpty(FileName)) return null;
+
+            var achxFolder = new FilePath(FileName).GetDirectoryContainingThis();
+
+            var projectFileRelative = AnimationChainListSave?.ProjectFile;
+            if (!string.IsNullOrEmpty(projectFileRelative))
+            {
+                var projectFile = new FilePath(achxFolder.FullPath + projectFileRelative);
+                if (projectFile.Exists())
+                {
+                    var projectDirectory = projectFile.GetDirectoryContainingThis();
+                    var contentDirectory = new FilePath(projectDirectory.FullPath + "Content/");
+                    return (contentDirectory.Exists() ? contentDirectory : projectDirectory).FullPath;
+                }
+            }
+
+            return achxFolder.FullPath;
+        }
+
         private void TryLoadProjectFile(FilePath projectFile)
         {
             if (projectFile?.Exists() != true)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -225,12 +225,16 @@ namespace AnimationEditor.Core
         }
 
         /// <summary>
-        /// Root folder the Files panel should browse: the linked project's Content folder
-        /// when <see cref="AnimationChainListSave.ProjectFile"/> resolves to an existing
-        /// file, otherwise the folder containing the loaded .achx. Only the project file's
-        /// *location* on disk is used here — never its internal format — so this keeps
-        /// working for project file formats other than the FRB1 .gluj this repo currently
-        /// supports. Returns <c>null</c> when no .achx is loaded/saved yet.
+        /// Root folder the Files panel should browse, in order: (1) if
+        /// <see cref="AnimationChainListSave.ProjectFile"/> resolves to a directory that
+        /// exists, that directory (or its <c>Content</c> subfolder, if present) — the
+        /// referenced project file itself need not exist, since a relative link authored
+        /// against a source layout commonly goes stale once the .achx is copied to a
+        /// build-output folder, so only the *directory* is required to resolve; (2)
+        /// otherwise the nearest ancestor folder literally named <c>Content</c>, walking up
+        /// from the loaded .achx's folder — the convention every FlatRedBall content
+        /// pipeline (FRB1 and FRB2) copies assets into; (3) otherwise the folder containing
+        /// the .achx itself. Returns <c>null</c> when no .achx is loaded/saved yet.
         /// </summary>
         public string? ResolveFilesPanelRoot()
         {
@@ -242,15 +246,28 @@ namespace AnimationEditor.Core
             if (!string.IsNullOrEmpty(projectFileRelative))
             {
                 var projectFile = new FilePath(achxFolder.FullPath + projectFileRelative);
-                if (projectFile.Exists())
+                var projectDirectory = projectFile.GetDirectoryContainingThis();
+                if (projectDirectory.Exists())
                 {
-                    var projectDirectory = projectFile.GetDirectoryContainingThis();
                     var contentDirectory = new FilePath(projectDirectory.FullPath + "Content/");
                     return (contentDirectory.Exists() ? contentDirectory : projectDirectory).FullPath;
                 }
             }
 
-            return achxFolder.FullPath;
+            return FindContentAncestor(achxFolder.FullPath) ?? achxFolder.FullPath;
+        }
+
+        private static string? FindContentAncestor(string folderFullPath)
+        {
+            var segments = folderFullPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            for (int i = segments.Length - 1; i >= 0; i--)
+            {
+                if (string.Equals(segments[i], "Content", StringComparison.OrdinalIgnoreCase))
+                    return string.Join("/", segments, 0, i + 1) + "/";
+            }
+
+            return null;
         }
 
         private void TryLoadProjectFile(FilePath projectFile)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
@@ -71,6 +71,8 @@ public class AppCommandsSaveFailTests
 
         public void LoadAnimationChain(FilePath fileName, AnimationChainListSave? preParsed = null) { }
 
+        public string? ResolveFilesPanelRoot() => null;
+
         public void SaveAnimationChainList(string targetPath)
             => throw new InvalidOperationException("Simulated save failure");
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
@@ -6,11 +6,14 @@ using Xunit;
 namespace AnimationEditor.Core.Tests;
 
 /// <summary>
-/// Covers <see cref="ProjectManager.ResolveFilesPanelRoot"/>: the Files panel should
-/// browse the linked project's Content folder when one resolves, and fall back to the
-/// loaded .achx's own folder otherwise. Resolution only ever uses the project file's
-/// *location* on disk — never its internal format — so this keeps working even for
-/// project file formats other than the FRB1 .gluj this repo currently supports.
+/// Covers <see cref="ProjectManager.ResolveFilesPanelRoot"/>. Root resolution, in order:
+/// (1) if <see cref="AnimationChainListSave.ProjectFile"/> resolves to a directory that
+/// exists — the referenced project file itself need not exist, since a relative link
+/// authored against a source layout commonly goes stale once the .achx is copied to a
+/// build-output folder — use that directory (or its <c>Content</c> subfolder, if present);
+/// (2) otherwise walk up from the .achx's own folder to the nearest ancestor literally named
+/// <c>Content</c> — the convention every FlatRedBall content pipeline copies assets into;
+/// (3) otherwise the .achx's own folder.
 /// </summary>
 public class ProjectManagerFilesPanelRootTests
 {
@@ -23,14 +26,13 @@ public class ProjectManagerFilesPanelRootTests
     }
 
     [Fact]
-    public void ResolveFilesPanelRoot_WhenNoProjectFileSet_ReturnsAchxFolder()
+    public void ResolveFilesPanelRoot_WhenNoProjectFileAndNoContentAncestor_ReturnsAchxFolder()
     {
         using var temp = new TempDir();
 
         var sut = new ProjectManager
         {
-            FileName = Path.Combine(temp.Path, "Anim.achx"),
-            AnimationChainListSave = new AnimationChainListSave()
+            FileName = Path.Combine(temp.Path, "Anim.achx")
         };
 
         var root = sut.ResolveFilesPanelRoot();
@@ -39,7 +41,46 @@ public class ProjectManagerFilesPanelRootTests
     }
 
     [Fact]
-    public void ResolveFilesPanelRoot_WhenProjectFileResolvesWithContentFolder_ReturnsContentFolder()
+    public void ResolveFilesPanelRoot_WhenAchxIsNestedUnderContent_ReturnsContentFolder()
+    {
+        using var temp = new TempDir();
+
+        var contentDir = Path.Combine(temp.Path, "Content");
+        var achxDir = Path.Combine(contentDir, "Entities", "Enemy");
+        Directory.CreateDirectory(achxDir);
+        File.WriteAllText(Path.Combine(contentDir, "ChibiCthulhuTiles.png"), "");
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(achxDir, "Byakhee.achx")
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(contentDir + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_MatchesContentFolderNameCaseInsensitively()
+    {
+        using var temp = new TempDir();
+
+        var contentDir = Path.Combine(temp.Path, "CONTENT");
+        var achxDir = Path.Combine(contentDir, "Sub");
+        Directory.CreateDirectory(achxDir);
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(achxDir, "Anim.achx")
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(contentDir + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenProjectFileExists_UsesItsContentFolder()
     {
         using var temp = new TempDir();
 
@@ -61,39 +102,49 @@ public class ProjectManagerFilesPanelRootTests
     }
 
     [Fact]
-    public void ResolveFilesPanelRoot_WhenProjectFileResolvesWithoutContentFolder_ReturnsProjectFolder()
+    public void ResolveFilesPanelRoot_WhenReferencedProjectFileIsMissingButItsFolderExists_StillUsesThatFolder()
     {
+        // Mirrors a real repro: a build-output .achx (under a non-"Content"-named path)
+        // whose ProjectFile points at a project file that was never copied alongside it,
+        // but the project's own folder (and its Content subfolder) still exists on disk.
         using var temp = new TempDir();
 
+        var achxDir = Path.Combine(temp.Path, "Build", "Nested");
+        Directory.CreateDirectory(achxDir);
         var projectDir = Path.Combine(temp.Path, "Project");
-        Directory.CreateDirectory(projectDir);
-        File.WriteAllText(Path.Combine(projectDir, "Game.gluj"), "<Project/>");
+        var contentDir = Path.Combine(projectDir, "Content");
+        Directory.CreateDirectory(contentDir);
+        // Note: no "Game.glux" file is written — only the folder exists.
 
         var sut = new ProjectManager
         {
-            FileName = Path.Combine(temp.Path, "Anim.achx"),
-            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "Project/Game.gluj" }
+            FileName = Path.Combine(achxDir, "Anim.achx"),
+            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "../../Project/Game.glux" }
         };
 
         var root = sut.ResolveFilesPanelRoot();
 
-        Assert.Equal(new FilePath(projectDir + "/").Standardized, new FilePath(root!).Standardized);
+        Assert.Equal(new FilePath(contentDir + "/").Standardized, new FilePath(root!).Standardized);
     }
 
     [Fact]
-    public void ResolveFilesPanelRoot_WhenProjectFileDoesNotResolve_FallsBackToAchxFolder()
+    public void ResolveFilesPanelRoot_WhenProjectFileFolderDoesNotExist_FallsBackToContentAncestor()
     {
         using var temp = new TempDir();
 
+        var contentDir = Path.Combine(temp.Path, "Content");
+        var achxDir = Path.Combine(contentDir, "Entities", "Enemy");
+        Directory.CreateDirectory(achxDir);
+
         var sut = new ProjectManager
         {
-            FileName = Path.Combine(temp.Path, "Anim.achx"),
-            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "../NoSuchProject.gluj" }
+            FileName = Path.Combine(achxDir, "Byakhee.achx"),
+            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "../../../../NoSuchFolder/game.glux" }
         };
 
         var root = sut.ResolveFilesPanelRoot();
 
-        Assert.Equal(new FilePath(temp.Path + "/").Standardized, new FilePath(root!).Standardized);
+        Assert.Equal(new FilePath(contentDir + "/").Standardized, new FilePath(root!).Standardized);
     }
 
     private sealed class TempDir : IDisposable

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
@@ -128,6 +128,26 @@ public class ProjectManagerFilesPanelRootTests
     }
 
     [Fact]
+    public void ResolveFilesPanelRoot_PreservesLeadingSlashOnUnixStyleAbsolutePaths()
+    {
+        // Regression: the Content-ancestor walk-up must not lose a Unix-style absolute
+        // path's leading '/' when reconstructing the truncated path — losing it turns
+        // the result into a relative path, which FilePath then resolves against
+        // Environment.CurrentDirectory instead of the real root. Constructed directly
+        // (no real filesystem paths) so this reproduces on any host OS: Path.IsPathRooted
+        // treats a leading '/' as rooted on both Windows and Linux, so FilePath won't
+        // rewrite it, letting this test exercise the Linux-only code path everywhere.
+        var sut = new ProjectManager
+        {
+            FileName = "/tmp/AnimationEditorCoreTests/proj/Content/Entities/Enemy/Byakhee.achx"
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal("/tmp/AnimationEditorCoreTests/proj/Content/", root);
+    }
+
+    [Fact]
     public void ResolveFilesPanelRoot_WhenProjectFileFolderDoesNotExist_FallsBackToContentAncestor()
     {
         using var temp = new TempDir();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerFilesPanelRootTests.cs
@@ -1,0 +1,115 @@
+using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Covers <see cref="ProjectManager.ResolveFilesPanelRoot"/>: the Files panel should
+/// browse the linked project's Content folder when one resolves, and fall back to the
+/// loaded .achx's own folder otherwise. Resolution only ever uses the project file's
+/// *location* on disk — never its internal format — so this keeps working even for
+/// project file formats other than the FRB1 .gluj this repo currently supports.
+/// </summary>
+public class ProjectManagerFilesPanelRootTests
+{
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenNoFileLoaded_ReturnsNull()
+    {
+        var sut = new ProjectManager();
+
+        Assert.Null(sut.ResolveFilesPanelRoot());
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenNoProjectFileSet_ReturnsAchxFolder()
+    {
+        using var temp = new TempDir();
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(temp.Path, "Anim.achx"),
+            AnimationChainListSave = new AnimationChainListSave()
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(temp.Path + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenProjectFileResolvesWithContentFolder_ReturnsContentFolder()
+    {
+        using var temp = new TempDir();
+
+        var achxDir = Path.Combine(temp.Path, "Content", "Animations");
+        Directory.CreateDirectory(achxDir);
+        var projectDir = temp.Path;
+        var contentDir = Path.Combine(projectDir, "Content");
+        File.WriteAllText(Path.Combine(projectDir, "Game.gluj"), "<Project/>");
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(achxDir, "Anim.achx"),
+            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "../../Game.gluj" }
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(contentDir + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenProjectFileResolvesWithoutContentFolder_ReturnsProjectFolder()
+    {
+        using var temp = new TempDir();
+
+        var projectDir = Path.Combine(temp.Path, "Project");
+        Directory.CreateDirectory(projectDir);
+        File.WriteAllText(Path.Combine(projectDir, "Game.gluj"), "<Project/>");
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(temp.Path, "Anim.achx"),
+            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "Project/Game.gluj" }
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(projectDir + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    [Fact]
+    public void ResolveFilesPanelRoot_WhenProjectFileDoesNotResolve_FallsBackToAchxFolder()
+    {
+        using var temp = new TempDir();
+
+        var sut = new ProjectManager
+        {
+            FileName = Path.Combine(temp.Path, "Anim.achx"),
+            AnimationChainListSave = new AnimationChainListSave { ProjectFile = "../NoSuchProject.gluj" }
+        };
+
+        var root = sut.ResolveFilesPanelRoot();
+
+        Assert.Equal(new FilePath(temp.Path + "/").Standardized, new FilePath(root!).Standardized);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "AnimationEditorCoreTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
@@ -131,6 +131,8 @@ public class TabSwitchCacheTests : IDisposable
         public void SaveAnimationChainList(string targetPath) =>
             _inner.SaveAnimationChainList(targetPath);
 
+        public string? ResolveFilesPanelRoot() => _inner.ResolveFilesPanelRoot();
+
         public (int Width, int Height)? GetTextureSizeInPixels(string textureName) =>
             _inner.GetTextureSizeInPixels(textureName);
 


### PR DESCRIPTION
## Summary
- `ProjectManager.ResolveFilesPanelRoot()` resolves the Files panel's root folder, in order:
  1. If `ProjectFile` resolves to a *directory* that exists — the referenced project file itself need not exist, since that relative link commonly goes stale once an `.achx` is copied into a build-output folder — use that directory (or its `Content` subfolder, if present).
  2. Otherwise, walk up from the `.achx`'s own folder to the nearest ancestor literally named `Content` (the convention every FlatRedBall content pipeline copies assets into).
  3. Otherwise, the `.achx`'s own folder (today's behavior).
- Wired into `MainWindow.RefreshFilesPanel()`, which also drives the folder watcher.

Found via manual testing on a real project: the achx's `ProjectFile` pointed at a `.glux` that was never copied alongside a build-output `.achx`, so the exact file didn't exist — but its directory still did, and the actual textures lived in that directory's `Content` subfolder. Loosening the check to directory-existence (rather than requiring the referenced file itself) fixes that case without depending on any project-file format.

## Test plan
- [x] `ProjectManagerFilesPanelRootTests` (7 cases covering all three resolution tiers, including the directory-exists-but-file-missing repro) — TDD, confirmed failing before each implementation step.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1421 passed.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 544 passed.
- [x] Manual: open the real-world repro `.achx` and confirm the Files panel now shows the project's PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)