### PR TITLE
Animation Editor: auto-pan camera when dragging past the viewport edge

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/WireframeControl.cs
@@ -319,6 +319,18 @@ public class WireframeControl : Control
     private float _zoomPivotVpY;
     private const float ZoomAnimIntervalSeconds = 1f / 60f;
 
+    // ── Drag auto-pan (#540) ───────────────────────────────────────────────────
+    // While a handle/chain drag is active, the timer nudges the camera each tick via
+    // StepAutoPan whenever the last-known pointer position sits within AutoPanMarginPx of the
+    // viewport edge, then re-applies the drag at that same screen position — ScreenToTexture
+    // depends on _panX/_panY, so re-running Apply*Drag after the pan shifts yields a new
+    // texture-space delta and the dragged frame keeps tracking the cursor.
+    private DispatcherTimer? _autoPanTimer;
+    private Point _lastPointerPos;
+    private const float AutoPanMarginPx = 32f;
+    private const float AutoPanMaxSpeedPxPerSec = 900f;
+    private const float AutoPanIntervalSeconds = 1f / 60f;
+
     private bool _showGrid;
     private int _gridSize = 16;
 
@@ -751,6 +763,52 @@ public class WireframeControl : Control
         RaiseViewChanged();
     }
 
+    private void StartAutoPanTimer()
+    {
+        _autoPanTimer ??= CreateAutoPanTimer();
+        _autoPanTimer.Start();
+    }
+
+    private void StopAutoPanTimer() => _autoPanTimer?.Stop();
+
+    private DispatcherTimer CreateAutoPanTimer()
+    {
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(AutoPanIntervalSeconds) };
+        timer.Tick += (_, _) => StepAutoPan(AutoPanIntervalSeconds);
+        return timer;
+    }
+
+    /// <summary>
+    /// Nudges the camera toward <see cref="_lastPointerPos"/> when it sits within
+    /// <see cref="AutoPanMarginPx"/> of the viewport edge during an active handle or chain drag
+    /// (<see cref="CanvasTransform.AutoPanVelocity"/>), then re-applies the drag at that same
+    /// screen position so the dragged frame keeps tracking the cursor. Live-driven by
+    /// <see cref="_autoPanTimer"/>; tests call this directly for determinism (see
+    /// <see cref="StepZoomAnimation"/> for the same pattern). No-op with no active drag, no
+    /// bitmap, or before layout has produced a real viewport.
+    /// </summary>
+    public void StepAutoPan(float dtSeconds)
+    {
+        if (_bitmap is null || Bounds.Width <= 1) return;
+        if (_draggingRect is null && !_draggingChain) return;
+
+        var (vx, vy) = CanvasTransform.AutoPanVelocity(
+            (float)_lastPointerPos.X, (float)_lastPointerPos.Y,
+            (float)Bounds.Width, (float)Bounds.Height,
+            AutoPanMarginPx, AutoPanMaxSpeedPxPerSec);
+        if (vx == 0f && vy == 0f) return;
+
+        _panX += vx * dtSeconds;
+        _panY += vy * dtSeconds;
+        ClampCamera();
+
+        if (_draggingRect != null) ApplyHandleDrag(_lastPointerPos);
+        else ApplyChainDrag(_lastPointerPos);
+
+        InvalidateVisual();
+        RaiseViewChanged();
+    }
+
     // ── Public API ────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -1097,6 +1155,78 @@ public class WireframeControl : Control
 
         ChainRegionChanged?.Invoke(chain);
         _draggingChain = false;
+        _chainDragStarts.Clear();
+    }
+
+    /// <summary>
+    /// Test-only: begins a handle-drag gesture without applying an end position, mirroring the
+    /// handle-hit branch of <see cref="OnPointerPressed"/>. Pairs with
+    /// <see cref="SimulateDragPointerMove"/> and <see cref="StepAutoPan"/> to observe auto-pan
+    /// (#540) mid-drag; use <see cref="SimulateHandleDrag"/> instead for a one-shot gesture that
+    /// doesn't need intermediate ticks. No-op when no frame is selected or no texture is loaded.
+    /// </summary>
+    public void SimulateHandleDragBegin(HandleKind handle, float startScreenX, float startScreenY)
+    {
+        var sel = PrimaryFrameRect();
+        if (sel is null || _bitmap is null) return;
+
+        _draggingRect    = sel;
+        _draggingHandle  = handle;
+        _dragStartWorld  = ScreenToTexture(startScreenX, startScreenY);
+        _dragStartBounds = sel.Bounds;
+        _dragBeforeL = sel.Frame.LeftCoordinate;
+        _dragBeforeT = sel.Frame.TopCoordinate;
+        _dragBeforeR = sel.Frame.RightCoordinate;
+        _dragBeforeB = sel.Frame.BottomCoordinate;
+        _bulkHandleDragStarts.Clear();
+        _lastPointerPos = new Point(startScreenX, startScreenY);
+    }
+
+    /// <summary>
+    /// Test-only: begins a chain-drag gesture without applying an end position — the
+    /// chain-drag counterpart of <see cref="SimulateHandleDragBegin"/>. No-op when no chain is
+    /// selected, no frames are visible, or no texture is loaded.
+    /// </summary>
+    public void SimulateChainDragBegin(float startScreenX, float startScreenY)
+    {
+        var chain = _selectedState?.SelectedChain;
+        if (chain is null || _bitmap is null || _frameRects.Count == 0) return;
+
+        _draggingChain = true;
+        _chainDragStarts.Clear();
+        foreach (var fr in _frameRects)
+            _chainDragStarts.Add((fr, fr.Bounds,
+                fr.Frame.LeftCoordinate, fr.Frame.TopCoordinate,
+                fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
+        _dragStartWorld = ScreenToTexture(startScreenX, startScreenY);
+        _lastPointerPos = new Point(startScreenX, startScreenY);
+    }
+
+    /// <summary>
+    /// Test-only: continues the handle/chain drag started by <see cref="SimulateHandleDragBegin"/>
+    /// or <see cref="SimulateChainDragBegin"/> to the given <b>viewport-space</b> pointer
+    /// position, mirroring the dragging branch of <see cref="OnPointerMoved"/>. No-op when no
+    /// drag is active.
+    /// </summary>
+    public void SimulateDragPointerMove(float vpX, float vpY)
+    {
+        _lastPointerPos = new Point(vpX, vpY);
+        if (_draggingRect != null) ApplyHandleDrag(_lastPointerPos);
+        else if (_draggingChain) ApplyChainDrag(_lastPointerPos);
+    }
+
+    /// <summary>
+    /// Test-only: ends the drag started by <see cref="SimulateHandleDragBegin"/> or
+    /// <see cref="SimulateChainDragBegin"/>, without recording undo or firing region-changed
+    /// events — tests that need those should use the one-shot <see cref="SimulateHandleDrag"/>/
+    /// <see cref="SimulateChainDrag"/> instead.
+    /// </summary>
+    public void SimulateDragEnd()
+    {
+        _draggingRect    = null;
+        _draggingHandle  = HandleKind.None;
+        _bulkHandleDragStarts.Clear();
+        _draggingChain   = false;
         _chainDragStarts.Clear();
     }
 
@@ -1485,6 +1615,8 @@ public class WireframeControl : Control
                             fr.Frame.RightCoordinate, fr.Frame.BottomCoordinate));
                     _dragStartWorld = ScreenToTexture((float)pos.X, (float)pos.Y);
                 }
+                _lastPointerPos = pos;
+                StartAutoPanTimer();
                 e.Pointer.Capture(this);
                 return;
             }
@@ -1561,12 +1693,14 @@ public class WireframeControl : Control
 
         if (_draggingRect != null)
         {
+            _lastPointerPos = pos;
             ApplyHandleDrag(pos);
             return;
         }
 
         if (_draggingChain)
         {
+            _lastPointerPos = pos;
             ApplyChainDrag(pos);
             return;
         }
@@ -1643,6 +1777,7 @@ public class WireframeControl : Control
             }
             _draggingRect = null;
             _draggingHandle = HandleKind.None;
+            StopAutoPanTimer();
             e.Pointer.Capture(null);
         }
 
@@ -1667,6 +1802,7 @@ public class WireframeControl : Control
             }
             _draggingChain = false;
             _chainDragStarts.Clear();
+            StopAutoPanTimer();
             e.Pointer.Capture(null);
         }
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/CanvasTransform.cs
@@ -187,4 +187,41 @@ public static class CanvasTransform
         var (cpx, cpy) = ClampWireframePan(npx, npy, viewW, viewH, bitmapW, bitmapH, nz);
         return (cpx, cpy, nz);
     }
+
+    // ── Drag auto-pan (#540) ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Camera pan velocity (screen pixels/second) to auto-scroll a viewport while a drag holds
+    /// the pointer near or past its edge — the "drag past the edge and it scrolls" behaviour of
+    /// most canvas editors. Zero inside the viewport minus <paramref name="marginPx"/>; ramps
+    /// linearly from zero (at the margin boundary) to <paramref name="maxSpeed"/> (at the
+    /// viewport edge itself), then holds at <paramref name="maxSpeed"/> for a pointer captured
+    /// past the edge (a capturing drag can report coordinates outside the control's own bounds).
+    /// <para>
+    /// The sign follows the wireframe's pan convention (<c>screenX = panX + textureX × zoom</c>):
+    /// overflow on the min side (left/top) returns a positive velocity — panX/panY must increase
+    /// to reveal more content in that direction — and overflow on the max side (right/bottom)
+    /// returns negative.
+    /// </para>
+    /// </summary>
+    public static (float VelX, float VelY) AutoPanVelocity(
+        float pointerX, float pointerY,
+        float viewW, float viewH,
+        float marginPx, float maxSpeed)
+        => (AutoPanAxisVelocity(pointerX, viewW, marginPx, maxSpeed),
+            AutoPanAxisVelocity(pointerY, viewH, marginPx, maxSpeed));
+
+    private static float AutoPanAxisVelocity(float pointer, float viewExtent, float marginPx, float maxSpeed)
+    {
+        if (marginPx <= 0f) return 0f;
+
+        if (pointer < marginPx)
+            return Math.Clamp((marginPx - pointer) / marginPx, 0f, 1f) * maxSpeed;
+
+        float farBoundary = viewExtent - marginPx;
+        if (pointer > farBoundary)
+            return -Math.Clamp((pointer - farBoundary) / marginPx, 0f, 1f) * maxSpeed;
+
+        return 0f;
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeAutoPanTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeAutoPanTests.cs
@@ -1,0 +1,200 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Integration tests for auto-pan while dragging past the wireframe viewport edge (#540).
+/// The value under test is specifically that <see cref="WireframeControl.StepAutoPan"/>, called
+/// repeatedly with the pointer held at a FIXED screen position past the edge, keeps moving the
+/// camera tick over tick — a single <c>ApplyHandleDrag</c>/<c>ApplyChainDrag</c> call is a pure
+/// function of (pointer, camera) and can't produce that on its own; only the timer-driven nudge
+/// can, which is what proves auto-pan actually engages rather than just being a no-op wrapper.
+/// </summary>
+public class WireframeAutoPanTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier             = 1f;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, SKColor color, int size, string name = "sprite.png")
+    {
+        var path = System.IO.Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        System.IO.File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// A 512×512 texture (bigger than the 400×300 viewport, so there's room to pan) with one
+    /// full-UV frame selected, camera fixed at pan(0,0) zoom 1 so texture pixels == screen pixels.
+    /// </summary>
+    private static (WireframeControl ctrl, AnimationFrameSave frame, string dir)
+        BuildCtrlWithSelectedFrame(TestServices ctx)
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.DarkGray, size: 512);
+
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0f, TopCoordinate    = 0f,
+            RightCoordinate  = 1f, BottomCoordinate = 1f,
+            ShapesSave = new ShapesSave(),
+        };
+        var chain = new AnimationChainSave { Name = "Test" };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.Measure(new Size(400, 300));
+        ctrl.Arrange(new Rect(0, 0, 400, 300));
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.RefreshFrames();
+
+        return (ctrl, frame, dir);
+    }
+
+    [AvaloniaFact]
+    public void StepAutoPan_HandleDragHeldPastRightEdge_PansCameraLeftEachTick()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            // Grab the BotRight handle at its starting corner (512,512) and drag to (390,150) —
+            // inside the 400-wide viewport but within the 32px right-edge margin (400-32=368).
+            ctrl.SimulateHandleDragBegin(HandleKind.BotRight, startScreenX: 512f, startScreenY: 512f);
+            ctrl.SimulateDragPointerMove(390f, 150f);
+
+            float rightAfterMove = frame.RightCoordinate;
+            float panXAfterMove = ctrl.CameraState.PanX;
+
+            // Hold the pointer at the SAME screen position and step the auto-pan tick five times.
+            float prevPanX = panXAfterMove;
+            float prevRight = rightAfterMove;
+            for (int i = 0; i < 5; i++)
+            {
+                ctrl.StepAutoPan(1f / 60f);
+
+                float panX = ctrl.CameraState.PanX;
+                float right = frame.RightCoordinate;
+
+                // Camera keeps panning further left (more negative) tick over tick...
+                Assert.True(panX < prevPanX, $"tick {i}: expected panX ({panX}) < previous ({prevPanX})");
+                // ...and the dragged edge keeps tracking further right in texture space as a result —
+                // impossible from a single ApplyHandleDrag call with an unchanged pointer position.
+                Assert.True(right > prevRight, $"tick {i}: expected right UV ({right}) > previous ({prevRight})");
+
+                prevPanX = panX;
+                prevRight = right;
+            }
+
+            ctrl.SimulateDragEnd();
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void StepAutoPan_ChainDragHeldPastBottomEdge_PansCameraUpEachTick()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            // Grab the chain at its top-left origin and drag down to (150, 290) — inside the
+            // 300-tall viewport but within the 32px bottom-edge margin (300-32=268).
+            ctrl.SimulateChainDragBegin(startScreenX: 0f, startScreenY: 0f);
+            ctrl.SimulateDragPointerMove(150f, 290f);
+
+            float topAfterMove = frame.TopCoordinate;
+            float panYAfterMove = ctrl.CameraState.PanY;
+
+            float prevPanY = panYAfterMove;
+            float prevTop = topAfterMove;
+            for (int i = 0; i < 5; i++)
+            {
+                ctrl.StepAutoPan(1f / 60f);
+
+                float panY = ctrl.CameraState.PanY;
+                float top = frame.TopCoordinate;
+
+                Assert.True(panY < prevPanY, $"tick {i}: expected panY ({panY}) < previous ({prevPanY})");
+                Assert.True(top > prevTop, $"tick {i}: expected top UV ({top}) > previous ({prevTop})");
+
+                prevPanY = panY;
+                prevTop = top;
+            }
+
+            ctrl.SimulateDragEnd();
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void StepAutoPan_PointerWellInsideViewport_DoesNotMoveCamera()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            ctrl.SimulateHandleDragBegin(HandleKind.BotRight, startScreenX: 512f, startScreenY: 512f);
+            ctrl.SimulateDragPointerMove(200f, 150f); // dead centre of the 400×300 viewport
+
+            var (panX0, panY0, _) = ctrl.CameraState;
+            ctrl.StepAutoPan(1f / 60f);
+            var (panX1, panY1, _) = ctrl.CameraState;
+
+            Assert.Equal(panX0, panX1, 4);
+            Assert.Equal(panY0, panY1, 4);
+
+            ctrl.SimulateDragEnd();
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void StepAutoPan_NoActiveDrag_DoesNothing()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, frame, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            var (panX0, panY0, _) = ctrl.CameraState;
+            ctrl.StepAutoPan(1f / 60f); // no drag in progress — must no-op even at the edge
+            var (panX1, panY1, _) = ctrl.CameraState;
+
+            Assert.Equal(panX0, panX1, 4);
+            Assert.Equal(panY0, panY1, 4);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CanvasTransformTests.cs
@@ -428,4 +428,86 @@ public class CanvasTransformTests
         Assert.Equal(startPanY, py, 2);
         Assert.Equal(startZoom, z, 4);
     }
+
+    // ── AutoPanVelocity (#540) ─────────────────────────────────────────────────
+
+    [Fact]
+    public void AutoPanVelocity_PointerWellInsideViewport_ReturnsZero()
+    {
+        var (vx, vy) = CanvasTransform.AutoPanVelocity(400f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(0f, vx);
+        Assert.Equal(0f, vy);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerExactlyAtMarginBoundary_ReturnsZero()
+    {
+        // The margin band starts just inside the boundary; at the boundary itself there is
+        // no overflow yet.
+        var (vx, vy) = CanvasTransform.AutoPanVelocity(32f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(0f, vx);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerAtLeftEdge_ReturnsMaxSpeedPositiveX()
+    {
+        // Left overflow reveals content further left, which means panX (the screen position
+        // of texture pixel 0,0) must increase.
+        var (vx, vy) = CanvasTransform.AutoPanVelocity(0f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(900f, vx, 3);
+        Assert.Equal(0f, vy);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerPastLeftEdge_ClampsToMaxSpeed()
+    {
+        // A captured pointer can report coordinates outside the control once it leaves the
+        // control's screen area; speed must not exceed the configured max.
+        var (vx, _) = CanvasTransform.AutoPanVelocity(-200f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(900f, vx, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerAtRightEdge_ReturnsMaxSpeedNegativeX()
+    {
+        var (vx, _) = CanvasTransform.AutoPanVelocity(800f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(-900f, vx, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerPastRightEdge_ClampsToMaxSpeed()
+    {
+        var (vx, _) = CanvasTransform.AutoPanVelocity(1000f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(-900f, vx, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerHalfwayIntoLeftMargin_ReturnsHalfMaxSpeed()
+    {
+        // 16px into a 32px margin → halfway through the ramp.
+        var (vx, _) = CanvasTransform.AutoPanVelocity(16f, 300f, 800f, 600f, 32f, 900f);
+        Assert.Equal(450f, vx, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerAtTopEdge_ReturnsMaxSpeedPositiveY()
+    {
+        var (_, vy) = CanvasTransform.AutoPanVelocity(400f, 0f, 800f, 600f, 32f, 900f);
+        Assert.Equal(900f, vy, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerAtBottomEdge_ReturnsMaxSpeedNegativeY()
+    {
+        var (_, vy) = CanvasTransform.AutoPanVelocity(400f, 600f, 800f, 600f, 32f, 900f);
+        Assert.Equal(-900f, vy, 3);
+    }
+
+    [Fact]
+    public void AutoPanVelocity_PointerInTopLeftCorner_ReturnsBothAxesPositive()
+    {
+        var (vx, vy) = CanvasTransform.AutoPanVelocity(0f, 0f, 800f, 600f, 32f, 900f);
+        Assert.Equal(900f, vx, 3);
+        Assert.Equal(900f, vy, 3);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `CanvasTransform.AutoPanVelocity`, a pure function that returns camera pan velocity (px/sec) based on how far the pointer sits within/past a viewport-edge margin, ramping 0→max and clamping beyond the edge.
- Wires it into `WireframeControl` via a `DispatcherTimer` (`StepAutoPan`) started when a handle or chain drag begins and stopped when it ends: each tick nudges `_panX`/`_panY` toward the pointer, clamps via the existing `ClampCamera`, then re-applies the active drag at the same last-known pointer position — so the dragged frame keeps tracking the cursor as the camera pans.
- Adds test-only `SimulateHandleDragBegin`/`SimulateChainDragBegin`/`SimulateDragPointerMove`/`SimulateDragEnd` hooks (mirroring the existing `Simulate*` conventions) so tests can drive a drag mid-gesture and tick `StepAutoPan` deterministically, without relying on the real timer.

## Test plan
- [x] `CanvasTransformTests`: 10 new cases for `AutoPanVelocity` (inside/at-margin/at-edge/past-edge, both axes, corner case).
- [x] `WireframeAutoPanTests` (new): handle-drag and chain-drag cases assert that holding the pointer fixed past the edge produces a monotonically-panning camera and a frame that keeps tracking the cursor tick over tick (the behavior a single `ApplyHandleDrag`/`ApplyChainDrag` call can't produce on its own); plus no-op cases (pointer centered, no active drag).
- [x] Full suite: `dotnet test AnimationEditorAvalonia.slnx` → 1499 + 623 passed, 0 failed.

Closes #540