### PR TITLE
Animation Editor: borrow a texture for an empty chain so Ctrl+click can add frames

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1616,13 +1616,19 @@ public partial class MainWindow : Window
             ?? _selectedState.SelectedChains.SelectMany(c => c.Frames).FirstOrDefault()
             ?? _selectedState.SelectedChain?.Frames?.FirstOrDefault();
 
-        if (frame != null && !string.IsNullOrEmpty(frame.TextureName) &&
-            !string.IsNullOrEmpty(_projectManager.FileName))
+        // When the selected chain is empty, borrow the first texture referenced anywhere in the
+        // project so the combo + wireframe show something Ctrl-clickable to seed the first frame
+        // (issue #618). Mirrors WireframeControl.DetermineTexturePath's fallback.
+        string? textureName = frame?.TextureName;
+        if (string.IsNullOrEmpty(textureName))
+            textureName = TextureListBuilder.GetFirstTextureName(_projectManager.AnimationChainListSave);
+
+        if (!string.IsNullOrEmpty(textureName) && !string.IsNullOrEmpty(_projectManager.FileName))
         {
             string achxFolder = (Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty);
-            var abs = System.IO.Path.IsPathRooted(frame.TextureName)
-                ? frame.TextureName
-                : Path.Combine(achxFolder, frame.TextureName);
+            var abs = System.IO.Path.IsPathRooted(textureName)
+                ? textureName
+                : Path.Combine(achxFolder, textureName);
             texPath = new FilePath(abs).Standardized;
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
@@ -35,4 +35,18 @@ public static class TextureListBuilder
             .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
             .ToList()!;
     }
+
+    /// <summary>
+    /// Returns the <c>TextureName</c> of the first frame — in chain-then-frame list order —
+    /// that references a non-empty texture, or <c>null</c> when nothing in
+    /// <paramref name="acls"/> does. Used to borrow a texture for a chain that has no frames
+    /// of its own, so the wireframe shows something the user can Ctrl+click to seed the first
+    /// frame, and so the +Add button can inherit a texture (issues #618 / #617).
+    /// </summary>
+    /// <param name="acls">The animation chain list; may be <c>null</c>.</param>
+    public static string? GetFirstTextureName(AnimationChainListSave? acls) =>
+        acls?.AnimationChains
+            .SelectMany(c => c.Frames)
+            .Select(f => f.TextureName)
+            .FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Data;
 using AnimationEditor.Core.Rendering;
 using Avalonia;
 using Avalonia.Controls;
@@ -1409,6 +1410,11 @@ public class WireframeControl : TextureViewport
     {
         string? textureName = _selectedState!.SelectedFrame?.TextureName
                            ?? _selectedState!.SelectedChain?.Frames?.FirstOrDefault()?.TextureName;
+
+        // Empty chain: borrow the first texture referenced anywhere in the project so the
+        // wireframe shows something to Ctrl+click on to seed the first frame (issue #618).
+        if (string.IsNullOrEmpty(textureName))
+            textureName = TextureListBuilder.GetFirstTextureName(_projectManager!.AnimationChainListSave);
 
         if (string.IsNullOrEmpty(textureName))
             return null;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
@@ -362,6 +362,55 @@ public class WireframeTextureTests
         }
     }
 
+    // ── Empty chain borrows a texture so Ctrl+click can add frames (issue #618) ─
+
+    /// <summary>
+    /// Issue #618: when the selected chain has no frames of its own, the wireframe must
+    /// borrow the first texture referenced by any other chain so the user has something to
+    /// Ctrl+click on to seed the first frame. Without this, an empty chain resolves to no
+    /// texture and <see cref="WireframeControl.RefreshAll"/> clears the wireframe, making
+    /// Ctrl+click-to-add a silent no-op.
+    /// </summary>
+    [AvaloniaFact]
+    public void Wireframe_RefreshAll_EmptySelectedChain_BorrowsTextureFromOtherChain()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            WriteSolidPng(dir, "hero.png", SKColors.Magenta, size: 32);
+            ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+
+            var textured = new AnimationChainSave { Name = "Walk" };
+            textured.Frames.Add(new AnimationFrameSave
+            {
+                TextureName = "hero.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            });
+            var empty = new AnimationChainSave { Name = "NewChain" };   // no frames
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(textured);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(empty);
+
+            // Select the empty chain — nothing in it references a texture.
+            ctx.SelectedState.SelectedChain = empty;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.RefreshAll();
+
+            Assert.NotNull(ctrl.LoadedTexturePath);
+            Assert.True(ctrl.LoadedTexturePath!.EndsWith("hero.png", System.StringComparison.OrdinalIgnoreCase),
+                $"Empty chain should borrow hero.png; got: {ctrl.LoadedTexturePath}");
+        }
+        finally
+        {
+            ctx.SelectedState.SelectedChain = null;
+            ctx.ProjectManager.FileName     = string.Empty;
+            System.IO.Directory.Delete(dir, true);
+        }
+    }
+
     // ── LoadedTexturePath reflects current texture ────────────────────────────
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
@@ -125,4 +125,38 @@ public class TextureListBuilderTests
         var result = TextureListBuilder.GetAvailableTextures(acls);
         Assert.Single(result);
     }
+
+    // ── GetFirstTextureName (borrow for empty chain — issue #618) ─────────
+
+    [Fact]
+    public void GetFirstTextureName_NullAcls_ReturnsNull()
+    {
+        Assert.Null(TextureListBuilder.GetFirstTextureName(null));
+    }
+
+    [Fact]
+    public void GetFirstTextureName_NoTexturedFrames_ReturnsNull()
+    {
+        // Empty/whitespace texture names and frameless chains contribute nothing.
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+        acls.AnimationChains.Add(AclsWithTextures("", " ").AnimationChains[0]);
+
+        Assert.Null(TextureListBuilder.GetFirstTextureName(acls));
+    }
+
+    [Fact]
+    public void GetFirstTextureName_EmptyChainThenTexturedChain_ReturnsFirstTextureInListOrder()
+    {
+        // The #618 scenario: the selected (first) chain has no frames, so the texture
+        // must be borrowed from a later chain — the first one referenced, in list order.
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+        var textured = new AnimationChainSave { Name = "Walk" };
+        textured.Frames.Add(new AnimationFrameSave { TextureName = "hero.png" });
+        textured.Frames.Add(new AnimationFrameSave { TextureName = "later.png" });
+        acls.AnimationChains.Add(textured);
+
+        Assert.Equal("hero.png", TextureListBuilder.GetFirstTextureName(acls));
+    }
 }


### PR DESCRIPTION
Closes #618

## Problem

Viewing an animation chain that has **no frames** left the wireframe blank, so there was nothing to **Ctrl+click** on to start adding frames — a silent dead end for empty chains (very common right after creating a new chain, or for a single-PNG `.achx`).

The issue framed this as a `SyncTextureCombo` gap, but the root cause is deeper: on every selection change **two** texture-resolution paths fire —

1. `MainWindow.SyncTextureCombo` (syncs the combo + loads), and
2. `WireframeControl.RefreshAll` → `DetermineTexturePath` (subscribed at `WireframeControl.cs:333`).

For an empty chain `DetermineTexturePath` returned `null`, so `RefreshAll` called `LoadTexture(null)` and **cleared** the wireframe. Fixing only `SyncTextureCombo` would have been clobbered by `RefreshAll`, so the fallback had to live in both paths.

## Fix

- **`WireframeControl.DetermineTexturePath`** (load-bearing): when the selection yields no texture, borrow the first texture referenced anywhere in the project. This is what `RefreshAll` displays.
- **`MainWindow.SyncTextureCombo`**: mirrors the same fallback so the texture combo selection matches what the wireframe shows.
- **`TextureListBuilder.GetFirstTextureName`** — new pure resolver returning the first non-empty `TextureName` in chain-then-frame list order. Both call sites share it. This is the **same resolver #617** needs (inherit a texture when the **+** button adds a frame).

The borrowed texture is a **display hint only** — nothing is written to the empty chain until the user actually Ctrl+clicks. At that point the existing path inherits `WireframeControl.LoadedTexturePath` onto the new frame (16×16 default via `PlainClickFrameRegionCalculator.MinSize` when there's no prior frame to size from).

**Multi-texture ordering:** resolved per the issue's *Desired behavior* — "first texture across all chains in list order." Unambiguous for the common single-PNG `.achx`.

## Tests (TDD)

- `TextureListBuilderTests` — 3 unit tests for `GetFirstTextureName` (null acls, no textured frames, empty-chain-then-textured-chain returns first in list order).
- `WireframeTextureTests.Wireframe_RefreshAll_EmptySelectedChain_BorrowsTextureFromOtherChain` — [AvaloniaFact] driving `RefreshAll` on an empty selected chain; asserts the wireframe borrows the other chain's texture. Confirmed red (`LoadedTexturePath` null) before the fix, green after.

Full suites green: **1547** Core + **642** App, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)