### PR TITLE
Fix flaky Avalonia headless compositor race in AnimationEditor.App.Tests

### DIFF
--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestAppBuilder.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestAppBuilder.cs
@@ -2,8 +2,16 @@
 // AvaloniaTestApplicationAttribute lives in Avalonia.Headless (not Avalonia.Headless.XUnit).
 using Avalonia;
 using Avalonia.Headless;
+using Xunit;
 
 [assembly: AvaloniaTestApplication(typeof(AnimationEditor.App.Tests.TestAppBuilder))]
+// Avalonia.Headless.XUnit's HeadlessUnitTestSession lazily creates a single shared
+// headless Compositor/render loop on first [AvaloniaFact] use, and that object enforces
+// single-thread affinity via Dispatcher.VerifyAccess. xUnit's default parallelization runs
+// different test collections on separate worker threads, so two [AvaloniaFact] tests racing
+// to initialize it concurrently throw "a different thread owns it" - flaky on CI runners with
+// more parallel workers than a dev machine. Force serial execution to remove the race.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace AnimationEditor.App.Tests;
 


### PR DESCRIPTION
## Summary
- xUnit's default parallelization ran different `AnimationEditor.App.Tests` collections on separate worker threads, and Avalonia.Headless.XUnit lazily initializes one shared headless `Compositor`/render loop on first `[AvaloniaFact]` use that enforces single-thread affinity via `Dispatcher.VerifyAccess`
- Two `[AvaloniaFact]` tests racing to initialize it concurrently intermittently threw `InvalidOperationException: The calling thread cannot access this object because a different thread owns it` as a **cleanup** failure attributed to an unrelated test, flaky on ubuntu CI runners (more parallel workers than a dev box)
- Added `[assembly: CollectionBehavior(DisableTestParallelization = true)]` to `TestAppBuilder.cs` to force serial execution and remove the race at its source

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj -c Release` — all 553 tests pass serially, ~43s (well under a minute, matching the issue's ask to confirm no meaningful slowdown)
- No new unit test added — this is test-runner configuration (assembly-level parallelization setting), not product behavior, so there is no separate testable unit; confirmed by running the full suite serially and observing no regression and no flake.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)