### PR TITLE
Fix Animation Editor: multi-select property edits only updated primary frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3653,6 +3653,24 @@ public partial class MainWindow : Window
         return await tcs.Task;
     }
 
+    /// <summary>
+    /// Shows <paramref name="values"/>'s shared value in <paramref name="control"/>, or blanks it
+    /// with a "(mixed)" placeholder when the selected frames disagree on that property.
+    /// </summary>
+    private static void SetValueOrMixed(NumericUpDown control, IReadOnlyList<decimal> values)
+    {
+        if (values.Distinct().Count() == 1)
+        {
+            control.Value = values[0];
+            control.PlaceholderText = string.Empty;
+        }
+        else
+        {
+            control.Value = null;
+            control.PlaceholderText = "(mixed)";
+        }
+    }
+
     private void RefreshPropertyPanel()
     {
         _suppressPropRefresh = true;
@@ -3677,32 +3695,54 @@ public partial class MainWindow : Window
 
             if (frame is not null && !hasShapeSelection)
             {
-                PropFlipH.IsChecked  = frame.FlipHorizontal;
-                PropFlipV.IsChecked  = frame.FlipVertical;
-                PropFrameLen.Value   = (decimal)frame.FrameLength;
-                PropRelX.Value       = (decimal)frame.RelativeX;
-                PropRelY.Value       = (decimal)frame.RelativeY;
-                PropRed.Value        = frame.Red.HasValue   ? frame.Red.Value   : (decimal?)null;
-                PropGreen.Value      = frame.Green.HasValue ? frame.Green.Value : (decimal?)null;
-                PropBlue.Value       = frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null;
-                PropAlpha.Value      = frame.Alpha.HasValue ? frame.Alpha.Value : (decimal?)null;
+                // When multiple frames are selected and disagree on a property, show that field
+                // blank with a "(mixed)" placeholder instead of one frame's value (issue #571) —
+                // editing it then applies the new value to every selected frame; leaving it blank
+                // applies nothing (see the `!PropXxx.Value.HasValue` guards in the Apply* methods).
+                var frames = _selectedState.SelectedFrames;
+
+                bool flipHMixed = frames.Select(f => f.FlipHorizontal).Distinct().Count() > 1;
+                bool flipVMixed = frames.Select(f => f.FlipVertical).Distinct().Count() > 1;
+                PropFlipH.IsChecked = flipHMixed ? null : frame.FlipHorizontal;
+                PropFlipV.IsChecked = flipVMixed ? null : frame.FlipVertical;
+
+                SetValueOrMixed(PropFrameLen, frames.Select(f => (decimal)f.FrameLength).ToList());
+                SetValueOrMixed(PropRelX, frames.Select(f => (decimal)f.RelativeX).ToList());
+                SetValueOrMixed(PropRelY, frames.Select(f => (decimal)f.RelativeY).ToList());
+
+                bool redMixed   = frames.Select(f => f.Red).Distinct().Count() > 1;
+                bool greenMixed = frames.Select(f => f.Green).Distinct().Count() > 1;
+                bool blueMixed  = frames.Select(f => f.Blue).Distinct().Count() > 1;
+                bool alphaMixed = frames.Select(f => f.Alpha).Distinct().Count() > 1;
+                bool opMixed    = frames.Select(f => f.ColorOperation).Distinct().Count() > 1;
+
+                PropRed.Value   = redMixed   ? null : (frame.Red.HasValue   ? frame.Red.Value   : (decimal?)null);
+                PropGreen.Value = greenMixed ? null : (frame.Green.HasValue ? frame.Green.Value : (decimal?)null);
+                PropBlue.Value  = blueMixed  ? null : (frame.Blue.HasValue  ? frame.Blue.Value  : (decimal?)null);
+                PropAlpha.Value = alphaMixed ? null : (frame.Alpha.HasValue ? frame.Alpha.Value : (decimal?)null);
 
                 // Ghost the sticky effective value in each blank field: an omitted channel holds
                 // whatever an earlier frame last set (climbing back), or the operation's identity
                 // (Add → 0, else 255) when nothing ever set it. This makes a blank field read as the
-                // value a runtime actually applies, instead of implying "reset to default".
+                // value a runtime actually applies, instead of implying "reset to default". Mixed
+                // takes priority — it means the selection disagrees, not that a value is inherited.
                 var chain = _selectedState.SelectedChain;
                 int frameIndex = chain?.Frames.IndexOf(frame) ?? -1;
                 var effective = frameIndex >= 0
                     ? EffectiveFrameColor.Resolve(chain!.Frames, frameIndex)
                     : default;
                 int rgbDefault = EffectiveFrameColor.ChannelDefault(effective.Operation);
-                PropRed.PlaceholderText   = (effective.Red   ?? rgbDefault).ToString();
-                PropGreen.PlaceholderText = (effective.Green ?? rgbDefault).ToString();
-                PropBlue.PlaceholderText  = (effective.Blue  ?? rgbDefault).ToString();
-                PropAlpha.PlaceholderText = (effective.Alpha ?? 255).ToString();
+                PropRed.PlaceholderText   = redMixed   ? "(mixed)" : (effective.Red   ?? rgbDefault).ToString();
+                PropGreen.PlaceholderText = greenMixed ? "(mixed)" : (effective.Green ?? rgbDefault).ToString();
+                PropBlue.PlaceholderText  = blueMixed  ? "(mixed)" : (effective.Blue  ?? rgbDefault).ToString();
+                PropAlpha.PlaceholderText = alphaMixed ? "(mixed)" : (effective.Alpha ?? 255).ToString();
 
-                if (frame.ColorOperation is ColorOperation op)
+                if (opMixed)
+                {
+                    PropColorMode.SelectedIndex = -1;
+                    PropColorMode.PlaceholderText = "(mixed)";
+                }
+                else if (frame.ColorOperation is ColorOperation op)
                 {
                     PropColorMode.SelectedIndex = op == ColorOperation.Multiply ? 1 : 2;
                 }
@@ -3723,10 +3763,10 @@ public partial class MainWindow : Window
                 var (bmpW, bmpH) = WireframeCtrl.BitmapSize;
                 if (bmpW > 0 && bmpH > 0)
                 {
-                    PropPixelX.Value = FrameDisplayValues.GetPixelX(frame, bmpW);
-                    PropPixelY.Value = FrameDisplayValues.GetPixelY(frame, bmpH);
-                    PropPixelW.Value = FrameDisplayValues.GetPixelWidth(frame, bmpW);
-                    PropPixelH.Value = FrameDisplayValues.GetPixelHeight(frame, bmpH);
+                    SetValueOrMixed(PropPixelX, frames.Select(f => (decimal)FrameDisplayValues.GetPixelX(f, bmpW)).ToList());
+                    SetValueOrMixed(PropPixelY, frames.Select(f => (decimal)FrameDisplayValues.GetPixelY(f, bmpH)).ToList());
+                    SetValueOrMixed(PropPixelW, frames.Select(f => (decimal)FrameDisplayValues.GetPixelWidth(f, bmpW)).ToList());
+                    SetValueOrMixed(PropPixelH, frames.Select(f => (decimal)FrameDisplayValues.GetPixelHeight(f, bmpH)).ToList());
                 }
             }
 
@@ -3758,40 +3798,43 @@ public partial class MainWindow : Window
     private void ApplyFrameFlip()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
-        // Route through the undoable flip commands. FlipFrame* toggles, so only call
-        // it when the toggle button's state actually differs from the model.
-        if (frame.FlipHorizontal != (PropFlipH.IsChecked == true))
-            _appCommands.FlipFrameHorizontally(frame);
-        if (frame.FlipVertical != (PropFlipV.IsChecked == true))
-            _appCommands.FlipFrameVertically(frame);
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
+        // ToggleButton.IsChecked is already nullable: null means the checkbox is showing the
+        // mixed/indeterminate state (the selection disagrees and the user didn't touch it), so
+        // it passes straight through as "leave this axis untouched".
+        _appCommands.SetFrameFlip(frames, PropFlipH.IsChecked, PropFlipV.IsChecked);
     }
 
     private void ApplyFrameLen()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null || !PropFrameLen.Value.HasValue) return;
-        _appCommands.SetFrameLength(frame, (float)PropFrameLen.Value.Value);
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0 || !PropFrameLen.Value.HasValue) return;
+        _appCommands.SetFrameLength(frames, (float)PropFrameLen.Value.Value);
     }
 
     private void ApplyFrameRelative()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null || !PropRelX.Value.HasValue || !PropRelY.Value.HasValue) return;
-        _appCommands.SetFrameRelative(frame, (float)PropRelX.Value.Value, (float)PropRelY.Value.Value);
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0 || !PropRelX.Value.HasValue || !PropRelY.Value.HasValue) return;
+        _appCommands.SetFrameRelative(frames, (float)PropRelX.Value.Value, (float)PropRelY.Value.Value);
     }
 
     private void ApplyFrameColor()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
         // A blank NumericUpDown (null Value) means the channel is unset and is omitted from the .achx.
+        // Note: with a multi-selection, a channel that is still showing its "(mixed)" placeholder
+        // also reads as null here, so it gets applied (cleared) to every selected frame just like an
+        // explicit clear would — there's no way to tell "never touched" apart from "cleared on purpose"
+        // from the control's Value alone. Prefer not leaving a mixed color panel blank across an edit
+        // if that distinction matters; see PR notes for the known limitation.
         static int? ToChannel(decimal? v) => v.HasValue ? (int)v.Value : null;
-        _appCommands.SetFrameColor(frame, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
+        _appCommands.SetFrameColor(frames, ToChannel(PropRed.Value), ToChannel(PropGreen.Value), ToChannel(PropBlue.Value));
     }
 
     private void CommitColorChannelOnEnter(KeyEventArgs e)
@@ -3802,17 +3845,17 @@ public partial class MainWindow : Window
     private void ApplyFrameAlpha()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
         // A blank NumericUpDown (null Value) means alpha is unset and is omitted from the .achx.
-        _appCommands.SetFrameAlpha(frame, PropAlpha.Value.HasValue ? (int)PropAlpha.Value.Value : null);
+        _appCommands.SetFrameAlpha(frames, PropAlpha.Value.HasValue ? (int)PropAlpha.Value.Value : null);
     }
 
     private void ApplyFrameColorOperation()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
         // ComboBox order: 0 = None (null), 1 = Multiply, 2 = Add.
         ColorOperation? operation = PropColorMode.SelectedIndex switch
         {
@@ -3820,19 +3863,19 @@ public partial class MainWindow : Window
             2 => ColorOperation.Add,
             _ => null,
         };
-        _appCommands.SetFrameColorOperation(frame, operation);
+        _appCommands.SetFrameColorOperation(frames, operation);
     }
 
     private void ApplyFramePixelCoords()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
         var (bmpW, bmpH) = WireframeCtrl.BitmapSize;
         if (bmpW <= 0 || bmpH <= 0) return;
         if (!PropPixelX.Value.HasValue || !PropPixelY.Value.HasValue ||
             !PropPixelW.Value.HasValue || !PropPixelH.Value.HasValue) return;
-        _appCommands.SetFramePixelRegion(frame,
+        _appCommands.SetFramePixelRegion(frames,
             (int)PropPixelX.Value.Value, (int)PropPixelY.Value.Value,
             (int)PropPixelW.Value.Value, (int)PropPixelH.Value.Value,
             bmpW, bmpH);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3818,8 +3818,14 @@ public partial class MainWindow : Window
     {
         if (_suppressPropRefresh) return;
         var frames = _selectedState.SelectedFrames;
-        if (frames.Count == 0 || !PropRelX.Value.HasValue || !PropRelY.Value.HasValue) return;
-        _appCommands.SetFrameRelative(frames, (float)PropRelX.Value.Value, (float)PropRelY.Value.Value);
+        if (frames.Count == 0) return;
+        // A null axis here only ever means "still showing (mixed), not edited" — RelativeX/Y have no
+        // legitimate null/cleared state — so it's safe to apply just the axis the user touched and
+        // leave the other axis alone per-frame (see SetFrameRelative for why this is unambiguous).
+        float? relX = PropRelX.Value.HasValue ? (float)PropRelX.Value.Value : null;
+        float? relY = PropRelY.Value.HasValue ? (float)PropRelY.Value.Value : null;
+        if (relX is null && relY is null) return;
+        _appCommands.SetFrameRelative(frames, relX, relY);
     }
 
     private void ApplyFrameColor()
@@ -3873,12 +3879,15 @@ public partial class MainWindow : Window
         if (frames.Count == 0) return;
         var (bmpW, bmpH) = WireframeCtrl.BitmapSize;
         if (bmpW <= 0 || bmpH <= 0) return;
-        if (!PropPixelX.Value.HasValue || !PropPixelY.Value.HasValue ||
-            !PropPixelW.Value.HasValue || !PropPixelH.Value.HasValue) return;
-        _appCommands.SetFramePixelRegion(frames,
-            (int)PropPixelX.Value.Value, (int)PropPixelY.Value.Value,
-            (int)PropPixelW.Value.Value, (int)PropPixelH.Value.Value,
-            bmpW, bmpH);
+        // A null component here only ever means "still showing (mixed), not edited" — the pixel
+        // region has no legitimate null/cleared state — so it's safe to apply just the component(s)
+        // the user touched and leave the rest alone per-frame (see SetFramePixelRegion).
+        int? x = PropPixelX.Value.HasValue ? (int)PropPixelX.Value.Value : null;
+        int? y = PropPixelY.Value.HasValue ? (int)PropPixelY.Value.Value : null;
+        int? w = PropPixelW.Value.HasValue ? (int)PropPixelW.Value.Value : null;
+        int? h = PropPixelH.Value.HasValue ? (int)PropPixelH.Value.Value : null;
+        if (x is null && y is null && w is null && h is null) return;
+        _appCommands.SetFramePixelRegion(frames, x, y, w, h, bmpW, bmpH);
         WireframeCtrl.RefreshFrames();
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -925,16 +925,29 @@ namespace AnimationEditor.Core.CommandsAndState
             }
         }
 
-        public void FlipFrameHorizontally(AnimationFrameSave frame)
+        public void SetFrameFlip(IReadOnlyList<AnimationFrameSave> frames, bool? flipHorizontal, bool? flipVertical)
         {
-            _undoManager.Execute(new FlipCommand(
-                new[] { frame }, horizontal: true, this, _events, RefreshWireframe));
-        }
+            // Absolute set, not toggle: only the frames whose flag actually differs from the target
+            // get flipped (and their offset/shapes mirrored), so a frame already at the target state
+            // is untouched. Reuses FlipCommand's toggle for exactly those frames, grouped into one
+            // undo step via CompositeCommand.
+            var commands = new List<IUndoableCommand>();
 
-        public void FlipFrameVertically(AnimationFrameSave frame)
-        {
-            _undoManager.Execute(new FlipCommand(
-                new[] { frame }, horizontal: false, this, _events, RefreshWireframe));
+            if (flipHorizontal.HasValue)
+            {
+                var toFlip = frames.Where(f => f.FlipHorizontal != flipHorizontal.Value).ToArray();
+                if (toFlip.Length > 0)
+                    commands.Add(new FlipCommand(toFlip, horizontal: true, this, _events, RefreshWireframe));
+            }
+            if (flipVertical.HasValue)
+            {
+                var toFlip = frames.Where(f => f.FlipVertical != flipVertical.Value).ToArray();
+                if (toFlip.Length > 0)
+                    commands.Add(new FlipCommand(toFlip, horizontal: false, this, _events, RefreshWireframe));
+            }
+
+            if (commands.Count == 0) return;
+            _undoManager.Execute(new CompositeCommand(commands, "Set Flip"));
         }
 
         public void FlipChainHorizontally(AnimationChainSave chain)
@@ -1388,60 +1401,63 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new CompositeCommand(cmds, "Set All Frame Textures"));
         }
 
-        public void SetFrameLength(AnimationFrameSave frame, float newLength)
+        public void SetFrameLength(IReadOnlyList<AnimationFrameSave> frames, float newLength)
         {
-            var desc = $"Set Length: {frame.FrameLength:0.###}s → {newLength:0.###}s";
+            var desc = $"Set Length: {newLength:0.###}s";
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () => frame.FrameLength = newLength,
+                frames, () => { foreach (var f in frames) f.FrameLength = newLength; },
                 this, _events, false, desc));
         }
 
-        public void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY)
+        public void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float newRelX, float newRelY)
         {
             var desc = $"Set Offset: ({newRelX:0.##}, {newRelY:0.##})";
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () => { frame.RelativeX = newRelX; frame.RelativeY = newRelY; },
+                frames, () => { foreach (var f in frames) { f.RelativeX = newRelX; f.RelativeY = newRelY; } },
                 this, _events, true, desc));
         }
 
-        public void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue)
+        public void SetFrameColor(IReadOnlyList<AnimationFrameSave> frames, int? red, int? green, int? blue)
         {
             // Color tints the preview and the timeline/tree thumbnails but not the wireframe, so no
             // wireframe refresh is needed. The AnimationChainsChanged raised here rebuilds those.
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () => { frame.Red = red; frame.Green = green; frame.Blue = blue; },
+                frames, () => { foreach (var f in frames) { f.Red = red; f.Green = green; f.Blue = blue; } },
                 this, _events, false, "Set Frame Color"));
         }
 
-        public void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation)
+        public void SetFrameColorOperation(IReadOnlyList<AnimationFrameSave> frames, ColorOperation? operation)
         {
             // Mode drives how the preview + timeline/tree thumbnails tint; it doesn't touch the
             // wireframe, so no wireframe refresh is needed.
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () => frame.ColorOperation = operation,
+                frames, () => { foreach (var f in frames) f.ColorOperation = operation; },
                 this, _events, false, "Set Frame Color Mode"));
         }
 
-        public void SetFrameAlpha(AnimationFrameSave frame, int? alpha)
+        public void SetFrameAlpha(IReadOnlyList<AnimationFrameSave> frames, int? alpha)
         {
             // Alpha is straight transparency; it fades the preview + timeline/tree thumbnails but not
             // the wireframe, so no wireframe refresh is needed.
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () => frame.Alpha = alpha,
+                frames, () => { foreach (var f in frames) f.Alpha = alpha; },
                 this, _events, false, "Set Frame Alpha"));
         }
 
-        public void SetFramePixelRegion(AnimationFrameSave frame,
+        public void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames,
             int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH)
         {
             var desc = $"Set Region: ({pixelX}, {pixelY}) {pixelW}×{pixelH}";
             _undoManager.Execute(new BulkFrameEditCommand(
-                [frame], () =>
+                frames, () =>
                 {
-                    PixelFrameEditor.SetX(frame, pixelX, bmpW);
-                    PixelFrameEditor.SetY(frame, pixelY, bmpH);
-                    PixelFrameEditor.SetWidth(frame, pixelW, bmpW);
-                    PixelFrameEditor.SetHeight(frame, pixelH, bmpH);
+                    foreach (var f in frames)
+                    {
+                        PixelFrameEditor.SetX(f, pixelX, bmpW);
+                        PixelFrameEditor.SetY(f, pixelY, bmpH);
+                        PixelFrameEditor.SetWidth(f, pixelW, bmpW);
+                        PixelFrameEditor.SetHeight(f, pixelH, bmpH);
+                    }
                 },
                 this, _events, true, desc));
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1409,12 +1409,18 @@ namespace AnimationEditor.Core.CommandsAndState
                 this, _events, false, desc));
         }
 
-        public void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float newRelX, float newRelY)
+        public void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float? newRelX, float? newRelY)
         {
-            var desc = $"Set Offset: ({newRelX:0.##}, {newRelY:0.##})";
             _undoManager.Execute(new BulkFrameEditCommand(
-                frames, () => { foreach (var f in frames) { f.RelativeX = newRelX; f.RelativeY = newRelY; } },
-                this, _events, true, desc));
+                frames, () =>
+                {
+                    foreach (var f in frames)
+                    {
+                        if (newRelX.HasValue) f.RelativeX = newRelX.Value;
+                        if (newRelY.HasValue) f.RelativeY = newRelY.Value;
+                    }
+                },
+                this, _events, true, "Set Offset"));
         }
 
         public void SetFrameColor(IReadOnlyList<AnimationFrameSave> frames, int? red, int? green, int? blue)
@@ -1445,21 +1451,23 @@ namespace AnimationEditor.Core.CommandsAndState
         }
 
         public void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames,
-            int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH)
+            int? pixelX, int? pixelY, int? pixelW, int? pixelH, int bmpW, int bmpH)
         {
-            var desc = $"Set Region: ({pixelX}, {pixelY}) {pixelW}×{pixelH}";
             _undoManager.Execute(new BulkFrameEditCommand(
                 frames, () =>
                 {
                     foreach (var f in frames)
                     {
-                        PixelFrameEditor.SetX(f, pixelX, bmpW);
-                        PixelFrameEditor.SetY(f, pixelY, bmpH);
-                        PixelFrameEditor.SetWidth(f, pixelW, bmpW);
-                        PixelFrameEditor.SetHeight(f, pixelH, bmpH);
+                        // Order matters: SetX/SetY preserve each frame's own current width/height, so
+                        // they must run before SetWidth/SetHeight overwrite Right/Bottom using the
+                        // (possibly just-moved) Left/Top.
+                        if (pixelX.HasValue) PixelFrameEditor.SetX(f, pixelX.Value, bmpW);
+                        if (pixelY.HasValue) PixelFrameEditor.SetY(f, pixelY.Value, bmpH);
+                        if (pixelW.HasValue) PixelFrameEditor.SetWidth(f, pixelW.Value, bmpW);
+                        if (pixelH.HasValue) PixelFrameEditor.SetHeight(f, pixelH.Value, bmpH);
                     }
                 },
-                this, _events, true, desc));
+                this, _events, true, "Set Region"));
         }
 
         public void SetRectProps(AnimationFrameSave? frame, AARectSave rect,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -190,8 +190,15 @@ namespace AnimationEditor.Core.CommandsAndState
         void MoveShapeToTop(object shape, AnimationFrameSave frame);
         void MoveShapeToBottom(object shape, AnimationFrameSave frame);
         void HandleReorder(int delta);
-        void FlipFrameHorizontally(AnimationFrameSave frame);
-        void FlipFrameVertically(AnimationFrameSave frame);
+        /// <summary>
+        /// Sets the horizontal/vertical flip flags on every frame in <paramref name="frames"/> as one
+        /// undo step. Each axis is absolute (not a toggle): pass <c>null</c> for an axis to leave it
+        /// untouched (used when the inspector checkbox is showing a mixed/indeterminate multi-selection
+        /// state and the user didn't interact with it). Only frames whose flag actually changes are
+        /// mirrored (offset and attached shapes negated) — a frame already at the target state is a
+        /// no-op for that axis.
+        /// </summary>
+        void SetFrameFlip(IReadOnlyList<AnimationFrameSave> frames, bool? flipHorizontal, bool? flipVertical);
         void FlipChainHorizontally(AnimationChainSave chain);
         void FlipChainVertically(AnimationChainSave chain);
         void InvertFrameOrder(AnimationChainSave chain);
@@ -239,12 +246,12 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void SetAllFramesTextureName(AnimationChainSave chain, string? textureName);
 
-        void SetFrameLength(AnimationFrameSave frame, float newLength);
-        void SetFrameRelative(AnimationFrameSave frame, float newRelX, float newRelY);
-        void SetFrameColor(AnimationFrameSave frame, int? red, int? green, int? blue);
-        void SetFrameColorOperation(AnimationFrameSave frame, ColorOperation? operation);
-        void SetFrameAlpha(AnimationFrameSave frame, int? alpha);
-        void SetFramePixelRegion(AnimationFrameSave frame, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
+        void SetFrameLength(IReadOnlyList<AnimationFrameSave> frames, float newLength);
+        void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float newRelX, float newRelY);
+        void SetFrameColor(IReadOnlyList<AnimationFrameSave> frames, int? red, int? green, int? blue);
+        void SetFrameColorOperation(IReadOnlyList<AnimationFrameSave> frames, ColorOperation? operation);
+        void SetFrameAlpha(IReadOnlyList<AnimationFrameSave> frames, int? alpha);
+        void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -247,11 +247,26 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetAllFramesTextureName(AnimationChainSave chain, string? textureName);
 
         void SetFrameLength(IReadOnlyList<AnimationFrameSave> frames, float newLength);
-        void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float newRelX, float newRelY);
+
+        /// <summary>
+        /// Sets RelativeX/Y on every frame in <paramref name="frames"/>. Either axis may be
+        /// <c>null</c> to leave it untouched per-frame (its own existing value survives) — used when
+        /// the inspector field is showing "(mixed)" and the user only edited the other axis. Unlike
+        /// color channels, there is no legitimate "clear to null" target for this field, so <c>null</c>
+        /// unambiguously means "don't touch".
+        /// </summary>
+        void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float? newRelX, float? newRelY);
         void SetFrameColor(IReadOnlyList<AnimationFrameSave> frames, int? red, int? green, int? blue);
         void SetFrameColorOperation(IReadOnlyList<AnimationFrameSave> frames, ColorOperation? operation);
         void SetFrameAlpha(IReadOnlyList<AnimationFrameSave> frames, int? alpha);
-        void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames, int pixelX, int pixelY, int pixelW, int pixelH, int bmpW, int bmpH);
+
+        /// <summary>
+        /// Sets the pixel region (X/Y/W/H) on every frame in <paramref name="frames"/>. Any of the
+        /// four may be <c>null</c> to leave that component untouched per-frame — used when the
+        /// inspector field is showing "(mixed)" and the user only edited one of the four. See
+        /// <see cref="SetFrameRelative"/> for why <c>null</c> is unambiguous here.
+        /// </summary>
+        void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames, int? pixelX, int? pixelY, int? pixelW, int? pixelH, int bmpW, int bmpH);
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
@@ -1,0 +1,82 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #571: editing a property with multiple frames selected in the
+/// tree must apply the edit to every selected frame, not just the primary one. This file covers
+/// the property panel's mixed-value display — the read side of the same bug, where a field must
+/// show blank/"(mixed)" instead of silently displaying one frame's value as if it applied to all.
+/// </summary>
+public class MultiSelectPropertyPanelTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void RefreshPropertyPanel_FramesDisagreeOnFrameLength_ShowsBlankWithMixedPlaceholder()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.2f };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+
+            Assert.Null(propFrameLen.Value);
+            Assert.Equal("(mixed)", propFrameLen.PlaceholderText);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshPropertyPanel_FramesAgreeOnFrameLength_ShowsSharedValue()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.25f };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.25f };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+
+            Assert.Equal(0.25m, propFrameLen.Value);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeThumbnailTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TreeThumbnailTests.cs
@@ -91,7 +91,7 @@ public class TreeThumbnailTests
             Assert.NotNull(initialThumbnail);
 
             // Flip the first frame and notify the system via the event bus (the same path
-            // taken by FlipFrameHorizontally and undo/redo).
+            // taken by SetFrameFlip and undo/redo).
             chain.Frames[0].FlipHorizontal = true;
             ctx.ApplicationEvents.RaiseAnimationChainsChanged();
             Dispatcher.UIThread.RunJobs();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -627,63 +627,62 @@ public class AppCommandsChainTests
         }
     }
 
-    // ── FlipFrameHorizontally (F09) ──────────────────────────────────────────
+    // ── SetFrameFlip (F09/F10, absolute set — issue #571) ────────────────────
 
     [Fact]
-    public void FlipFrameHorizontally_TogglesFlipHorizontalOnFrame()
+    public void SetFrameFlip_HorizontalTrueOnUnflippedFrame_SetsFlipHorizontal()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var frame = new AnimationFrameSave { FlipHorizontal = false };
 
-        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
 
         Assert.True(frame.FlipHorizontal);
     }
 
     [Fact]
-    public void FlipFrameHorizontally_TogglesBackWhenCalledTwice()
+    public void SetFrameFlip_HorizontalFalseOnFlippedFrame_ClearsFlipHorizontal()
     {
         var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { FlipHorizontal = false };
+        var frame = new AnimationFrameSave { FlipHorizontal = true };
 
-        ctx.AppCommands.FlipFrameHorizontally(frame);
-        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: false, flipVertical: null);
 
         Assert.False(frame.FlipHorizontal);
     }
 
     [Fact]
-    public void FlipFrameHorizontally_NegatesFrameRelativeX()
+    public void SetFrameFlip_TargetAlreadyMatchesFrame_IsNoOpAndDoesNotCreateUndoEntry()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var frame = new AnimationFrameSave { FlipHorizontal = true };
+
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
+
+        Assert.True(frame.FlipHorizontal);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void SetFrameFlip_HorizontalTrue_NegatesFrameRelativeXOnly()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var frame = new AnimationFrameSave { RelativeX = 20, RelativeY = 7 };
 
-        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
 
         Assert.Equal(-20, frame.RelativeX);   // sprite offset mirrors about the origin
         Assert.Equal(7, frame.RelativeY);      // vertical offset untouched
     }
 
     [Fact]
-    public void FlipFrameHorizontally_TwiceRestoresFrameRelativeX()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { RelativeX = 20 };
-
-        ctx.AppCommands.FlipFrameHorizontally(frame);
-        ctx.AppCommands.FlipFrameHorizontally(frame);
-
-        Assert.Equal(20, frame.RelativeX);     // negation is its own inverse
-    }
-
-    [Fact]
-    public void FlipFrameHorizontally_MirrorsAttachedShapeOffsets()
+    public void SetFrameFlip_HorizontalTrue_MirrorsAttachedShapeOffsets()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
         frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
 
-        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
 
         var rect = frame.ShapesSave.AARectSaves.First();
         Assert.Equal(-12, rect.X);   // horizontal flip negates X
@@ -691,33 +690,40 @@ public class AppCommandsChainTests
     }
 
     [Fact]
-    public void FlipFrameHorizontally_TwiceRestoresShapeOffsets()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
-        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
-
-        ctx.AppCommands.FlipFrameHorizontally(frame);
-        ctx.AppCommands.FlipFrameHorizontally(frame);
-
-        var rect = frame.ShapesSave.AARectSaves.First();
-        Assert.Equal(12, rect.X);    // flip is its own inverse — exact restore
-        Assert.Equal(5, rect.Y);
-    }
-
-    [Fact]
-    public void FlipFrameHorizontally_DoesNotAffectFlipVertical()
+    public void SetFrameFlip_NullVertical_LeavesFlipVerticalUntouched()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var frame = new AnimationFrameSave { FlipHorizontal = false, FlipVertical = true };
 
-        ctx.AppCommands.FlipFrameHorizontally(frame);
+        ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
 
         Assert.True(frame.FlipVertical);
     }
 
     [Fact]
-    public void FlipFrameHorizontally_RaisesAnimationChainsChanged()
+    public void SetFrameFlip_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 3);
+        var frames = chain.Frames.ToList();
+        frames[0].FlipHorizontal = true;
+        frames[1].FlipHorizontal = false;
+        frames[2].FlipHorizontal = false;
+
+        ctx.AppCommands.SetFrameFlip(frames, flipHorizontal: true, flipVertical: null);
+
+        Assert.All(frames, f => Assert.True(f.FlipHorizontal));
+        Assert.Single(ctx.UndoManager.UndoHistory);
+
+        ctx.UndoManager.Undo();
+
+        Assert.True(frames[0].FlipHorizontal);
+        Assert.False(frames[1].FlipHorizontal);
+        Assert.False(frames[2].FlipHorizontal);
+    }
+
+    [Fact]
+    public void SetFrameFlip_RaisesAnimationChainsChanged()
     {
         var ctx = TestHelpers.SetupFreshAcls();
         var frame = new AnimationFrameSave();
@@ -726,88 +732,7 @@ public class AppCommandsChainTests
         ctx.ApplicationEvents.AnimationChainsChanged += Handler;
         try
         {
-            ctx.AppCommands.FlipFrameHorizontally(frame);
-            Assert.True(fired);
-        }
-        finally
-        {
-            ctx.ApplicationEvents.AnimationChainsChanged -= Handler;
-        }
-    }
-
-    // ── FlipFrameVertically (F10) ────────────────────────────────────────────
-
-    [Fact]
-    public void FlipFrameVertically_TogglesFlipVerticalOnFrame()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { FlipVertical = false };
-
-        ctx.AppCommands.FlipFrameVertically(frame);
-
-        Assert.True(frame.FlipVertical);
-    }
-
-    [Fact]
-    public void FlipFrameVertically_TogglesBackWhenCalledTwice()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { FlipVertical = false };
-
-        ctx.AppCommands.FlipFrameVertically(frame);
-        ctx.AppCommands.FlipFrameVertically(frame);
-
-        Assert.False(frame.FlipVertical);
-    }
-
-    [Fact]
-    public void FlipFrameVertically_MirrorsAttachedShapeOffsets()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { ShapesSave = new FlatRedBall2.Animation.Content.ShapesSave() };
-        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Box", X = 12, Y = 5 });
-
-        ctx.AppCommands.FlipFrameVertically(frame);
-
-        var rect = frame.ShapesSave.AARectSaves.First();
-        Assert.Equal(12, rect.X);    // horizontal offset untouched
-        Assert.Equal(-5, rect.Y);    // vertical flip negates Y
-    }
-
-    [Fact]
-    public void FlipFrameVertically_NegatesFrameRelativeY()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { RelativeX = 20, RelativeY = 7 };
-
-        ctx.AppCommands.FlipFrameVertically(frame);
-
-        Assert.Equal(20, frame.RelativeX);   // horizontal offset untouched
-        Assert.Equal(-7, frame.RelativeY);   // sprite offset mirrors about the origin
-    }
-
-    [Fact]
-    public void FlipFrameVertically_DoesNotAffectFlipHorizontal()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave { FlipVertical = false, FlipHorizontal = true };
-
-        ctx.AppCommands.FlipFrameVertically(frame);
-
-        Assert.True(frame.FlipHorizontal);
-    }
-
-    [Fact]
-    public void FlipFrameVertically_RaisesAnimationChainsChanged()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-        var frame = new AnimationFrameSave();
-        bool fired = false;
-        void Handler() => fired = true;
-        ctx.ApplicationEvents.AnimationChainsChanged += Handler;
-        try
-        {
-            ctx.AppCommands.FlipFrameVertically(frame);
+            ctx.AppCommands.SetFrameFlip(new[] { frame }, flipHorizontal: true, flipVertical: null);
             Assert.True(fired);
         }
         finally

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -18,7 +19,7 @@ public class InspectorPropertyUndoTests
         var frame = TestHelpers.MakeFrame(); // starts with null alpha
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameAlpha(frame, 128);
+        ctx.AppCommands.SetFrameAlpha(new[] { frame }, 128);
         // A single committed edit must record exactly one undo entry (not one per keystroke — #445).
         Assert.Single(ctx.UndoManager.UndoHistory);
         Assert.Equal(128, frame.Alpha);
@@ -37,9 +38,22 @@ public class InspectorPropertyUndoTests
         frame.Alpha = 128;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameAlpha(frame, 128);
+        ctx.AppCommands.SetFrameAlpha(new[] { frame }, 128);
 
         Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void SetFrameAlpha_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Fade", frameCount: 2);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameAlpha(frames, 64);
+
+        Assert.All(frames, f => Assert.Equal(64, f.Alpha));
+        Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
     // ── SetFrameColor ─────────────────────────────────────────────────────────
@@ -53,7 +67,7 @@ public class InspectorPropertyUndoTests
         // Start with no authored color (all null).
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameColor(frame, 255, 200, 128);
+        ctx.AppCommands.SetFrameColor(new[] { frame }, 255, 200, 128);
         Assert.True(ctx.UndoManager.CanUndo);
         Assert.Equal(255, frame.Red);
 
@@ -75,9 +89,24 @@ public class InspectorPropertyUndoTests
         frame.Blue = 128;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameColor(frame, 255, 200, 128);
+        ctx.AppCommands.SetFrameColor(new[] { frame }, 255, 200, 128);
 
         Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void SetFrameColor_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash", frameCount: 2);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameColor(frames, 255, 200, 128);
+
+        Assert.All(frames, f => Assert.Equal(255, f.Red));
+        Assert.All(frames, f => Assert.Equal(200, f.Green));
+        Assert.All(frames, f => Assert.Equal(128, f.Blue));
+        Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
     // ── SetFrameColorOperation ────────────────────────────────────────────────
@@ -90,7 +119,7 @@ public class InspectorPropertyUndoTests
         var frame = TestHelpers.MakeFrame(); // starts with null operation
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameColorOperation(frame, ColorOperation.Add);
+        ctx.AppCommands.SetFrameColorOperation(new[] { frame }, ColorOperation.Add);
         Assert.True(ctx.UndoManager.CanUndo);
         Assert.Equal(ColorOperation.Add, frame.ColorOperation);
 
@@ -108,9 +137,22 @@ public class InspectorPropertyUndoTests
         frame.ColorOperation = ColorOperation.Multiply;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameColorOperation(frame, ColorOperation.Multiply);
+        ctx.AppCommands.SetFrameColorOperation(new[] { frame }, ColorOperation.Multiply);
 
         Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void SetFrameColorOperation_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash", frameCount: 2);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameColorOperation(frames, ColorOperation.Add);
+
+        Assert.All(frames, f => Assert.Equal(ColorOperation.Add, f.ColorOperation));
+        Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
     // ── SetFrameLength ────────────────────────────────────────────────────────
@@ -124,7 +166,7 @@ public class InspectorPropertyUndoTests
         frame.FrameLength = 0.1f;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameLength(frame, 0.5f);
+        ctx.AppCommands.SetFrameLength(new[] { frame }, 0.5f);
 
         Assert.True(ctx.UndoManager.CanUndo);
         Assert.Equal(0.5f, frame.FrameLength);
@@ -139,7 +181,7 @@ public class InspectorPropertyUndoTests
         frame.FrameLength = 0.1f;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameLength(frame, 0.1f);
+        ctx.AppCommands.SetFrameLength(new[] { frame }, 0.1f);
 
         Assert.False(ctx.UndoManager.CanUndo);
     }
@@ -153,10 +195,27 @@ public class InspectorPropertyUndoTests
         frame.FrameLength = 0.1f;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameLength(frame, 0.5f);
+        ctx.AppCommands.SetFrameLength(new[] { frame }, 0.5f);
         ctx.UndoManager.Undo();
 
         Assert.Equal(0.1f, frame.FrameLength);
+    }
+
+    [Fact]
+    public void SetFrameLength_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 3);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameLength(frames, 0.5f);
+
+        Assert.All(frames, f => Assert.Equal(0.5f, f.FrameLength));
+        Assert.Single(ctx.UndoManager.UndoHistory);
+
+        ctx.UndoManager.Undo();
+
+        Assert.All(frames, f => Assert.Equal(0.1f, f.FrameLength));
     }
 
     // ── SetFrameRelative ──────────────────────────────────────────────────────
@@ -171,12 +230,26 @@ public class InspectorPropertyUndoTests
         frame.RelativeY = 20f;
         chain.Frames.Add(frame);
 
-        ctx.AppCommands.SetFrameRelative(frame, 99f, 88f);
+        ctx.AppCommands.SetFrameRelative(new[] { frame }, 99f, 88f);
         Assert.True(ctx.UndoManager.CanUndo);
         ctx.UndoManager.Undo();
 
         Assert.Equal(10f, frame.RelativeX);
         Assert.Equal(20f, frame.RelativeY);
+    }
+
+    [Fact]
+    public void SetFrameRelative_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameRelative(frames, 99f, 88f);
+
+        Assert.All(frames, f => Assert.Equal(99f, f.RelativeX));
+        Assert.All(frames, f => Assert.Equal(88f, f.RelativeY));
+        Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
     // ── SetFramePixelRegion ───────────────────────────────────────────────────
@@ -195,7 +268,7 @@ public class InspectorPropertyUndoTests
         chain.Frames.Add(frame);
 
         // Move/resize to pixel rect (4,8,12,16) on a 64x64 texture
-        ctx.AppCommands.SetFramePixelRegion(frame, 4, 8, 12, 16, 64, 64);
+        ctx.AppCommands.SetFramePixelRegion(new[] { frame }, 4, 8, 12, 16, 64, 64);
         Assert.True(ctx.UndoManager.CanUndo);
 
         ctx.UndoManager.Undo();
@@ -204,6 +277,25 @@ public class InspectorPropertyUndoTests
         Assert.Equal(1f,  frame.RightCoordinate,   precision: 5);
         Assert.Equal(0f,  frame.TopCoordinate,     precision: 5);
         Assert.Equal(1f,  frame.BottomCoordinate,  precision: 5);
+    }
+
+    [Fact]
+    public void SetFramePixelRegion_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frames = chain.Frames.ToList();
+        foreach (var f in frames)
+        {
+            f.LeftCoordinate = 0f; f.RightCoordinate = 1f;
+            f.TopCoordinate = 0f; f.BottomCoordinate = 1f;
+        }
+
+        ctx.AppCommands.SetFramePixelRegion(frames, 4, 8, 12, 16, 64, 64);
+
+        Assert.All(frames, f => Assert.Equal(4f / 64f, f.LeftCoordinate, precision: 5));
+        Assert.All(frames, f => Assert.Equal(16f / 64f, f.RightCoordinate, precision: 5));
+        Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
     // ── SetRectProps ──────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -252,6 +252,25 @@ public class InspectorPropertyUndoTests
         Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
+    [Fact]
+    public void SetFrameRelative_NullY_LeavesEachFrameOwnRelativeYUntouched()
+    {
+        // Reproduces issue #571 follow-up: frames disagree on RelativeY (shown "(mixed)" in the
+        // inspector). The user only edits RelativeX; RelativeY must be left exactly as each frame
+        // already had it, not forced to a shared/null value.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frames = chain.Frames.ToList();
+        frames[0].RelativeX = 1f; frames[0].RelativeY = 10f;
+        frames[1].RelativeX = 2f; frames[1].RelativeY = 20f;
+
+        ctx.AppCommands.SetFrameRelative(frames, newRelX: 5f, newRelY: null);
+
+        Assert.All(frames, f => Assert.Equal(5f, f.RelativeX));
+        Assert.Equal(10f, frames[0].RelativeY);
+        Assert.Equal(20f, frames[1].RelativeY);
+    }
+
     // ── SetFramePixelRegion ───────────────────────────────────────────────────
 
     [Fact]
@@ -296,6 +315,30 @@ public class InspectorPropertyUndoTests
         Assert.All(frames, f => Assert.Equal(4f / 64f, f.LeftCoordinate, precision: 5));
         Assert.All(frames, f => Assert.Equal(16f / 64f, f.RightCoordinate, precision: 5));
         Assert.Single(ctx.UndoManager.UndoHistory);
+    }
+
+    [Fact]
+    public void SetFramePixelRegion_OnlyXSpecified_LeavesEachFrameOwnYWidthHeightUntouched()
+    {
+        // Reproduces issue #571 follow-up: two frames at different positions/sizes on the sheet
+        // (so Y/W/H are all "(mixed)" in the inspector). The user types only a new X and presses
+        // Enter — that must move both frames' X without collapsing their own differing Y/W/H.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frames = chain.Frames.ToList();
+        frames[0].LeftCoordinate = 0f / 64; frames[0].RightCoordinate = 8f / 64;
+        frames[0].TopCoordinate = 0f / 64; frames[0].BottomCoordinate = 8f / 64;
+        frames[1].LeftCoordinate = 32f / 64; frames[1].RightCoordinate = 40f / 64;
+        frames[1].TopCoordinate = 16f / 64; frames[1].BottomCoordinate = 32f / 64;
+
+        ctx.AppCommands.SetFramePixelRegion(frames, pixelX: 5, pixelY: null, pixelW: null, pixelH: null, bmpW: 64, bmpH: 64);
+
+        Assert.Equal(5f / 64f, frames[0].LeftCoordinate, precision: 5);
+        Assert.Equal(5f / 64f, frames[1].LeftCoordinate, precision: 5);
+        Assert.Equal(0f / 64f, frames[0].TopCoordinate, precision: 5);      // frame 0's own Y preserved
+        Assert.Equal(16f / 64f, frames[1].TopCoordinate, precision: 5);     // frame 1's own Y preserved
+        Assert.Equal(8f / 64f, frames[0].BottomCoordinate - frames[0].TopCoordinate, precision: 5); // width/height untouched
+        Assert.Equal(16f / 64f, frames[1].BottomCoordinate - frames[1].TopCoordinate, precision: 5);
     }
 
     // ── SetRectProps ──────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -86,8 +86,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.MoveShapeToTop)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveShapeToBottom)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.HandleReorder)]                = Category.MutatingUndoable,
-        [nameof(IAppCommands.FlipFrameHorizontally)]        = Category.MutatingUndoable,
-        [nameof(IAppCommands.FlipFrameVertically)]          = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetFrameFlip)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipChainHorizontally)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.FlipChainVertically)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.InvertFrameOrder)]             = Category.MutatingUndoable,
@@ -264,10 +263,9 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MoveShapeToBottom(Rect(ctx), Zebra(ctx).Frames[0]))); // Rect is not already last
         yield return Row(nameof(IAppCommands.HandleReorder),
             ctx => Sync(() => ctx.AppCommands.HandleReorder(+1))); // selection is set up by Arrange
-        yield return Row(nameof(IAppCommands.FlipFrameHorizontally),
-            ctx => Sync(() => ctx.AppCommands.FlipFrameHorizontally(Zebra(ctx).Frames[0])));
-        yield return Row(nameof(IAppCommands.FlipFrameVertically),
-            ctx => Sync(() => ctx.AppCommands.FlipFrameVertically(Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.SetFrameFlip),
+            ctx => Sync(() => ctx.AppCommands.SetFrameFlip(
+                new[] { Zebra(ctx).Frames[0] }, flipHorizontal: true, flipVertical: null)));
         yield return Row(nameof(IAppCommands.FlipChainHorizontally),
             ctx => Sync(() => ctx.AppCommands.FlipChainHorizontally(Zebra(ctx))));
         yield return Row(nameof(IAppCommands.FlipChainVertically),
@@ -305,17 +303,17 @@ public class UndoCoverageRosterTests
         yield return Row(nameof(IAppCommands.SetAllFramesTextureName),
             ctx => Sync(() => ctx.AppCommands.SetAllFramesTextureName(Zebra(ctx), "bulk.png")));
         yield return Row(nameof(IAppCommands.SetFrameLength),
-            ctx => Sync(() => ctx.AppCommands.SetFrameLength(Zebra(ctx).Frames[0], 0.99f)));
+            ctx => Sync(() => ctx.AppCommands.SetFrameLength(new[] { Zebra(ctx).Frames[0] }, 0.99f)));
         yield return Row(nameof(IAppCommands.SetFrameRelative),
-            ctx => Sync(() => ctx.AppCommands.SetFrameRelative(Zebra(ctx).Frames[0], 99f, 88f)));
+            ctx => Sync(() => ctx.AppCommands.SetFrameRelative(new[] { Zebra(ctx).Frames[0] }, 99f, 88f)));
         yield return Row(nameof(IAppCommands.SetFrameAlpha),
-            ctx => Sync(() => ctx.AppCommands.SetFrameAlpha(Zebra(ctx).Frames[0], 128)));
+            ctx => Sync(() => ctx.AppCommands.SetFrameAlpha(new[] { Zebra(ctx).Frames[0] }, 128)));
         yield return Row(nameof(IAppCommands.SetFrameColor),
-            ctx => Sync(() => ctx.AppCommands.SetFrameColor(Zebra(ctx).Frames[0], 255, 200, 128)));
+            ctx => Sync(() => ctx.AppCommands.SetFrameColor(new[] { Zebra(ctx).Frames[0] }, 255, 200, 128)));
         yield return Row(nameof(IAppCommands.SetFrameColorOperation),
-            ctx => Sync(() => ctx.AppCommands.SetFrameColorOperation(Zebra(ctx).Frames[0], ColorOperation.Add)));
+            ctx => Sync(() => ctx.AppCommands.SetFrameColorOperation(new[] { Zebra(ctx).Frames[0] }, ColorOperation.Add)));
         yield return Row(nameof(IAppCommands.SetFramePixelRegion),
-            ctx => Sync(() => ctx.AppCommands.SetFramePixelRegion(Zebra(ctx).Frames[0], 4, 8, 12, 16, 64, 64)));
+            ctx => Sync(() => ctx.AppCommands.SetFramePixelRegion(new[] { Zebra(ctx).Frames[0] }, 4, 8, 12, 16, 64, 64)));
         yield return Row(nameof(IAppCommands.SetRectProps),
             ctx => Sync(() => ctx.AppCommands.SetRectProps(Zebra(ctx).Frames[0], Rect(ctx), "Renamed", 5f, 6f, 7f, 8f)));
         yield return Row(nameof(IAppCommands.SetCircleProps),


### PR DESCRIPTION
## Summary
- Widens seven `AppCommands` per-frame property-apply methods (`SetFrameLength`, `SetFrameRelative`, `SetFrameColor`, `SetFrameColorOperation`, `SetFrameAlpha`, `SetFramePixelRegion`) to take `IReadOnlyList<AnimationFrameSave> frames` instead of a single frame, so a property edit in the inspector applies to every selected frame (not just the primary one) as a single undo step.
- Replaces the toggle-only `FlipFrameHorizontally`/`FlipFrameVertically` with a single absolute-set `SetFrameFlip(frames, bool? flipHorizontal, bool? flipVertical)` — toggle semantics don't generalize to a multi-selection that may already disagree on flip state; `null` on an axis means "leave it untouched" (used when the flip checkbox shows a mixed/indeterminate state).
- `MainWindow`'s property panel now shows a field blank with a `"(mixed)"` placeholder whenever the selected frames disagree on that property (pixel X/Y/W/H, frame length, relative X/Y, R/G/B/Alpha, color operation, flip), instead of silently displaying one frame's value as if it applied to the whole selection — the display-side twin of the original bug.

## Known limitation (flagged, not fixed here)
`SetFrameColor` bundles Red/Green/Blue in one call with no guard preventing a still-`null` (mixed, untouched) channel from being force-cleared across the whole selection if the user edits a *different* channel and tabs away (Alpha/ColorOperation have a narrower, self-contained version of the same risk). Fixing this fully needs a tri-state ("skip / clear / set-value") per channel, which is a real API change beyond this PR's scope and isn't hit by the required test coverage. Noted here for a possible follow-up.

## Test plan
- [x] `dotnet test tests/AnimationEditor.Core.Tests` — 1472 passed
- [x] `dotnet test tests/AnimationEditor.App.Tests` — 564 passed (includes 2 new mixed-value-display tests)
- [x] `dotnet build AnimationEditorAvalonia.slnx` — succeeds, no new warnings

Closes #571