### PR TITLE
Enlarge tree expand/collapse chevron hit-test area

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -468,11 +468,17 @@
                         <Style Selector="TreeViewItem:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
                             <Setter Property="Width" Value="10" />
                         </Style>
+                        <!-- Issue #586: the 10px indent column above (kept narrow so tree content isn't
+                             pushed right) makes a poor click target on its own. A negative margin lets
+                             the ToggleButton overflow that column — enlarging the hit-test area — while
+                             the container's own width, and the 12×12 chevron icon centered inside, stay
+                             visually unchanged. -->
                         <Style Selector="TreeViewItem /template/ ToggleButton#PART_ExpandCollapseChevron">
                             <Setter Property="VerticalAlignment" Value="Stretch" />
                             <Setter Property="HorizontalAlignment" Value="Stretch" />
                             <Setter Property="Width" Value="NaN" />
                             <Setter Property="Height" Value="NaN" />
+                            <Setter Property="Margin" Value="-6,-3,-6,-3" />
                             <Setter Property="Template">
                                 <ControlTemplate>
                                     <Border Background="Transparent">

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -880,6 +880,46 @@ public class HeadlessTreeViewTests
         finally { window.Close(); }
     }
 
+    /// <summary>
+    /// Issue #586: the expand/collapse indent column (PART_ExpandCollapseChevronContainer) was
+    /// narrowed to 10px to tighten row indentation, which also shrank the chevron ToggleButton's
+    /// click target to that same 10px width — too small to hit reliably. The fix must enlarge the
+    /// ToggleButton's hit-test area via a negative margin (so it overflows its 10px container)
+    /// without changing the container's own (visible) width.
+    /// </summary>
+    [AvaloniaFact]
+    public void ExpandCollapseChevron_HitTestAreaLargerThanVisibleColumn()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree = GetTree(window);
+            var chainNode = GetRoots(tree)[0];
+            var chainTvi = tree.GetVisualDescendants().OfType<TreeViewItem>()
+                .First(tvi => ReferenceEquals(tvi.DataContext, chainNode));
+
+            var chevronContainer = chainTvi.GetVisualDescendants().OfType<Panel>()
+                .First(p => p.Name == "PART_ExpandCollapseChevronContainer");
+            var chevronButton = chainTvi.GetVisualDescendants().OfType<ToggleButton>()
+                .First(t => t.Name == "PART_ExpandCollapseChevron");
+
+            // Visible indent column stays exactly as authored...
+            Assert.Equal(10, chevronContainer.Bounds.Width);
+            // ...but the actual click target must extend well beyond it.
+            Assert.True(chevronButton.Bounds.Width > chevronContainer.Bounds.Width + 8,
+                $"Chevron click target width was {chevronButton.Bounds.Width}, expected it to overflow " +
+                $"the {chevronContainer.Bounds.Width}px visible column by more than 8px.");
+        }
+        finally { window.Close(); }
+    }
+
     [AvaloniaFact]
     public void ZebraBands_ConsecutiveRows_HaveNoVerticalSeam()
     {


### PR DESCRIPTION
## Summary
- The expand/collapse chevron's visible indent column was narrowed to 10px in #551 to tighten row layout, which also shrank the ToggleButton's click target to that same 10px width — requiring pixel-precise aim to expand/collapse a chain.
- Give the chevron `ToggleButton` a negative margin (`-6,-3,-6,-3`) so its hit-test bounds overflow the 10px column, while the container's visible width and the 12x12 chevron icon stay exactly as authored.

Closes #586

## Test plan
- [x] Added `ExpandCollapseChevron_HitTestAreaLargerThanVisibleColumn` (failing before the fix, passing after) verifying the container stays 10px wide while the ToggleButton's actual bounds exceed it by more than 8px.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 576 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1476 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)