### PR TITLE
Animation Editor: composite multi-select preview with per-chain timeline tracks

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -33,6 +33,13 @@ public class PreviewControl : Control
     private readonly DispatcherTimer _timer;
     private readonly AnimationEditor.Core.CommandsAndState.PlaybackController _playback = new();
 
+    // -- Group (multi-chain) preview playback (#576) ---------------------------
+    // One independent PlaybackController per selected chain, keyed by chain identity. Synced
+    // (added/removed) only when ISelectedState.SelectedChains membership changes — never
+    // recreated on unrelated selection changes (e.g. selecting a shape) — so drift and paused
+    // positions survive everything except the group itself changing.
+    private readonly Dictionary<AnimationChainSave, PlaybackController> _groupPlayback = new();
+
     // Measures real wall-clock time between timer ticks so playback advances by true
     // elapsed time, not the timer's nominal interval (a DispatcherTimer fires later than
     // its Interval, which otherwise makes the animation run slow — see #526).
@@ -190,12 +197,139 @@ public class PreviewControl : Control
     public double SpeedMultiplier
     {
         get => _playback.SpeedMultiplier;
-        set => _playback.SpeedMultiplier = value;
+        set
+        {
+            _playback.SpeedMultiplier = value;
+            foreach (var c in _groupPlayback.Values) c.SpeedMultiplier = value;
+        }
     }
 
-    public void Play()  => _playback.Play();
-    public void Pause() => _playback.Pause();
-    public void StopPlayback() { _playback.Reset(); InvalidateVisual(); }
+    public void Play()
+    {
+        _playback.Play();
+        foreach (var c in _groupPlayback.Values) c.Play();
+    }
+
+    public void Pause()
+    {
+        _playback.Pause();
+        foreach (var c in _groupPlayback.Values) c.Pause();
+    }
+
+    public void StopPlayback()
+    {
+        _playback.Reset();
+        foreach (var c in _groupPlayback.Values) c.Reset();
+        InvalidateVisual();
+    }
+
+    // -- Group (multi-chain) preview playback (#576) ---------------------------
+
+    /// <summary>True when 2+ whole AnimationChains are selected — the preview composites every
+    /// selected chain (see <see cref="GroupTracks"/>) instead of showing the single SelectedChain.</summary>
+    public bool IsGroupPreviewActive => _groupPlayback.Count >= 2;
+
+    /// <summary>
+    /// The active group's chains and their independent PlaybackControllers, back-to-front in
+    /// selection (click) order — see <see cref="ISelectedState.SelectedNodes"/>. Empty when
+    /// <see cref="IsGroupPreviewActive"/> is false.
+    /// </summary>
+    public IReadOnlyList<(AnimationChainSave Chain, PlaybackController Playback)> GroupTracks
+    {
+        get
+        {
+            if (_groupPlayback.Count == 0) return Array.Empty<(AnimationChainSave, PlaybackController)>();
+            var chains = _selectedState!.SelectedChains;
+            var result = new List<(AnimationChainSave, PlaybackController)>(chains.Count);
+            foreach (var chain in chains)
+                if (_groupPlayback.TryGetValue(chain, out var controller))
+                    result.Add((chain, controller));
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Fired when the set of group tracks changes (entering/leaving group mode, or a chain being
+    /// added to/removed from the group) — a structural change the host must rebuild its per-track
+    /// timeline rows for. Not fired for playback ticks; see <see cref="GroupPlaybackTicked"/>.
+    /// </summary>
+    public event Action? GroupTracksChanged;
+
+    /// <summary>
+    /// Fired after every group-mode timer tick and after <see cref="ScrubGroupTrack"/>, so the host
+    /// can refresh each track's playhead position without rebuilding the track list.
+    /// </summary>
+    public event Action? GroupPlaybackTicked;
+
+    /// <summary>
+    /// Scrubs <paramref name="chain"/>'s own track to (<paramref name="frameIndex"/>,
+    /// <paramref name="fraction"/>) while pausing every group track in place (#576 scope item 6).
+    /// Unlike <see cref="ScrubToFrame"/>, this never touches <see cref="ISelectedState.SelectedChain"/>
+    /// or <see cref="ISelectedState.SelectedFrame"/> — the singular selection stays exactly as it
+    /// was before the group was formed.
+    /// </summary>
+    public void ScrubGroupTrack(AnimationChainSave chain, int frameIndex, double fraction)
+    {
+        _playback.Pause();
+        foreach (var c in _groupPlayback.Values) c.Pause();
+        if (_groupPlayback.TryGetValue(chain, out var controller))
+            controller.SeekToFrame(frameIndex, fraction);
+        InvalidateVisual();
+        GroupPlaybackTicked?.Invoke();
+    }
+
+    /// <summary>
+    /// Adds/removes per-chain PlaybackControllers to match <see cref="ISelectedState.SelectedChains"/>.
+    /// A no-op (no event fired) when the group's membership hasn't actually changed, so unrelated
+    /// selection changes (e.g. selecting a shape while a group is active) never disturb playback.
+    /// </summary>
+    private void SyncGroupPlayback()
+    {
+        var chains = _selectedState!.SelectedChains;
+        if (chains.Count < 2)
+        {
+            bool hadAny = _groupPlayback.Count > 0;
+            _groupPlayback.Clear();
+            if (hadAny) GroupTracksChanged?.Invoke();
+            return;
+        }
+
+        var (toAdd, toRemove) = AnimationEditor.Core.CommandsAndState.GroupPlaybackSync.ComputeDiff(
+            _groupPlayback.Keys, chains);
+        foreach (var chain in toRemove) _groupPlayback.Remove(chain);
+        foreach (var chain in toAdd)
+        {
+            var controller = new PlaybackController { SpeedMultiplier = _playback.SpeedMultiplier };
+            controller.SetChain(chain);
+            _groupPlayback[chain] = controller;
+        }
+
+        if (toAdd.Count > 0 || toRemove.Count > 0)
+            GroupTracksChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Builds the back-to-front layer list for the active group (#576 scope items 2–4): each
+    /// selected chain's current frame at its own RelativeX/Y offset. Warms the texture cache for
+    /// every layer, mirroring the single-selection render path.
+    /// </summary>
+    private PreviewLayer[] BuildGroupLayers()
+    {
+        var chains = _selectedState!.SelectedChains;
+        var layers = new List<PreviewLayer>(chains.Count);
+        foreach (var chain in chains)
+        {
+            if (!_groupPlayback.TryGetValue(chain, out var controller)) continue;
+            if (chain.Frames.Count == 0) continue;
+
+            int idx = Math.Clamp(controller.CurrentFrameIndex, 0, chain.Frames.Count - 1);
+            var frame = chain.Frames[idx];
+            string? texPath = _thumbnailService!.ResolveTexturePath(frame);
+            _thumbnailService.GetImage(texPath);
+            layers.Add(new PreviewLayer(frame, texPath, frame.RelativeX, frame.RelativeY, ResolveColor(chain, frame)));
+        }
+        return layers.ToArray();
+    }
 
     /// <summary>Whether the animation is currently playing.</summary>
     public bool IsPlaying => _playback.IsPlaying;
@@ -222,27 +356,36 @@ public class PreviewControl : Control
     {
         // Clearing the pinned frame lets OnSelectionChanged keep the playback position (it only
         // re-seeks when the chain changes), so playback continues from where the playhead sits.
-        if (_selectedState!.SelectedFrame is not null)
+        // Skipped in group mode (#576): singular SelectedFrame must stay untouched by group code.
+        if (!IsGroupPreviewActive && _selectedState!.SelectedFrame is not null)
             _selectedState!.SelectedFrame = null;
         _playback.Play();
+        foreach (var c in _groupPlayback.Values) c.Play();
         StartAutoTimer();
         InvalidateVisual();
     }
 
     /// <summary>
     /// Pauses playback and pins the frame currently showing so the inspector/wireframe reflect it.
-    /// Keeps the sub-frame playhead position (does not snap to the frame's start).
+    /// Keeps the sub-frame playhead position (does not snap to the frame's start). In group mode
+    /// (#576) every group track is paused too, but the singular SelectedChain/SelectedFrame pinning
+    /// is skipped — group-preview code never touches the singular selection.
     /// </summary>
     public void PausePlayback()
     {
         _playback.Pause();
-        var chain = _selectedState!.SelectedChain;
-        if (chain is not null && chain.Frames.Count > 0)
+        foreach (var c in _groupPlayback.Values) c.Pause();
+
+        if (!IsGroupPreviewActive)
         {
-            int idx = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
-            var frame = chain.Frames[idx];
-            if (!ReferenceEquals(_selectedState!.SelectedFrame, frame))
-                _selectedState!.SelectedFrame = frame;
+            var chain = _selectedState!.SelectedChain;
+            if (chain is not null && chain.Frames.Count > 0)
+            {
+                int idx = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
+                var frame = chain.Frames[idx];
+                if (!ReferenceEquals(_selectedState!.SelectedFrame, frame))
+                    _selectedState!.SelectedFrame = frame;
+            }
         }
         InvalidateVisual();
     }
@@ -322,6 +465,32 @@ public class PreviewControl : Control
     /// </summary>
     public SKBitmap RenderToBitmap(int width, int height)
     {
+        var snap = BuildRenderSnapshot(width, height);
+        UpdatePalette();
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        RenderSkCore(canvas, snap, _thumbnailService!.ImageCache, _palette);
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Builds the snapshot both the live and off-screen render paths draw from. In group-preview
+    /// mode (#576, <see cref="IsGroupPreviewActive"/>) this returns <see cref="RenderSnapshot.GroupLayers"/>
+    /// populated and Frame/OnionFrame null; otherwise it mirrors the pre-#576 single-selection logic.
+    /// </summary>
+    private RenderSnapshot BuildRenderSnapshot(float width, float height)
+    {
+        if (IsGroupPreviewActive)
+        {
+            return new RenderSnapshot(
+                null, null, _zoom, _panX, _panY, _showGuides, null, null, width, height,
+                _appState!.OffsetMultiplier,
+                _hGuides.ToArray(), _vGuides.ToArray(),
+                _draggedGuideIdx, _draggingHGuide,
+                BuildShapeInfos(), 0f, 0f, default, default,
+                BuildGroupLayers());
+        }
+
         var chain         = _selectedState!.SelectedChain;
         var selectedFrame = _selectedState!.SelectedFrame;
 
@@ -353,18 +522,14 @@ public class PreviewControl : Control
 
         var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
 
-        var snap   = new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
-                                        _showGuides, texPath, onionPath, width, height,
-                                        _appState!.OffsetMultiplier,
-                                        _hGuides.ToArray(), _vGuides.ToArray(),
-                                        _draggedGuideIdx, _draggingHGuide,
-                                        BuildShapeInfos(), frameOffX, frameOffY,
-                                        ResolveColor(chain, displayFrame), ResolveColor(chain, onionFrame));
-        UpdatePalette();
-        var bitmap = new SKBitmap(width, height);
-        using var canvas = new SKCanvas(bitmap);
-        RenderSkCore(canvas, snap, _thumbnailService.ImageCache, _palette);
-        return bitmap;
+        return new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
+                                  _showGuides, texPath, onionPath, width, height,
+                                  _appState!.OffsetMultiplier,
+                                  _hGuides.ToArray(), _vGuides.ToArray(),
+                                  _draggedGuideIdx, _draggingHGuide,
+                                  BuildShapeInfos(), frameOffX, frameOffY,
+                                  ResolveColor(chain, displayFrame), ResolveColor(chain, onionFrame),
+                                  Array.Empty<PreviewLayer>());
     }
 
     // -- Injected services -----------------------------------------------------
@@ -449,16 +614,27 @@ public class PreviewControl : Control
         // Tick every time so the baseline stays current even while paused/pinned; this keeps
         // a resume from crediting the whole paused span as one huge delta.
         double delta = _clock.Tick();
+        double clamped = Math.Min(delta, MaxTickSeconds);
 
         // Only advance when the whole chain is playing (no specific frame pinned)
-        if (_selectedState!.SelectedFrame is not null) return;
-        _playback.Advance(Math.Min(delta, MaxTickSeconds));
+        if (_selectedState!.SelectedFrame is null)
+            _playback.Advance(clamped);
+
+        // Each group track loops on its own clock (#576 scope item 4) — paused tracks no-op.
+        if (_groupPlayback.Count > 0)
+        {
+            foreach (var c in _groupPlayback.Values) c.Advance(clamped);
+            InvalidateVisual();
+            GroupPlaybackTicked?.Invoke();
+        }
     }
 
     // -- State reset -----------------------------------------------------------
 
     private void OnSelectionChanged()
     {
+        SyncGroupPlayback();
+
         var chain = _selectedState!.SelectedChain;
         var frame = _selectedState!.SelectedFrame;
 
@@ -915,29 +1091,6 @@ public class PreviewControl : Control
 
     public override void Render(DrawingContext ctx)
     {
-        var chain         = _selectedState!.SelectedChain;
-        var selectedFrame = _selectedState!.SelectedFrame;
-
-        AnimationFrameSave? displayFrame = null;
-        AnimationFrameSave? onionFrame   = null;
-
-        if (selectedFrame is not null)
-        {
-            displayFrame = selectedFrame;
-            if (_showOnionSkin && chain is not null && chain.Frames.Count > 1)
-            {
-                int idx     = chain.Frames.IndexOf(selectedFrame);
-                int prevIdx = (idx - 1 + chain.Frames.Count) % chain.Frames.Count;
-                if (prevIdx != idx)
-                    onionFrame = chain.Frames[prevIdx];
-            }
-        }
-        else if (chain is not null && chain.Frames.Count > 0)
-        {
-            int idx  = Math.Clamp(_playback.CurrentFrameIndex, 0, chain.Frames.Count - 1);
-            displayFrame = chain.Frames[idx];
-        }
-
         double w = Bounds.Width;
         double h = Bounds.Height;
         if (w <= 0 || h <= 0) return;
@@ -945,24 +1098,11 @@ public class PreviewControl : Control
         // Pre-fill the image cache synchronously before handing off to the render thread.
         // GetImage warms both the image cache (drawn by the render op) and the bitmap cache it
         // decodes from — the cached SKImage is what avoids a per-frame full-atlas copy (#514).
-        string? texPath   = _thumbnailService!.ResolveTexturePath(displayFrame);
-        string? onionPath = _thumbnailService!.ResolveTexturePath(onionFrame);
-        _thumbnailService.GetImage(texPath);
-        _thumbnailService.GetImage(onionPath);
-
-        var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
+        var snap = BuildRenderSnapshot((float)w, (float)h);
 
         UpdatePalette();
         ctx.Custom(new DrawOp(
-            new RenderSnapshot(
-                displayFrame, onionFrame, _zoom, _panX, _panY, _showGuides,
-                texPath, onionPath, (float)w, (float)h,
-                _appState!.OffsetMultiplier,
-                _hGuides.ToArray(), _vGuides.ToArray(),
-                _draggedGuideIdx, _draggingHGuide,
-                BuildShapeInfos(), frameOffX, frameOffY,
-                ResolveColor(chain, displayFrame), ResolveColor(chain, onionFrame)),
-            _thumbnailService.ImageCache, _palette, _showDiagnostics ? _drawTimes : null));
+            snap, _thumbnailService!.ImageCache, _palette, _showDiagnostics ? _drawTimes : null));
     }
 
     // ActualThemeVariant resolves Default to the concrete platform variant, so a simple
@@ -1758,7 +1898,15 @@ public class PreviewControl : Control
         float  FrameOffsetX, float FrameOffsetY,
         // Sticky per-channel color for the live frame and onion frame — an omitted channel holds
         // whatever an earlier frame last set, matching runtime, rather than resetting each frame.
-        ResolvedFrameColor FrameColor, ResolvedFrameColor OnionColor);
+        ResolvedFrameColor FrameColor, ResolvedFrameColor OnionColor,
+        // Multi-select group preview (#576): when non-empty, RenderSkCore draws these back-to-front
+        // INSTEAD of Frame/OnionFrame. Empty for the ordinary single-selection render path.
+        PreviewLayer[] GroupLayers);
+
+    /// <summary>One composited chain in a multi-select group preview (#576) — its current frame,
+    /// resolved texture path, and its own resting RelativeX/Y offset and effective color.</summary>
+    private record PreviewLayer(
+        AnimationFrameSave Frame, string? TexturePath, float OffsetX, float OffsetY, ResolvedFrameColor Color);
 
     /// <summary>
     /// Resolves a frame's sticky effective color within its chain. Returns an all-unset result
@@ -1786,22 +1934,40 @@ public class PreviewControl : Control
         canvas.Save();
         canvas.ClipRect(new SKRect(RulerSize, RulerSize, s.Width, s.Height));
 
-        if (s.OnionFrame is not null &&
-            s.OnionTexturePath is not null &&
-            cache.TryGetValue(s.OnionTexturePath, out var onionImg) && onionImg is not null)
+        if (s.GroupLayers.Length > 0)
         {
-            float ocx = cx + s.OnionFrame.RelativeX * s.OffsetMultiplier * s.Zoom;
-            float ocy = cy - s.OnionFrame.RelativeY * s.OffsetMultiplier * s.Zoom;
-            DrawFrameCore(canvas, s.OnionFrame, s.OnionColor, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f);
-        }
+            // Multi-select group preview (#576): draw every selected chain's current frame
+            // back-to-front, each at its own resting offset — no onion skin in this mode.
+            foreach (var layer in s.GroupLayers)
+            {
+                if (layer.TexturePath is null ||
+                    !cache.TryGetValue(layer.TexturePath, out var limg) || limg is null)
+                    continue;
 
-        if (s.Frame is not null &&
-            s.TexturePath is not null &&
-            cache.TryGetValue(s.TexturePath, out var img) && img is not null)
+                float lcx = cx + layer.OffsetX * s.OffsetMultiplier * s.Zoom;
+                float lcy = cy - layer.OffsetY * s.OffsetMultiplier * s.Zoom;
+                DrawFrameCore(canvas, layer.Frame, layer.Color, limg, lcx, lcy, s.Zoom, alpha: 1.0f);
+            }
+        }
+        else
         {
-            float fcx = cx + s.FrameOffsetX * s.OffsetMultiplier * s.Zoom;
-            float fcy = cy - s.FrameOffsetY * s.OffsetMultiplier * s.Zoom;
-            DrawFrameCore(canvas, s.Frame, s.FrameColor, img, fcx, fcy, s.Zoom, alpha: 1.0f);
+            if (s.OnionFrame is not null &&
+                s.OnionTexturePath is not null &&
+                cache.TryGetValue(s.OnionTexturePath, out var onionImg) && onionImg is not null)
+            {
+                float ocx = cx + s.OnionFrame.RelativeX * s.OffsetMultiplier * s.Zoom;
+                float ocy = cy - s.OnionFrame.RelativeY * s.OffsetMultiplier * s.Zoom;
+                DrawFrameCore(canvas, s.OnionFrame, s.OnionColor, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f);
+            }
+
+            if (s.Frame is not null &&
+                s.TexturePath is not null &&
+                cache.TryGetValue(s.TexturePath, out var img) && img is not null)
+            {
+                float fcx = cx + s.FrameOffsetX * s.OffsetMultiplier * s.Zoom;
+                float fcy = cy - s.FrameOffsetY * s.OffsetMultiplier * s.Zoom;
+                DrawFrameCore(canvas, s.Frame, s.FrameColor, img, fcx, fcy, s.Zoom, alpha: 1.0f);
+            }
         }
 
         // Origin crosshair (toggled by ShowGuides)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -830,7 +830,15 @@
 
                 <!-- ── Preview block: toolbar + animated canvas + timeline ── -->
                 <!-- GridSplitter at Row 2 resizes Row 1 (wireframe) and Row 3 (this block). -->
-                <Grid Grid.Row="3" RowDefinitions="Auto,*,52" MinHeight="80">
+                <Grid x:Name="PreviewBlockGrid" Grid.Row="3" MinHeight="80">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <!-- Fixed height for the single-row timeline; grown in code-behind (see
+                             PreviewBlockGrid.RowDefinitions[2]) while the multi-select group
+                             preview (#576) shows 2+ track rows. -->
+                        <RowDefinition Height="52" />
+                    </Grid.RowDefinitions>
 
                     <!-- ── Preview toolbar ── -->
                     <Border Grid.Row="0"
@@ -1050,6 +1058,92 @@
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
                             </ScrollViewer>
+                            </Border>
+
+                            <!-- Multi-select group preview timeline (#576): one row per selected
+                                 AnimationChain, each with its own frame cells and playhead. Shown
+                                 instead of TimelineScrubSurface when 2+ chains are selected. -->
+                            <Border x:Name="GroupTimelineScrubHost"
+                                    Grid.Row="1"
+                                    Background="{DynamicResource BgCanvas}"
+                                    BorderBrush="{DynamicResource LineBrush}"
+                                    BorderThickness="0,0,0,0"
+                                    IsVisible="False">
+                                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                              VerticalScrollBarVisibility="Auto">
+                                    <ItemsControl x:Name="GroupTimelineTracks">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Vertical" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="models:ChainTimelineTrackVm">
+                                                <Grid ColumnDefinitions="70,*" Height="40">
+                                                    <Border Grid.Column="0"
+                                                            Background="{DynamicResource BgRail}"
+                                                            BorderBrush="{DynamicResource LineBrush}"
+                                                            BorderThickness="0,0,1,1"
+                                                            Padding="6,0">
+                                                        <TextBlock Text="{Binding ChainName}"
+                                                                   FontSize="9" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource InkDim}"
+                                                                   VerticalAlignment="Center"
+                                                                   TextTrimming="CharacterEllipsis" />
+                                                    </Border>
+                                                    <Border Grid.Column="1"
+                                                            Background="{DynamicResource BgCanvas}"
+                                                            BorderBrush="{DynamicResource LineBrush}"
+                                                            BorderThickness="0,0,0,1"
+                                                            Cursor="Hand">
+                                                        <ItemsControl x:Name="TrackFramesList"
+                                                                      ItemsSource="{Binding Frames}">
+                                                            <ItemsControl.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <StackPanel Orientation="Horizontal" />
+                                                                </ItemsPanelTemplate>
+                                                            </ItemsControl.ItemsPanel>
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate x:DataType="models:TimelineFrameVm">
+                                                                    <Grid Width="{Binding Width}" Height="38">
+                                                                        <Border BorderBrush="{DynamicResource LineBrush}"
+                                                                                BorderThickness="0,0,1,0"
+                                                                                Background="{DynamicResource BgPanel}">
+                                                                            <StackPanel VerticalAlignment="Center"
+                                                                                        HorizontalAlignment="Center"
+                                                                                        Spacing="2">
+                                                                                <Border Width="22" Height="18"
+                                                                                        Background="{DynamicResource BgCanvas}"
+                                                                                        BorderBrush="{DynamicResource LineStrong}"
+                                                                                        BorderThickness="1"
+                                                                                        CornerRadius="2">
+                                                                                    <Image Source="{Binding Thumbnail}"
+                                                                                           Stretch="Uniform" />
+                                                                                </Border>
+                                                                                <TextBlock Text="{Binding IndexLabel}"
+                                                                                           HorizontalAlignment="Center"
+                                                                                           FontSize="9"
+                                                                                           Foreground="{DynamicResource InkDim}" />
+                                                                            </StackPanel>
+                                                                        </Border>
+                                                                        <Canvas ClipToBounds="True"
+                                                                                IsHitTestVisible="False"
+                                                                                IsVisible="{Binding IsCurrent}">
+                                                                            <Border Width="2"
+                                                                                    Height="38"
+                                                                                    Background="{DynamicResource Accent}"
+                                                                                    Canvas.Left="{Binding ScrubberOffset}" />
+                                                                        </Canvas>
+                                                                    </Grid>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </Border>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </ScrollViewer>
                             </Border>
                         </Grid>
                     </Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1658,6 +1658,7 @@ public partial class MainWindow : Window
         };
 
         TimelineStrip.ItemsSource = _timelineFrames;
+        GroupTimelineTracks.ItemsSource = _groupTimelineTracks;
 
         PreviewZoomCombo.ItemsSource = _previewZoomPresetTexts;
         PreviewZoomCombo.KeyDown += OnPreviewZoomComboKeyDown;
@@ -1677,6 +1678,8 @@ public partial class MainWindow : Window
         PreviewCtrl.PanChanged  += (_, _) => SaveCompanionFile();
         PreviewCtrl.Playback.FrameIndexChanged += OnPreviewPlaybackFrameIndexChanged;
         PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
+        PreviewCtrl.GroupTracksChanged += RefreshGroupTimelineTracks;
+        PreviewCtrl.GroupPlaybackTicked += RefreshGroupTimelineScrubbers;
 
         // ── Preview scrollbars (#415) ──
         // Two-way sync between the manual pan and the scrollbars, mirroring the
@@ -1831,6 +1834,14 @@ public partial class MainWindow : Window
     // Structure of the strip the cells were last built from; compared on each refresh so a
     // pure selection change (scrub) skips the clear-and-rebuild (#452).
     private TimelineStripSignature? _timelineSignature;
+
+    // ── Multi-select group preview timeline (#576) ──────────────────────────────
+    // One row per selected chain, rebuilt whenever PreviewCtrl.GroupTracksChanged fires
+    // (chain added/removed from the group) — never on every render or unrelated selection change.
+    private readonly ObservableCollection<ChainTimelineTrackVm> _groupTimelineTracks = new();
+    private bool _isGroupTimelineScrubbing;
+    private ChainTimelineTrackVm? _groupScrubTrack;
+    private ItemsControl? _groupScrubFramesList;
 
     private void WireTreeView()
     {
@@ -2990,8 +3001,29 @@ public partial class MainWindow : Window
         }
     }
 
+    // The single-row timeline's fixed height (14px ruler + one ~38px frame-cell row).
+    private const double SingleTimelineAreaHeight = 52;
+    // Group-preview timeline area (#576): tall enough for ~4 track rows at once; more chains
+    // scroll within GroupTimelineScrubHost's ScrollViewer rather than growing the row further.
+    private const double GroupTimelineAreaHeight = 160;
+
     private void RefreshTimelineStrip()
     {
+        // Multi-select group preview (#576): 2+ whole chains selected swaps the single-row strip
+        // for a per-chain track stack. TimelineScrubSurface/GroupTimelineScrubHost occupy the same
+        // grid cell, so only one is ever visible. The host row is also grown so the extra track
+        // rows aren't clipped to the single-row strip's original fixed height.
+        bool groupActive = _selectedState.SelectedChains.Count >= 2;
+        TimelineScrubSurface.IsVisible = !groupActive;
+        GroupTimelineScrubHost.IsVisible = groupActive;
+        PreviewBlockGrid.RowDefinitions[2].Height =
+            new GridLength(groupActive ? GroupTimelineAreaHeight : SingleTimelineAreaHeight);
+        if (groupActive)
+        {
+            RefreshGroupTimelineTracks();
+            return;
+        }
+
         var chain = GetTimelineChain();
 
         // Only clear-and-rebuild the cells when the frame structure (chain identity, count,
@@ -3044,6 +3076,110 @@ public partial class MainWindow : Window
         double elapsed = PreviewCtrl.Playback.FrameElapsed;
         double travelWidth = Math.Max(0, _timelineFrames[frameIndex].Width - TimelineFrameVm.PlayheadWidth);
         _timelineFrames[frameIndex].ScrubberOffset = Math.Min(elapsed * _timelineEffectivePps, travelWidth);
+    }
+
+    // ── Multi-select group preview timeline (#576) ──────────────────────────────
+
+    /// <summary>
+    /// Rebuilds the per-chain track rows from <see cref="PreviewControl.GroupTracks"/>. Fired by
+    /// <see cref="PreviewControl.GroupTracksChanged"/> — only when the group's chain membership
+    /// actually changes, not on every render or unrelated selection change.
+    /// </summary>
+    private void RefreshGroupTimelineTracks()
+    {
+        _groupTimelineTracks.Clear();
+
+        foreach (var (chain, _) in PreviewCtrl.GroupTracks)
+        {
+            var track = new ChainTimelineTrackVm(chain, TimelineBuilder.BuildFrameItems(chain));
+            if (chain.Frames.Count > 0)
+            {
+                var colors = EffectiveFrameColor.ResolveAll(chain.Frames);
+                for (int i = 0; i < chain.Frames.Count && i < track.Frames.Count; i++)
+                    track.Frames[i].Thumbnail = _thumbnailService.GetFrameThumbnail(chain.Frames[i], colors[i], 22, 18);
+            }
+            _groupTimelineTracks.Add(track);
+        }
+
+        RefreshGroupTimelineScrubbers();
+    }
+
+    /// <summary>
+    /// Updates every track's current-frame highlight and sub-frame playhead offset from its own
+    /// PlaybackController. Fired by <see cref="PreviewControl.GroupPlaybackTicked"/> on every
+    /// group-mode timer tick and after a per-track scrub.
+    /// </summary>
+    private void RefreshGroupTimelineScrubbers()
+    {
+        foreach (var (chain, playback) in PreviewCtrl.GroupTracks)
+        {
+            var track = _groupTimelineTracks.FirstOrDefault(t => ReferenceEquals(t.Chain, chain));
+            if (track is null || track.Frames.Count == 0) continue;
+
+            int idx = Math.Clamp(playback.CurrentFrameIndex, 0, track.Frames.Count - 1);
+            for (int i = 0; i < track.Frames.Count; i++)
+                track.Frames[i].IsCurrent = i == idx;
+
+            double pps = TimelineBuilder.ComputeEffectivePixelsPerSecond(chain);
+            double travelWidth = Math.Max(0, track.Frames[idx].Width - TimelineFrameVm.PlayheadWidth);
+            track.Frames[idx].ScrubberOffset = Math.Min(playback.FrameElapsed * pps, travelWidth);
+        }
+    }
+
+    private (ChainTimelineTrackVm Track, ItemsControl FramesList)? FindGroupTrackAndFramesList(PointerEventArgs e)
+    {
+        if (e.Source is not Avalonia.Visual source) return null;
+        var self = new[] { source }.Concat(source.GetVisualAncestors());
+        var framesList = self.OfType<ItemsControl>().FirstOrDefault(ic => ic.Name == "TrackFramesList");
+        return framesList?.DataContext is ChainTimelineTrackVm track ? (track, framesList) : null;
+    }
+
+    private void OnGroupTimelinePointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(GroupTimelineTracks).Properties.IsLeftButtonPressed) return;
+        var hit = FindGroupTrackAndFramesList(e);
+        if (hit is null) return;
+
+        _isGroupTimelineScrubbing = true;
+        _groupScrubTrack = hit.Value.Track;
+        _groupScrubFramesList = hit.Value.FramesList;
+        e.Pointer.Capture(GroupTimelineTracks);
+        ScrubGroupTimelineToPointer(e);
+    }
+
+    private void OnGroupTimelinePointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_isGroupTimelineScrubbing) ScrubGroupTimelineToPointer(e);
+    }
+
+    private void OnGroupTimelinePointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_isGroupTimelineScrubbing) return;
+        _isGroupTimelineScrubbing = false;
+        _groupScrubTrack = null;
+        _groupScrubFramesList = null;
+        e.Pointer.Capture(null);
+    }
+
+    /// <summary>
+    /// Scrubs the track captured at press time to the pointer's position within its own frames
+    /// list. Position is resolved against the captured <see cref="_groupScrubFramesList"/>, not
+    /// <c>e.Source</c>, since pointer capture keeps routing move/release events to
+    /// <c>GroupTimelineTracks</c> regardless of which row is physically under the cursor.
+    /// </summary>
+    private void ScrubGroupTimelineToPointer(PointerEventArgs e)
+    {
+        var track = _groupScrubTrack;
+        var framesList = _groupScrubFramesList;
+        if (track is null || framesList is null || track.Frames.Count == 0) return;
+
+        double contentX = e.GetPosition(framesList).X;
+        var widths = new double[track.Frames.Count];
+        for (int i = 0; i < widths.Length; i++) widths[i] = track.Frames[i].Width;
+
+        var result = TimelineScrubMapper.Resolve(contentX, widths);
+        // Fires GroupPlaybackTicked synchronously, which refreshes every track's playhead.
+        PreviewCtrl.ScrubGroupTrack(track.Chain, result.FrameIndex, result.Fraction);
     }
 
     private AnimationChainSave? GetTimelineChain()
@@ -3902,6 +4038,15 @@ public partial class MainWindow : Window
         TimelineScrubSurface.AddHandler(InputElement.PointerMovedEvent, OnTimelinePointerMoved,
             RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
         TimelineScrubSurface.AddHandler(InputElement.PointerReleasedEvent, OnTimelinePointerReleased,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+
+        // Multi-select group preview timeline (#576) — same tunnel+bubble pattern, scoped to
+        // whichever track row's frames list is under the pointer at press time.
+        GroupTimelineTracks.AddHandler(InputElement.PointerPressedEvent, OnGroupTimelinePointerPressed,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+        GroupTimelineTracks.AddHandler(InputElement.PointerMovedEvent, OnGroupTimelinePointerMoved,
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+        GroupTimelineTracks.AddHandler(InputElement.PointerReleasedEvent, OnGroupTimelinePointerReleased,
             RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/GroupPlaybackSync.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/GroupPlaybackSync.cs
@@ -1,0 +1,26 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Pure diff for keeping a per-chain <see cref="PlaybackController"/> dictionary in sync with the
+/// current multi-select group (#576): which chains need a brand-new controller and which existing
+/// controllers belong to chains that dropped out of the selection and should be removed.
+/// Chains that are in both sets are left untouched, so an unrelated selection change never resets
+/// a group track's in-flight playback position.
+/// </summary>
+public static class GroupPlaybackSync
+{
+    public static (List<AnimationChainSave> ToAdd, List<AnimationChainSave> ToRemove) ComputeDiff(
+        IEnumerable<AnimationChainSave> existingKeys, IReadOnlyList<AnimationChainSave> desiredChains)
+    {
+        var existingSet = existingKeys.ToHashSet();
+        var desiredSet = desiredChains.ToHashSet();
+
+        var toAdd = desiredChains.Where(c => !existingSet.Contains(c)).ToList();
+        var toRemove = existingSet.Where(c => !desiredSet.Contains(c)).ToList();
+        return (toAdd, toRemove);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ChainTimelineTrackVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/ChainTimelineTrackVm.cs
@@ -1,0 +1,23 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace AnimationEditor.Core.ViewModels;
+
+/// <summary>
+/// One row of the multi-track group-preview timeline (#576): a chain's display name plus its own
+/// independent set of <see cref="TimelineFrameVm"/> cells, built the same way as the single-chain
+/// <see cref="TimelineBuilder"/> strip.
+/// </summary>
+public sealed class ChainTimelineTrackVm
+{
+    public AnimationChainSave Chain { get; }
+    public string ChainName => Chain.Name ?? string.Empty;
+    public ObservableCollection<TimelineFrameVm> Frames { get; }
+
+    public ChainTimelineTrackVm(AnimationChainSave chain, IEnumerable<TimelineFrameVm> frames)
+    {
+        Chain = chain;
+        Frames = new ObservableCollection<TimelineFrameVm>(frames);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupPreviewPlaybackTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupPreviewPlaybackTests.cs
@@ -1,0 +1,145 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Multi-select preview compositing (#576): 2+ selected AnimationChains each get their own
+/// independent PlaybackController, drawn back-to-front in selection (click) order.
+/// </summary>
+public class GroupPreviewPlaybackTests
+{
+    private static AnimationChainSave MakeChain(string name, int frameCount, float frameLength = 0.1f)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        for (int i = 0; i < frameCount; i++)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = $"{name}_{i}.png", FrameLength = frameLength, ShapesSave = new ShapesSave() });
+        return chain;
+    }
+
+    [AvaloniaFact]
+    public void IsGroupPreviewActive_TwoChainsSelected_IsTrue()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 2);
+        var b = MakeChain("B", 2);
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(ctrl.IsGroupPreviewActive);
+        Assert.Equal(2, ctrl.GroupTracks.Count);
+    }
+
+    [AvaloniaFact]
+    public void GroupTracks_ReturnsChainsInSelectionClickOrder()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 2);
+        var b = MakeChain("B", 2);
+
+        var ctrl = ctx.CreatePreviewControl();
+        // Selected B first, then A — click order is [B, A], the reverse of declaration order.
+        ctx.SelectedState.SelectedNodes = new List<object> { b, a };
+        Dispatcher.UIThread.RunJobs();
+
+        var tracks = ctrl.GroupTracks;
+        Assert.Same(b, tracks[0].Chain);
+        Assert.Same(a, tracks[1].Chain);
+    }
+
+    /// <summary>
+    /// Each track's PlaybackController is independent: advancing time moves a 2-frame chain to its
+    /// second frame while a 4-frame chain (same per-frame length) is still on its first.
+    /// </summary>
+    [AvaloniaFact]
+    public void GroupTracks_DifferentFrameLengths_AdvanceIndependently()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var shortChain = MakeChain("Short", 2, frameLength: 0.1f);
+        var longChain = MakeChain("Long", 4, frameLength: 0.1f);
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+        ctx.SelectedState.SelectedNodes = new List<object> { shortChain, longChain };
+        Dispatcher.UIThread.RunJobs();
+
+        foreach (var (_, playback) in ctrl.GroupTracks)
+        {
+            playback.Play();
+            playback.Advance(0.15); // past frame 0 (0.1s) for both chains
+        }
+
+        var shortTrack = ctrl.GroupTracks.First(t => t.Chain == shortChain);
+        var longTrack = ctrl.GroupTracks.First(t => t.Chain == longChain);
+        Assert.Equal(1, shortTrack.Playback.CurrentFrameIndex);
+        Assert.Equal(1, longTrack.Playback.CurrentFrameIndex);
+
+        // Advance further: the 2-frame chain wraps back to 0, the 4-frame chain keeps progressing.
+        foreach (var (_, playback) in ctrl.GroupTracks)
+            playback.Advance(0.1);
+
+        Assert.Equal(0, shortTrack.Playback.CurrentFrameIndex); // wrapped
+        Assert.Equal(2, longTrack.Playback.CurrentFrameIndex);  // still progressing
+    }
+
+    /// <summary>
+    /// Scrubbing one track seeks only that track's controller but pauses every group track in
+    /// place (#576 scope item 6), and leaves the singular SelectedChain/SelectedFrame untouched.
+    /// </summary>
+    [AvaloniaFact]
+    public void ScrubGroupTrack_SeeksOnlyThatChain_ButPausesAllTracks()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 3);
+        var b = MakeChain("B", 3);
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+        ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+        Dispatcher.UIThread.RunJobs();
+
+        foreach (var (_, playback) in ctrl.GroupTracks) playback.Play();
+
+        ctrl.ScrubGroupTrack(b, frameIndex: 2, fraction: 0.5);
+
+        var trackA = ctrl.GroupTracks.First(t => t.Chain == a);
+        var trackB = ctrl.GroupTracks.First(t => t.Chain == b);
+        Assert.Equal(0, trackA.Playback.CurrentFrameIndex); // untouched, just paused
+        Assert.False(trackA.Playback.IsPlaying);
+        Assert.Equal(2, trackB.Playback.CurrentFrameIndex); // seeked
+        Assert.False(trackB.Playback.IsPlaying);
+
+        Assert.Null(ctx.SelectedState.SelectedFrame); // singular selection left untouched
+    }
+
+    /// <summary>
+    /// The transport Play/Pause resumes every group track together, overriding an
+    /// individually-scrubbed pause (#576 scope item 7).
+    /// </summary>
+    [AvaloniaFact]
+    public void TogglePlayPause_ResumesEveryGroupTrackTogether()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 3);
+        var b = MakeChain("B", 3);
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.PauseAutoPlayback();
+        ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+        Dispatcher.UIThread.RunJobs();
+
+        foreach (var (_, playback) in ctrl.GroupTracks) playback.Play();
+        ctrl.ScrubGroupTrack(a, frameIndex: 1, fraction: 0); // pauses both tracks
+
+        ctrl.TogglePlayPause(); // global resume
+
+        Assert.True(ctrl.GroupTracks.All(t => t.Playback.IsPlaying));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupPreviewRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupPreviewRenderTests.cs
@@ -1,0 +1,100 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Canvas compositing for the multi-select group preview (#576 scope items 2–3): every selected
+/// chain draws in the same canvas at the shared entity origin, back-to-front in selection (click)
+/// order — the most recently selected chain draws on top.
+/// </summary>
+public class GroupPreviewRenderTests
+{
+    private static string WritePng(string dir, string name, SKColor color, int size = 64)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    private static AnimationChainSave MakeSingleFrameChain(string name, string texturePath)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = texturePath,
+            FrameLength = 1f,
+            LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+            ShapesSave = new ShapesSave(),
+        });
+        return chain;
+    }
+
+    [AvaloniaFact]
+    public void RenderToBitmap_TwoOverlappingChainsSelected_MostRecentlySelectedDrawsOnTop()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var redPath  = WritePng(dir, "red.png", SKColors.Red);
+            var bluePath = WritePng(dir, "blue.png", SKColors.Blue);
+            var redChain  = MakeSingleFrameChain("Red", redPath);
+            var blueChain = MakeSingleFrameChain("Blue", bluePath);
+
+            var ctx = TestHelpers.BuildServices();
+            var ctrl = ctx.CreatePreviewControl();
+            ctrl.PauseAutoPlayback();
+
+            // Click order [Red, Blue]: Red selected first (back), Blue selected last (front).
+            ctx.SelectedState.SelectedNodes = new List<object> { redChain, blueChain };
+            Dispatcher.UIThread.RunJobs();
+
+            using var bitmap = ctrl.RenderToBitmap(200, 200);
+            var center = bitmap.GetPixel(100, 100);
+
+            Assert.Equal(SKColors.Blue.Red,  center.Red);
+            Assert.Equal(SKColors.Blue.Blue, center.Blue);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [AvaloniaFact]
+    public void RenderToBitmap_ReversedClickOrder_ReversesWhichChainDrawsOnTop()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var redPath  = WritePng(dir, "red.png", SKColors.Red);
+            var bluePath = WritePng(dir, "blue.png", SKColors.Blue);
+            var redChain  = MakeSingleFrameChain("Red", redPath);
+            var blueChain = MakeSingleFrameChain("Blue", bluePath);
+
+            var ctx = TestHelpers.BuildServices();
+            var ctrl = ctx.CreatePreviewControl();
+            ctrl.PauseAutoPlayback();
+
+            // Click order [Blue, Red]: Blue selected first (back), Red selected last (front).
+            ctx.SelectedState.SelectedNodes = new List<object> { blueChain, redChain };
+            Dispatcher.UIThread.RunJobs();
+
+            using var bitmap = ctrl.RenderToBitmap(200, 200);
+            var center = bitmap.GetPixel(100, 100);
+
+            Assert.Equal(SKColors.Red.Red,  center.Red);
+            Assert.Equal(SKColors.Red.Blue, center.Blue);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupTimelineUiTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GroupTimelineUiTests.cs
@@ -1,0 +1,163 @@
+using AnimationEditor.Core.ViewModels;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Multi-track group-preview timeline UI (#576 scope items 5–6): TimelineScrubSurface (single-row)
+/// is swapped for GroupTimelineTracks (one row per selected chain) once 2+ chains are selected.
+/// </summary>
+public class GroupTimelineUiTests
+{
+    private static AnimationChainSave MakeChain(string name, int frameCount)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        for (int i = 0; i < frameCount; i++)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = $"{name}_{i}.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+        return chain;
+    }
+
+    private static void LoadProjectIntoWindow(TestServices ctx, MainWindow window, AnimationChainListSave acls)
+    {
+        ctx.ProjectManager.AnimationChainListSave = acls;
+        typeof(MainWindow)
+            .GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object[] { Array.Empty<string>() });
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void RefreshTimelineStrip_TwoChainsSelected_ShowsOneTrackRowPerChain()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 2);
+        var b = MakeChain("B", 3);
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(a);
+        acls.AnimationChains.Add(b);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Dispatcher.UIThread.RunJobs();
+            LoadProjectIntoWindow(ctx, window, acls);
+
+            ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+            Dispatcher.UIThread.RunJobs();
+
+            var singleStrip = window.FindControl<Border>("TimelineScrubSurface")!;
+            var groupHost = window.FindControl<Border>("GroupTimelineScrubHost")!;
+            Assert.False(singleStrip.IsVisible);
+            Assert.True(groupHost.IsVisible);
+
+            var tracks = window.FindControl<ItemsControl>("GroupTimelineTracks")!;
+            var items = Assert.IsType<ObservableCollection<ChainTimelineTrackVm>>(tracks.ItemsSource);
+            Assert.Equal(2, items.Count);
+            Assert.Equal("A", items[0].ChainName);
+            Assert.Equal("B", items[1].ChainName);
+            Assert.Equal(2, items[0].Frames.Count);
+            Assert.Equal(3, items[1].Frames.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RefreshTimelineStrip_DropBackToSingleSelection_RestoresSingleRowStrip()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 2);
+        var b = MakeChain("B", 2);
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(a);
+        acls.AnimationChains.Add(b);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Dispatcher.UIThread.RunJobs();
+            LoadProjectIntoWindow(ctx, window, acls);
+
+            ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+            Dispatcher.UIThread.RunJobs();
+
+            ctx.SelectedState.SelectedNodes = new List<object>();
+            ctx.SelectedState.SelectedChain = a;
+            Dispatcher.UIThread.RunJobs();
+
+            var singleStrip = window.FindControl<Border>("TimelineScrubSurface")!;
+            var groupHost = window.FindControl<Border>("GroupTimelineScrubHost")!;
+            Assert.True(singleStrip.IsVisible);
+            Assert.False(groupHost.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Clicking a frame cell in one track's row scrubs only that chain's PlaybackController and
+    /// pauses every track, without touching the singular SelectedFrame (#576 scope item 6).
+    /// </summary>
+    [AvaloniaFact]
+    public void ClickingSecondTrackFrameCell_ScrubsOnlyThatChainAndPausesAll()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var a = MakeChain("A", 2);
+        var b = MakeChain("B", 3);
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(a);
+        acls.AnimationChains.Add(b);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            Dispatcher.UIThread.RunJobs();
+            LoadProjectIntoWindow(ctx, window, acls);
+
+            ctx.SelectedState.SelectedNodes = new List<object> { a, b };
+            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs();
+
+            foreach (var (_, playback) in window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")!.GroupTracks) playback.Play();
+
+            var tracks = window.FindControl<ItemsControl>("GroupTimelineTracks")!;
+            // Row 1 (chain B)'s frames list, third frame cell (index 2).
+            var framesLists = tracks.GetVisualDescendants().OfType<ItemsControl>()
+                .Where(ic => ic.Name == "TrackFramesList").ToList();
+            Assert.Equal(2, framesLists.Count);
+            var bFramesList = framesLists[1];
+
+            var frameCells = bFramesList.GetVisualDescendants().OfType<Grid>()
+                .Where(g => g.DataContext is TimelineFrameVm).ToList();
+            var thirdCell = frameCells.First(g => ((TimelineFrameVm)g.DataContext!).Index == 2);
+
+            var centre = new Point(thirdCell.Bounds.Width / 2, thirdCell.Bounds.Height / 2);
+            var pointInWindow = thirdCell.TranslatePoint(centre, window)!.Value;
+            window.MouseDown(pointInWindow, MouseButton.Left);
+            window.MouseUp(pointInWindow, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            var trackA = window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")!.GroupTracks.First(t => t.Chain == a);
+            var trackB = window.FindControl<AnimationEditor.App.Controls.PreviewControl>("PreviewCtrl")!.GroupTracks.First(t => t.Chain == b);
+            Assert.Equal(2, trackB.Playback.CurrentFrameIndex);
+            Assert.False(trackB.Playback.IsPlaying);
+            Assert.False(trackA.Playback.IsPlaying); // scrubbing pauses every track
+            Assert.Null(ctx.SelectedState.SelectedFrame); // singular selection untouched
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GroupPlaybackSyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GroupPlaybackSyncTests.cs
@@ -1,0 +1,38 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class GroupPlaybackSyncTests
+{
+    [Fact]
+    public void ComputeDiff_ChainDroppedAndChainAdded_ReturnsBothInOneDiff()
+    {
+        var a = new AnimationChainSave { Name = "A" };
+        var b = new AnimationChainSave { Name = "B" };
+        var c = new AnimationChainSave { Name = "C" };
+
+        var (toAdd, toRemove) = GroupPlaybackSync.ComputeDiff(
+            existingKeys: new[] { a, b },
+            desiredChains: new List<AnimationChainSave> { b, c });
+
+        Assert.Equal(new[] { c }, toAdd);
+        Assert.Equal(new[] { a }, toRemove);
+    }
+
+    [Fact]
+    public void ComputeDiff_SameChains_ReturnsEmptyDiff()
+    {
+        var a = new AnimationChainSave { Name = "A" };
+        var b = new AnimationChainSave { Name = "B" };
+
+        var (toAdd, toRemove) = GroupPlaybackSync.ComputeDiff(
+            existingKeys: new[] { a, b },
+            desiredChains: new List<AnimationChainSave> { a, b });
+
+        Assert.Empty(toAdd);
+        Assert.Empty(toRemove);
+    }
+}


### PR DESCRIPTION
## Summary
- When 2+ `AnimationChain`s are multi-selected in the tree, the Preview panel now plays every selected chain simultaneously, each on its own independent `PlaybackController`, composited in the same canvas back-to-front in selection (click) order. Single-chain and frame-only selection are unaffected.
- Each chain still applies its own per-frame `RelativeX`/`RelativeY` offset when composited, and different-length chains loop independently (expected drift, not a bug).
- The Timeline panel now shows one track row per selected chain (each with its own frame cells + playhead) instead of the single-row strip, reusing the same per-frame-cell visual as today.
- Clicking anywhere on a track scrubs only that chain's own controller to the clicked frame/fraction, but pauses **every** track in place. The global Play/Pause/Speed toolbar still starts/resumes/pauses every track together.
- The singular `SelectedChain`/`SelectedFrame` are never touched by any group-preview code path — group-preview state is keyed entirely off `SelectedChains`/`SelectedNodes`, per the issue's explicit scope note.

## Click-order verification
The issue flagged as unverified whether `AnimTree.SelectedItems` actually preserves click order (vs. tree/visual order) for z-order purposes. I wrote a throwaway headless test that added tree nodes to the selection out of visual order and read the order back — confirmed `TreeView.SelectedItems` **does** preserve add/click order (unlike flat `ListBox`/`SelectionModel<T>`, which is index-range-sorted per Avalonia's source). So the existing `SelectedState.SelectedNodes`/`SelectedChains` pipeline already gives correct back-to-front z-order — no new click-order-tracking mechanism was needed. The throwaway test was deleted; `GroupPreviewRenderTests` (real PNG pixel checks, both selection orders) is the permanent regression coverage for this behavior.

## What I built
- `AnimationEditor.Core`: `GroupPlaybackSync` (pure diff for which chains need a new/removed `PlaybackController`), `ChainTimelineTrackVm` (one multi-track timeline row).
- `PreviewControl`: per-chain `PlaybackController` dictionary synced only on `SelectedChains` membership change; `IsGroupPreviewActive`/`GroupTracks`/`ScrubGroupTrack` public API; `GroupTracksChanged` (structural) / `GroupPlaybackTicked` (per-tick) events; render pipeline refactored to a shared `BuildRenderSnapshot` with a new `PreviewLayer[]` group-compositing path in `RenderSkCore`; transport methods (`Play`/`Pause`/`ResumePlayback`/`PausePlayback`/`TogglePlayPause`/`SpeedMultiplier`) extended to affect every group track together, skipping singular-selection side effects while in group mode.
- `MainWindow`: new `GroupTimelineScrubHost`/`GroupTimelineTracks` XAML (parallel to the existing `TimelineScrubSurface`/`TimelineStrip`, toggled by visibility) with per-track pointer-scrub wiring; the containing row's height is grown from the single-track fixed 52px to 160px while a group is active, since the original fixed height clipped a real multi-track UI test in headless testing (see below) — otherwise 2+ track rows would be squeezed into a near-invisible scrollable sliver.

## Testing
- New tests: `GroupPlaybackSyncTests` (Core, pure diff), `GroupPreviewPlaybackTests` (independent-controller creation, click-order z-order, independent drift, scrub-pauses-all, global-resume-overrides-track-pause), `GroupPreviewRenderTests` (real PNG pixel checks proving z-order compositing both directions), `GroupTimelineUiTests` (multi-track rows appear/disappear with selection, real simulated pointer click on a track's frame cell scrubs only that chain and pauses all — this test caught the timeline-row clipping bug above).
- Full suites green: `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` (1475/1475) and `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` (572/572).
- `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — clean, no new warnings (the 2 warnings present are pre-existing, unrelated `Line.cs` XML-doc issues already tracked in `design/TODOS.md`).

## Rough edges / follow-ups (not in scope for this issue)
- `PreviewControl.ComputeContentExtentScreenPx()` (pan-clamp / scrollbar range) still only considers the singular `SelectedChain`, not the active group — panning/zooming while a group is active is bounded by whatever the last single-selected chain's extent was, not the composited group's bounds.
- `RefreshGroupTimelineTracks()` does a full rebuild (all thumbnails regenerated) on every group-membership change, without the signature-based skip-rebuild optimization the single-track strip has (#452). Fine for typical small group sizes; worth revisiting if group sizes grow large.

Closes #576