### PR TITLE
Fix Animation Editor: multi-select chain reorder for Alt+Arrow and drag-and-drop

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -76,16 +76,18 @@ public partial class MainWindow : Window
     private Border? _frameDropLine;
     private Border? _frameDropBox;
 
-    // ── Chain drag-and-drop reorder state ──────────────────────────────────────
-    // Mirrors the frame path above, but for top-level animation-chain nodes. Single-chain
-    // drag only; the dragged chain lives in _pendingChainDrag since the drag is same-process.
+    // ── Chain drag-and-drop reorder state (issue #566) ──────────────────────────
+    // Mirrors the frame path above, but for top-level animation-chain nodes. The
+    // dragged chain(s) live in _pendingChainDrag since the drag is always same-process.
     private static readonly DataFormat<string> ChainDragDataFormat =
         DataFormat.CreateStringApplicationFormat("animationeditor-chain-drag");
     private const string ChainDragToken = "chain";
-    private AnimationChainSave? _pendingChainDrag;
+    private ChainDragSource? _pendingChainDrag;
     private AnimationChainSave? _chainDragCandidate;
     private Avalonia.Point? _chainDragPressPoint;
     private PointerPressedEventArgs? _chainDragPressArgs;
+    private List<object>? _chainDragSelectionSnapshot;
+    private AnimationChainSave? _pendingSingleSelectChain;
     private bool _chainDragInProgress;
     private int _untitledCounter;
     private bool _suppressPropRefresh;
@@ -1869,6 +1871,10 @@ public partial class MainWindow : Window
             InputElement.PointerMovedEvent,
             OnTreeChainDragPointerMoved,
             RoutingStrategies.Bubble);
+        AnimTree.AddHandler(
+            InputElement.PointerReleasedEvent,
+            OnTreeChainDragPointerReleased,
+            RoutingStrategies.Bubble);
 
         // "Add Animation" button under the tree
         AddChainBtn.Click += (_, _) =>
@@ -2062,9 +2068,9 @@ public partial class MainWindow : Window
         }
 
         // Internal chain reorder drag.
-        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { } draggedChain)
+        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { IsValid: true } chainDrag)
         {
-            var target = ResolveChainDrop(e, draggedChain);
+            var target = ResolveChainDrop(e, chainDrag.Chains);
             if (target.IsValid)
             {
                 e.DragEffects = DragDropEffects.Move;
@@ -2117,12 +2123,12 @@ public partial class MainWindow : Window
         }
 
         // Internal chain reorder drop.
-        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { } draggedChain)
+        if (e.DataTransfer.Contains(ChainDragDataFormat) && _pendingChainDrag is { IsValid: true } chainDrag)
         {
             RemoveFrameDropIndicators();
-            var target = ResolveChainDrop(e, draggedChain);
+            var target = ResolveChainDrop(e, chainDrag.Chains);
             if (target.IsValid)
-                _appCommands.MoveChainToIndex(draggedChain, target.InsertIndex);
+                _appCommands.MoveChainsToIndex(chainDrag.Chains, target.InsertIndex);
             e.Handled = true;
             return;
         }
@@ -2494,6 +2500,20 @@ public partial class MainWindow : Window
         _chainDragCandidate = null;
         _chainDragPressPoint = null;
         _chainDragPressArgs = null;
+        _chainDragSelectionSnapshot = null;
+        _pendingSingleSelectChain = null;
+    }
+
+    private void SelectSingleChain(AnimationChainSave chain)
+    {
+        var vm = TreeBuilder.FindNodeForData(_treeRoots, chain);
+        if (vm is null) return;
+
+        bool prior = _suppressTreeSelectionHandling;
+        _suppressTreeSelectionHandling = true;
+        try { AnimTree.SelectedItems?.Clear(); }
+        finally { _suppressTreeSelectionHandling = prior; }
+        AnimTree.SelectedItem = vm;
     }
 
     private async void OnTreeChainDragPointerMoved(object? sender, PointerEventArgs e)
@@ -2513,9 +2533,16 @@ public partial class MainWindow : Window
             Math.Abs(pos.Y - _chainDragPressPoint.Value.Y) <= 4)
             return;
 
-        var chain = _chainDragCandidate;
+        if (!TryBuildChainDragSource(out var dragSource))
+        {
+            ClearChainDragCandidate();
+            return;
+        }
+
+        // A drag is happening, so the deferred single-select must not fire on release.
+        _pendingSingleSelectChain = null;
         e.Pointer.Capture(null); // release press-capture so the drag system can take over
-        _pendingChainDrag = chain;
+        _pendingChainDrag = dragSource;
         _chainDragInProgress = true;
 
         var data = new DataTransfer();
@@ -2533,13 +2560,64 @@ public partial class MainWindow : Window
         }
     }
 
-    private ChainDropTarget ResolveChainDrop(DragEventArgs e, AnimationChainSave draggedChain)
+    private void OnTreeChainDragPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_chainDragInProgress) return;
+
+        // A press on an already-multi-selected chain that did not turn into a drag collapses
+        // the selection to that single chain now (the select-on-press was suppressed so the
+        // multi-selection could survive a potential drag).
+        if (_pendingSingleSelectChain is { } chain)
+        {
+            e.Pointer.Capture(null);
+            SelectSingleChain(chain);
+        }
+        ClearChainDragCandidate();
+    }
+
+    /// <summary>
+    /// Decides which chains a drag moves. Dragging a chain that is part of a valid chain
+    /// multi-selection moves the whole set; a mixed selection that includes the dragged chain
+    /// is rejected with a toast; otherwise just the dragged chain moves. Mirrors
+    /// <see cref="TryBuildFrameDragSource"/>.
+    /// </summary>
+    private bool TryBuildChainDragSource(out ChainDragSource dragSource)
+    {
+        dragSource = default;
+        var candidate = _chainDragCandidate;
+        if (candidate is null) return false;
+
+        var snapshot = _chainDragSelectionSnapshot ?? new List<object>();
+        bool candidateInSnapshot = snapshot.Any(n => ReferenceEquals(n, candidate));
+        var classified = ChainDropResolver.ClassifySelection(snapshot);
+
+        if (candidateInSnapshot)
+        {
+            if (classified.IsValid)
+            {
+                dragSource = classified;
+                return true;
+            }
+            if (classified.Validity is ChainDragValidity.MixedTypes)
+            {
+                ShowStatusMessage(
+                    "Can't reorder a mixed selection — select only animations.", isError: true);
+                return false;
+            }
+        }
+
+        // Drag just the single pressed chain.
+        dragSource = new ChainDragSource(new[] { candidate }, ChainDragValidity.Valid);
+        return true;
+    }
+
+    private ChainDropTarget ResolveChainDrop(DragEventArgs e, IReadOnlyList<AnimationChainSave> draggedChains)
     {
         var chains = _projectManager.AnimationChainListSave?.AnimationChains;
         if (chains is null) return ChainDropTarget.None;
         var (nodeData, half, _) = HitTestFrameRow(e.GetPosition(AnimTree));
         return ChainDropResolver.Resolve(
-            nodeData, half, draggedChain, chains,
+            nodeData, half, draggedChains, chains,
             f => _objectFinder.GetAnimationChainContaining(f));
     }
 
@@ -3078,13 +3156,32 @@ public partial class MainWindow : Window
                 chainSrc.FindAncestorOfType<TreeViewItem>(includeSelf: true)?.DataContext
                     is TreeNodeVm { Data: AnimationChainSave chain })
             {
-                // Arm a chain-drag candidate. Do not handle/capture — normal selection and the
-                // context menu still run; the platform drag only begins once the pointer moves
-                // past the threshold, so a plain click never starts a drag.
+                // Arm a chain-drag candidate. Snapshot the selection BEFORE the TreeView mutates
+                // it on press, so dragging a chain that is part of a multi-selection can move
+                // the whole set. Tunnel phase runs ahead of the TreeView's own selection handling.
                 ClearFrameDragCandidate();
                 _chainDragCandidate = chain;
                 _chainDragPressPoint = e.GetPosition(AnimTree);
                 _chainDragPressArgs = e;
+                _chainDragSelectionSnapshot = new List<object>(_selectedState.SelectedNodes);
+
+                // Pressing a chain that's part of a chain multi-selection (no modifiers) must
+                // not collapse the selection — otherwise a drag would only move one chain. Mark
+                // the press handled to suppress the TreeView's select-on-press, capture so the
+                // move/release still arrive here, and defer the single-select to release if no
+                // drag happens. Ctrl/Shift presses fall through to normal selection editing.
+                bool noModifiers = (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Shift)) == 0;
+                if (noModifiers &&
+                    ChainDropResolver.IsChainMultiSelectionContaining(_chainDragSelectionSnapshot, chain))
+                {
+                    _pendingSingleSelectChain = chain;
+                    e.Pointer.Capture(AnimTree);
+                    e.Handled = true;
+                }
+                else
+                {
+                    _pendingSingleSelectChain = null;
+                }
             }
             else
             {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -654,6 +654,41 @@ namespace AnimationEditor.Core.CommandsAndState
                 "Move Animation"));
         }
 
+        /// <inheritdoc cref="IAppCommands.MoveChainsToIndex"/>
+        public void MoveChainsToIndex(IReadOnlyList<AnimationChainSave> chains, int insertIndex)
+        {
+            var list = _pm.AnimationChainListSave?.AnimationChains;
+            if (list is null || chains.Count == 0) return;
+
+            var indices = chains
+                .Select(c => list.IndexOf(c))
+                .Where(i => i >= 0)
+                .Distinct()
+                .OrderBy(i => i)
+                .ToList();
+            if (indices.Count == 0) return;
+
+            var moved = indices.Select(i => list[i]).ToArray();
+
+            // insertIndex is measured against the list before removal; removing the moved
+            // chains shifts the landing spot left by however many of them sat ahead of it
+            // (mirrors MoveFramesCommand).
+            int insertAt = insertIndex - indices.Count(i => i < insertIndex);
+
+            _undoManager.Execute(new ReorderCommand<AnimationChainSave>(
+                list,
+                () =>
+                {
+                    foreach (var chain in moved)
+                        list.Remove(chain);
+                    int at = Math.Clamp(insertAt, 0, list.Count);
+                    for (int i = 0; i < moved.Length; i++)
+                        list.Insert(at + i, moved[i]);
+                },
+                this, _events, RefreshTreeView,
+                moved.Length == 1 ? "Move Animation" : $"Move {moved.Length} Animations"));
+        }
+
         public void MoveChainToTop(AnimationChainSave chain)
         {
             var chains = _pm.AnimationChainListSave?.AnimationChains;
@@ -759,6 +794,50 @@ namespace AnimationEditor.Core.CommandsAndState
                 delta > 0 ? "Move Frames Down" : "Move Frames Up"));
         }
 
+        /// <inheritdoc cref="IAppCommands.MoveChainsRelative"/>
+        public void MoveChainsRelative(IReadOnlyList<AnimationChainSave> chains, int delta)
+        {
+            var list = _pm.AnimationChainListSave?.AnimationChains;
+            if (list is null || delta == 0 || chains.Count == 0) return;
+
+            var indices = chains
+                .Select(c => list.IndexOf(c))
+                .Where(i => i >= 0)
+                .Distinct()
+                .OrderBy(i => i)
+                .ToList();
+            if (indices.Count == 0) return;
+
+            // Rigid group: if shifting either edge by delta would cross a boundary, no-op.
+            if (indices[0] + delta < 0) return;
+            if (indices[^1] + delta > list.Count - 1) return;
+
+            var selected = new HashSet<int>(indices);
+
+            _undoManager.Execute(new ReorderCommand<AnimationChainSave>(
+                list,
+                () =>
+                {
+                    var reordered = new AnimationChainSave[list.Count];
+                    // Selected chains land at their shifted slots (gaps preserved)...
+                    foreach (int i in indices)
+                        reordered[i + delta] = list[i];
+                    // ...and the rest slot into the remaining holes in original order.
+                    int cursor = 0;
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        if (selected.Contains(i)) continue;
+                        while (reordered[cursor] is not null) cursor++;
+                        reordered[cursor] = list[i];
+                    }
+                    list.Clear();
+                    foreach (var chain in reordered)
+                        list.Add(chain);
+                },
+                this, _events, RefreshTreeView,
+                delta > 0 ? "Move Animations Down" : "Move Animations Up"));
+        }
+
         public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {
             var shapes = frame.ShapesSave?.Shapes;
@@ -800,7 +879,9 @@ namespace AnimationEditor.Core.CommandsAndState
         /// Moves the currently-selected shape, frame, or chain up (<paramref name="delta"/> = -1)
         /// or down (<paramref name="delta"/> = +1) in the tree.
         /// Shape selection takes highest priority: if a shape is selected it is reordered within
-        /// its frame's shape list. Frame selection takes next priority; chain is last.
+        /// its frame's shape list. Frame selection takes next priority; chain is last. When more
+        /// than one frame or chain is selected, the whole group moves together as a rigid,
+        /// gap-preserving block (<see cref="MoveFramesRelative"/> / <see cref="MoveChainsRelative"/>).
         /// No-op when nothing is selected or when the item is already at the boundary.
         /// </summary>
         public void HandleReorder(int delta)
@@ -833,7 +914,15 @@ namespace AnimationEditor.Core.CommandsAndState
                     MoveFrame(frame, chain, delta);
             }
             else if (chain is not null)
-                MoveChain(chain, delta);
+            {
+                // Reorder the whole multi-selection together (gaps preserved); fall back to
+                // the single-chain move when only the primary chain is selected.
+                var chains = _selectedState.SelectedChains;
+                if (chains.Count > 1)
+                    MoveChainsRelative(chains, delta);
+                else
+                    MoveChain(chain, delta);
+            }
         }
 
         public void FlipFrameHorizontally(AnimationFrameSave frame)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -139,6 +139,16 @@ namespace AnimationEditor.Core.CommandsAndState
         /// an index landing on the chain's own slot is a no-op with no undo entry.
         /// </summary>
         void MoveChainToIndex(AnimationChainSave chain, int insertIndex);
+
+        /// <summary>
+        /// Moves <paramref name="chains"/> to an absolute slot in the chain list as one undo
+        /// step — the multi-selection drag-and-drop reorder entry point (parallel to
+        /// <see cref="MoveFrames"/> for frames). <paramref name="insertIndex"/> is interpreted
+        /// against the current list <em>before</em> the chains are removed, so it is adjusted
+        /// internally for the removal. The chains are sorted by their current index and become
+        /// a contiguous, gap-squashed block at the destination.
+        /// </summary>
+        void MoveChainsToIndex(IReadOnlyList<AnimationChainSave> chains, int insertIndex);
         void MoveChainToTop(AnimationChainSave chain);
         void MoveChainToBottom(AnimationChainSave chain);
         void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta);
@@ -166,6 +176,16 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void MoveFramesRelative(IReadOnlyList<AnimationFrameSave> frames,
             AnimationChainSave chain, int delta);
+
+        /// <summary>
+        /// Shifts <paramref name="chains"/> within the chain list by <paramref name="delta"/>
+        /// slots (−1 = up, +1 = down) as one rigid group, preserving the gaps between
+        /// non-contiguous chains, as a single undo step. The whole group is clamped at the
+        /// list boundaries: if the shift would push any selected chain past an end, nothing
+        /// moves. Drives the Alt+Arrow keyboard reorder when multiple chains are selected —
+        /// mirrors <see cref="MoveFramesRelative"/> for frames.
+        /// </summary>
+        void MoveChainsRelative(IReadOnlyList<AnimationChainSave> chains, int delta);
         void MoveShape(object shape, AnimationFrameSave frame, int delta);
         void MoveShapeToTop(object shape, AnimationFrameSave frame);
         void MoveShapeToBottom(object shape, AnimationFrameSave frame);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/ChainDropResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/ChainDropResolver.cs
@@ -1,18 +1,39 @@
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AnimationEditor.Core.DragDrop;
 
 /// <summary>
-/// The resolved landing spot for an animation-chain drag: the index the chain will be
+/// The resolved landing spot for an animation-chain drag: the index the chain(s) will be
 /// inserted at in the chains list, interpreted against the current list before the dragged
-/// chain is removed. <see cref="IsValid"/> is false when the drop is a no-op (landing on the
-/// dragged chain's own slot) or has no valid target, in which case no indicator is shown.
+/// chains are removed. <see cref="IsValid"/> is false when the drop would land inside the
+/// dragged selection's own span (a no-op / ambiguous squash) or has no valid target, in which
+/// case no indicator is shown.
 /// </summary>
 public readonly record struct ChainDropTarget(int InsertIndex, bool IsValid)
 {
     public static readonly ChainDropTarget None = new(-1, false);
+}
+
+/// <summary>
+/// Why a chain drag may or may not be initiated from the current selection. Mirrors
+/// <see cref="FrameDragValidity"/>: <see cref="Valid"/> is the only state that starts a drag;
+/// <see cref="MixedTypes"/> warrants an error/info toast, while <see cref="Empty"/> and
+/// <see cref="NotChains"/> silently suppress the drag.
+/// </summary>
+public enum ChainDragValidity { Valid, Empty, NotChains, MixedTypes }
+
+/// <summary>
+/// The chains a drag would move. <see cref="Chains"/> is non-empty only when
+/// <see cref="Validity"/> is <see cref="ChainDragValidity.Valid"/>.
+/// </summary>
+public readonly record struct ChainDragSource(
+    IReadOnlyList<AnimationChainSave> Chains,
+    ChainDragValidity Validity)
+{
+    public bool IsValid => Validity == ChainDragValidity.Valid;
 }
 
 /// <summary>
@@ -23,21 +44,58 @@ public readonly record struct ChainDropTarget(int InsertIndex, bool IsValid)
 public static class ChainDropResolver
 {
     /// <summary>
-    /// Resolves where a single-chain drag would land given the tree node under the pointer.
+    /// Classifies the current tree selection for drag eligibility. A homogeneous set of
+    /// chains is <see cref="ChainDragValidity.Valid"/>; any non-chain mixed in is
+    /// <see cref="ChainDragValidity.MixedTypes"/>. Pure non-chain or empty selections do
+    /// not drag. Mirrors <see cref="FrameDropResolver.ClassifySelection"/>.
+    /// </summary>
+    public static ChainDragSource ClassifySelection(IReadOnlyList<object>? selectedNodes)
+    {
+        if (selectedNodes is null || selectedNodes.Count == 0)
+            return new(Array.Empty<AnimationChainSave>(), ChainDragValidity.Empty);
+
+        var chains = selectedNodes.OfType<AnimationChainSave>().ToList();
+
+        if (chains.Count == 0)
+            return new(chains, ChainDragValidity.NotChains);
+
+        if (chains.Count != selectedNodes.Count)
+            return new(chains, ChainDragValidity.MixedTypes);
+
+        return new(chains, ChainDragValidity.Valid);
+    }
+
+    /// <summary>
+    /// True when <paramref name="candidate"/> is one of several chains in a homogeneous
+    /// chain multi-selection. Pressing such a chain must NOT collapse the selection (so a
+    /// drag can move the whole set); a plain click that never drags collapses on release
+    /// instead. Returns false for single selections or any selection containing a non-chain.
+    /// Mirrors <see cref="FrameDropResolver.IsFrameMultiSelectionContaining"/>.
+    /// </summary>
+    public static bool IsChainMultiSelectionContaining(
+        IReadOnlyList<object>? selection, AnimationChainSave candidate)
+    {
+        if (selection is null || selection.Count < 2) return false;
+        if (!selection.All(n => n is AnimationChainSave)) return false;
+        return selection.Any(n => ReferenceEquals(n, candidate));
+    }
+
+    /// <summary>
+    /// Resolves where a chain drag would land given the tree node under the pointer.
     /// A chain node resolves to before it (upper half) or after it (lower half); a frame node
     /// resolves to just after its owning chain (so dropping over an expanded chain's frames
-    /// lands after that chain); anything else is no drop. Dropping onto the dragged chain's
-    /// own slot (its index or index+1) is a no-op and returns <see cref="ChainDropTarget.None"/>'s
-    /// invalidity with the computed index.
+    /// lands after that chain); anything else is no drop. A drop landing strictly inside the
+    /// index span of <paramref name="draggedChains"/> is rejected as a no-op / ambiguous
+    /// squash (mirrors <see cref="FrameDropResolver.Resolve"/>'s same-chain guard).
     /// </summary>
     /// <param name="half">Which half of a chain row the pointer is over (ignored for frame targets).</param>
-    /// <param name="draggedChain">The chain being dragged.</param>
+    /// <param name="draggedChains">The chain(s) being dragged.</param>
     /// <param name="chains">The current top-level chain list.</param>
     /// <param name="getChainContainingFrame">Maps a target frame to its owning chain.</param>
     public static ChainDropTarget Resolve(
         object? nodeData,
         FrameRowHalf half,
-        AnimationChainSave draggedChain,
+        IReadOnlyList<AnimationChainSave> draggedChains,
         IReadOnlyList<AnimationChainSave> chains,
         Func<AnimationFrameSave, AnimationChainSave?> getChainContainingFrame)
     {
@@ -63,10 +121,16 @@ public static class ChainDropResolver
                 return ChainDropTarget.None;
         }
 
-        // Squash guard: an insert at the dragged chain's own index or index+1 leaves the list
-        // unchanged for a single-item move, so surface the index but mark it invalid.
-        int draggedIndex = IndexOf(chains, draggedChain);
-        bool valid = insertIndex != draggedIndex && insertIndex != draggedIndex + 1;
+        var indices = draggedChains
+            .Select(c => IndexOf(chains, c))
+            .Where(i => i >= 0)
+            .OrderBy(i => i)
+            .ToList();
+        if (indices.Count == 0) return ChainDropTarget.None;
+
+        int minSel = indices[0];
+        int maxSel = indices[^1];
+        bool valid = insertIndex <= minSel || insertIndex >= maxSel + 1;
         return new ChainDropTarget(insertIndex, valid);
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainDragReorderHeadlessTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainDragReorderHeadlessTests.cs
@@ -80,4 +80,39 @@ public class ChainDragReorderHeadlessTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// Multi-chain drag: dragging a selection of several chains moves the whole set together
+    /// as a contiguous block, preserving relative order (issue #566). Exercises the resolved
+    /// move via AppCommands.MoveChainsToIndex, which is what the drop handler calls for a
+    /// multi-chain drag source.
+    /// </summary>
+    [AvaloniaFact]
+    public void MoveChainsToIndex_MultiSelection_ReordersRootTreeNodesAsBlock_OneUndoReverts()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var acls = ctx.ProjectManager.AnimationChainListSave!;
+            var a = MakeChain(acls, "A");
+            var b = MakeChain(acls, "B");
+            var c = MakeChain(acls, "C");
+            var d = MakeChain(acls, "D");
+            RebuildTree(window);
+
+            // Drag {B, D} to the front — non-contiguous selection squashes to a block.
+            ctx.AppCommands.MoveChainsToIndex(new[] { b, d }, 0);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(new[] { b, d, a, c },
+                Roots(window).Select(n => n.Data).ToArray());
+
+            ctx.UndoManager.Undo();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(new[] { a, b, c, d },
+                Roots(window).Select(n => n.Data).ToArray());
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsReorderTests.cs
@@ -56,6 +56,116 @@ public class AppCommandsReorderTests
         Assert.Equal(walk, acls.AnimationChains[0]);
     }
 
+    // ── HandleReorder — multiple chains selected (issue #566) ────────────────
+
+    [Fact]
+    public void HandleReorder_MultiChainContiguous_DeltaPos1_MovesBlockDown()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c = ctx.Acls;
+        TestHelpers.MakeChain(c, "A");
+        TestHelpers.MakeChain(c, "B");
+        TestHelpers.MakeChain(c, "C");
+        TestHelpers.MakeChain(c, "D");
+        var chains = c.AnimationChains.ToArray();
+        ctx.SelectedState.SelectedChain = chains[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { chains[0], chains[1] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(new[] { chains[2], chains[0], chains[1], chains[3] }, c.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiChainContiguous_DeltaNeg1_MovesBlockUp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c = ctx.Acls;
+        TestHelpers.MakeChain(c, "A");
+        TestHelpers.MakeChain(c, "B");
+        TestHelpers.MakeChain(c, "C");
+        TestHelpers.MakeChain(c, "D");
+        var chains = c.AnimationChains.ToArray();
+        ctx.SelectedState.SelectedChain = chains[2];
+        ctx.SelectedState.SelectedNodes = new List<object> { chains[2], chains[3] };
+
+        ctx.AppCommands.HandleReorder(-1);
+
+        Assert.Equal(new[] { chains[0], chains[2], chains[3], chains[1] }, c.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiChainNonContiguous_DeltaPos1_PreservesGaps()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c = ctx.Acls;
+        for (int i = 0; i < 6; i++)
+            TestHelpers.MakeChain(c, $"Chain{i}");
+        var chains = c.AnimationChains.ToArray();
+        ctx.SelectedState.SelectedChain = chains[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { chains[0], chains[2], chains[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // 0,2,4 → 1,3,5; gaps preserved, non-selected fill remaining slots in order.
+        Assert.Equal(
+            new[] { chains[1], chains[0], chains[3], chains[2], chains[5], chains[4] },
+            c.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiChainAtBottom_DeltaPos1_IsNoOp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c = ctx.Acls;
+        TestHelpers.MakeChain(c, "A");
+        TestHelpers.MakeChain(c, "B");
+        TestHelpers.MakeChain(c, "C");
+        TestHelpers.MakeChain(c, "D");
+        var chains = c.AnimationChains.ToArray();
+        ctx.SelectedState.SelectedChain = chains[2];
+        ctx.SelectedState.SelectedNodes = new List<object> { chains[2], chains[3] };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        // Bottommost selected chain is already at the end — whole group is clamped.
+        Assert.Equal(chains, c.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_MultiChain_SingleUndo_RevertsWholeMove()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var c = ctx.Acls;
+        for (int i = 0; i < 6; i++)
+            TestHelpers.MakeChain(c, $"Chain{i}");
+        var chains = c.AnimationChains.ToArray();
+        ctx.SelectedState.SelectedChain = chains[0];
+        ctx.SelectedState.SelectedNodes = new List<object> { chains[0], chains[2], chains[4] };
+
+        ctx.AppCommands.HandleReorder(+1);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(chains, c.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void HandleReorder_SingleChainSelectedInNodesToo_UsesSingleChainMove()
+    {
+        // SelectedChains resolves to exactly one chain — must still go through the
+        // single-chain MoveChain path, not MoveChainsRelative.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var walk = TestHelpers.MakeChain(acls, "Walk");
+        var run = TestHelpers.MakeChain(acls, "Run");
+        ctx.SelectedState.SelectedChain = walk;
+        ctx.SelectedState.SelectedNodes = new List<object> { walk };
+
+        ctx.AppCommands.HandleReorder(+1);
+
+        Assert.Equal(new[] { run, walk }, acls.AnimationChains.ToArray());
+    }
+
     // ── MoveChainToIndex ─────────────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainDropResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainDropResolverTests.cs
@@ -1,12 +1,14 @@
 using AnimationEditor.Core.DragDrop;
 using FlatRedBall2.Animation.Content;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
 
 /// <summary>
-/// Pure drop-target logic for animation-chain (top-level node) drag-and-drop reorder.
+/// Pure drop-target and selection-classification logic for animation-chain (top-level node)
+/// drag-and-drop reorder, including multi-chain selections (issue #566).
 /// </summary>
 public class ChainDropResolverTests
 {
@@ -22,7 +24,7 @@ public class ChainDropResolverTests
     public void Resolve_ChainNodeLowerHalf_InsertsAfterThatChain()
     {
         var chains = Chains("A", "B", "C");
-        var dragged = chains[0];
+        var dragged = new[] { chains[0] };
 
         // Drop A onto the lower half of B (index 1) → insert after B.
         var result = ChainDropResolver.Resolve(
@@ -36,7 +38,7 @@ public class ChainDropResolverTests
     public void Resolve_ChainNodeUpperHalf_InsertsBeforeThatChain()
     {
         var chains = Chains("A", "B", "C");
-        var dragged = chains[2];
+        var dragged = new[] { chains[2] };
 
         // Drop C onto the upper half of B (index 1) → insert before B.
         var result = ChainDropResolver.Resolve(
@@ -50,7 +52,7 @@ public class ChainDropResolverTests
     public void Resolve_FrameNode_MapsToAfterOwningChain()
     {
         var chains = Chains("A", "B", "C");
-        var dragged = chains[0];
+        var dragged = new[] { chains[0] };
         var frame = new AnimationFrameSave { TextureName = "f.png" };
         chains[1].Frames.Add(frame);
 
@@ -68,7 +70,7 @@ public class ChainDropResolverTests
         var chains = Chains("A", "B");
 
         var result = ChainDropResolver.Resolve(
-            new AARectSave { Name = "Hit" }, FrameRowHalf.Upper, chains[0], chains, _ => null);
+            new AARectSave { Name = "Hit" }, FrameRowHalf.Upper, new[] { chains[0] }, chains, _ => null);
 
         Assert.False(result.IsValid);
         Assert.Equal(-1, result.InsertIndex);
@@ -80,36 +82,136 @@ public class ChainDropResolverTests
         var chains = Chains("A", "B");
 
         var result = ChainDropResolver.Resolve(
-            null, FrameRowHalf.Upper, chains[0], chains, _ => null);
+            null, FrameRowHalf.Upper, new[] { chains[0] }, chains, _ => null);
 
         Assert.False(result.IsValid);
     }
 
     [Fact]
-    public void Resolve_OwnIndex_Invalid()
+    public void Resolve_MultiChain_DropInsideSelectionSpan_Invalid()
     {
-        var chains = Chains("A", "B", "C");
-        var dragged = chains[1];
+        // Chains A..F; select indices 1,3,4. Span is [1,4]; dropping between 1 and 2
+        // (insert index 2) is inside the span and must be rejected.
+        var chains = Chains("A", "B", "C", "D", "E", "F");
+        var selected = new[] { chains[1], chains[3], chains[4] };
 
-        // Dropping B on its own upper half resolves to its own index → no-op.
         var result = ChainDropResolver.Resolve(
-            chains[1], FrameRowHalf.Upper, dragged, chains, _ => null);
-
-        Assert.Equal(1, result.InsertIndex);
-        Assert.False(result.IsValid);
-    }
-
-    [Fact]
-    public void Resolve_OwnIndexPlusOne_Invalid()
-    {
-        var chains = Chains("A", "B", "C");
-        var dragged = chains[1];
-
-        // Dropping B on its own lower half resolves to index+1 → still a no-op.
-        var result = ChainDropResolver.Resolve(
-            chains[1], FrameRowHalf.Lower, dragged, chains, _ => null);
+            chains[2], FrameRowHalf.Upper, selected, chains, _ => null);
 
         Assert.Equal(2, result.InsertIndex);
         Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_MultiChain_DropAfterLastSelected_Valid()
+    {
+        // Same setup; dropping after the last chain (index 6) is outside the span → valid.
+        var chains = Chains("A", "B", "C", "D", "E", "F");
+        var selected = new[] { chains[1], chains[3], chains[4] };
+
+        var result = ChainDropResolver.Resolve(
+            chains[5], FrameRowHalf.Lower, selected, chains, _ => null);
+
+        Assert.Equal(6, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Resolve_MultiChain_DropBeforeFirstSelected_Valid()
+    {
+        var chains = Chains("A", "B", "C", "D", "E", "F");
+        var selected = new[] { chains[1], chains[3], chains[4] };
+
+        var result = ChainDropResolver.Resolve(
+            chains[0], FrameRowHalf.Upper, selected, chains, _ => null);
+
+        Assert.Equal(0, result.InsertIndex);
+        Assert.True(result.IsValid);
+    }
+
+    // ── ClassifySelection ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ClassifySelection_Empty_NoDrag()
+    {
+        var result = ChainDropResolver.ClassifySelection(new List<object>());
+        Assert.Equal(ChainDragValidity.Empty, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ClassifySelection_MultipleChains_Valid()
+    {
+        var chains = Chains("A", "B", "C");
+        var selection = new List<object> { chains[0], chains[2] };
+
+        var result = ChainDropResolver.ClassifySelection(selection);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(2, result.Chains.Count);
+    }
+
+    [Fact]
+    public void ClassifySelection_ChainMixedWithFrame_MixedTypes()
+    {
+        var chains = Chains("A", "B");
+        var frame = new AnimationFrameSave { TextureName = "f.png" };
+        var selection = new List<object> { chains[0], frame };
+
+        var result = ChainDropResolver.ClassifySelection(selection);
+
+        Assert.Equal(ChainDragValidity.MixedTypes, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void ClassifySelection_NoChains_NotChains()
+    {
+        var frame = new AnimationFrameSave { TextureName = "f.png" };
+        var selection = new List<object> { frame };
+
+        var result = ChainDropResolver.ClassifySelection(selection);
+
+        Assert.Equal(ChainDragValidity.NotChains, result.Validity);
+        Assert.False(result.IsValid);
+    }
+
+    // ── IsChainMultiSelectionContaining ──────────────────────────────────────
+
+    [Fact]
+    public void IsChainMultiSelectionContaining_ChainInMultiChainSelection_True()
+    {
+        var chains = Chains("A", "B", "C");
+        var selection = new List<object> { chains[0], chains[2] };
+
+        Assert.True(ChainDropResolver.IsChainMultiSelectionContaining(selection, chains[0]));
+    }
+
+    [Fact]
+    public void IsChainMultiSelectionContaining_SingleSelection_False()
+    {
+        var chains = Chains("A", "B");
+        var selection = new List<object> { chains[0] };
+
+        Assert.False(ChainDropResolver.IsChainMultiSelectionContaining(selection, chains[0]));
+    }
+
+    [Fact]
+    public void IsChainMultiSelectionContaining_MixedSelection_False()
+    {
+        var chains = Chains("A", "B");
+        var frame = new AnimationFrameSave { TextureName = "f.png" };
+        var selection = new List<object> { chains[0], frame };
+
+        Assert.False(ChainDropResolver.IsChainMultiSelectionContaining(selection, chains[0]));
+    }
+
+    [Fact]
+    public void IsChainMultiSelectionContaining_CandidateNotInSelection_False()
+    {
+        var chains = Chains("A", "B", "C");
+        var selection = new List<object> { chains[0], chains[1] };
+
+        Assert.False(ChainDropResolver.IsChainMultiSelectionContaining(selection, chains[2]));
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveChainsCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveChainsCommandTests.cs
@@ -1,0 +1,97 @@
+using AnimationEditor.Core;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Drag-and-drop multi-chain move command: gap squash and single-undo semantics
+/// (issue #566), parallel to <see cref="MoveFramesCommandTests"/> for frames.
+/// </summary>
+[Collection("SequentialSingletons")]
+public class MoveChainsCommandTests
+{
+    [Fact]
+    public void MoveChainsToIndex_MultiSelectSquashesGapsAndPreservesOrder()
+    {
+        // Chains 0..5; move {1,3,4} to the end → 0,2,5,1,3,4 (block squashed, order kept).
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        for (int i = 0; i < 6; i++)
+            TestHelpers.MakeChain(acls, $"Chain{i}");
+        var chains = acls.AnimationChains.ToArray();
+        var selected = new[] { chains[1], chains[3], chains[4] };
+
+        ctx.AppCommands.MoveChainsToIndex(selected, insertIndex: 6);
+
+        Assert.Equal(
+            new[] { chains[0], chains[2], chains[5], chains[1], chains[3], chains[4] },
+            acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainsToIndex_OneUndoRestoresOriginalOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        for (int i = 0; i < 4; i++)
+            TestHelpers.MakeChain(acls, $"Chain{i}");
+        var original = acls.AnimationChains.ToArray();
+
+        // Move chain 0 to the end.
+        ctx.AppCommands.MoveChainsToIndex(new[] { original[0] }, insertIndex: 4);
+        Assert.Equal(new[] { original[1], original[2], original[3], original[0] }, acls.AnimationChains.ToArray());
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(original, acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainsToIndex_Redo_ReappliesMove()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        for (int i = 0; i < 4; i++)
+            TestHelpers.MakeChain(acls, $"Chain{i}");
+        var original = acls.AnimationChains.ToArray();
+
+        ctx.AppCommands.MoveChainsToIndex(new[] { original[0] }, insertIndex: 4);
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Equal(new[] { original[1], original[2], original[3], original[0] }, acls.AnimationChains.ToArray());
+    }
+
+    [Fact]
+    public void MoveChainsToIndex_DropAtSamePosition_NoUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        for (int i = 0; i < 3; i++)
+            TestHelpers.MakeChain(acls, $"Chain{i}");
+        var chains = acls.AnimationChains.ToArray();
+
+        // Upper half of chain 1, moving chain 1 — lands in its own slot → no change.
+        ctx.AppCommands.MoveChainsToIndex(new[] { chains[1] }, insertIndex: 1);
+
+        Assert.Equal(chains, acls.AnimationChains.ToArray());
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void MoveChainsToIndex_NonContiguousSelection_LaterPosition_AdjustsForRemoval()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        for (int i = 0; i < 5; i++)
+            TestHelpers.MakeChain(acls, $"Chain{i}");
+        var chains = acls.AnimationChains.ToArray();
+
+        // Move {0,2} to insertIndex 5 (end, pre-removal) → lands after the rest, in order.
+        ctx.AppCommands.MoveChainsToIndex(new[] { chains[0], chains[2] }, insertIndex: 5);
+
+        Assert.Equal(
+            new[] { chains[1], chains[3], chains[4], chains[0], chains[2] },
+            acls.AnimationChains.ToArray());
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -73,6 +73,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AddFrame)]                     = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChain)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToIndex)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChainsToIndex)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChainToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrame)]                    = Category.MutatingUndoable,
@@ -80,6 +81,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveFrameToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFrames)]                   = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveFramesRelative)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.MoveChainsRelative)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShape)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToBottom)]            = Category.MutatingUndoable,
@@ -225,6 +227,9 @@ public class UndoCoverageRosterTests
         yield return Row(nameof(IAppCommands.MoveChainToIndex),
             // Drag Alpha (index 1) to the front of the two-chain list.
             ctx => Sync(() => ctx.AppCommands.MoveChainToIndex(Alpha(ctx), 0)));
+        yield return Row(nameof(IAppCommands.MoveChainsToIndex),
+            // Multi-chain drag: drag Alpha (index 1) to the front of the two-chain list.
+            ctx => Sync(() => ctx.AppCommands.MoveChainsToIndex(new[] { Alpha(ctx) }, 0)));
         yield return Row(nameof(IAppCommands.MoveChainToTop),
             ctx => Sync(() => ctx.AppCommands.MoveChainToTop(Alpha(ctx))));
         yield return Row(nameof(IAppCommands.MoveChainToBottom),
@@ -243,6 +248,9 @@ public class UndoCoverageRosterTests
             // Rigid multi-frame shift: frames 0 and 1 of Zebra (3 frames) move down → 2,0,1.
             ctx => Sync(() => ctx.AppCommands.MoveFramesRelative(
                 new[] { Zebra(ctx).Frames[0], Zebra(ctx).Frames[1] }, Zebra(ctx), +1)));
+        yield return Row(nameof(IAppCommands.MoveChainsRelative),
+            // Rigid chain-group shift: Zebra (index 0) moves down past Alpha.
+            ctx => Sync(() => ctx.AppCommands.MoveChainsRelative(new[] { Zebra(ctx) }, +1)));
         yield return Row(nameof(IAppCommands.MoveShape),
             ctx => Sync(() => ctx.AppCommands.MoveShape(Rect(ctx), Zebra(ctx).Frames[0], +1)));
         yield return Row(nameof(IAppCommands.MoveShapeToTop),


### PR DESCRIPTION
## Summary
- Adds `MoveChainsRelative` (rigid, gap-preserving group shift, mirrors `MoveFramesRelative`) used by `HandleReorder` for Alt+Arrow when more than one chain is selected.
- Adds `MoveChainsToIndex` (contiguous-block squash, mirrors `MoveFramesCommand`) as the multi-chain drag-and-drop reorder entry point, replacing the single-chain-only `MoveChainToIndex` call in the drop handler.
- Extends `ChainDropResolver` with `ClassifySelection`/`IsChainMultiSelectionContaining` and a multi-chain span guard, mirroring `FrameDropResolver`. `MainWindow` now snapshots the chain selection on press and defers single-select to release, so pressing a chain that's part of a multi-selection doesn't collapse it before a drag can start (mirrors the existing frame-drag path from issue #500).

## Test plan
- [x] `dotnet test tests/AnimationEditor.Core.Tests/` — 1471 passed (new: `AppCommandsReorderTests` multi-chain `HandleReorder` cases, `MoveChainsCommandTests`, `ChainDropResolverTests` multi-chain span-guard + classification cases, `UndoCoverageRosterTests` roster/round-trip coverage for the two new commands)
- [x] `dotnet test tests/AnimationEditor.App.Tests/` — 558 passed (new: `ChainDragReorderHeadlessTests.MoveChainsToIndex_MultiSelection_ReordersRootTreeNodesAsBlock_OneUndoReverts`)
- [x] Full solution build clean

Closes #566