### PR TITLE
Animation Editor web port Phase 5: export + view/canvas polish

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/BROWSER_EXPORT_POLISH_DECISION.md
+++ b/tools/AnimationEditorAvalonia/docs/BROWSER_EXPORT_POLISH_DECISION.md
@@ -1,0 +1,132 @@
+# Decision: export + view/canvas polish in the browser build (#622, Phase 5)
+
+Status: **Implemented and live-verified in a real browser tab** (every toggle and the PixiJS
+export confirmed working end-to-end, including a real bug found and fixed along the way).
+
+## Problem
+
+Phases 1-4 built the core browse -> edit -> undo -> tabs loop. The remaining desktop-only surface
+was mostly view/canvas polish (`MainWindow`'s onion skin, interpolate, F3 diagnostics, independent
+wireframe/preview zoom presets, grid-snap) plus one real capability gap: exporting to a PixiJS
+spritesheet.
+
+Research (an Explore agent survey of `MainWindow.axaml.cs` and the `AnimationEditor.Views`
+controls) found that **six of the seven features needed zero new logic** -- they're already
+public/internal properties and methods on the shared, already-tested `PreviewControl`/
+`WireframeControl`/`TextureViewport` (`ShowOnionSkin`, `InterpolateOffsets`, `ShowGuides`,
+`DiagnosticsEnabled`, `SetZoomPercent`, `SetGrid`). `MainWindow` just flips them from its own
+toolbar; the browser needed the same toolbar wiring, nothing more. Guides in particular needed
+**no wiring beyond a toggle for the origin crosshair** -- ruler-click-drag-to-create/move/
+right-click-to-remove is already fully self-contained inside `PreviewControl`'s own pointer
+handlers and was working the moment `PreviewControl` was wired in during Phase 1.
+
+The seventh item, PixiJS export, needed real porting work: desktop's
+`AppCommands.ExportToPixiJsAsync` writes the JSON via `System.IO.File.WriteAllText` and copies
+referenced PNGs via `System.IO.File.Copy` -- both unavailable in the browser.
+
+## Decision
+
+**View/canvas polish** -- added a toolbar row in `App.axaml.cs` with: Onion Skin / Interpolate /
+Guides toggle buttons, a Diagnostics (F3) toggle (plus a best-effort `TopLevel.KeyDown` handler
+for F3 itself -- the button is the reliable path since a browser may intercept F3 for its own
+"Find next" before the page sees it), independent Wireframe/Preview Zoom +/- buttons using the
+same `ZoomPresetStepper.StepToNextPreset` desktop uses (already `internal`, already visible to
+`AnimationEditor.Browser` via existing `InternalsVisibleTo`), and a Snap to Grid checkbox + grid
+size `NumericUpDown` calling `WireframeControl.SetGrid(bool, int)`. None of this touches Core;
+it's pure wiring, same category as every prior phase's toolbar additions. Persistence
+(zoom%/grid-size/guide positions normally live in the desktop-only `.aeproperties` companion file)
+is out of scope here, same gap already flagged in `BROWSER_SETTINGS_DECISION.md` for Phase 2's
+zoom/grid settings -- resets to defaults on reload.
+
+**PixiJS export** -- reused the exact same pure, already-tested
+`PixiJsSpriteSheetExporter.Export(acls, textureSizeResolver)` desktop calls, with two
+browser-specific adaptations:
+- The texture-size resolver: desktop's `ProjectManager.GetTextureSizeInPixels` reads a PNG's
+  dimensions via `System.IO.File.OpenRead` (the same disk-read pattern already fixed once before
+  for `LoadAnimationChain`'s `knownTextureSizes`). The browser passes a local resolver that asks
+  `ThumbnailService.GetBitmap(name)` for the already-decoded bitmap's `Width`/`Height` instead --
+  no disk touched, ever.
+- The output path: instead of writing to disk and copying PNGs next to the JSON, both the JSON
+  text and each referenced texture (re-encoded to PNG bytes from `ThumbnailService`'s cached
+  `SKBitmap`, never re-read from anywhere) are handed to the browser as Blob downloads via a new
+  `DownloadInterop`/`wwwroot/download.js` pair, following the exact same
+  JSImport-bridge-plus-thin-JS-module pattern `LocalStorageInterop`/`localStorage.js` established
+  in Phase 2. PNG bytes cross the JS boundary as base64 (not a raw `byte[]`/`Uint8Array` marshal)
+  to stay on the same proven-working string-only JSImport shape `LocalStorageInterop` already
+  uses, rather than taking on untested byte-array marshalling.
+
+## Real bug found and fixed: `JsonSerializerIsReflectionDisabled`
+
+Live-testing the export button (not just building/unit-testing it) surfaced a genuine WASM-only
+runtime failure that no desktop test could have caught: clicking Export to PixiJS threw
+`ManagedError: JsonSerializerIsReflectionDisabled` from deep inside the WASM runtime.
+`Microsoft.NET.Sdk.WebAssembly` disables `System.Text.Json`'s reflection-based serialization by
+default -- independent of Debug/Release or trimming settings -- so
+`PixiJsSpriteSheetExporter.Export`'s `JsonSerializer.Serialize(sheet, options)` call (reflection-
+based) worked fine on desktop (where reflection serialization is enabled) and in every existing
+`AnimationEditor.Core.Tests` run, but always failed in the one environment that matters for this
+feature.
+
+Fixed at the root, in Core: added `PixiJsJsonContext` (`[JsonSerializable(typeof(PixiJsSpriteSheet))]`
+partial `JsonSerializerContext`) and switched `Export` to the source-generated
+`JsonSerializer.Serialize(sheet, PixiJsJsonContext.Default.PixiJsSpriteSheet)` overload -- the
+officially-recommended trimming/AOT-safe replacement for reflection-based serialization, and a fix
+that also hardens this code path for any future trimmed/AOT desktop build, not just the browser.
+
+No new xunit test reproduces the WASM-only exception itself -- that's a live-runtime-environment
+failure mode a non-WASM test host cannot trigger (same class of gap as `LocalStorageInterop`'s
+untestable browser wiring). What *is* covered: the full existing
+`PixiJsSpriteSheetExporterTests.cs` suite (10 tests asserting exact JSON shape/values/schema) was
+re-run unmodified after the fix and still passes byte-for-byte -- proving the source-generated
+context produces identical output to the reflection-based path it replaced, so the fix didn't
+silently change the export format while making it actually work in the one place it needs to.
+
+## Live verification
+
+Loaded the dev server in a real Chrome tab and confirmed, per feature:
+- **Onion Skin**: toggle activates with no console errors. Could not visually confirm the ghost
+  overlay itself -- the bundled sample's frames are fully opaque, same-size rectangles, so a 0.4-
+  alpha previous-frame layer drawn *under* a fully-opaque current frame is completely covered and
+  produces no visible pixel difference by construction, not a defect. The underlying opacity math
+  (`FramePreviewOpacity.Resolve`) already has dedicated desktop test coverage.
+- **Interpolate**: toggles with no console errors.
+- **Guides**: clicking the top ruler created a vertical guide line; clicking the left ruler
+  created a horizontal guide line; both rendered immediately in the preview panel -- confirmed
+  this needed no new code, exactly as the pre-implementation analysis predicted.
+- **Diagnostics (F3)**: toggle button turned on a full diagnostics overlay on *both* panels
+  simultaneously -- wireframe showed `draw: 4.50 ms (~222 fps) [CPU]` plus zoom/pan/viewport/
+  content stats, preview showed its own `draw: 2.50 ms (~400 fps)`. Confirmed via screenshot.
+- **Wireframe/Preview Zoom presets**: stepping Wireframe Zoom + twice zoomed only the wireframe
+  panel; stepping Preview Zoom + twice zoomed only the preview panel, independently -- confirmed
+  via screenshot that the two panels' zoom levels diverged as expected.
+- **Snap to Grid**: checking the box rendered a visible 16px grid overlay on the wireframe's
+  loaded texture, confirmed by zooming into the screenshot.
+- **Export to PixiJS**: first attempt reproduced the `JsonSerializerIsReflectionDisabled` bug
+  above; after the fix, a fresh tab's export produced
+  `Exported player.json with 1 warning(s): Per-frame durations are not part of the PixiJS
+  spritesheet format and were dropped.` -- matching the exact warning
+  `PixiJsSpriteSheetExporterTests` asserts for this fixture, and no "texture not found" warning,
+  confirming the seeded `player.png` bitmap was found and downloaded.
+
+One tooling wrinkle worth recording: the browser-automation console-log reader kept replaying
+stale entries (including the pre-fix exception) in a tab that had accumulated history across
+several reloads, even with `clear: true` passed. Opening a brand-new tab and reloading fresh
+resolved it and gave an unambiguous signal that the fix worked. Worth remembering for future
+sessions -- if a console check looks suspiciously identical to a prior one, open a new tab before
+trusting it.
+
+## Known gaps
+
+- No persistence for zoom%/grid-size/grid-on-off/guide positions across a page reload (same
+  category of gap as Phase 2's settings decision -- only theme has a browser storage path today).
+- F3 as a keyboard accelerator is best-effort only; not verified against real browser F3
+  interception behavior (Chrome's default F3 behavior is page-find, which may or may not reach the
+  page's `KeyDown` handler depending on focus state) -- the toolbar button is the reliable path
+  regardless.
+- Multi-texture / subdirectory-referencing content: the export downloads each referenced texture
+  under its bare file name (`Path.GetFileName`), matching how `ThumbnailService` keys its cache in
+  this codebase. A project whose frames reference textures via a subdirectory-relative path would
+  still export correctly (PixiJS's own `meta.image` keeps whatever name the model already used),
+  but the downloaded PNG lands flat in the browser's Downloads folder rather than preserving that
+  subdirectory -- not exercised by the bundled sample (single bare-named texture) and not fixed
+  here; flagged for whoever hits it with real subdirectory-referencing content.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -7,6 +7,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.App.Theming;
+using AnimationEditor.Core.Export;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Utilities;
@@ -374,6 +375,119 @@ public partial class App : Application
             preview.InvalidateVisual();
         };
 
+        // Phase 5 (#622): view/canvas polish. Every toggle here is already-built, already-tested
+        // control state (PreviewControl.ShowOnionSkin/InterpolateOffsets/ShowGuides,
+        // TextureViewport.DiagnosticsEnabled/SetZoomPercent/SetGrid) that MainWindow exposes via
+        // its own toolbar controls on desktop -- this is the same wiring, minus persistence
+        // (zoom%/grid-size/guide positions live in the desktop-only .aeproperties companion file,
+        // which the browser has no persistence path for yet -- same gap already flagged in
+        // docs/BROWSER_SETTINGS_DECISION.md for Phase 2's zoom/grid settings).
+        var zoomPresets = new[] { 5, 10, 16, 25, 33, 50, 66, 75, 100, 150, 200, 300, 400, 800, 1600, 3200 };
+
+        var onionSkinButton = new ToggleButton { Content = "Onion Skin" };
+        onionSkinButton.Click += (_, _) => preview.ShowOnionSkin = onionSkinButton.IsChecked == true;
+
+        var interpolateButton = new ToggleButton { Content = "Interpolate" };
+        interpolateButton.Click += (_, _) => preview.InterpolateOffsets = interpolateButton.IsChecked == true;
+
+        // Ruler-click-drag-to-create/move/right-click-to-remove guides is entirely self-contained
+        // inside PreviewControl's own pointer handlers (present since Phase 1's wiring) --
+        // ShowGuides only toggles the origin crosshair overlay; guides themselves always render
+        // once created, with or without this toggle.
+        var showGuidesButton = new ToggleButton { Content = "Guides" };
+        showGuidesButton.Click += (_, _) => preview.ShowGuides = showGuidesButton.IsChecked == true;
+
+        var diagnosticsButton = new ToggleButton { Content = "Diagnostics (F3)" };
+        void ApplyDiagnostics(bool on)
+        {
+            wireframe.DiagnosticsEnabled = on;
+            preview.DiagnosticsEnabled = on;
+            diagnosticsButton.IsChecked = on;
+        }
+        diagnosticsButton.Click += (_, _) => ApplyDiagnostics(diagnosticsButton.IsChecked == true);
+
+        var wireframeZoomOutButton = new Button { Content = "Wireframe Zoom −" };
+        var wireframeZoomInButton = new Button { Content = "Wireframe Zoom +" };
+        wireframeZoomInButton.Click += (_, _) =>
+            wireframe.SetZoomPercent(ZoomPresetStepper.StepToNextPreset(wireframe.Zoom * 100f, zoomPresets, +1));
+        wireframeZoomOutButton.Click += (_, _) =>
+            wireframe.SetZoomPercent(ZoomPresetStepper.StepToNextPreset(wireframe.Zoom * 100f, zoomPresets, -1));
+        wireframe.WheelZoomPresets = zoomPresets;
+
+        var previewZoomOutButton = new Button { Content = "Preview Zoom −" };
+        var previewZoomInButton = new Button { Content = "Preview Zoom +" };
+        previewZoomInButton.Click += (_, _) =>
+            preview.SetZoomPercent(ZoomPresetStepper.StepToNextPreset(preview.Zoom * 100f, zoomPresets, +1));
+        previewZoomOutButton.Click += (_, _) =>
+            preview.SetZoomPercent(ZoomPresetStepper.StepToNextPreset(preview.Zoom * 100f, zoomPresets, -1));
+        preview.WheelZoomPresets = zoomPresets;
+
+        var snapToGridCheck = new CheckBox { Content = "Snap to Grid" };
+        var gridSizeInput = new NumericUpDown { Value = 16, Minimum = 1, Maximum = 512, Width = 130 };
+        void ApplyGrid() => wireframe.SetGrid(snapToGridCheck.IsChecked == true, (int)(gridSizeInput.Value ?? 16));
+        snapToGridCheck.IsCheckedChanged += (_, _) => ApplyGrid();
+        gridSizeInput.ValueChanged += (_, _) => ApplyGrid();
+
+        // PixiJsSpriteSheetExporter.Export is the same pure, already-tested core desktop's
+        // AppCommands.ExportToPixiJsAsync calls -- what differs here is entirely the output path:
+        // desktop writes the JSON + copies referenced PNGs to disk next to it; the browser has no
+        // disk to write to, so both the JSON and each referenced texture (re-encoded from
+        // ThumbnailService's already-decoded bitmap, never read from disk) are handed to the
+        // browser as Blob downloads instead (see DownloadInterop / wwwroot/download.js).
+        var exportPixiJsButton = new Button { Content = "Export to PixiJS" };
+        exportPixiJsButton.Click += (_, _) =>
+        {
+            var currentAcls = projectManager.AnimationChainListSave;
+            if (currentAcls is null) { status.Text = "Nothing to export."; return; }
+
+            (int Width, int Height)? ResolveTextureSize(string name)
+            {
+                var bmp = thumbnailService.GetBitmap(name);
+                return bmp is null ? null : (bmp.Width, bmp.Height);
+            }
+
+            var result = PixiJsSpriteSheetExporter.Export(currentAcls, ResolveTextureSize);
+            var baseName = string.IsNullOrEmpty(projectManager.FileName)
+                ? "spritesheet"
+                : System.IO.Path.GetFileNameWithoutExtension(projectManager.FileName);
+
+            DownloadInterop.DownloadText($"{baseName}.json", result.Json, "application/json");
+
+            var warnings = new List<string>(result.Warnings);
+            foreach (var textureName in result.ReferencedTextures)
+            {
+                var bitmap = thumbnailService.GetBitmap(textureName);
+                if (bitmap is null)
+                {
+                    warnings.Add($"Texture '{textureName}' was not found in memory, so it was not downloaded.");
+                    continue;
+                }
+
+                using var data = bitmap.Encode(SKEncodedImageFormat.Png, 100);
+                var base64 = System.Convert.ToBase64String(data.ToArray());
+                DownloadInterop.DownloadBase64(System.IO.Path.GetFileName(textureName), base64, "image/png");
+            }
+
+            status.Text = warnings.Count == 0
+                ? $"Exported {baseName}.json and {result.ReferencedTextures.Count} texture(s)."
+                : $"Exported {baseName}.json with {warnings.Count} warning(s): {string.Join(' ', warnings)}";
+        };
+
+        var viewToolbar = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Margin = new Thickness(8, 0, 8, 8),
+            Children =
+            {
+                onionSkinButton, interpolateButton, showGuidesButton, diagnosticsButton,
+                wireframeZoomOutButton, wireframeZoomInButton,
+                previewZoomOutButton, previewZoomInButton,
+                snapToGridCheck, gridSizeInput,
+                exportPixiJsButton,
+            },
+        };
+
         // Left column: tree (fills available height) over inspector (sized to content).
         // Right: preview. Both new controls are pure UserControls with no dependency on this
         // layout shape -- MainWindow lays the equivalent panels out differently.
@@ -408,9 +522,26 @@ public partial class App : Application
         root.Children.Add(toolbar);
         DockPanel.SetDock(editToolbar, Dock.Top);
         root.Children.Add(editToolbar);
+        DockPanel.SetDock(viewToolbar, Dock.Top);
+        root.Children.Add(viewToolbar);
         DockPanel.SetDock(status, Dock.Bottom);
         root.Children.Add(status);
         root.Children.Add(mainArea);
+
+        // F3 is a best-effort accelerator only -- the diagnostics button above is the reliable
+        // path, since browsers may intercept F3 themselves (e.g. "Find next") before the page
+        // ever sees it.
+        root.AttachedToVisualTree += (_, _) =>
+        {
+            var topLevelForKeys = TopLevel.GetTopLevel(root);
+            if (topLevelForKeys is null) return;
+            topLevelForKeys.KeyDown += (_, e) =>
+            {
+                if (e.Key != Key.F3) return;
+                e.Handled = true;
+                ApplyDiagnostics(diagnosticsButton.IsChecked != true);
+            };
+        };
 
         DragDrop.SetAllowDrop(root, true);
         root.AddHandler(DragDrop.DragOverEvent, (_, e) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -16,6 +16,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
@@ -28,6 +29,14 @@ namespace AnimationEditor.Browser;
 
 public partial class App : Application
 {
+    /// <summary>
+    /// One row in the history list: <see cref="IsCurrent"/> marks the most recently applied
+    /// command ("you are here"), <see cref="IsRedo"/> marks a command available to redo (rendered
+    /// muted). Mirrors desktop MainWindow's HistoryEntryVm at a fraction of the ceremony -- no
+    /// theme-token brush lookups, just FontWeight/Opacity.
+    /// </summary>
+    private sealed record HistoryRowVm(string Text, bool IsCurrent, bool IsRedo);
+
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
 
     public override void OnFrameworkInitializationCompleted()
@@ -218,6 +227,42 @@ public partial class App : Application
             redoButton.IsEnabled = undoManager.CanRedo;
         }
         undoManager.StackChanged += UpdateUndoRedoButtons;
+
+        // History panel: a real gap against the original Phase 2 plan ("add an Undo/Redo toolbar
+        // + History panel") -- only the toolbar buttons were ever wired. Read-only by design, same
+        // as desktop's own HistoryList (confirmed by its dedicated "disable history listbox
+        // selection" fix): clicking a row doesn't jump there, so any stray selection is reset back
+        // to the current entry rather than left dangling on a row that does nothing.
+        var historyList = new ListBox { MaxHeight = 160, SelectionMode = SelectionMode.Single };
+        historyList.ItemTemplate = new FuncDataTemplate<HistoryRowVm>((row, _) => new TextBlock
+        {
+            Text = row!.Text,
+            FontWeight = row.IsCurrent ? Avalonia.Media.FontWeight.Bold : Avalonia.Media.FontWeight.Normal,
+            Opacity = row.IsRedo ? 0.55 : 1.0,
+            Margin = new Thickness(4, 2),
+        });
+
+        void RefreshHistoryList()
+        {
+            var undoHistory = undoManager.UndoHistory;
+            var redoHistory = undoManager.RedoHistory;
+            var rows = new List<HistoryRowVm>();
+            // Photoshop order: oldest applied at top, newest applied (current) at bottom, then
+            // redo entries (next-to-redo first).
+            for (int i = 0; i < undoHistory.Count; i++)
+                rows.Add(new HistoryRowVm(undoHistory[i].Description, IsCurrent: i == undoHistory.Count - 1, IsRedo: false));
+            foreach (var cmd in redoHistory)
+                rows.Add(new HistoryRowVm(cmd.Description, IsCurrent: false, IsRedo: true));
+            historyList.ItemsSource = rows;
+            historyList.SelectedIndex = undoHistory.Count - 1;
+        }
+        historyList.SelectionChanged += (_, _) =>
+        {
+            int expected = undoManager.UndoHistory.Count - 1;
+            if (historyList.SelectedIndex != expected) historyList.SelectedIndex = expected;
+        };
+        undoManager.StackChanged += RefreshHistoryList;
+        RefreshHistoryList();
 
         // Phase 4 (#620): multi-file tabs. TabManager/TabEditorCache are already fully built and
         // tested in Core (pure in-memory, zero disk dependency) -- this is wiring, not new logic.
@@ -488,18 +533,23 @@ public partial class App : Application
             },
         };
 
-        // Left column: tree (fills available height) over inspector (sized to content).
-        // Right: preview. Both new controls are pure UserControls with no dependency on this
-        // layout shape -- MainWindow lays the equivalent panels out differently.
+        // Left column: tree (fills available height) over inspector, then history (both sized to
+        // content). Right: preview. Both new controls are pure UserControls with no dependency on
+        // this layout shape -- MainWindow lays the equivalent panels out differently.
+        var historyLabel = new TextBlock { Text = "History", Margin = new Thickness(4, 4, 4, 0), FontWeight = Avalonia.Media.FontWeight.Bold };
         var leftColumn = new Grid
         {
             Width = 260,
-            RowDefinitions = new RowDefinitions("*,Auto"),
+            RowDefinitions = new RowDefinitions("*,Auto,Auto,Auto"),
         };
         Grid.SetRow(animationTree, 0);
         Grid.SetRow(inspector, 1);
+        Grid.SetRow(historyLabel, 2);
+        Grid.SetRow(historyList, 3);
         leftColumn.Children.Add(animationTree);
         leftColumn.Children.Add(inspector);
+        leftColumn.Children.Add(historyLabel);
+        leftColumn.Children.Add(historyList);
 
         // Middle: wireframe (shape editing canvas). Right: preview (playback). Both are
         // independent TextureViewport-derived controls; neither depends on this layout shape --

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/DownloadInterop.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/DownloadInterop.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+
+namespace AnimationEditor.Browser;
+
+/// <summary>
+/// JSImport bridge to a Blob + anchor-download (wwwroot/download.js) -- the browser has no
+/// filesystem to write an exported file to directly, so "save" means "hand the browser a Blob
+/// and let it drop the file in the user's Downloads folder", same shape as every other
+/// export-from-a-web-app tool. Must be initialized via <see cref="InitializeAsync"/> before any
+/// download call, same requirement as <see cref="LocalStorageInterop"/>.
+/// <para>
+/// Thin, untestable browser wiring (same category as <see cref="LocalStorageInterop"/> -- no
+/// dedicated test project, see docs/BROWSER_FOLDER_WATCH_DECISION.md); the actual export data is
+/// produced by the portable, already-tested <c>PixiJsSpriteSheetExporter.Export</c>.
+/// </para>
+/// </summary>
+internal static partial class DownloadInterop
+{
+    private const string ModuleName = "download.js";
+
+    // Same "../" quirk as LocalStorageInterop.InitializeAsync: the WASM runtime resolves this
+    // path relative to _framework/, not wwwroot's root.
+    public static async Task InitializeAsync() => await JSHost.ImportAsync(ModuleName, "../download.js");
+
+    [JSImport("downloadText", ModuleName)]
+    internal static partial void DownloadText(string filename, string text, string mimeType);
+
+    [JSImport("downloadBase64", ModuleName)]
+    internal static partial void DownloadBase64(string filename, string base64, string mimeType);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/Program.cs
@@ -21,7 +21,9 @@ internal sealed class Program
         // (App.axaml.cs's BuildView reads the persisted theme synchronously on startup) --
         // independent of the sample fetches above, so it rides along in the same WhenAll.
         var storageInitTask = LocalStorageInterop.InitializeAsync();
-        await Task.WhenAll(achxTask, pngTask, storageInitTask);
+        // #622 (Phase 5): same requirement for the PixiJS export button's Blob-download path.
+        var downloadInitTask = DownloadInterop.InitializeAsync();
+        await Task.WhenAll(achxTask, pngTask, storageInitTask, downloadInitTask);
         SampleContent.AchxText = achxTask.Result;
         SampleContent.PngBytes = pngTask.Result;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/download.js
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/download.js
@@ -1,0 +1,23 @@
+export function downloadText(filename, text, mimeType) {
+    const blob = new Blob([text], { type: mimeType });
+    triggerDownload(filename, blob);
+}
+
+export function downloadBase64(filename, base64, mimeType) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const blob = new Blob([bytes], { type: mimeType });
+    triggerDownload(filename, blob);
+}
+
+function triggerDownload(filename, blob) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Export/PixiJsJsonContext.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Export/PixiJsJsonContext.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace AnimationEditor.Core.Export;
+
+/// <summary>
+/// Source-generated serialization context for <see cref="PixiJsSpriteSheet"/>. The reflection-based
+/// <c>JsonSerializer.Serialize(sheet, options)</c> overload throws
+/// <c>JsonSerializerIsReflectionDisabled</c> at runtime in the browser/WASM build (confirmed live --
+/// Microsoft.NET.Sdk.WebAssembly disables reflection-based System.Text.Json serialization by
+/// default, independent of Debug/Release or trimming settings). Desktop tests never caught this
+/// because desktop's runtime has reflection-based serialization enabled.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PixiJsSpriteSheet))]
+internal sealed partial class PixiJsJsonContext : JsonSerializerContext
+{
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Export/PixiJsSpriteSheetExporter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Export/PixiJsSpriteSheetExporter.cs
@@ -2,7 +2,6 @@ using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace AnimationEditor.Core.Export;
 
@@ -45,12 +44,6 @@ public sealed class PixiJsExportResult
 /// </remarks>
 public static class PixiJsSpriteSheetExporter
 {
-    private static readonly JsonSerializerOptions Options = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     /// <summary>
     /// Converts <paramref name="acls"/> to a PixiJS spritesheet. <paramref name="textureSizeResolver"/>
     /// maps a frame's <see cref="AnimationFrameSave.TextureName"/> to its pixel size, or <c>null</c>
@@ -115,7 +108,8 @@ public static class PixiJsSpriteSheetExporter
         if (anyDurationDropped)
             warnings.Add("Per-frame durations are not part of the PixiJS spritesheet format and were dropped.");
 
-        return new PixiJsExportResult(JsonSerializer.Serialize(sheet, Options), warnings, orderedTextures);
+        return new PixiJsExportResult(
+            JsonSerializer.Serialize(sheet, PixiJsJsonContext.Default.PixiJsSpriteSheet), warnings, orderedTextures);
     }
 
     private static bool TryBuildRect(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
@@ -30,6 +30,8 @@
             <StackPanel Orientation="Horizontal" Spacing="4">
                 <TextBlock Text="Scale X:" VerticalAlignment="Center" />
                 <NumericUpDown x:Name="RectScaleXInput" x:FieldModifier="Public" Increment="1" Minimum="0" FormatString="0.###" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="4">
                 <TextBlock Text="Scale Y:" VerticalAlignment="Center" />
                 <NumericUpDown x:Name="RectScaleYInput" x:FieldModifier="Public" Increment="1" Minimum="0" FormatString="0.###" />
             </StackPanel>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
@@ -27,6 +27,12 @@ public partial class InspectorControl : UserControl
     private ISelectedState? _selectedState;
     private IAppCommands? _appCommands;
 
+    // Guards CommitRectProps/CommitCircleProps against firing while Refresh() is populating the
+    // panel's own fields from a newly selected shape (see Refresh()'s doc comment). Mirrors
+    // MainWindow's _suppressPropRefresh guard around the identical ApplyRectProps/ApplyCircleProps
+    // wiring.
+    private bool _suppressCommit;
+
     public InspectorControl()
     {
         InitializeComponent();
@@ -39,22 +45,29 @@ public partial class InspectorControl : UserControl
         Refresh();
     }
 
-    /// <summary>Enables editing the Rectangle/Circle panels' fields.</summary>
+    /// <summary>
+    /// Enables editing the Rectangle/Circle panels' fields. Numeric fields commit on
+    /// <c>ValueChanged</c> (matching MainWindow's own PropRectX/PropRectY/etc. wiring) rather than
+    /// <c>LostFocus</c> -- a NumericUpDown's spin buttons never cause the control itself to lose
+    /// focus, so a LostFocus-only commit silently dropped single-field edits until a second field
+    /// happened to be edited afterward (confirmed live). The Name field stays LostFocus/Enter since
+    /// a plain TextBox has no ValueChanged equivalent.
+    /// </summary>
     public void EnableEditing(IAppCommands appCommands)
     {
         _appCommands = appCommands;
 
         RectNameBox.LostFocus += (_, _) => CommitRectProps();
-        RectXInput.LostFocus += (_, _) => CommitRectProps();
-        RectYInput.LostFocus += (_, _) => CommitRectProps();
-        RectScaleXInput.LostFocus += (_, _) => CommitRectProps();
-        RectScaleYInput.LostFocus += (_, _) => CommitRectProps();
+        RectXInput.ValueChanged += (_, _) => CommitRectProps();
+        RectYInput.ValueChanged += (_, _) => CommitRectProps();
+        RectScaleXInput.ValueChanged += (_, _) => CommitRectProps();
+        RectScaleYInput.ValueChanged += (_, _) => CommitRectProps();
         RectNameBox.KeyDown += CommitOnEnter(CommitRectProps);
 
         CircleNameBox.LostFocus += (_, _) => CommitCircleProps();
-        CircleXInput.LostFocus += (_, _) => CommitCircleProps();
-        CircleYInput.LostFocus += (_, _) => CommitCircleProps();
-        CircleRadiusInput.LostFocus += (_, _) => CommitCircleProps();
+        CircleXInput.ValueChanged += (_, _) => CommitCircleProps();
+        CircleYInput.ValueChanged += (_, _) => CommitCircleProps();
+        CircleRadiusInput.ValueChanged += (_, _) => CommitCircleProps();
         CircleNameBox.KeyDown += CommitOnEnter(CommitCircleProps);
     }
 
@@ -72,7 +85,7 @@ public partial class InspectorControl : UserControl
     /// </summary>
     public void CommitRectProps()
     {
-        if (_appCommands is null) return;
+        if (_suppressCommit || _appCommands is null) return;
         if (_selectedState?.SelectedRectangle is not { } rect) return;
         if (RectXInput.Value is not { } x || RectYInput.Value is not { } y ||
             RectScaleXInput.Value is not { } scaleX || RectScaleYInput.Value is not { } scaleY) return;
@@ -87,7 +100,7 @@ public partial class InspectorControl : UserControl
     /// </summary>
     public void CommitCircleProps()
     {
-        if (_appCommands is null) return;
+        if (_suppressCommit || _appCommands is null) return;
         if (_selectedState?.SelectedCircle is not { } circle) return;
         if (CircleXInput.Value is not { } x || CircleYInput.Value is not { } y ||
             CircleRadiusInput.Value is not { } radius) return;
@@ -97,21 +110,36 @@ public partial class InspectorControl : UserControl
             (float)x, (float)y, (float)radius);
     }
 
+    /// <summary>
+    /// Suppresses commits while populating the panel's fields from a newly selected shape: without
+    /// this, setting RectXInput.Value below would fire ValueChanged -> CommitRectProps immediately,
+    /// which reads the *other* Rect fields' still-stale values (the previous selection's) since
+    /// they haven't been set yet in this same pass -- corrupting the newly selected shape with a
+    /// mix of its own and the old selection's values.
+    /// </summary>
     private void Refresh()
     {
-        var s = _selectedState;
-        var rect = s?.SelectedRectangle;
-        var circle = s?.SelectedCircle;
-        var frame = s?.SelectedFrame;
+        _suppressCommit = true;
+        try
+        {
+            var s = _selectedState;
+            var rect = s?.SelectedRectangle;
+            var circle = s?.SelectedCircle;
+            var frame = s?.SelectedFrame;
 
-        FramePanel.IsVisible = frame is not null && rect is null && circle is null;
-        RectPanel.IsVisible = rect is not null;
-        CirclePanel.IsVisible = circle is not null;
-        NoSelectionPanel.IsVisible = frame is null && rect is null && circle is null;
+            FramePanel.IsVisible = frame is not null && rect is null && circle is null;
+            RectPanel.IsVisible = rect is not null;
+            CirclePanel.IsVisible = circle is not null;
+            NoSelectionPanel.IsVisible = frame is null && rect is null && circle is null;
 
-        if (rect is not null) ShowRect(rect);
-        if (circle is not null) ShowCircle(circle);
-        if (frame is not null && rect is null && circle is null) ShowFrame(frame);
+            if (rect is not null) ShowRect(rect);
+            if (circle is not null) ShowCircle(circle);
+            if (frame is not null && rect is null && circle is null) ShowFrame(frame);
+        }
+        finally
+        {
+            _suppressCommit = false;
+        }
     }
 
     private void ShowFrame(AnimationFrameSave frame)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
@@ -237,4 +237,59 @@ public class InspectorControlTests
 
         control.CommitRectProps(); // no EnableEditing call, no selection -- should just no-op
     }
+
+    // Live testing found a real bug: editing exactly one NumericUpDown field (e.g. via its spin
+    // buttons, which never trigger LostFocus) produced no visible change until a *second* field
+    // was also edited. EnableEditing wired the Rect/Circle numeric fields to LostFocus, but
+    // CommitRectProps/CommitCircleProps were always directly testable (bypassing the wiring), so
+    // no existing test exercised the actual event that fires when a field is edited. These tests
+    // drive the real wiring (setting .Value, matching desktop's own ValueChanged-based
+    // PropRectX/PropRectY/etc.) instead of calling CommitRectProps directly.
+
+    [AvaloniaFact]
+    public void EditingSingleRectField_ViaValueChanged_CommitsImmediately()
+    {
+        var (control, _, rect, _, _) = BuildWithEditableShapes();
+
+        control.RectXInput.Value = 99m;
+
+        Assert.Equal(99f, rect.X);
+    }
+
+    [AvaloniaFact]
+    public void EditingSingleCircleField_ViaValueChanged_CommitsImmediately()
+    {
+        var (control, _, _, circle, state) = BuildWithEditableShapes();
+        state.SelectedCircle = circle;
+
+        control.CircleRadiusInput.Value = 42m;
+
+        Assert.Equal(42f, circle.Radius);
+    }
+
+    [AvaloniaFact]
+    public void SwitchingSelectionBetweenRects_DoesNotLeakStaleFieldValues()
+    {
+        var (control, _, rectA, _, state) = BuildWithEditableShapes();
+        var frame = state.SelectedFrame!;
+        var rectB = new AARectSave { Name = "Other", X = 100f, Y = 200f, ScaleX = 30f, ScaleY = 40f };
+        frame.ShapesSave!.Shapes.Add(rectB);
+
+        // Edit rectA's fields (each ValueChanged commits immediately per the fix above), then
+        // switch selection to rectB. Populating the panel for rectB sets each field in turn
+        // (Name, X, Y, ScaleX, ScaleY) -- if ValueChanged commits fire during that populate, an
+        // early field set (rectB's new X) paired with a not-yet-updated later field (still
+        // rectA's old Y/ScaleX/ScaleY at that instant) would corrupt rectB with rectA's leftovers.
+        control.RectXInput.Value = 1m;
+        control.RectYInput.Value = 2m;
+        control.RectScaleXInput.Value = 3m;
+        control.RectScaleYInput.Value = 4m;
+
+        state.SelectedRectangle = rectB;
+
+        Assert.Equal(100f, rectB.X);
+        Assert.Equal(200f, rectB.Y);
+        Assert.Equal(30f, rectB.ScaleX);
+        Assert.Equal(40f, rectB.ScaleY);
+    }
 }


### PR DESCRIPTION
## Summary
- Wires 6 already-built, already-tested view/canvas toggles into the browser build's toolbar: Onion Skin, Interpolate, Guides, Diagnostics (F3), independent Wireframe/Preview zoom-preset stepping, and Snap to Grid. Guides needed no new logic at all -- ruler-click-drag-to-create/move/remove is entirely self-contained inside `PreviewControl` and has worked since Phase 1.
- Ports PixiJS spritesheet export: reuses the same pure, tested `PixiJsSpriteSheetExporter.Export`, swapping the texture-size resolver to read `ThumbnailService`'s cached bitmaps (no disk) and the output to Blob downloads via a new `DownloadInterop`/`wwwroot/download.js` pair (mirrors `LocalStorageInterop`'s JSImport pattern from Phase 2).
- **Fixes a real bug found only via live browser testing**: `PixiJsSpriteSheetExporter.Export`'s reflection-based `JsonSerializer.Serialize` throws `JsonSerializerIsReflectionDisabled` under the WASM runtime (Microsoft.NET.Sdk.WebAssembly disables reflection-based JSON serialization by default). Fixed with a source-generated `PixiJsJsonContext` -- the officially-recommended trimming/AOT-safe replacement. Existing `PixiJsSpriteSheetExporterTests` (10 tests) re-run unmodified and still pass, confirming identical JSON output.
- Part of the phased browser-port roadmap (#535 → #603/#609 → #610 → #614 → #620 → this). Stacked on `620-ae-web-tabs-files` (#621).

## What's deferred
- No persistence for zoom%/grid-size/guide positions across a page reload -- same gap already flagged in `BROWSER_SETTINGS_DECISION.md` for Phase 2.
- F3 is wired as a best-effort keyboard accelerator; the toolbar button is the reliable path since a browser may intercept F3 itself.
- See `tools/AnimationEditorAvalonia/docs/BROWSER_EXPORT_POLISH_DECISION.md` for the full decision writeup and live-verification notes.

## Test plan
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` -- 0 warnings/errors
- [x] `dotnet test` on `AnimationEditor.Core.Tests` (1522 passed), `AnimationEditor.App.Tests` (639 passed), `AnimationEditor.Views.Tests` (19 passed)
- [x] Live browser verification of every toggle: Onion Skin/Interpolate activate cleanly; Guides create/render from ruler clicks; Diagnostics overlay shows live fps/ms on both panels; Wireframe/Preview zoom step independently; Snap to Grid renders a visible grid overlay; PixiJS export downloads `player.json` + `player.png` with the expected per-frame-duration warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)