### PR TITLE
Animation Editor: guide-line color override + Canvas Colors settings section

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/PreviewControl.cs
@@ -144,6 +144,24 @@ public class PreviewControl : Control
             InvalidateVisual();
         }
     }
+
+    private uint? _guideLineOverride;
+
+    /// <summary>
+    /// Optional user-chosen guide-line color as a packed <c>0xAARRGGBB</c> value; <c>null</c>
+    /// follows the theme. Setting it re-resolves the palette and repaints.
+    /// </summary>
+    public uint? GuideLineOverride
+    {
+        get => _guideLineOverride;
+        set
+        {
+            if (_guideLineOverride == value) return;
+            _guideLineOverride = value;
+            UpdatePalette();
+            InvalidateVisual();
+        }
+    }
     private readonly List<float> _hGuides = new(); // world-Y values (positive = down on screen)
     private readonly List<float> _vGuides = new(); // world-X values (positive = right on screen)
     private int  _draggedGuideIdx = -1;
@@ -1108,7 +1126,7 @@ public class PreviewControl : Control
     // ActualThemeVariant resolves Default to the concrete platform variant, so a simple
     // "is it Light?" check correctly handles the follow-system case.
     private void UpdatePalette() =>
-        _palette = CanvasPalette.Resolve(ActualThemeVariant != ThemeVariant.Light, _canvasBackgroundOverride);
+        _palette = CanvasPalette.Resolve(ActualThemeVariant != ThemeVariant.Light, _canvasBackgroundOverride, _guideLineOverride);
 
     // -- Guide helpers ---------------------------------------------------------
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -122,14 +122,6 @@
                             <MenuItem Header="_Dark"          x:Name="MenuThemeDark"   ToggleType="Radio" />
                             <MenuItem Header="Follow _System" x:Name="MenuThemeSystem" ToggleType="Radio" />
                         </MenuItem>
-                        <MenuItem Header="Canvas _Background">
-                            <MenuItem Header="Theme _Default" x:Name="MenuBgThemeDefault" ToggleType="Radio" GroupName="CanvasBg" />
-                            <MenuItem Header="_Black"         x:Name="MenuBgBlack"        ToggleType="Radio" GroupName="CanvasBg" />
-                            <MenuItem Header="_White"         x:Name="MenuBgWhite"        ToggleType="Radio" GroupName="CanvasBg" />
-                            <MenuItem Header="Mid _Gray"      x:Name="MenuBgMidGray"      ToggleType="Radio" GroupName="CanvasBg" />
-                            <Separator />
-                            <MenuItem Header="_Custom…"       x:Name="MenuBgCustom"       ToggleType="Radio" GroupName="CanvasBg" />
-                        </MenuItem>
                     </MenuItem>
                     <MenuItem Header="_Help">
                         <MenuItem Header="Show _Render Diagnostics" x:Name="MenuShowDiagnostics"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -187,7 +187,7 @@ public partial class MainWindow : Window
         WireAppCommands();
         LoadSettingsFile();
         ApplyPersistedTheme();
-        ApplyPersistedCanvasBackground();
+        ApplyPersistedCanvasColors();
         WireMenuEvents();
         WireWireframeToolbar();
         WireWireframeControl();
@@ -1426,12 +1426,6 @@ public partial class MainWindow : Window
         MenuThemeLight.Click  += (_, _) => SetTheme(AppTheme.Light);
         MenuThemeDark.Click   += (_, _) => SetTheme(AppTheme.Dark);
         MenuThemeSystem.Click += (_, _) => SetTheme(AppTheme.System);
-
-        MenuBgThemeDefault.Click += (_, _) => SetCanvasBackground(null);
-        MenuBgBlack.Click        += (_, _) => SetCanvasBackground(CanvasBgBlack);
-        MenuBgWhite.Click        += (_, _) => SetCanvasBackground(CanvasBgWhite);
-        MenuBgMidGray.Click      += (_, _) => SetCanvasBackground(CanvasBgMidGray);
-        MenuBgCustom.Click       += async (_, _) => await PickCustomCanvasBackgroundAsync();
         // C#-built surfaces (tab strip, history rows) hold static brush snapshots, so
         // rebuild them when the variant changes. XAML surfaces follow via DynamicResource.
         ActualThemeVariantChanged += (_, _) => { RebuildTabStrip(); RefreshHistoryPanel(); };
@@ -1549,12 +1543,17 @@ public partial class MainWindow : Window
 
     private void OnSettingsClick(object? sender, RoutedEventArgs e)
     {
+        var themedPalette = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light);
         var dialog = Settings.SettingsWindowBuilder.Build(
             new Settings.SettingsWindowModel
             {
                 FileAssociationSupported = _fileAssociation.IsSupported,
                 FileAssociationStatus = _fileAssociation.GetStatus(),
                 SuppressDefaultHandlerPrompt = _appSettings.SuppressDefaultHandlerPrompt,
+                CanvasBackgroundArgb = _appSettings.CanvasBackgroundArgb,
+                ThemeDefaultBackgroundArgb = ToArgb(themedPalette.Background),
+                GuideLineArgb = _appSettings.GuideLineArgb,
+                ThemeDefaultGuideLineArgb = ToArgb(themedPalette.GuideLine),
             },
             new Settings.SettingsWindowCallbacks
             {
@@ -1565,6 +1564,10 @@ public partial class MainWindow : Window
                     SaveSettingsFile();
                     ShowDefaultHandlerBannerIfAppropriate();
                 },
+                OnCanvasBackgroundChanged = SetCanvasBackground,
+                OnPickCustomCanvasBackground = PickCustomCanvasBackgroundAsync,
+                OnGuideLineChanged = SetGuideLineColor,
+                OnPickCustomGuideLine = PickCustomGuideLineColorAsync,
             });
         _ = dialog.ShowDialog(this);
     }
@@ -4340,18 +4343,15 @@ public partial class MainWindow : Window
         MenuThemeSystem.IsChecked = _appSettings.Theme == AppTheme.System;
     }
 
-    // ── Canvas background ──────────────────────────────────────────────────────
-    // Preset backgrounds for the View → Canvas Background menu (packed 0xAARRGGBB, opaque).
-    private const uint CanvasBgBlack   = 0xFF000000;
-    private const uint CanvasBgWhite   = 0xFFFFFFFF;
-    private const uint CanvasBgMidGray = 0xFF808080;
+    // ── Canvas colors (background + guide line) ────────────────────────────────
+    // Both live in the Settings → Canvas Colors section; see SettingsWindowBuilder.
 
-    /// <summary>Pushes the persisted canvas-background override onto both canvases and syncs the menu.</summary>
-    private void ApplyPersistedCanvasBackground()
+    /// <summary>Pushes the persisted canvas-color overrides onto the canvases affected by each.</summary>
+    private void ApplyPersistedCanvasColors()
     {
         WireframeCtrl.CanvasBackgroundOverride = _appSettings.CanvasBackgroundArgb;
         PreviewCtrl.CanvasBackgroundOverride   = _appSettings.CanvasBackgroundArgb;
-        SyncCanvasBackgroundMenuChecks();
+        PreviewCtrl.GuideLineOverride          = _appSettings.GuideLineArgb;
     }
 
     private void SetCanvasBackground(uint? argb)
@@ -4359,33 +4359,25 @@ public partial class MainWindow : Window
         _appSettings.CanvasBackgroundArgb = argb;
         WireframeCtrl.CanvasBackgroundOverride = argb;
         PreviewCtrl.CanvasBackgroundOverride   = argb;
-        SyncCanvasBackgroundMenuChecks();
         SaveSettingsFile();
     }
 
-    private void SyncCanvasBackgroundMenuChecks()
+    private void SetGuideLineColor(uint? argb)
     {
-        var argb = _appSettings.CanvasBackgroundArgb;
-        MenuBgThemeDefault.IsChecked = argb is null;
-        MenuBgBlack.IsChecked        = argb == CanvasBgBlack;
-        MenuBgWhite.IsChecked        = argb == CanvasBgWhite;
-        MenuBgMidGray.IsChecked      = argb == CanvasBgMidGray;
-        // "Custom" covers any opaque color that isn't one of the named presets.
-        MenuBgCustom.IsChecked =
-            argb is uint v && v != CanvasBgBlack && v != CanvasBgWhite && v != CanvasBgMidGray;
+        _appSettings.GuideLineArgb = argb;
+        PreviewCtrl.GuideLineOverride = argb;
+        SaveSettingsFile();
     }
 
-    /// <summary>
-    /// Opens a color picker seeded with the current background, and on OK stores the chosen
-    /// color (forced opaque) as the custom canvas background.
-    /// </summary>
-    private async Task PickCustomCanvasBackgroundAsync()
-    {
-        var themed = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light).Background;
-        var seed = _appSettings.CanvasBackgroundArgb is uint v
-            ? Color.FromUInt32(v)
-            : Color.FromArgb(themed.Alpha, themed.Red, themed.Green, themed.Blue);
+    private static uint ToArgb(SKColor color) =>
+        (uint)((color.Alpha << 24) | (color.Red << 16) | (color.Green << 8) | color.Blue);
 
+    /// <summary>
+    /// Opens a color picker seeded with <paramref name="seed"/> and returns the chosen color
+    /// (forced opaque) as a packed <c>0xAARRGGBB</c> value, or <c>null</c> if cancelled.
+    /// </summary>
+    private async Task<uint?> PickCustomColorAsync(string title, Color seed)
+    {
         var colorView = new ColorView { Color = seed };
 
         var okBtn     = new Button { Content = "OK",     MinWidth = 80 };
@@ -4406,7 +4398,7 @@ public partial class MainWindow : Window
 
         var dialog = new Window
         {
-            Title = "Canvas Background",
+            Title = title,
             SizeToContent = SizeToContent.WidthAndHeight,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = false,
@@ -4415,17 +4407,29 @@ public partial class MainWindow : Window
         okBtn.Click     += (_, _) => dialog.Close(true);
         cancelBtn.Click += (_, _) => dialog.Close(false);
 
-        if (await dialog.ShowDialog<bool>(this))
-        {
-            // Force opaque — a translucent canvas fill would composite unpredictably.
-            uint argb = 0xFF000000u | (colorView.Color.ToUInt32() & 0x00FFFFFFu);
-            SetCanvasBackground(argb);
-        }
-        else
-        {
-            // Re-sync so the "Custom…" radio doesn't stay selected after a cancel.
-            SyncCanvasBackgroundMenuChecks();
-        }
+        if (!await dialog.ShowDialog<bool>(this))
+            return null;
+
+        // Force opaque — a translucent canvas fill/guide would composite unpredictably.
+        return 0xFF000000u | (colorView.Color.ToUInt32() & 0x00FFFFFFu);
+    }
+
+    private Task<uint?> PickCustomCanvasBackgroundAsync()
+    {
+        var themed = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light).Background;
+        var seed = _appSettings.CanvasBackgroundArgb is uint v
+            ? Color.FromUInt32(v)
+            : Color.FromArgb(themed.Alpha, themed.Red, themed.Green, themed.Blue);
+        return PickCustomColorAsync("Canvas Background", seed);
+    }
+
+    private Task<uint?> PickCustomGuideLineColorAsync()
+    {
+        var themed = CanvasPalette.For(ActualThemeVariant != ThemeVariant.Light).GuideLine;
+        var seed = _appSettings.GuideLineArgb is uint v
+            ? Color.FromUInt32(v)
+            : Color.FromArgb(255, themed.Red, themed.Green, themed.Blue);
+        return PickCustomColorAsync("Guide Line Color", seed);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AnimationEditor.Core.IO;
 using Avalonia;
 using Avalonia.Controls;
@@ -15,6 +16,18 @@ public sealed class SettingsWindowModel
     public AchxFileAssociationStatus FileAssociationStatus { get; init; }
 
     public bool SuppressDefaultHandlerPrompt { get; init; }
+
+    /// <summary>Current canvas-background override (packed <c>0xAARRGGBB</c>), or <c>null</c> for the theme default.</summary>
+    public uint? CanvasBackgroundArgb { get; init; }
+
+    /// <summary>The active theme's default canvas background (packed <c>0xAARRGGBB</c>), shown when no override is set.</summary>
+    public uint ThemeDefaultBackgroundArgb { get; init; }
+
+    /// <summary>Current guide-line color override (packed <c>0xAARRGGBB</c>), or <c>null</c> for the theme default.</summary>
+    public uint? GuideLineArgb { get; init; }
+
+    /// <summary>The active theme's default guide-line color (packed <c>0xAARRGGBB</c>), shown when no override is set.</summary>
+    public uint ThemeDefaultGuideLineArgb { get; init; }
 }
 
 /// <summary>Callbacks from the settings dialog back to <see cref="MainWindow"/>.</summary>
@@ -23,6 +36,18 @@ public sealed class SettingsWindowCallbacks
     public Action? OnSetDefaultAchx { get; init; }
 
     public Action<bool>? OnSuppressDefaultHandlerPromptChanged { get; init; }
+
+    /// <summary>Invoked with the new packed <c>0xAARRGGBB</c> value (<c>null</c> = theme default) when the canvas background changes.</summary>
+    public Action<uint?>? OnCanvasBackgroundChanged { get; init; }
+
+    /// <summary>Opens a custom-color picker seeded with the current background; returns the chosen packed ARGB, or <c>null</c> if cancelled.</summary>
+    public Func<Task<uint?>>? OnPickCustomCanvasBackground { get; init; }
+
+    /// <summary>Invoked with the new packed <c>0xAARRGGBB</c> value (<c>null</c> = theme default) when the guide-line color changes.</summary>
+    public Action<uint?>? OnGuideLineChanged { get; init; }
+
+    /// <summary>Opens a custom-color picker seeded with the current guide-line color; returns the chosen packed ARGB, or <c>null</c> if cancelled.</summary>
+    public Func<Task<uint?>>? OnPickCustomGuideLine { get; init; }
 }
 
 /// <summary>Builds the editor settings window. New sections belong here as the dialog grows.</summary>
@@ -52,7 +77,7 @@ public static class SettingsWindowBuilder
             Width = 480,
             MinWidth = 400,
             MinHeight = 200,
-            Height = 320,
+            Height = 420,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = true,
             Content = root,
@@ -66,19 +91,111 @@ public static class SettingsWindowBuilder
     {
         var sections = new StackPanel { Spacing = 20 };
 
+        sections.Children.Add(BuildCanvasColorsSection(model, callbacks));
+
         if (model.FileAssociationSupported)
             sections.Children.Add(BuildFileAssociationSection(model, callbacks));
 
-        if (sections.Children.Count == 0)
+        return sections;
+    }
+
+    // Named background presets (packed 0xAARRGGBB, opaque). Guide-line color has no named
+    // presets — arbitrary named colors don't help there the way Black/White/Mid Gray do for a
+    // canvas fill — so it only offers Theme Default and Custom.
+    private static readonly (string Name, uint Argb)[] _backgroundPresets =
+    {
+        ("Black", 0xFF000000),
+        ("White", 0xFFFFFFFF),
+        ("Mid Gray", 0xFF808080),
+    };
+
+    private static Control BuildCanvasColorsSection(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
+    {
+        return new StackPanel
         {
-            sections.Children.Add(new TextBlock
+            Spacing = 10,
+            Children =
             {
-                TextWrapping = TextWrapping.Wrap,
-                Text = "No settings are available on this platform yet.",
-            });
+                new TextBlock
+                {
+                    Text = "Canvas colors",
+                    FontWeight = FontWeight.SemiBold,
+                    FontSize = 14,
+                },
+                BuildColorRow(
+                    "Background",
+                    model.CanvasBackgroundArgb,
+                    model.ThemeDefaultBackgroundArgb,
+                    _backgroundPresets,
+                    callbacks.OnCanvasBackgroundChanged,
+                    callbacks.OnPickCustomCanvasBackground),
+                BuildColorRow(
+                    "Guide line",
+                    model.GuideLineArgb,
+                    model.ThemeDefaultGuideLineArgb,
+                    Array.Empty<(string, uint)>(),
+                    callbacks.OnGuideLineChanged,
+                    callbacks.OnPickCustomGuideLine),
+            },
+        };
+    }
+
+    /// <summary>
+    /// One labeled color row: a swatch reflecting the current color, a "Theme Default" button,
+    /// a button per named preset, and a "Custom…" button that defers to <paramref name="onPickCustom"/>.
+    /// Buttons (not checkable toggles) so re-picking "Custom…" always re-opens the picker even
+    /// when it's already the active color — there is no "checked" state to keep in sync.
+    /// </summary>
+    private static Control BuildColorRow(
+        string label,
+        uint? currentArgb,
+        uint themeDefaultArgb,
+        (string Name, uint Argb)[] presets,
+        Action<uint?>? onChanged,
+        Func<Task<uint?>>? onPickCustom)
+    {
+        var swatch = new Border
+        {
+            Width = 20,
+            Height = 20,
+            CornerRadius = new CornerRadius(3),
+            BorderBrush = Brushes.Gray,
+            BorderThickness = new Thickness(1),
+            Background = new SolidColorBrush(Color.FromUInt32(currentArgb ?? themeDefaultArgb)),
+        };
+
+        void SetColor(uint? argb)
+        {
+            swatch.Background = new SolidColorBrush(Color.FromUInt32(argb ?? themeDefaultArgb));
+            onChanged?.Invoke(argb);
         }
 
-        return sections;
+        var buttons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, Children = { swatch } };
+
+        var themeBtn = new Button { Content = "Theme Default" };
+        themeBtn.Click += (_, _) => SetColor(null);
+        buttons.Children.Add(themeBtn);
+
+        foreach (var (name, argb) in presets)
+        {
+            var presetBtn = new Button { Content = name };
+            presetBtn.Click += (_, _) => SetColor(argb);
+            buttons.Children.Add(presetBtn);
+        }
+
+        var customBtn = new Button { Content = "Custom…" };
+        customBtn.Click += async (_, _) =>
+        {
+            if (onPickCustom is null) return;
+            if (await onPickCustom() is uint picked) SetColor(picked);
+        };
+        buttons.Children.Add(customBtn);
+
+        return new StackPanel
+        {
+            Spacing = 4,
+            Children = { new TextBlock { Text = label }, buttons },
+        };
     }
 
     private static Control BuildFileAssociationSection(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using AnimationEditor.Core.IO;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.Media;
 
@@ -65,11 +66,7 @@ public static class SettingsWindowBuilder
         var root = new DockPanel { Margin = new Thickness(20) };
         DockPanel.SetDock(closeBtn, Dock.Bottom);
         root.Children.Add(closeBtn);
-        root.Children.Add(new ScrollViewer
-        {
-            Content = BuildSections(model, callbacks),
-            VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
-        });
+        root.Children.Add(BuildTabs(model, callbacks));
 
         var window = new Window
         {
@@ -86,18 +83,40 @@ public static class SettingsWindowBuilder
         return window;
     }
 
-    /// <summary>Section stack for the settings dialog. Extracted so layout can be unit-tested without a <see cref="Window"/>.</summary>
-    internal static StackPanel BuildSections(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
+    /// <summary>
+    /// Tab strip for the settings dialog. Extracted so layout can be unit-tested without a
+    /// <see cref="Window"/>. Each category (colors, file association, ...) is its own tab rather
+    /// than a flat scrolling list of sections, so the dialog can keep growing (grid, rulers, etc.)
+    /// without becoming an ever-taller scroll.
+    /// </summary>
+    internal static TabControl BuildTabs(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
     {
-        var sections = new StackPanel { Spacing = 20 };
-
-        sections.Children.Add(BuildCanvasColorsSection(model, callbacks));
+        var tabs = new TabControl
+        {
+            Items =
+            {
+                new TabItem { Header = "Colors", Content = InTab(BuildCanvasColorsSection(model, callbacks)) },
+            },
+        };
 
         if (model.FileAssociationSupported)
-            sections.Children.Add(BuildFileAssociationSection(model, callbacks));
+        {
+            tabs.Items.Add(new TabItem
+            {
+                Header = "File Association",
+                Content = InTab(BuildFileAssociationSection(model, callbacks)),
+            });
+        }
 
-        return sections;
+        return tabs;
     }
+
+    private static ScrollViewer InTab(Control content) => new()
+    {
+        Content = content,
+        Padding = new Thickness(0, 12, 0, 0),
+        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+    };
 
     // Named background presets (packed 0xAARRGGBB, opaque). Guide-line color has no named
     // presets — arbitrary named colors don't help there the way Black/White/Mid Gray do for a
@@ -113,15 +132,9 @@ public static class SettingsWindowBuilder
     {
         return new StackPanel
         {
-            Spacing = 10,
+            Spacing = 14,
             Children =
             {
-                new TextBlock
-                {
-                    Text = "Canvas colors",
-                    FontWeight = FontWeight.SemiBold,
-                    FontSize = 14,
-                },
                 BuildColorRow(
                     "Background",
                     model.CanvasBackgroundArgb,
@@ -229,18 +242,7 @@ public static class SettingsWindowBuilder
         return new StackPanel
         {
             Spacing = 10,
-            Children =
-            {
-                new TextBlock
-                {
-                    Text = "File association",
-                    FontWeight = FontWeight.SemiBold,
-                    FontSize = 14,
-                },
-                statusText,
-                setDefaultBtn,
-                suppressCheck,
-            },
+            Children = { statusText, setDefaultBtn, suppressCheck },
         };
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Theming/CanvasPalette.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Theming/CanvasPalette.cs
@@ -59,14 +59,20 @@ internal readonly record struct CanvasPalette(
     /// </summary>
     public CanvasPalette WithBackground(SKColor background) => this with { Background = background };
 
+    /// <summary>Returns a copy with <see cref="GuideLine"/> replaced by <paramref name="guideLine"/>.</summary>
+    public CanvasPalette WithGuideLine(SKColor guideLine) => this with { GuideLine = guideLine };
+
     /// <summary>
-    /// Resolves the palette for a theme variant, applying an optional user background override
-    /// (packed <c>0xAARRGGBB</c>). <c>null</c> keeps the theme background; a value replaces only
-    /// the background via <see cref="WithBackground"/>, leaving chrome theme-driven.
+    /// Resolves the palette for a theme variant, applying optional user overrides (packed
+    /// <c>0xAARRGGBB</c>) for the canvas background and guide-line color. <c>null</c> keeps that
+    /// color theme-driven; a value replaces only that color, leaving the rest of the palette
+    /// theme-driven.
     /// </summary>
-    public static CanvasPalette Resolve(bool isDark, uint? overrideArgb)
+    public static CanvasPalette Resolve(bool isDark, uint? backgroundOverrideArgb, uint? guideLineOverrideArgb = null)
     {
         var palette = For(isDark);
-        return overrideArgb is uint argb ? palette.WithBackground(new SKColor(argb)) : palette;
+        if (backgroundOverrideArgb is uint bg) palette = palette.WithBackground(new SKColor(bg));
+        if (guideLineOverrideArgb is uint gl) palette = palette.WithGuideLine(new SKColor(gl));
+        return palette;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -34,6 +34,13 @@ namespace AnimationEditor.Core.Models
         public uint? CanvasBackgroundArgb { get; set; }
 
         /// <summary>
+        /// Optional override for the guide-line color drawn in the preview panel, as a packed
+        /// <c>0xAARRGGBB</c> value. <c>null</c> follows the theme default. Like
+        /// <see cref="CanvasBackgroundArgb"/>, this is a per-user viewing preference only.
+        /// </summary>
+        public uint? GuideLineArgb { get; set; }
+
+        /// <summary>
         /// When <c>true</c>, the editor never offers to register itself as the default
         /// application for <c>.achx</c> files. Set when the user clicks "Don't show again"
         /// on the file-association prompt. Defaults to <c>false</c> so the prompt can appear

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CanvasPaletteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CanvasPaletteTests.cs
@@ -45,22 +45,56 @@ public class CanvasPaletteTests
     {
         var expected = CanvasPalette.For(isDark: true).Background;
 
-        Assert.Equal(expected, CanvasPalette.Resolve(isDark: true, overrideArgb: null).Background);
+        Assert.Equal(expected, CanvasPalette.Resolve(isDark: true, backgroundOverrideArgb: null).Background);
     }
 
     [Fact]
-    public void Resolve_WithOverride_UsesOverrideBackgroundAndKeepsChrome()
+    public void Resolve_WithBackgroundOverride_UsesOverrideBackgroundAndKeepsChrome()
     {
         // Opaque steel blue as a packed 0xAARRGGBB value.
         uint argb = 0xFF4080C0;
         var themed = CanvasPalette.For(isDark: true);
 
-        var result = CanvasPalette.Resolve(isDark: true, overrideArgb: argb);
+        var result = CanvasPalette.Resolve(isDark: true, backgroundOverrideArgb: argb);
 
         Assert.Equal(new SKColor(argb), result.Background);
         // Chrome stays theme-driven — only the background is overridden.
         Assert.Equal(themed.GridLine, result.GridLine);
         Assert.Equal(themed.GuideLine, result.GuideLine);
+    }
+
+    [Fact]
+    public void Resolve_NullGuideLineOverride_UsesThemeGuideLine()
+    {
+        var expected = CanvasPalette.For(isDark: true).GuideLine;
+
+        Assert.Equal(expected, CanvasPalette.Resolve(isDark: true, backgroundOverrideArgb: null, guideLineOverrideArgb: null).GuideLine);
+    }
+
+    [Fact]
+    public void Resolve_WithGuideLineOverride_UsesOverrideGuideLineAndKeepsBackground()
+    {
+        // Opaque magenta as a packed 0xAARRGGBB value.
+        uint argb = 0xFFFF00FF;
+        var themed = CanvasPalette.For(isDark: true);
+
+        var result = CanvasPalette.Resolve(isDark: true, backgroundOverrideArgb: null, guideLineOverrideArgb: argb);
+
+        Assert.Equal(new SKColor(argb), result.GuideLine);
+        // Background stays theme-driven — only the guide line is overridden.
+        Assert.Equal(themed.Background, result.Background);
+    }
+
+    [Fact]
+    public void Resolve_WithBothOverrides_AppliesBothIndependently()
+    {
+        uint bgArgb = 0xFF4080C0;
+        uint guideArgb = 0xFFFF00FF;
+
+        var result = CanvasPalette.Resolve(isDark: true, backgroundOverrideArgb: bgArgb, guideLineOverrideArgb: guideArgb);
+
+        Assert.Equal(new SKColor(bgArgb), result.Background);
+        Assert.Equal(new SKColor(guideArgb), result.GuideLine);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
@@ -9,22 +9,24 @@ namespace AnimationEditor.App.Tests;
 
 public class SettingsWindowBuilderTests
 {
+    private static StackPanel SectionOf(TabItem tab) => (StackPanel)((ScrollViewer)tab.Content!).Content!;
+
     [Fact]
-    public void BuildSections_AlwaysIncludesCanvasColorsHeader()
+    public void BuildTabs_AlwaysIncludesColorsTab()
     {
-        var sections = SettingsWindowBuilder.BuildSections(
+        var tabs = SettingsWindowBuilder.BuildTabs(
             new SettingsWindowModel { FileAssociationSupported = false },
             new SettingsWindowCallbacks());
 
-        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[0]).Children[0]);
+        var colorsTab = Assert.IsType<TabItem>(tabs.Items[0]);
 
-        Assert.Equal("Canvas colors", header.Text);
+        Assert.Equal("Colors", colorsTab.Header);
     }
 
     [Fact]
-    public void BuildSections_WithFileAssociation_IncludesSectionHeader()
+    public void BuildTabs_WithFileAssociation_IncludesFileAssociationTab()
     {
-        var sections = SettingsWindowBuilder.BuildSections(
+        var tabs = SettingsWindowBuilder.BuildTabs(
             new SettingsWindowModel
             {
                 FileAssociationSupported = true,
@@ -33,32 +35,32 @@ public class SettingsWindowBuilderTests
             },
             new SettingsWindowCallbacks());
 
-        // Canvas colors is always first; file association follows when supported.
-        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[1]).Children[0]);
+        // Colors is always first; File Association follows when supported.
+        var fileAssocTab = Assert.IsType<TabItem>(tabs.Items[1]);
 
-        Assert.Equal("File association", header.Text);
+        Assert.Equal("File Association", fileAssocTab.Header);
     }
 
     [Fact]
-    public void BuildSections_WithoutFileAssociation_OmitsFileAssociationSection()
+    public void BuildTabs_WithoutFileAssociation_OnlyHasColorsTab()
     {
-        var sections = SettingsWindowBuilder.BuildSections(
+        var tabs = SettingsWindowBuilder.BuildTabs(
             new SettingsWindowModel { FileAssociationSupported = false },
             new SettingsWindowCallbacks());
 
-        Assert.Single(sections.Children);
+        Assert.Single(tabs.Items);
     }
 
     [AvaloniaFact]
-    public void BuildSections_CanvasBackgroundRow_ThemeDefaultButton_InvokesCallbackWithNull()
+    public void BuildTabs_CanvasBackgroundRow_ThemeDefaultButton_InvokesCallbackWithNull()
     {
         uint? received = 0xFF123456;
-        var sections = SettingsWindowBuilder.BuildSections(
+        var tabs = SettingsWindowBuilder.BuildTabs(
             new SettingsWindowModel { CanvasBackgroundArgb = 0xFF123456, ThemeDefaultBackgroundArgb = 0xFF0E0F12 },
             new SettingsWindowCallbacks { OnCanvasBackgroundChanged = argb => received = argb });
 
-        var canvasColors = (StackPanel)sections.Children[0];
-        var backgroundRow = (StackPanel)canvasColors.Children[1];
+        var colorsSection = SectionOf((TabItem)tabs.Items[0]!);
+        var backgroundRow = (StackPanel)colorsSection.Children[0];
         var buttonsRow = (StackPanel)backgroundRow.Children[1];
         // buttonsRow.Children[0] is the swatch; [1] is "Theme Default".
         var themeDefaultButton = Assert.IsType<Button>(buttonsRow.Children[1]);
@@ -70,14 +72,14 @@ public class SettingsWindowBuilderTests
     }
 
     [Fact]
-    public void BuildSections_GuideLineRow_HasNoNamedPresets()
+    public void BuildTabs_GuideLineRow_HasNoNamedPresets()
     {
-        var sections = SettingsWindowBuilder.BuildSections(
+        var tabs = SettingsWindowBuilder.BuildTabs(
             new SettingsWindowModel(),
             new SettingsWindowCallbacks());
 
-        var canvasColors = (StackPanel)sections.Children[0];
-        var guideLineRow = (StackPanel)canvasColors.Children[2];
+        var colorsSection = SectionOf((TabItem)tabs.Items[0]!);
+        var guideLineRow = (StackPanel)colorsSection.Children[1];
         var buttonsRow = (StackPanel)guideLineRow.Children[1];
 
         // Swatch + "Theme Default" + "Custom…" only — no Black/White/Mid Gray presets.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
@@ -1,12 +1,26 @@
 using AnimationEditor.App.Settings;
 using AnimationEditor.Core.IO;
 using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
 
 public class SettingsWindowBuilderTests
 {
+    [Fact]
+    public void BuildSections_AlwaysIncludesCanvasColorsHeader()
+    {
+        var sections = SettingsWindowBuilder.BuildSections(
+            new SettingsWindowModel { FileAssociationSupported = false },
+            new SettingsWindowCallbacks());
+
+        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[0]).Children[0]);
+
+        Assert.Equal("Canvas colors", header.Text);
+    }
+
     [Fact]
     public void BuildSections_WithFileAssociation_IncludesSectionHeader()
     {
@@ -19,8 +33,54 @@ public class SettingsWindowBuilderTests
             },
             new SettingsWindowCallbacks());
 
-        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[0]).Children[0]);
+        // Canvas colors is always first; file association follows when supported.
+        var header = Assert.IsType<TextBlock>(((StackPanel)sections.Children[1]).Children[0]);
 
         Assert.Equal("File association", header.Text);
+    }
+
+    [Fact]
+    public void BuildSections_WithoutFileAssociation_OmitsFileAssociationSection()
+    {
+        var sections = SettingsWindowBuilder.BuildSections(
+            new SettingsWindowModel { FileAssociationSupported = false },
+            new SettingsWindowCallbacks());
+
+        Assert.Single(sections.Children);
+    }
+
+    [AvaloniaFact]
+    public void BuildSections_CanvasBackgroundRow_ThemeDefaultButton_InvokesCallbackWithNull()
+    {
+        uint? received = 0xFF123456;
+        var sections = SettingsWindowBuilder.BuildSections(
+            new SettingsWindowModel { CanvasBackgroundArgb = 0xFF123456, ThemeDefaultBackgroundArgb = 0xFF0E0F12 },
+            new SettingsWindowCallbacks { OnCanvasBackgroundChanged = argb => received = argb });
+
+        var canvasColors = (StackPanel)sections.Children[0];
+        var backgroundRow = (StackPanel)canvasColors.Children[1];
+        var buttonsRow = (StackPanel)backgroundRow.Children[1];
+        // buttonsRow.Children[0] is the swatch; [1] is "Theme Default".
+        var themeDefaultButton = Assert.IsType<Button>(buttonsRow.Children[1]);
+        Assert.Equal("Theme Default", themeDefaultButton.Content);
+
+        themeDefaultButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Null(received);
+    }
+
+    [Fact]
+    public void BuildSections_GuideLineRow_HasNoNamedPresets()
+    {
+        var sections = SettingsWindowBuilder.BuildSections(
+            new SettingsWindowModel(),
+            new SettingsWindowCallbacks());
+
+        var canvasColors = (StackPanel)sections.Children[0];
+        var guideLineRow = (StackPanel)canvasColors.Children[2];
+        var buttonsRow = (StackPanel)guideLineRow.Children[1];
+
+        // Swatch + "Theme Default" + "Custom…" only — no Black/White/Mid Gray presets.
+        Assert.Equal(3, buttonsRow.Children.Count);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -149,6 +149,26 @@ public class AppSettingsModelTests
     }
 
     [Fact]
+    public void GuideLineArgb_DefaultsToNull()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.Null(model.GuideLineArgb);
+    }
+
+    [Fact]
+    public void GuideLineArgb_SurvivesJsonRoundTrip()
+    {
+        // Packed 0xAARRGGBB — opaque magenta.
+        var model = new AppSettingsModel { GuideLineArgb = 0xFFFF00FF };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.Equal(0xFFFF00FFu, restored!.GuideLineArgb);
+    }
+
+    [Fact]
     public void SuppressDefaultHandlerPrompt_DefaultsToFalse()
     {
         var model = new AppSettingsModel();


### PR DESCRIPTION
## Summary
- Extends `CanvasPalette` with `WithGuideLine`/an updated `Resolve(isDark, backgroundOverrideArgb, guideLineOverrideArgb)` so guide-line color can be overridden independently of background, mirroring the existing background-override support.
- Adds `AppSettingsModel.GuideLineArgb` (packed `0xAARRGGBB`, persisted the same way as `CanvasBackgroundArgb`) and wires it through `PreviewControl.GuideLineOverride` (the only panel that draws guides).
- Removes the ad-hoc `View > Canvas _Background` menu and replaces it with a "Canvas colors" section in the `Settings…` dialog (`SettingsWindowBuilder`), covering both Background and Guide Line color with the same preset/custom-picker UX as before. This addresses the issue's suggestion to promote these into a proper settings section rather than growing the View menu with more color submenus.
- Background keeps its Theme Default / Black / White / Mid Gray / Custom presets; Guide Line only offers Theme Default / Custom, since arbitrary named color presets don't make sense for a guide line the way they do for a canvas fill.

## Why
Guide lines were hardcoded per theme (cyan on dark, deep blue on light) with no override, so a user-chosen background could end up low-contrast against them. This closes that gap and, per the issue's "needs design" note, moves canvas coloring into a dedicated settings view instead of continuing to grow the View menu.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1478 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 583 passed
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — succeeds, no new warnings

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)