### PR TITLE
Route context-menu Duplicate items through multi-select-aware paths

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3132,7 +3132,7 @@ public partial class MainWindow : Window
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
             AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(rect));
+            AddMenuItem("Duplicate", HandleDuplicate);
             AddSeparator();
             AddMenuItem("Rename…", () => BeginInlineRename(vm!, rect.Name));
             AddSeparator();
@@ -3144,7 +3144,7 @@ public partial class MainWindow : Window
             AddMenuItem("Copy",  () => _ = HandleCopyAsync());
             AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            AddMenuItem("Duplicate", () => _appCommands.DuplicateShape(circle));
+            AddMenuItem("Duplicate", HandleDuplicate);
             AddSeparator();
             AddMenuItem("Rename…", () => BeginInlineRename(vm!, circle.Name));
             AddSeparator();
@@ -3171,7 +3171,7 @@ public partial class MainWindow : Window
             AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             if (chain2 is not null)
-                AddMenuItem("Duplicate", () => _appCommands.DuplicateFrame(frame2, chain2));
+                AddMenuItem("Duplicate", HandleDuplicate);
             AddSeparator();
             AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame2));
             AddSeparator();
@@ -3204,9 +3204,9 @@ public partial class MainWindow : Window
             AddMenuItem("Cut",   () => _ = HandleCutAsync());
             AddMenuItem("Paste", () => _ = HandlePasteAsync());
             AddSubMenu("Duplicate",
-                ("Original",        () => _appCommands.DuplicateChain(chain)),
-                ("Flip Horizontal", () => _appCommands.DuplicateChain(chain, flipH: true)),
-                ("Flip Vertical",   () => _appCommands.DuplicateChain(chain, flipV: true)));
+                ("Original",        HandleDuplicate),
+                ("Flip Horizontal", () => HandleDuplicateChainsFlip(chain, flipH: true, flipV: false)),
+                ("Flip Vertical",   () => HandleDuplicateChainsFlip(chain, flipH: false, flipV: true)));
             AddSeparator();
             AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
             AddMenuItem("Rename…",          () => BeginInlineRenameSelected(chain));
@@ -4809,6 +4809,19 @@ public partial class MainWindow : Window
             RefreshFrameNode(shapeFrame);
             SyncTreeSelection();
         }
+    }
+
+    // Flip variants aren't part of the Ctrl+D path (HandleDuplicate has no flip concept),
+    // so this mirrors its multi-select dispatch for chains only: duplicate every selected
+    // chain (falling back to the right-clicked one when nothing is selected) with the flip
+    // flag applied, via the same AppCommands.DuplicateChains batch HandleDuplicate uses.
+    private void HandleDuplicateChainsFlip(AnimationChainSave rightClicked, bool flipH, bool flipV)
+    {
+        var selected = _selectedState.SelectedChains;
+        var sources = selected.Count > 0 ? selected : new List<AnimationChainSave> { rightClicked };
+        var copies = _appCommands.DuplicateChains(sources, flipH, flipV);
+        QueuePastedChainExpandFromSources(sources, copies);
+        RefreshTreeView();
     }
 
     // ── Delete ────────────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -886,49 +886,35 @@ namespace AnimationEditor.Core.CommandsAndState
             bool   flipV    = false,
             string? newName = null)
         {
-            var acls = _pm.AnimationChainListSave;
-            if (acls is null) return null;
+            var copies = DuplicateChains(new[] { source }, flipH, flipV);
+            if (copies.Count == 0) return null;
 
-            var copyName = newName ?? StringFunctions.MakeStringUnique(
-                source.Name + "Copy",
-                acls.AnimationChains.Select(c => c.Name).ToList());
+            var copy = copies[0];
+            if (newName is not null) copy.Name = newName;
+            return copy;
+        }
 
-            var copy = new AnimationChainSave { Name = copyName };
+        // Clones a chain and, when requested, mirrors every frame and shape horizontally
+        // and/or vertically. Shared by DuplicateChain (single) and DuplicateChains (batch)
+        // so right-click Duplicate's Original/Flip Horizontal/Flip Vertical submenu items
+        // behave identically whether one or many chains are selected.
+        private static AnimationChainSave CloneChainWithFlip(AnimationChainSave source, bool flipH, bool flipV)
+        {
+            var copy = new AnimationChainSave { Name = source.Name };
             foreach (var frame in source.Frames)
             {
-                var fCopy = new AnimationFrameSave
-                {
-                    TextureName      = frame.TextureName,
-                    LeftCoordinate   = frame.LeftCoordinate,
-                    RightCoordinate  = frame.RightCoordinate,
-                    TopCoordinate    = frame.TopCoordinate,
-                    BottomCoordinate = frame.BottomCoordinate,
-                    FrameLength      = frame.FrameLength,
-                    FlipHorizontal   = flipH ? !frame.FlipHorizontal : frame.FlipHorizontal,
-                    FlipVertical     = flipV ? !frame.FlipVertical   : frame.FlipVertical,
-                    // Mirror the sprite offset about the entity origin so an off-center frame stays
-                    // aligned with its (also-mirrored) shapes after the flip.
-                    RelativeX        = flipH ? -frame.RelativeX : frame.RelativeX,
-                    RelativeY        = flipV ? -frame.RelativeY : frame.RelativeY,
-                    ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave()
-                };
-                if (frame.ShapesSave != null)
-                {
-                    foreach (var shape in frame.ShapesSave.Shapes)
-                        if (AnimationCloneHelper.CloneShape(shape) is { } shapeCopy)
-                        {
-                            // Mirror the copy's offsets so collision tracks the flipped sprite.
-                            ShapeFlip.Mirror(shapeCopy, flipH, flipV);
-                            fCopy.ShapesSave!.Shapes.Add(shapeCopy);
-                        }
-                }
+                var fCopy = AnimationCloneHelper.CloneFrame(frame);
+                fCopy.FlipHorizontal = flipH ? !frame.FlipHorizontal : frame.FlipHorizontal;
+                fCopy.FlipVertical   = flipV ? !frame.FlipVertical   : frame.FlipVertical;
+                // Mirror the sprite offset about the entity origin so an off-center frame stays
+                // aligned with its (also-mirrored) shapes after the flip.
+                fCopy.RelativeX = flipH ? -frame.RelativeX : frame.RelativeX;
+                fCopy.RelativeY = flipV ? -frame.RelativeY : frame.RelativeY;
+                if (fCopy.ShapesSave is not null)
+                    foreach (var shape in fCopy.ShapesSave.Shapes)
+                        ShapeFlip.Mirror(shape, flipH, flipV);
                 copy.Frames.Add(fCopy);
             }
-
-            // Place the copy right after its source so it appears adjacent in the tree.
-            int sourceIndex = acls.AnimationChains.IndexOf(source);
-            int? insertIndex = sourceIndex >= 0 ? sourceIndex + 1 : null;
-            _undoManager.Execute(new AddChainCommand(copy, acls, this, _events, _selectedState, insertIndex));
             return copy;
         }
 
@@ -952,7 +938,7 @@ namespace AnimationEditor.Core.CommandsAndState
             switch (payload.Kind)
             {
                 case CopySelectionKind.Chain:
-                    DuplicateChainsBatch(payload.Chains);
+                    DuplicateChains(payload.Chains);
                     break;
                 case CopySelectionKind.Frame:
                     DuplicateFramesBatch(payload.Frames);
@@ -963,7 +949,9 @@ namespace AnimationEditor.Core.CommandsAndState
             }
         }
 
-        private IReadOnlyList<AnimationChainSave> DuplicateChainsBatch(IReadOnlyList<AnimationChainSave> sources)
+        /// <inheritdoc cref="IAppCommands.DuplicateChains"/>
+        public IReadOnlyList<AnimationChainSave> DuplicateChains(
+            IReadOnlyList<AnimationChainSave> sources, bool flipH = false, bool flipV = false)
         {
             var acls = _pm.AnimationChainListSave;
             if (acls is null || sources.Count == 0) return Array.Empty<AnimationChainSave>();
@@ -975,7 +963,7 @@ namespace AnimationEditor.Core.CommandsAndState
             var items = new List<(AnimationChainSave Source, AnimationChainSave Copy)>();
             foreach (var source in ordered)
             {
-                var copy = AnimationCloneHelper.CloneChain(source);
+                var copy = CloneChainWithFlip(source, flipH, flipV);
                 copy.Name = StringFunctions.MakeStringUnique(source.Name + "Copy", existingNames, 2);
                 existingNames.Add(copy.Name);
                 items.Add((source, copy));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -179,6 +179,17 @@ namespace AnimationEditor.Core.CommandsAndState
         AnimationChainSave? DuplicateChain(AnimationChainSave source, bool flipH = false, bool flipV = false, string? newName = null);
 
         /// <summary>
+        /// Deep-copies every chain in <paramref name="sources"/> and inserts the copies as one
+        /// contiguous block after the last source, in a single undo step. When <paramref name="flipH"/>
+        /// or <paramref name="flipV"/> is set, every copied frame and shape is mirrored along that axis.
+        /// Backs both <see cref="DuplicateSelection"/> (no flip) and the tree context menu's
+        /// Duplicate → Flip Horizontal/Vertical submenu items (which apply to the whole selection,
+        /// not just the right-clicked chain).
+        /// </summary>
+        IReadOnlyList<AnimationChainSave> DuplicateChains(
+            IReadOnlyList<AnimationChainSave> sources, bool flipH = false, bool flipV = false);
+
+        /// <summary>
         /// Deep-copies <paramref name="source"/> and inserts the copy immediately after it
         /// in <paramref name="chain"/>. All UV coordinates, timing, flip flags, relative offsets,
         /// and attached shapes are copied. Undoable.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeFlip.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeFlip.cs
@@ -11,7 +11,7 @@ namespace AnimationEditor.Core.CommandsAndState;
 /// same flip restores the original offsets with no rounding drift.
 /// <para>
 /// Shared by <see cref="Commands.FlipCommand"/> (in-place flip) and the duplicate-with-flip
-/// path in <c>AppCommands.DuplicateChain</c> so both use identical logic.
+/// path in <c>AppCommands.DuplicateChains</c> so both use identical logic.
 /// </para>
 /// </summary>
 public static class ShapeFlip

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RightClickContextMenuDuplicateAppTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RightClickContextMenuDuplicateAppTests.cs
@@ -1,0 +1,247 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.Animation.Content;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #565: right-click preserves a multi-selection (see
+/// <see cref="RightClickMultiSelectAppTests"/> and <see cref="RightClickContextMenuDeleteAppTests"/>),
+/// but the context menu's "Duplicate" items must also act on the whole preserved selection,
+/// not just the right-clicked node — matching Ctrl+D (<c>HandleDuplicate</c>).
+/// </summary>
+public class RightClickContextMenuDuplicateAppTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object[] { System.Array.Empty<string>() });
+        FlushUi();
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TreeNodeVm FirstChainNode(TreeView tree) =>
+        tree.ItemsSource is System.Collections.IEnumerable roots
+            ? roots.Cast<TreeNodeVm>().First()
+            : throw new Xunit.Sdk.XunitException("No tree roots");
+
+    // Right-clicks the realized TreeViewItem for `node` via a real pointer press, so the
+    // test exercises OnTreePointerPressed's selection-preserving logic, not just its effect.
+    private static void RightClick(MainWindow window, TreeView tree, TreeNodeVm node)
+    {
+        var tvi = tree.GetVisualDescendants().OfType<TreeViewItem>()
+            .First(t => ReferenceEquals(t.DataContext, node));
+        var centre = new Point(tvi.Bounds.Width / 2, tvi.Bounds.Height / 2);
+        var pointInWindow = tvi.TranslatePoint(centre, window)!.Value;
+        window.MouseDown(pointInWindow, MouseButton.Right);
+        FlushUi();
+    }
+
+    private static void OpenContextMenu(MainWindow window) =>
+        typeof(MainWindow)
+            .GetMethod("OnTreeContextMenuOpening", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object?[] { null, new CancelEventArgs() });
+
+    private static void ClickContextMenuItem(TreeView tree, string header)
+    {
+        var item = tree.ContextMenu!.Items
+            .OfType<MenuItem>()
+            .First(m => m.Header?.ToString() == header);
+        item.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+    }
+
+    private static void ClickContextSubMenuItem(TreeView tree, string parentHeader, string childHeader)
+    {
+        var parent = tree.ContextMenu!.Items
+            .OfType<MenuItem>()
+            .First(m => m.Header?.ToString() == parentHeader);
+        var child = parent.Items
+            .OfType<MenuItem>()
+            .First(m => m.Header?.ToString() == childHeader);
+        child.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+    }
+
+    [AvaloniaFact]
+    public void DuplicateFrame_ContextMenu_OnMultiSelection_DuplicatesAllSelectedFrames()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f };
+            var f2 = new AnimationFrameSave { TextureName = "c.png", FrameLength = 0.1f };
+            chain.Frames.AddRange(new[] { f0, f1, f2 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+
+            var frameNodes = chainNode.Children;
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(frameNodes[0]);
+            tree.SelectedItems.Add(frameNodes[1]);
+            tree.SelectedItems.Add(frameNodes[2]);
+            FlushUi();
+
+            // Right-click a non-primary member of the selection — selection must survive
+            // (already fixed for #561), and Duplicate must then act on all 3.
+            RightClick(window, tree, frameNodes[1]);
+            Assert.Equal(3, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextMenuItem(tree, "Duplicate");
+
+            Assert.Equal(6, chain.Frames.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void DuplicateRectangle_ContextMenu_OnMultiSelection_DuplicatesAllSelectedRectangles()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "a.png", ShapesSave = new ShapesSave() };
+            var r0 = new AARectSave { Name = "R0" };
+            var r1 = new AARectSave { Name = "R1" };
+            frame.ShapesSave.Shapes.Add(r0);
+            frame.ShapesSave.Shapes.Add(r1);
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+
+            var frameNode = chainNode.Children[0];
+            frameNode.IsExpanded = true;
+            FlushUi();
+
+            var rectNodes = frameNode.Children;
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rectNodes[0]);
+            tree.SelectedItems.Add(rectNodes[1]);
+            FlushUi();
+
+            RightClick(window, tree, rectNodes[0]);
+            Assert.Equal(2, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextMenuItem(tree, "Duplicate");
+
+            Assert.Equal(4, frame.ShapesSave.AARectSaves.Count());
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void DuplicateChain_ContextMenu_OriginalOnMultiSelection_DuplicatesAllSelectedChains()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var walk = new AnimationChainSave { Name = "Walk" };
+            var run  = new AnimationChainSave { Name = "Run" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(walk);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(run);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNodes = tree.ItemsSource is System.Collections.IEnumerable roots
+                ? roots.Cast<TreeNodeVm>().ToList()
+                : throw new Xunit.Sdk.XunitException("No tree roots");
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(chainNodes[0]);
+            tree.SelectedItems.Add(chainNodes[1]);
+            FlushUi();
+
+            RightClick(window, tree, chainNodes[0]);
+            Assert.Equal(2, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextSubMenuItem(tree, "Duplicate", "Original");
+
+            Assert.Equal(4, ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void DuplicateChain_ContextMenu_FlipHorizontalOnMultiSelection_DuplicatesAllSelectedChainsFlipped()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var walk = new AnimationChainSave { Name = "Walk" };
+            walk.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FlipHorizontal = false });
+            var run = new AnimationChainSave { Name = "Run" };
+            run.Frames.Add(new AnimationFrameSave { TextureName = "b.png", FlipHorizontal = false });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(walk);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(run);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNodes = tree.ItemsSource is System.Collections.IEnumerable roots
+                ? roots.Cast<TreeNodeVm>().ToList()
+                : throw new Xunit.Sdk.XunitException("No tree roots");
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(chainNodes[0]);
+            tree.SelectedItems.Add(chainNodes[1]);
+            FlushUi();
+
+            RightClick(window, tree, chainNodes[0]);
+            Assert.Equal(2, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextSubMenuItem(tree, "Duplicate", "Flip Horizontal");
+
+            var acls = ctx.ProjectManager.AnimationChainListSave!;
+            Assert.Equal(4, acls.AnimationChains.Count);
+            var walkCopy = acls.AnimationChains.Single(c => c.Name.StartsWith("Walk") && c != walk);
+            var runCopy  = acls.AnimationChains.Single(c => c.Name.StartsWith("Run") && c != run);
+            Assert.True(walkCopy.Frames[0].FlipHorizontal);
+            Assert.True(runCopy.Frames[0].FlipHorizontal);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -538,6 +538,24 @@ public class AppCommandsChainTests
         Assert.Null(result);
     }
 
+    // ── DuplicateChains (batch, with flip) ───────────────────────────────────
+
+    [Fact]
+    public void DuplicateChains_WithFlipH_TogglesFlipHorizontalOnAllCopiedChains()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var walk = TestHelpers.MakeChain(acls, "Walk", 1);
+        var run  = TestHelpers.MakeChain(acls, "Run", 1);
+        walk.Frames[0].FlipHorizontal = false;
+        run.Frames[0].FlipHorizontal  = false;
+
+        var copies = ctx.AppCommands.DuplicateChains(new[] { walk, run }, flipH: true);
+
+        Assert.Equal(2, copies.Count);
+        Assert.All(copies, c => Assert.True(c.Frames[0].FlipHorizontal));
+    }
+
     // ── SortAnimationsAlphabetically ─────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -91,6 +91,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.InvertFrameOrder)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetAllFrameLengths)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.DuplicateChain)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.DuplicateChains)]              = Category.MutatingUndoable,
         [nameof(IAppCommands.DuplicateFrame)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.DuplicateShape)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SortAnimationsAlphabetically)] = Category.MutatingUndoable,
@@ -269,6 +270,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetAllFrameLengths(Zebra(ctx), 0.5f)));
         yield return Row(nameof(IAppCommands.DuplicateChain),
             ctx => Sync(() => ctx.AppCommands.DuplicateChain(Zebra(ctx))));
+        yield return Row(nameof(IAppCommands.DuplicateChains),
+            ctx => Sync(() => ctx.AppCommands.DuplicateChains(new[] { Zebra(ctx) })));
         yield return Row(nameof(IAppCommands.DuplicateFrame),
             ctx => Sync(() => ctx.AppCommands.DuplicateFrame(Zebra(ctx).Frames[0], Zebra(ctx))));
         yield return Row(nameof(IAppCommands.DuplicateShape),


### PR DESCRIPTION
## Summary
- Right-click **Duplicate** on Frame/Rectangle/Circle/Animation each hardcoded single-item duplication, ignoring the rest of a preserved multi-selection — the same divergence pattern fixed for context-menu Delete in #563/#561.
- Rewired all four to `HandleDuplicate()`, the same batch path Ctrl+D already uses (`SelectionCopyContext` → `AppCommands.DuplicateSelection`), so right-click Duplicate now matches Ctrl+D exactly for frames/rects/circles/chains.
- The chain submenu's **Flip Horizontal**/**Flip Vertical** variants have no Ctrl+D equivalent (Ctrl+D never flips), so they needed new batch support: added `AppCommands.DuplicateChains(sources, flipH, flipV)`, which duplicates every selected chain with the flip applied as one undo step. `DuplicateChain` (single) and `DuplicateSelection`'s chain case now both delegate to it, eliminating a second independent flip-clone implementation.

Closes #565

## Test plan
- [x] New `RightClickContextMenuDuplicateAppTests.cs` (4 tests): multi-select Frame/Rectangle/chain-Original/chain-Flip-Horizontal, right-click a non-primary member, click the context menu item, assert the whole selection duplicated. Verified these fail against the pre-fix code (3/3/3/4 instead of 4/4/4/6) and pass after the fix.
- [x] New `AppCommandsChainTests.DuplicateChains_WithFlipH_TogglesFlipHorizontalOnAllCopiedChains` covers the new batch-with-flip method directly.
- [x] `UndoCoverageRosterTests` updated to categorize and round-trip-test `DuplicateChains`.
- [x] Full suite green: `AnimationEditor.Core.Tests` (1451 passed), `AnimationEditor.App.Tests` (561 passed).