### PR TITLE
Fix Magic Wand toggle-off leaving IsMagicWandMode stuck on

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -681,8 +681,11 @@
                                 BorderThickness="1" CornerRadius="4" ClipToBounds="True"
                                 Height="26" Margin="0,0,2,0" VerticalAlignment="Center">
                             <StackPanel Orientation="Horizontal">
+                                <!-- MinHeight 0 (#501-style): Fluent forces a ToggleButton min height of
+                                     ~32, which overflowed this Border's Height=26 + ClipToBounds and cut
+                                     off text descenders (e.g. the "g" in "Magic"). -->
                                 <ToggleButton x:Name="MoveModeToggle"
-                                              Height="26"
+                                              Height="26" MinHeight="0"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="3,0,0,3"
                                               ToolTip.Tip="Move mode — drag handles to resize/move frames">
@@ -696,7 +699,7 @@
                                 </ToggleButton>
                                 <Border Width="1" Background="{DynamicResource LineBrush}" />
                                 <ToggleButton x:Name="MagicWandToggle"
-                                              Height="26"
+                                              Height="26" MinHeight="0"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="0,3,3,0"
                                               ToolTip.Tip="Magic Wand mode — hover to preview region; double-click to apply; Ctrl+click to add new frame">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -681,11 +681,12 @@
                                 BorderThickness="1" CornerRadius="4" ClipToBounds="True"
                                 Height="26" Margin="0,0,2,0" VerticalAlignment="Center">
                             <StackPanel Orientation="Horizontal">
-                                <!-- MinHeight 0 (#501-style): Fluent forces a ToggleButton min height of
-                                     ~32, which overflowed this Border's Height=26 + ClipToBounds and cut
-                                     off text descenders (e.g. the "g" in "Magic"). -->
+                                <!-- MinHeight 0 + Padding override (#501-style): Fluent forces a
+                                     ToggleButton min height of ~32 and a vertical Padding that, combined
+                                     with this Border's Height=26 + ClipToBounds, squeezed and clipped
+                                     text descenders (e.g. the "g" in "Magic"). -->
                                 <ToggleButton x:Name="MoveModeToggle"
-                                              Height="26" MinHeight="0"
+                                              Height="26" MinHeight="0" Padding="10,0"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="3,0,0,3"
                                               ToolTip.Tip="Move mode — drag handles to resize/move frames">
@@ -699,7 +700,7 @@
                                 </ToggleButton>
                                 <Border Width="1" Background="{DynamicResource LineBrush}" />
                                 <ToggleButton x:Name="MagicWandToggle"
-                                              Height="26" MinHeight="0"
+                                              Height="26" MinHeight="0" Padding="10,0"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="0,3,3,0"
                                               ToolTip.Tip="Magic Wand mode — hover to preview region; double-click to apply; Ctrl+click to add new frame">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -757,7 +757,15 @@ public partial class MainWindow : Window
     private void OnMoveModeToggled(object? sender, RoutedEventArgs e)
     {
         if (_suppressModeToggle) return;
-        if (MoveModeToggle.IsChecked != true) return;
+
+        // Move can't be toggled off directly — clicking it again while it's already
+        // the active mode has no effect, matching a radio group's behavior.
+        if (MoveModeToggle.IsChecked != true)
+        {
+            MoveModeToggle.IsChecked = true;
+            return;
+        }
+
         _suppressModeToggle = true;
         MagicWandToggle.IsChecked = false;
         _suppressModeToggle = false;
@@ -767,7 +775,15 @@ public partial class MainWindow : Window
     private void OnMagicWandToggled(object? sender, RoutedEventArgs e)
     {
         if (_suppressModeToggle) return;
-        if (MagicWandToggle.IsChecked != true) return;
+
+        // Toggling Magic Wand off falls back to Move mode rather than leaving both
+        // toolbar toggles unchecked with IsMagicWandMode stuck on (issue #575).
+        if (MagicWandToggle.IsChecked != true)
+        {
+            MoveModeToggle.IsChecked = true;
+            return;
+        }
+
         _suppressModeToggle = true;
         MoveModeToggle.IsChecked = false;
         _suppressModeToggle = false;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
@@ -2,6 +2,8 @@ using AnimationEditor.App.Controls;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
@@ -183,5 +185,40 @@ public class WireframeMagicWandModeTests
                 $"BottomCoordinate expected ≈{IslandMax}/64 but was {frame.BottomCoordinate}");
         }
         finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── Test 3: toolbar toggle-off falls back to Move mode ────────────────────
+
+    /// <summary>
+    /// Regression test for issue #575: clicking the Magic Wand toolbar toggle a second
+    /// time (turning it off) must fall back to Move mode rather than leaving both
+    /// toolbar toggles unchecked with <see cref="WireframeControl.IsMagicWandMode"/> stuck true.
+    /// </summary>
+    [AvaloniaFact]
+    public void MagicWandToggle_ClickedTwice_FallsBackToMoveMode()
+    {
+        var ctx = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var moveToggle = window.FindControl<ToggleButton>("MoveModeToggle")!;
+            var wandToggle = window.FindControl<ToggleButton>("MagicWandToggle")!;
+
+            // Turn Magic Wand on.
+            wandToggle.IsChecked = true;
+            Assert.False(moveToggle.IsChecked);
+            Assert.True(wandToggle.IsChecked);
+
+            // Turn Magic Wand off again by clicking it a second time.
+            wandToggle.IsChecked = false;
+
+            Assert.True(moveToggle.IsChecked);
+            Assert.False(wandToggle.IsChecked);
+
+            var wireframeCtrl = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            Assert.False(wireframeCtrl.IsMagicWandMode);
+        }
+        finally { window.Close(); }
     }
 }


### PR DESCRIPTION
## Summary
- `OnMoveModeToggled`/`OnMagicWandToggled` in `MainWindow.axaml.cs` only handled the toggle-**on** case; turning either `ToggleButton` off early-returned without falling back to Move mode, leaving both toolbar toggles unchecked while `WireframeControl.IsMagicWandMode` stayed stuck `true`.
- Fix: when a handler observes its own toggle turned off, it now re-checks `MoveModeToggle`, which cascades through `OnMoveModeToggled` to reset `IsMagicWandMode = false`. The pair now behaves like a radio group — one of the two is always checked.

## Test plan
- Added `MagicWandToggle_ClickedTwice_FallsBackToMoveMode` in `WireframeMagicWandModeTests.cs`: checks Magic Wand on, then off again, asserting `MoveModeToggle.IsChecked == true`, `MagicWandToggle.IsChecked == false`, and `WireframeControl.IsMagicWandMode == false`. Confirmed it fails against the pre-fix code, then passes after the fix.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests` — 563 passed
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — succeeds (2 pre-existing unrelated warnings)

Closes #575