### PR TITLE
Fix title bar drag not working over the open-file name text

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -137,7 +137,10 @@
             </DockPanel>
             <!-- Centered title overlay. Static parts use IsHitTestVisible="False" so clicks pass
                  through to the drag region underneath. TitleFileName is interactive (tooltip +
-                 right-click context menu), so it keeps the default IsHitTestVisible=True. -->
+                 right-click context menu), so it keeps the default IsHitTestVisible=True — but it
+                 sits on top of (not inside) the drag region, so it must wire the same drag/maximize
+                 handlers itself or clicks on the file name would swallow the event instead of
+                 moving the window (issue #583). -->
             <StackPanel Orientation="Horizontal" Spacing="6"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center">
@@ -161,7 +164,9 @@
                            FontSize="12"
                            LineHeight="16"
                            Foreground="{DynamicResource InkMid}"
-                           IsVisible="False">
+                           IsVisible="False"
+                           PointerPressed="OnTitleBarPointerPressed"
+                           DoubleTapped="OnTitleBarDoubleTapped">
                     <TextBlock.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Open Containing Folder"

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowChromeTests.cs
@@ -1,6 +1,9 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using System;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -55,6 +58,40 @@ public class MainWindowChromeTests
             Assert.NotNull(window.FindControl<Button>("MinimizeBtn"));
             Assert.NotNull(window.FindControl<Button>("MaximizeBtn"));
             Assert.NotNull(window.FindControl<Button>("CloseBtn"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // ── Regression #583: title bar drag must work over the file name text ─────
+
+    [AvaloniaFact]
+    public void DoubleTapOnTitleFileName_TogglesMaximize()
+    {
+        // TitleFileName sits on top of (not inside) the drag-region Border, so it
+        // must wire the same DoubleTapped handler itself. Before the fix, double-
+        // tapping the file name text did nothing because no handler was attached.
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var titleFileName = window.FindControl<TextBlock>("TitleFileName");
+            Assert.NotNull(titleFileName);
+            Assert.Equal(WindowState.Normal, window.WindowState);
+
+            // Construct TappedEventArgs without calling its constructor (which requires
+            // a live PointerEventArgs) — same approach used elsewhere in this test suite
+            // for synthesizing gesture events. The handler only cares about the event
+            // having reached it, not its payload.
+            var fakeArgs = (TappedEventArgs)RuntimeHelpers.GetUninitializedObject(typeof(TappedEventArgs));
+            fakeArgs.RoutedEvent = InputElement.DoubleTappedEvent;
+            fakeArgs.Source = titleFileName;
+            titleFileName!.RaiseEvent(fakeArgs);
+
+            Assert.Equal(WindowState.Maximized, window.WindowState);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- `TitleFileName` (the open-file name shown in the title bar) is a separate overlay `TextBlock` layered on top of the drag-region `Border`, not a visual descendant of it — so `PointerPressed`/`DoubleTapped` on the file name never bubbled to `OnTitleBarPointerPressed`/`OnTitleBarDoubleTapped`, and dragging/double-click-to-maximize silently did nothing there.
- Wired the same two handlers directly onto `TitleFileName`, matching the drag-region `Border`. Right-click context menu and tooltip on the file name are unaffected (left-button-only check in `OnTitleBarPointerPressed`).

## Test plan
- Added `DoubleTapOnTitleFileName_TogglesMaximize` in `MainWindowChromeTests.cs`, which double-taps the `TitleFileName` control and asserts `WindowState` toggles to `Maximized`. Verified it fails without the fix and passes with it.
- The `PointerPressed` → `BeginMoveDrag` path itself is not covered by an automated test: `Window.BeginMoveDrag` drives native OS window-move machinery that Avalonia's headless test platform does not implement, so there's nothing observable to assert (the call doesn't throw, but no window actually moves in headless mode). The double-tap test above exercises the same regression class — an interaction handler missing from `TitleFileName` — via the one code path that *is* observable (`WindowState`).
- [ ] Open the Animation Editor, click-drag anywhere over the title bar including over the open file's name — window should move
- [ ] Double-click over the file name — window should maximize/restore
- [ ] Right-click the file name — context menu (Open Containing Folder / Copy Full Path) still appears
- [ ] Hover the file name — tooltip with the full path still appears

Closes #583