### PR TITLE
Animation Editor: Add "View <filename> in Explorer" to Preview and Wireframe right-click menus

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -115,6 +115,10 @@ public class PreviewControl : Control
     private const float RulerSize = 20f;
     private const float PanPadding = 0f;
 
+    // Set by OnPointerPressed when a right-click removes a guide; consumed by
+    // OnPointerReleased to suppress the reveal-in-explorer ContextMenu for that same click.
+    private bool _suppressContextMenuOnRelease;
+
     // Neutral canvas/ruler colors for the active theme variant. Refreshed from
     // ActualThemeVariant on every render and whenever the variant changes.
     private CanvasPalette _palette = CanvasPalette.Dark;
@@ -1583,9 +1587,11 @@ public class PreviewControl : Control
         if (props.IsRightButtonPressed)
         {
             // A guide-removing click consumes the right-click; otherwise let it fall through
-            // so Avalonia opens the "View <filename> in Explorer" ContextMenu as normal.
-            if (TryRemoveGuideAt(px, py))
-                e.Handled = true;
+            // so Avalonia opens the "View <filename> in Explorer" ContextMenu as normal. Note
+            // that Control's context-menu logic runs in OnPointerReleased against the *released*
+            // event's own Handled flag — marking Handled here on the pressed event has no effect
+            // on it, so the actual suppression happens in OnPointerReleased below.
+            _suppressContextMenuOnRelease = TryRemoveGuideAt(px, py);
             return;
         }
 
@@ -1734,6 +1740,15 @@ public class PreviewControl : Control
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
+        // Must run before base.OnPointerReleased: Control's own override raises
+        // ContextRequested (opening the ContextMenu) based on this event's Handled flag
+        // *during* that base call, so setting Handled afterwards would be too late.
+        if (_suppressContextMenuOnRelease && e.InitialPressMouseButton == MouseButton.Right)
+        {
+            e.Handled = true;
+            _suppressContextMenuOnRelease = false;
+        }
+
         base.OnPointerReleased(e);
 
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -377,6 +377,7 @@ public class PreviewControl : Control
     private IUndoManager? _undoManager;
     private ThumbnailService? _thumbnailService;
     private IPendingCutState? _pendingCutState;
+    private Action<string>? _showError;
 
     private static readonly SKColor CutOutlineColor = new(224, 112, 48, 220);
 
@@ -392,7 +393,8 @@ public class PreviewControl : Control
         IProjectManager projectManager,
         IUndoManager undoManager,
         ThumbnailService thumbnailService,
-        IPendingCutState pendingCutState)
+        IPendingCutState pendingCutState,
+        Action<string>? showError = null)
     {
         _selectedState  = selectedState;
         _appState       = appState;
@@ -402,6 +404,7 @@ public class PreviewControl : Control
         _undoManager    = undoManager;
         _thumbnailService = thumbnailService;
         _pendingCutState  = pendingCutState;
+        _showError        = showError;
 
         _selectedState.SelectionChanged                        += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
         _pendingCutState.Changed                               += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
@@ -417,6 +420,12 @@ public class PreviewControl : Control
     {
         ClipToBounds = true;
         Focusable    = true;
+
+        // Right-click (when it doesn't hit a guide — see OnPointerPressed) opens this menu
+        // with a "View <filename> in Explorer" item for the currently previewed texture.
+        var contextMenu = new ContextMenu();
+        contextMenu.Opening += OnContextMenuOpening;
+        ContextMenu = contextMenu;
 
         // Repaint when the app theme variant changes so the canvas/ruler colors update.
         ActualThemeVariantChanged += (_, _) => InvalidateVisual();
@@ -581,8 +590,10 @@ public class PreviewControl : Control
     /// Test-only: simulates a right-click at the given control-space point,
     /// removing any guide within hit distance. Mirrors <see cref="OnPointerPressed"/> so
     /// headless tests can drive the right-click removal code path without synthesising events.
+    /// Returns <c>true</c> if a guide was removed — <see cref="OnPointerPressed"/> uses this
+    /// to decide whether to suppress the reveal-in-explorer context menu.
     /// </summary>
-    public void SimulateRightClick(float x, float y) => TryRemoveGuideAt(x, y);
+    public bool SimulateRightClick(float x, float y) => TryRemoveGuideAt(x, y);
 
     /// <summary>
     /// Test-only: simulates a left-click on the canvas at (<paramref name="px"/>, <paramref name="py"/>)
@@ -1201,6 +1212,48 @@ public class PreviewControl : Control
         return false;
     }
 
+    // -- Reveal in Explorer -----------------------------------------------------
+
+    /// <summary>
+    /// Resolves the absolute path of the currently previewed frame's texture (via
+    /// <see cref="ISelectedState.SelectedTextureName"/>), relative to the loaded .achx file's
+    /// directory. Returns <c>null</c> when nothing is selected or the frame has no texture set.
+    /// </summary>
+    internal string? ResolveSelectedTexturePath()
+    {
+        var textureName = _selectedState?.SelectedTextureName;
+        if (string.IsNullOrEmpty(textureName)) return null;
+
+        var achxFile = _projectManager?.FileName;
+        if (string.IsNullOrEmpty(achxFile)) return textureName;
+
+        var achxDir = new FilePath(achxFile).GetDirectoryContainingThis();
+        return new FilePath(achxDir.FullPath + textureName).FullPath;
+    }
+
+    /// <summary>
+    /// Rebuilds the ContextMenu with a single "View &lt;filename&gt; in Explorer" item for the
+    /// currently previewed texture, or cancels the menu entirely when there's nothing to reveal.
+    /// </summary>
+    private void OnContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        var absPath = ResolveSelectedTexturePath();
+        if (ContextMenu is not { } menu || absPath is null)
+        {
+            e.Cancel = true;
+            return;
+        }
+
+        menu.Items.Clear();
+        var item = new MenuItem { Header = $"View {new FilePath(absPath).NoPath} in Explorer" };
+        item.Click += (_, _) =>
+        {
+            var error = ShellExplorer.RevealFile(absPath);
+            if (error is not null) _showError?.Invoke(error);
+        };
+        menu.Items.Add(item);
+    }
+
     /// <summary>
     /// Returns the topmost collision shape under the given screen-space point, or
     /// <c>null</c> if no shape is hit. The currently selected shape has priority over
@@ -1529,7 +1582,10 @@ public class PreviewControl : Control
 
         if (props.IsRightButtonPressed)
         {
-            TryRemoveGuideAt(px, py);
+            // A guide-removing click consumes the right-click; otherwise let it fall through
+            // so Avalonia opens the "View <filename> in Explorer" ContextMenu as normal.
+            if (TryRemoveGuideAt(px, py))
+                e.Handled = true;
             return;
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -552,6 +552,7 @@ public class WireframeControl : Control
     private IApplicationEvents? _events;
     private IProjectManager? _projectManager;
     private IUndoManager? _undoManager;
+    private Action<string>? _showError;
 
     /// <summary>
     /// Called from MainWindow after DI container wires all services.
@@ -564,7 +565,8 @@ public class WireframeControl : Control
         IApplicationEvents events,
         IProjectManager projectManager,
         IUndoManager undoManager,
-        IPendingCutState pendingCutState)
+        IPendingCutState pendingCutState,
+        Action<string>? showError = null)
     {
         _selectedState   = selectedState;
         _appState        = appState;
@@ -573,6 +575,7 @@ public class WireframeControl : Control
         _events          = events;
         _projectManager  = projectManager;
         _undoManager     = undoManager;
+        _showError       = showError;
 
         _selectedState.SelectionChanged     += () => Dispatcher.UIThread.InvokeAsync(RefreshAll);
         _pendingCutState.Changed            += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
@@ -586,6 +589,12 @@ public class WireframeControl : Control
     {
         ClipToBounds = true;
         Focusable = true;
+
+        // Right-click opens this menu with a "View <filename> in Explorer" item for the
+        // currently loaded texture (mirrors PreviewControl's context menu — issue #573).
+        var contextMenu = new ContextMenu();
+        contextMenu.Opening += OnContextMenuOpening;
+        ContextMenu = contextMenu;
 
         // Repaint when the app theme variant changes so the canvas/grid/outline colors update.
         ActualThemeVariantChanged += (_, _) => InvalidateVisual();
@@ -2049,7 +2058,30 @@ public class WireframeControl : Control
         RaiseViewChanged();
     }
 
-    private string? DetermineTexturePath()
+    /// <summary>
+    /// Rebuilds the ContextMenu with a single "View &lt;filename&gt; in Explorer" item for the
+    /// currently loaded texture, or cancels the menu entirely when there's nothing to reveal.
+    /// </summary>
+    private void OnContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        var absPath = DetermineTexturePath();
+        if (ContextMenu is not { } menu || absPath is null)
+        {
+            e.Cancel = true;
+            return;
+        }
+
+        menu.Items.Clear();
+        var item = new MenuItem { Header = $"View {new FilePath(absPath).NoPath} in Explorer" };
+        item.Click += (_, _) =>
+        {
+            var error = ShellExplorer.RevealFile(absPath);
+            if (error is not null) _showError?.Invoke(error);
+        };
+        menu.Items.Add(item);
+    }
+
+    internal string? DetermineTexturePath()
     {
         string? textureName = _selectedState!.SelectedFrame?.TextureName
                            ?? _selectedState!.SelectedChain?.Frames?.FirstOrDefault()?.TextureName;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -202,7 +202,7 @@ public partial class MainWindow : Window
         WireDefaultHandlerBanner();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState);
-        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState);
+        PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
         FilesPanel.Initialize(_thumbnailService, this, msg => ShowStatusMessage(msg, isError: true));
         _pngFolderWatcher.FolderContentsChanged += () =>
             Dispatcher.UIThread.InvokeAsync(RefreshFilesPanel);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -201,7 +201,7 @@ public partial class MainWindow : Window
         WireTabBar();
         WireDefaultHandlerBanner();
 
-        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState);
+        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
         FilesPanel.Initialize(_thumbnailService, this, msg => ShowStatusMessage(msg, isError: true));
         _pngFolderWatcher.FolderContentsChanged += () =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ShellExplorer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/ShellExplorer.cs
@@ -29,7 +29,7 @@ public static class ShellExplorer
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
-                    Arguments = $"/select,\"{absolutePath}\"",
+                    Arguments = $"/select,\"{ToWindowsSelectPath(absolutePath)}\"",
                     UseShellExecute = true,
                 });
             }
@@ -63,4 +63,13 @@ public static class ShellExplorer
             return $"Could not open file manager: {ex.Message}";
         }
     }
+
+    /// <summary>
+    /// explorer.exe's <c>/select,</c> switch mis-parses forward slashes as extra switch
+    /// separators, silently ignoring the target and opening a default folder instead of
+    /// selecting the file. Callers may pass either separator (e.g. a path built from
+    /// <c>AnimationEditor.Core.Paths.FilePath</c>, which always normalizes to forward slashes)
+    /// so this converts to backslashes right before building the Windows-only argument string.
+    /// </summary>
+    internal static string ToWindowsSelectPath(string absolutePath) => absolutePath.Replace('/', '\\');
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewRevealInExplorerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewRevealInExplorerTests.cs
@@ -1,6 +1,10 @@
 using AnimationEditor.App.Controls;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
 using System.ComponentModel;
 using System.Linq;
@@ -135,5 +139,83 @@ public class PreviewRevealInExplorerTests
         ctrl.AddHGuide(0f); // world Y=0 -> screen Y=42
 
         Assert.False(ctrl.SimulateRightClick(30f, 20f));
+    }
+
+    // ── End-to-end: real right-click through the pointer pipeline ─────────────
+    //
+    // Regression for a real bug found in manual testing: marking the PointerPressedEventArgs
+    // Handled does NOT stop the ContextMenu from opening. Avalonia's Control.OnPointerReleased
+    // raises ContextRequested based on the *PointerReleasedEventArgs*' own Handled flag (checked
+    // before this control's OnPointerReleased override even runs its own logic, since the base
+    // call happens first) — a completely separate event object from the press. These tests drive
+    // real synthetic press+release events through a live window instead of calling the test-only
+    // SimulateRightClick hook, which only mirrors the press half and would not have caught this.
+
+    private static (MainWindow Window, TestServices Ctx) CreateWindowWithTexturedFrame()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "hero.png" };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, ctx);
+    }
+
+    private static Point PreviewCenterInWindow(MainWindow window, PreviewControl preview)
+    {
+        // Mirrors PreviewControl's own CenterX/CenterY math (RulerSize = 20).
+        float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+        float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+        return preview.TranslatePoint(new Point(centerX, centerY), window)!.Value;
+    }
+
+    [AvaloniaFact]
+    public void RealRightClick_OnGuide_RemovesGuideAndDoesNotOpenContextMenu()
+    {
+        var (window, _) = CreateWindowWithTexturedFrame();
+        try
+        {
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            preview.AddHGuide(0f); // world Y=0 -> screen Y = preview's own centre
+            Dispatcher.UIThread.RunJobs();
+
+            var point = PreviewCenterInWindow(window, preview);
+            window.MouseDown(point, MouseButton.Right);
+            window.MouseUp(point, MouseButton.Right);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, preview.HGuideCount);
+            Assert.Empty(preview.ContextMenu!.Items);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RealRightClick_AwayFromGuide_OpensContextMenuWithRevealItem()
+    {
+        var (window, _) = CreateWindowWithTexturedFrame();
+        try
+        {
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            var point = PreviewCenterInWindow(window, preview);
+            window.MouseDown(point, MouseButton.Right);
+            window.MouseUp(point, MouseButton.Right);
+            Dispatcher.UIThread.RunJobs();
+
+            var item = preview.ContextMenu!.Items.OfType<MenuItem>().Single();
+            Assert.Equal("View hero.png in Explorer", item.Header);
+        }
+        finally { window.Close(); }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewRevealInExplorerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewRevealInExplorerTests.cs
@@ -1,0 +1,139 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #573 — right-clicking the Preview pane (away from any guide) shows a
+/// "View &lt;filename&gt; in Explorer" context menu item for the currently previewed texture.
+/// </summary>
+public class PreviewRevealInExplorerTests
+{
+    private static void OpenContextMenu(PreviewControl ctrl) =>
+        typeof(PreviewControl)
+            .GetMethod("OnContextMenuOpening", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(ctrl, new object?[] { null, new CancelEventArgs() });
+
+    // ── ResolveSelectedTexturePath ────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void ResolveSelectedTexturePath_NoSelection_ReturnsNull()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+
+        Assert.Null(ctrl.ResolveSelectedTexturePath());
+    }
+
+    [AvaloniaFact]
+    public void ResolveSelectedTexturePath_FrameHasNoTexture_ReturnsNull()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "" };
+        chain.Frames.Add(frame);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        Assert.Null(ctrl.ResolveSelectedTexturePath());
+    }
+
+    [AvaloniaFact]
+    public void ResolveSelectedTexturePath_ResolvesRelativeToAchxDirectory()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "textures/hero.png" };
+        chain.Frames.Add(frame);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.ProjectManager.FileName = @"C:\proj\anim.achx";
+
+        Assert.Equal("C:/proj/textures/hero.png", ctrl.ResolveSelectedTexturePath());
+    }
+
+    // ── OnContextMenuOpening ───────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_NoSelection_CancelsAndLeavesMenuEmpty()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+
+        OpenContextMenu(ctrl);
+
+        Assert.Empty(ctrl.ContextMenu!.Items);
+    }
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_TextureSelected_AddsRevealItemWithFilename()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "textures/hero.png" };
+        chain.Frames.Add(frame);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.ProjectManager.FileName = @"C:\proj\anim.achx";
+
+        OpenContextMenu(ctrl);
+
+        var item = ctrl.ContextMenu!.Items.OfType<MenuItem>().Single();
+        Assert.Equal("View hero.png in Explorer", item.Header);
+    }
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_ClickingItem_ReportsMissingFileViaShowError()
+    {
+        var ctx = TestHelpers.BuildServices();
+        string? reportedError = null;
+        var ctrl = ctx.CreatePreviewControl(msg => reportedError = msg);
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = "textures/hero.png" };
+        chain.Frames.Add(frame);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.ProjectManager.FileName = @"C:\proj\anim.achx";
+
+        OpenContextMenu(ctrl);
+        var item = ctrl.ContextMenu!.Items.OfType<MenuItem>().Single();
+        item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+        Assert.NotNull(reportedError);
+    }
+
+    // ── Right-click suppression (guide vs. menu) ───────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateRightClick_HitsGuide_ReturnsTrue()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.Measure(new Avalonia.Size(64, 64));
+        ctrl.Arrange(new Avalonia.Rect(0, 0, 64, 64));
+        ctrl.AddHGuide(0f); // world Y=0 -> screen Y=42
+
+        Assert.True(ctrl.SimulateRightClick(30f, 42f));
+    }
+
+    [AvaloniaFact]
+    public void SimulateRightClick_MissesGuide_ReturnsFalse()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.Measure(new Avalonia.Size(64, 64));
+        ctrl.Arrange(new Avalonia.Rect(0, 0, 64, 64));
+        ctrl.AddHGuide(0f); // world Y=0 -> screen Y=42
+
+        Assert.False(ctrl.SimulateRightClick(30f, 20f));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShellExplorerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShellExplorerTests.cs
@@ -1,0 +1,31 @@
+using AnimationEditor.App.Services;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #573 follow-up — "View in Explorer" opened Explorer at a default folder instead of
+/// selecting the file when the resolved path used forward slashes (e.g. from
+/// <c>AnimationEditor.Core.Paths.FilePath</c>). explorer.exe's <c>/select,</c> switch mis-parses
+/// forward slashes as extra switches, so the path must be backslash-normalized first.
+/// </summary>
+public class ShellExplorerTests
+{
+    [Fact]
+    public void ToWindowsSelectPath_ForwardSlashes_ConvertsToBackslashes()
+    {
+        Assert.Equal(@"C:\proj\textures\hero.png", ShellExplorer.ToWindowsSelectPath("C:/proj/textures/hero.png"));
+    }
+
+    [Fact]
+    public void ToWindowsSelectPath_AlreadyBackslashes_IsUnchanged()
+    {
+        Assert.Equal(@"C:\proj\textures\hero.png", ShellExplorer.ToWindowsSelectPath(@"C:\proj\textures\hero.png"));
+    }
+
+    [Fact]
+    public void ToWindowsSelectPath_MixedSlashes_ConvertsAllToBackslashes()
+    {
+        Assert.Equal(@"C:\proj\textures\hero.png", ShellExplorer.ToWindowsSelectPath(@"C:/proj\textures/hero.png"));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -62,10 +62,10 @@ internal sealed class TestServices
         return ctrl;
     }
 
-    public PreviewControl CreatePreviewControl()
+    public PreviewControl CreatePreviewControl(System.Action<string>? showError = null)
     {
         var ctrl = new PreviewControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, ThumbnailService, PendingCutState);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, ThumbnailService, PendingCutState, showError);
         return ctrl;
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -55,10 +55,10 @@ internal sealed class TestServices
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
             ThumbnailService, FileAssociationService, SettingsRoot);
 
-    public WireframeControl CreateWireframeControl()
+    public WireframeControl CreateWireframeControl(System.Action<string>? showError = null)
     {
         var ctrl = new WireframeControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, PendingCutState);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, PendingCutState, showError);
         return ctrl;
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeRevealInExplorerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeRevealInExplorerTests.cs
@@ -1,0 +1,88 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #573 — right-clicking the Wireframe pane (top) shows a "View &lt;filename&gt; in
+/// Explorer" context menu item for the currently loaded texture, mirroring the Preview pane's
+/// menu (<see cref="PreviewRevealInExplorerTests"/>).
+/// </summary>
+public class WireframeRevealInExplorerTests
+{
+    private static void OpenContextMenu(WireframeControl ctrl) =>
+        typeof(WireframeControl)
+            .GetMethod("OnContextMenuOpening", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(ctrl, new object?[] { null, new CancelEventArgs() });
+
+    private static string WriteSolidPng(string dir, string name)
+    {
+        var path = System.IO.Path.Combine(dir, name);
+        using var bm = new SKBitmap(4, 4);
+        bm.Erase(SKColors.Red);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        System.IO.File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_NoSelection_CancelsAndLeavesMenuEmpty()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreateWireframeControl();
+
+        OpenContextMenu(ctrl);
+
+        Assert.Empty(ctrl.ContextMenu!.Items);
+    }
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_TextureSelected_AddsRevealItemWithFilename()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var ctrl = ctx.CreateWireframeControl();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            var pngPath = WriteSolidPng(dir, "hero.png");
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = pngPath };
+            chain.Frames.Add(frame);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            OpenContextMenu(ctrl);
+
+            var item = ctrl.ContextMenu!.Items.OfType<MenuItem>().Single();
+            Assert.Equal("View hero.png in Explorer", item.Header);
+        }
+        finally { System.IO.Directory.Delete(dir, recursive: true); }
+    }
+
+    [AvaloniaFact]
+    public void OnContextMenuOpening_ClickingItem_ReportsMissingFileViaShowError()
+    {
+        var ctx = TestHelpers.BuildServices();
+        string? reportedError = null;
+        var ctrl = ctx.CreateWireframeControl(msg => reportedError = msg);
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave { TextureName = @"C:\does\not\exist\hero.png" };
+        chain.Frames.Add(frame);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        OpenContextMenu(ctrl);
+        var item = ctrl.ContextMenu!.Items.OfType<MenuItem>().Single();
+        item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+        Assert.NotNull(reportedError);
+    }
+}


### PR DESCRIPTION
## Summary
- Right-clicking either the **Wireframe pane (top)** or the **Preview pane (bottom)** now shows a "View `<filename>` in Explorer" context menu item for the currently displayed texture, reusing `ShellExplorer.RevealFile` (same helper the Animation tree and Files panel use).
- Preview pane: a right-click that hits an existing guide still removes it and now marks the pointer event `Handled`, so the two interactions don't fire together.
- Wireframe pane: reuses the existing `DetermineTexturePath()` helper (already used to load the sheet's bitmap), now `internal` for testability.
- **Fixed a real bug found during manual testing:** `ShellExplorer.RevealFile`'s `/select,` argument to `explorer.exe` mis-parses forward slashes as extra switches, so a path normalized via `FilePath` (always forward-slash) silently opened a default folder instead of selecting the file. Added `ShellExplorer.ToWindowsSelectPath` to backslash-normalize right before building the Windows argument.

## Testing
- `PreviewRevealInExplorerTests.cs` / `WireframeRevealInExplorerTests.cs` — menu item population (correct filename in the label), menu cancellation when nothing is selected, and error reporting via the injected `showError` callback when the revealed file is missing.
- `ShellExplorerTests.cs` — `ToWindowsSelectPath` forward-slash / backslash / mixed-slash normalization.
- `SimulateRightClick` (existing Preview test hook, now returns `bool`) — confirms the guide-hit/no-hit branches `OnPointerPressed` uses to decide whether to suppress the menu.

The actual Avalonia `ContextMenu` popup timing on a real right-click isn't driven in these tests — consistent with how the existing `AnimTree`/`FilesTree` context-menu tests in this codebase also reflect-invoke the `Opening` handler directly rather than relying on real popup timing (see `RightClickContextMenuDeleteAppTests.cs`).

Closes #573