### PR TITLE
Animation Editor: PNG drop on the wireframe canvas assigns to the selected frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -20,6 +20,9 @@ using System.Globalization;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using AnimationEditor.App.Services;
+using AnimationEditor.Core.DragDrop;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
 
 namespace AnimationEditor.App.Controls;
@@ -532,6 +535,14 @@ public class WireframeControl : Control
     /// </summary>
     public event Action<int, int, int, int>? FrameCreatedFromRegion;
 
+    /// <summary>
+    /// Set by <c>MainWindow</c> to apply a PNG dropped onto the canvas — the same path used by
+    /// the ANIMATIONS tree's PNG drop (issue #560): (targetChain, targetFrame, droppedFilePath,
+    /// ctrlHeld) → true if the drop was applied. Left null in standalone/test contexts, where
+    /// a drop is simply ignored.
+    /// </summary>
+    public Func<AnimationChainSave?, AnimationFrameSave?, string, bool, Task<bool>>? HandlePngDrop { get; set; }
+
     // ── Injected services ─────────────────────────────────────────────────────
 
     private ISelectedState? _selectedState;
@@ -594,7 +605,50 @@ public class WireframeControl : Control
         // Stop the smooth-zoom and diagnostics timers if the control leaves the tree.
         DetachedFromVisualTree += (_, _) => { StopZoomTimer(); _diagnosticsTimer?.Stop(); };
 
+        // PNG drop (issue #560) — same DragOver/Drop plumbing as the ANIMATIONS tree
+        // (OnTreeDragOver/OnTreeDrop in MainWindow), targeting the current selection instead
+        // of a hovered tree node.
+        DragDrop.SetAllowDrop(this, true);
+        AddHandler(DragDrop.DragOverEvent, OnPngDragOver);
+        AddHandler(DragDrop.DropEvent, OnPngDrop);
+
         // Subscriptions are deferred to InitializeServices (called from MainWindow)
+    }
+
+    // ── PNG drop ──────────────────────────────────────────────────────────────
+
+    private void OnPngDragOver(object? sender, DragEventArgs e)
+    {
+        var firstFile = DragDropFileResolver.GetFirstDroppedFilePath(e);
+
+        var wouldApply = !string.IsNullOrEmpty(firstFile) &&
+            TextureDropProcessor.ComputePngDrop(
+                _selectedState?.SelectedChain,
+                _selectedState?.SelectedFrame,
+                firstFile,
+                _projectManager?.FileName,
+                e.KeyModifiers.HasFlag(KeyModifiers.Control)).Result
+            != TextureDropResult.NotApplied;
+
+        e.DragEffects = wouldApply ? DragDropEffects.Copy : DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private async void OnPngDrop(object? sender, DragEventArgs e)
+    {
+        var firstFile = DragDropFileResolver.GetFirstDroppedFilePath(e);
+        if (string.IsNullOrEmpty(firstFile) || HandlePngDrop is null)
+            return;
+
+        // SelectedFrame's setter keeps SelectedChain in sync with its parent, so this already
+        // falls back to the selected chain (whole-chain retexture/create-first-frame) the same
+        // way SyncTextureCombo's texture-preview lookup does when no frame is selected.
+        var applied = await HandlePngDrop(
+            _selectedState?.SelectedChain, _selectedState?.SelectedFrame,
+            firstFile, e.KeyModifiers.HasFlag(KeyModifiers.Control));
+
+        if (applied)
+            e.Handled = true;
     }
 
     // ── Camera clamping + scrollbar integration ───────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
-﻿using AnimationEditor.App.Theming;
+﻿using AnimationEditor.App.Services;
+using AnimationEditor.App.Theming;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
@@ -890,6 +891,8 @@ public partial class MainWindow : Window
         WireframeCtrl.ChainRegionChanged     += OnChainRegionChanged;
         WireframeCtrl.FrameLiveUpdated       += OnFrameLiveUpdated;
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
+        // Same apply path the ANIMATIONS tree's PNG drop uses (issue #560).
+        WireframeCtrl.HandlePngDrop          = HandlePngDropAsync;
         // The combo follows every tick of a smooth wheel-zoom (#425); the companion file is only
         // persisted once the animation settles (IsZoomAnimating == false), not on every frame.
         WireframeCtrl.ZoomChanged            += zoomPct =>
@@ -2076,15 +2079,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        string? firstFile = e.DataTransfer.TryGetFiles()?
-            .FirstOrDefault()?.Path.LocalPath;
-
-        if (firstFile is null)
-        {
-            firstFile = e.DataTransfer.Items?
-                .Select(i => i.TryGetFile())
-                .FirstOrDefault(f => f is not null)?.Path.LocalPath;
-        }
+        string? firstFile = DragDropFileResolver.GetFirstDroppedFilePath(e);
 
         if (string.IsNullOrEmpty(firstFile) ||
             !string.Equals(Path.GetExtension(firstFile), ".png", StringComparison.OrdinalIgnoreCase))
@@ -2107,7 +2102,7 @@ public partial class MainWindow : Window
         e.Handled = true;
     }
 
-    private void OnTreeDrop(object? sender, DragEventArgs e)
+    private async void OnTreeDrop(object? sender, DragEventArgs e)
     {
         // Internal frame reorder drop — perform the move and let the external .png path below
         // stay untouched (external file drags never carry the frame marker format).
@@ -2132,7 +2127,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        var firstFile = GetFirstDroppedFilePath(e);
+        var firstFile = DragDropFileResolver.GetFirstDroppedFilePath(e);
         Trace.WriteLine($"[DragDrop] OnTreeDrop: firstFile={firstFile ?? "(null)"}, FileName={_projectManager.FileName ?? "(null)"}");
 
         if (string.IsNullOrEmpty(firstFile))
@@ -2141,91 +2136,74 @@ public partial class MainWindow : Window
             return;
         }
 
-        // If no ACHX is saved yet, allow the drop but use an absolute texture path.
-        // Relative-path conversion requires a base directory; without one we fall back to absolute.
-        if (string.IsNullOrEmpty(_projectManager.FileName))
-        {
-            Trace.WriteLine("[DragDrop] Warning: no ACHX file saved yet — texture path will be absolute");
-        }
-
         var (targetChain, targetFrame) = ResolveTreePngDropTarget(e);
 
         Trace.WriteLine($"[DragDrop] targetChain={targetChain?.Name ?? "(null)"}, targetFrame={targetFrame?.TextureName ?? "(null)"}, ctrl={e.KeyModifiers.HasFlag(KeyModifiers.Control)}");
 
+        bool applied = await HandlePngDropAsync(targetChain, targetFrame, firstFile, e.KeyModifiers.HasFlag(KeyModifiers.Control));
+        if (applied)
+            e.Handled = true;
+    }
+
+    /// <summary>
+    /// Single apply path for every PNG-drop entry point (ANIMATIONS tree — including PNGs
+    /// dragged in from the Files panel, which already ride the same OS drag/drop payload —
+    /// and the wireframe canvas, see issue #560). Prompts to copy the file alongside the .achx
+    /// when it lives outside the achx/project folder (<see cref="TextureCopyDecider"/>), computes
+    /// the drop via <see cref="TextureDropProcessor.ComputePngDrop"/>, and applies + refreshes.
+    /// Returns <see langword="true"/> when the drop actually changed something.
+    /// </summary>
+    private async Task<bool> HandlePngDropAsync(
+        AnimationChainSave? targetChain, AnimationFrameSave? targetFrame,
+        string droppedFilePath, bool createFrameOnCtrl)
+    {
+        if (!string.Equals(Path.GetExtension(droppedFilePath).TrimStart('.'), "png", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        string resolvedFilePath = droppedFilePath;
+        string achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
+            ? string.Empty
+            : (Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty);
+
+        if (!string.IsNullOrEmpty(achxFolder) &&
+            TextureCopyDecider.ShouldPromptToCopy(droppedFilePath, achxFolder, _appState.ProjectFolder))
+        {
+            var choice = await ShowTextureCopyDialogAsync(droppedFilePath);
+            if (choice == TextureCopyChoice.Cancel) return false;
+
+            if (choice == TextureCopyChoice.Copy)
+            {
+                string destination = Path.Combine(achxFolder, Path.GetFileName(droppedFilePath));
+                try
+                {
+                    File.Copy(droppedFilePath, destination, overwrite: true);
+                    resolvedFilePath = destination;
+                }
+                catch (Exception ex)
+                {
+                    ShowToast($"Could not copy: {ex.Message}");
+                    return false;
+                }
+            }
+        }
+
         var (result, relPath) = TextureDropProcessor.ComputePngDrop(
-            targetChain,
-            targetFrame,
-            firstFile,
-            _projectManager.FileName,
-            e.KeyModifiers.HasFlag(KeyModifiers.Control));
+            targetChain, targetFrame, resolvedFilePath, _projectManager.FileName, createFrameOnCtrl);
 
         Trace.WriteLine($"[DragDrop] Result={result}");
 
-        if (result == TextureDropResult.NotApplied)
+        bool applied = TextureDropApplier.Apply(_appCommands, _selectedState, targetChain, targetFrame, result, relPath);
+        if (!applied)
         {
             Trace.WriteLine("[DragDrop] NotApplied — no chain or frame targeted, or non-PNG dropped");
-            return;
-        }
-
-        switch (result)
-        {
-            case TextureDropResult.UpdatedFrame:
-                _appCommands.SetFrameTextureName(targetFrame!, relPath);
-                _appCommands.RefreshTreeNode(targetFrame!);
-                _selectedState.SelectedFrame = targetFrame!;
-                break;
-
-            case TextureDropResult.CreatedFrame:
-                _appCommands.AddFrame(targetChain!, relPath);
-                var createdFrame = targetChain!.Frames.LastOrDefault();
-                if (createdFrame is not null)
-                    _selectedState.SelectedFrame = createdFrame;
-                break;
-
-            case TextureDropResult.UpdatedChainFrames:
-                _appCommands.SetAllFramesTextureName(targetChain!, relPath);
-                _appCommands.RefreshTreeNode(targetChain!);
-                _selectedState.SelectedChain = targetChain;
-                break;
+            return false;
         }
 
         RefreshTextureCombo();
         _appCommands.RefreshWireframe();
         _events.RaiseAnimationChainsChanged();
         _appCommands.SyncHotReloadWatcher();  // watch the newly-referenced PNG directory
-        e.Handled = true;
-    }
-
-    private static string? GetFirstDroppedFilePath(DragEventArgs e)
-    {
-        // Log item formats so we can see exactly what the OS provides
-        var itemFormats = e.DataTransfer.Items?
-            .Select(i => "[" + string.Join(",", i.Formats) + "]")
-            .ToList();
-        Trace.WriteLine($"[DragDrop] Items and their formats: {(itemFormats == null ? "(null)" : string.Join(" ", itemFormats))}");
-        Trace.WriteLine($"[DragDrop] Contains(DataFormat.File)={e.DataTransfer.Contains(DataFormat.File)}");
-
-        // Correct Avalonia 12 API for OS file drops
-        var files = e.DataTransfer.TryGetFiles()?.ToList();
-        Trace.WriteLine($"[DragDrop] TryGetFiles() count={files?.Count ?? -1}");
-        if (files?.Count > 0)
-        {
-            var path = files[0].Path.LocalPath;
-            Trace.WriteLine($"[DragDrop] resolved path={path}");
-            return path;
-        }
-
-        // Fallback: per-item TryGetFile()
-        var items = e.DataTransfer.Items?.ToList();
-        Trace.WriteLine($"[DragDrop] Items count={items?.Count ?? -1}");
-        foreach (var item in items ?? new())
-            Trace.WriteLine($"[DragDrop] Item: Formats=[{string.Join(",", item.Formats)}] TryGetFile={item.TryGetFile()?.Path?.LocalPath ?? "(null)"}");
-
-        var fallback = items?
-            .Select(item => item.TryGetFile())
-            .FirstOrDefault(f => f is not null);
-        Trace.WriteLine($"[DragDrop] Items fallback resolved={fallback?.Path.LocalPath ?? "(null)"}");
-        return fallback?.Path.LocalPath;
+        return true;
     }
 
     private TreeNodeVm? GetTreeNodeAtDropPosition(DragEventArgs e)
@@ -3502,11 +3480,7 @@ public partial class MainWindow : Window
 
         if (!string.IsNullOrEmpty(achxFolder))
         {
-            bool isInAchxFolder    = IsPathUnder(pickedPath, achxFolder);
-            bool isInProjectFolder = !string.IsNullOrEmpty(_appState.ProjectFolder)
-                                     && IsPathUnder(pickedPath, _appState.ProjectFolder);
-
-            if (!isInAchxFolder && !isInProjectFolder)
+            if (TextureCopyDecider.ShouldPromptToCopy(pickedPath, achxFolder, _appState.ProjectFolder))
             {
                 var choice = await ShowTextureCopyDialogAsync(pickedPath);
                 if (choice == TextureCopyChoice.Cancel) return;
@@ -3591,14 +3565,6 @@ public partial class MainWindow : Window
 
         await dialog.ShowDialog(this);
         return await tcs.Task;
-    }
-
-    private static bool IsPathUnder(string path, string folder)
-    {
-        char sep = Path.DirectorySeparatorChar;
-        string normPath   = Path.GetFullPath(path).TrimEnd(sep);
-        string normFolder = Path.GetFullPath(folder).TrimEnd(sep) + sep;
-        return normPath.StartsWith(normFolder, StringComparison.OrdinalIgnoreCase);
     }
 
     private void RefreshPropertyPanel()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/DragDropFileResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/DragDropFileResolver.cs
@@ -1,0 +1,45 @@
+using Avalonia.Input;
+using System.Diagnostics;
+using System.Linq;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Extracts the first dropped file's local path from a <see cref="DragEventArgs"/>. Shared by
+/// every OS/Files-panel PNG drop target (ANIMATIONS tree, wireframe canvas) so they all resolve
+/// the dropped file the same way instead of each re-deriving it from <c>DataTransfer</c>.
+/// </summary>
+public static class DragDropFileResolver
+{
+    public static string? GetFirstDroppedFilePath(DragEventArgs e)
+    {
+        // Log item formats so we can see exactly what the OS provides
+        var itemFormats = e.DataTransfer.Items?
+            .Select(i => "[" + string.Join(",", i.Formats) + "]")
+            .ToList();
+        Trace.WriteLine($"[DragDrop] Items and their formats: {(itemFormats == null ? "(null)" : string.Join(" ", itemFormats))}");
+        Trace.WriteLine($"[DragDrop] Contains(DataFormat.File)={e.DataTransfer.Contains(DataFormat.File)}");
+
+        // Correct Avalonia 12 API for OS file drops
+        var files = e.DataTransfer.TryGetFiles()?.ToList();
+        Trace.WriteLine($"[DragDrop] TryGetFiles() count={files?.Count ?? -1}");
+        if (files?.Count > 0)
+        {
+            var path = files[0].Path.LocalPath;
+            Trace.WriteLine($"[DragDrop] resolved path={path}");
+            return path;
+        }
+
+        // Fallback: per-item TryGetFile()
+        var items = e.DataTransfer.Items?.ToList();
+        Trace.WriteLine($"[DragDrop] Items count={items?.Count ?? -1}");
+        foreach (var item in items ?? new())
+            Trace.WriteLine($"[DragDrop] Item: Formats=[{string.Join(",", item.Formats)}] TryGetFile={item.TryGetFile()?.Path?.LocalPath ?? "(null)"}");
+
+        var fallback = items?
+            .Select(item => item.TryGetFile())
+            .FirstOrDefault(f => f is not null);
+        Trace.WriteLine($"[DragDrop] Items fallback resolved={fallback?.Path.LocalPath ?? "(null)"}");
+        return fallback?.Path.LocalPath;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TextureDropApplier.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/TextureDropApplier.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.Linq;
+
+namespace AnimationEditor.Core.DragDrop;
+
+/// <summary>
+/// Applies a <see cref="TextureDropResult"/> already computed by
+/// <see cref="TextureDropProcessor.ComputePngDrop"/> — the undoable-command + selection side
+/// effects shared by every PNG-drop entry point (ANIMATIONS tree, wireframe canvas; see #560).
+/// </summary>
+public static class TextureDropApplier
+{
+    /// <summary>Returns <see langword="true"/> when <paramref name="result"/> was applied.</summary>
+    public static bool Apply(
+        IAppCommands appCommands, ISelectedState selectedState,
+        AnimationChainSave? targetChain, AnimationFrameSave? targetFrame,
+        TextureDropResult result, string? relativePath)
+    {
+        switch (result)
+        {
+            case TextureDropResult.UpdatedFrame:
+                appCommands.SetFrameTextureName(targetFrame!, relativePath);
+                appCommands.RefreshTreeNode(targetFrame!);
+                selectedState.SelectedFrame = targetFrame!;
+                return true;
+
+            case TextureDropResult.CreatedFrame:
+                appCommands.AddFrame(targetChain!, relativePath);
+                var createdFrame = targetChain!.Frames.LastOrDefault();
+                if (createdFrame is not null)
+                    selectedState.SelectedFrame = createdFrame;
+                return true;
+
+            case TextureDropResult.UpdatedChainFrames:
+                appCommands.SetAllFramesTextureName(targetChain!, relativePath);
+                appCommands.RefreshTreeNode(targetChain!);
+                selectedState.SelectedChain = targetChain;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TextureCopyDecider.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TextureCopyDecider.cs
@@ -32,4 +32,11 @@ public static class TextureCopyDecider
 
         return !normTexture.StartsWith(normFolder, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Overload for callers with two candidate "already inside" folders — e.g. the .achx
+    /// folder and the broader project folder. Prompts only when the texture is outside both.
+    /// </summary>
+    public static bool ShouldPromptToCopy(string? texturePath, string? primaryFolder, string? secondaryFolder)
+        => ShouldPromptToCopy(texturePath, primaryFolder) && ShouldPromptToCopy(texturePath, secondaryFolder);
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngDropApplyTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngDropApplyTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Covers <c>MainWindow.HandlePngDropAsync</c> — the single apply path shared by the ANIMATIONS
+/// tree's PNG drop and the wireframe canvas's PNG drop (issue #560). The pure decision/apply
+/// logic it delegates to (<c>TextureDropProcessor.ComputePngDrop</c>, <c>TextureDropApplier</c>,
+/// <c>TextureCopyDecider</c>) is covered directly in <c>AnimationEditor.Core.Tests</c>; what's
+/// left here is the orchestration around it (skip-the-copy-prompt-when-in-folder branch, refresh
+/// side effects). Avalonia's <see cref="DragEventArgs"/> can't be constructed from test code (no
+/// existing test in this suite does so — see the class comment on
+/// <c>FrameDragReorderHeadlessTests</c> for the same limitation with drag gestures), so these
+/// invoke the method directly via reflection with plain domain objects, bypassing the untestable
+/// Drop-event plumbing on either surface.
+/// </summary>
+public class PngDropApplyTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = TestPaths.Abs("Project", "Animations", "Hero.achx");
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static Task<bool> InvokeHandlePngDrop(
+        MainWindow window, AnimationChainSave? chain, AnimationFrameSave? frame, string droppedFilePath, bool ctrlHeld)
+    {
+        var method = typeof(MainWindow).GetMethod("HandlePngDropAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Task<bool>)method.Invoke(window, new object?[] { chain, frame, droppedFilePath, ctrlHeld })!;
+    }
+
+    [AvaloniaFact]
+    public async Task HandlePngDropAsync_NonPngFile_ReturnsFalseAndLeavesFrameUntouched()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "old.png" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            string droppedPath = TestPaths.Abs("Project", "Animations", "notes.txt");
+
+            bool applied = await InvokeHandlePngDrop(window, chain, frame, droppedPath, ctrlHeld: false);
+
+            Assert.False(applied);
+            Assert.Equal("old.png", frame.TextureName);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public async Task HandlePngDropAsync_TextureInsideAchxFolder_UpdatesFrameTextureNameWithoutPrompt()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "old.png" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+
+            // Inside the achx folder (TestPaths.Abs("Project", "Animations")) — no copy prompt
+            // should fire, so this must complete without ShowDialog ever being awaited.
+            string droppedPath = TestPaths.Abs("Project", "Animations", "new.png");
+
+            bool applied = await InvokeHandlePngDrop(window, chain, frame, droppedPath, ctrlHeld: false);
+
+            Assert.True(applied);
+            Assert.Equal("new.png", frame.TextureName);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void WireframeControl_Constructed_AllowsDrop()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreateWireframeControl();
+
+        Assert.True(DragDrop.GetAllowDrop(ctrl));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
@@ -83,4 +83,33 @@ public class TextureCopyDeciderTests
         string fwdFolder = Folder.Replace('\\', '/');
         Assert.False(TextureCopyDecider.ShouldPromptToCopy(Inside, fwdFolder));
     }
+
+    // ── Two-folder overload (e.g. achx folder + broader project folder) ──────
+
+    [Fact]
+    public void ShouldPromptToCopy_TwoFolders_TextureOutsideBoth_ReturnsTrue()
+    {
+        string projectFolder = TestPaths.Abs("project");
+        Assert.True(TextureCopyDecider.ShouldPromptToCopy(Outside, Folder, projectFolder));
+    }
+
+    [Fact]
+    public void ShouldPromptToCopy_TwoFolders_TextureInsidePrimaryOnly_ReturnsFalse()
+    {
+        string projectFolder = TestPaths.Abs("project");
+        Assert.False(TextureCopyDecider.ShouldPromptToCopy(Inside, Folder, projectFolder));
+    }
+
+    [Fact]
+    public void ShouldPromptToCopy_TwoFolders_TextureInsideSecondaryOnly_ReturnsFalse()
+    {
+        // Outside "Folder" (project/Content) but inside the broader "project" root.
+        string projectFolder = TestPaths.Abs("project");
+        string textureInProjectRoot = TestPaths.Abs("project", "OtherAssets", "enemy.png");
+        Assert.False(TextureCopyDecider.ShouldPromptToCopy(textureInProjectRoot, Folder, projectFolder));
+    }
+
+    [Fact]
+    public void ShouldPromptToCopy_TwoFolders_TextureNullOrEmpty_ReturnsFalse()
+        => Assert.False(TextureCopyDecider.ShouldPromptToCopy(null, Folder, Folder));
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropApplierTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropApplierTests.cs
@@ -1,0 +1,74 @@
+using AnimationEditor.Core.DragDrop;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TextureDropApplierTests
+{
+    [Fact]
+    public void Apply_CreatedFrame_AddsFrameToChainAndSelectsIt()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+
+        bool applied = TextureDropApplier.Apply(
+            ctx.AppCommands, ctx.SelectedState,
+            chain, targetFrame: null,
+            TextureDropResult.CreatedFrame, "new.png");
+
+        Assert.True(applied);
+        var createdFrame = Assert.Single(chain.Frames);
+        Assert.Equal("new.png", createdFrame.TextureName);
+        Assert.Same(createdFrame, ctx.SelectedState.SelectedFrame);
+    }
+
+    [Fact]
+    public void Apply_NotApplied_ReturnsFalseAndChangesNothing()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        var frame = chain.Frames[0];
+
+        bool applied = TextureDropApplier.Apply(
+            ctx.AppCommands, ctx.SelectedState,
+            chain, frame,
+            TextureDropResult.NotApplied, relativePath: null);
+
+        Assert.False(applied);
+        Assert.Equal("frame0.png", frame.TextureName);
+    }
+
+    [Fact]
+    public void Apply_UpdatedChainFrames_SetsTextureOnEveryFrameAndSelectsChain()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 3);
+
+        bool applied = TextureDropApplier.Apply(
+            ctx.AppCommands, ctx.SelectedState,
+            chain, targetFrame: null,
+            TextureDropResult.UpdatedChainFrames, "sheet.png");
+
+        Assert.True(applied);
+        Assert.All(chain.Frames, f => Assert.Equal("sheet.png", f.TextureName));
+        Assert.Same(chain, ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void Apply_UpdatedFrame_SetsTextureNameAndSelectsFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        var frame = chain.Frames[0];
+
+        bool applied = TextureDropApplier.Apply(
+            ctx.AppCommands, ctx.SelectedState,
+            chain, frame,
+            TextureDropResult.UpdatedFrame, "new.png");
+
+        Assert.True(applied);
+        Assert.Equal("new.png", frame.TextureName);
+        Assert.Same(frame, ctx.SelectedState.SelectedFrame);
+    }
+}


### PR DESCRIPTION
## Summary
- Dropping a PNG onto the wireframe canvas now assigns it to the selected frame (falling back to the selected chain), matching what already worked for the ANIMATIONS tree.
- Both the Files panel and OS Explorer drag a PNG through the same `DataTransfer` payload, so one `Drop` handler on `WireframeControl` covers both sources — no separate code path per origin.
- Boyscouted the existing tree-drop code while wiring this up:
  - Extracted the shared apply path into `MainWindow.HandlePngDropAsync`, used by both the tree's `OnTreeDrop` and the new wireframe handler.
  - Pulled the apply-and-select switch statement into a new, Core-testable `AnimationEditor.Core.DragDrop.TextureDropApplier`.
  - Deduped the `DragEventArgs` → first-file-path extraction (previously copy-pasted between `OnTreeDragOver` and `OnTreeDrop`) into `AnimationEditor.App.Services.DragDropFileResolver`.
  - Wired up `TextureCopyDecider.ShouldPromptToCopy` — this decider existed with full test coverage but had **zero production call sites**. It now backs the copy/keep/cancel prompt for both `BrowseForFrameTexture` and every PNG drop (tree, Files panel, wireframe), replacing an ad-hoc duplicate `IsPathUnder` check that only covered the Browse flow.

## Testing
- `TextureCopyDecider.ShouldPromptToCopy` two-folder overload — new, TDD'd (Core.Tests), covers the achx-folder-or-project-folder fallback.
- `TextureDropApplier.Apply` — new (Core.Tests), covers all four `TextureDropResult` branches without any Avalonia dependency.
- `PngDropApplyTests` (App.Tests) — covers `MainWindow.HandlePngDropAsync`'s orchestration (non-PNG rejection, in-folder drop skips the copy prompt) via reflection, plus a regression guard that `WireframeControl` has drag/drop enabled.
- Avalonia's `DragEventArgs` can't be constructed from test code (no existing test in this suite does so), so the actual `OnPngDragOver`/`OnPngDrop`/`OnTreeDragOver`/`OnTreeDrop` event wiring remains untested UI plumbing — same category as the pre-existing, still-untested tree handlers. All decision logic they call into is covered above.
- Full solution build + `dotnet test` on both test projects: 1441 + 553 passing, 0 failures.

## Note for follow-up (not fixed in this PR)
While wiring this up I found `MainWindow.axaml.cs` uses `System.IO.Path.GetDirectoryName`/`Path.Combine` on `ProjectManager.FileName` and drop paths in several places (including the code this PR touches) — the `animation-editor` skill flags this as a cross-platform footgun (`Path.GetFileName` on a Windows-authored path silently no-ops on Linux) and says to use `FilePath` instead. This is pre-existing and spans ~10+ call sites across the file, so fixing it is a separate, larger sweep rather than something to fold into this feature PR.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)