### PR TITLE
Animation Editor: centralize hotkey definitions into a single registry

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -94,13 +94,16 @@
                         </MenuItem>
                     </MenuItem>
                     <MenuItem Header="_Edit">
-                        <MenuItem Header="_Undo"            x:Name="MenuUndo"          InputGesture="Ctrl+Z" />
-                        <MenuItem Header="_Redo"            x:Name="MenuRedo"          InputGesture="Ctrl+Y" />
+                        <!-- InputGesture text for Undo/Redo/Copy/Cut/Paste/Duplicate is set in code from
+                             the hotkey registry (MainWindow.ApplyHotkeyMenuGestureText, issue #632) so
+                             it can never drift from what the KeyDown handler actually does. -->
+                        <MenuItem Header="_Undo"            x:Name="MenuUndo" />
+                        <MenuItem Header="_Redo"            x:Name="MenuRedo" />
                         <Separator />
-                        <MenuItem Header="_Copy"            x:Name="MenuCopy"          InputGesture="Ctrl+C" />
-                        <MenuItem Header="Cu_t"             x:Name="MenuCut"           InputGesture="Ctrl+X" />
-                        <MenuItem Header="_Paste"           x:Name="MenuPaste"         InputGesture="Ctrl+V" />
-                        <MenuItem Header="_Duplicate"       x:Name="MenuDuplicate"     InputGesture="Ctrl+D" />
+                        <MenuItem Header="_Copy"            x:Name="MenuCopy" />
+                        <MenuItem Header="Cu_t"             x:Name="MenuCut" />
+                        <MenuItem Header="_Paste"           x:Name="MenuPaste" />
+                        <MenuItem Header="_Duplicate"       x:Name="MenuDuplicate" />
                         <Separator />
                         <MenuItem Header="Reload _from Disk"    x:Name="MenuReloadFromDisk" />
                         <MenuItem Header="Enable Hot _Reload"   x:Name="MenuEnableHotReload" IsChecked="True" />
@@ -125,8 +128,9 @@
                         </MenuItem>
                     </MenuItem>
                     <MenuItem Header="_Help">
+                        <!-- InputGesture set in code from the hotkey registry — see note above. -->
                         <MenuItem Header="Show _Render Diagnostics" x:Name="MenuShowDiagnostics"
-                                  ToggleType="CheckBox" InputGesture="F3" />
+                                  ToggleType="CheckBox" />
                         <MenuItem Header="View _Log"      x:Name="MenuViewLog" />
                         <MenuItem Header="_About"         x:Name="MenuAbout" />
                     </MenuItem>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -7,6 +7,7 @@ using AnimationEditor.Core.Data;
 using AnimationEditor.Core.Diff;
 using AnimationEditor.Core.DragDrop;
 using AnimationEditor.Core.HotReload;
+using AnimationEditor.Core.Hotkeys;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
@@ -1759,8 +1760,7 @@ public partial class MainWindow : Window
         MenuAbout.Click  += OnAboutClick;
         MenuViewLog.Click += OnViewLogClick;
         // ToggleType="CheckBox" flips IsChecked before Click fires, so just apply the new state.
-        // F3 is handled separately in the global KeyDown handler (InputGesture on a MenuItem is
-        // display-only here — the same reason Ctrl+Z has its own KeyDown branch).
+        // F3 itself is dispatched through the hotkey registry (see WireKeyboard/BuildHotkeyDefinitions).
         MenuShowDiagnostics.Click += (_, _) => ApplyDiagnostics(MenuShowDiagnostics.IsChecked == true);
         MenuSettings.Click += OnSettingsClick;
         MenuCopy.Click          += (_, _) => _ = HandleCopyAsync();
@@ -5057,15 +5057,180 @@ public partial class MainWindow : Window
 
     // ── Keyboard wiring ───────────────────────────────────────────────────────
 
-    // Returns true when the platform command modifier is active.
-    // On macOS the Command key (⌘) maps to KeyModifiers.Meta; on Windows/Linux it is Control.
-    // Accepting both lets Ctrl+C/V/Z keep working in tests and on Windows/Linux while also
-    // handling Cmd+C/V/Z on macOS.
-    private static bool HasCommandModifier(KeyModifiers m)
-        => m.HasFlag(KeyModifiers.Control) || m.HasFlag(KeyModifiers.Meta);
+    // Single source of truth for global keyboard shortcuts (issue #632). Built once in
+    // WireKeyboard and consulted both by the KeyDown dispatch below and by
+    // ApplyHotkeyMenuGestureText, so the menu's InputGesture text can never drift from what a
+    // keypress actually does.
+    private List<HotkeyDefinition> _hotkeys = new();
+
+    /// <summary>Exposes the built registry for tests (e.g. asserting no duplicate gestures).</summary>
+    internal IReadOnlyList<HotkeyDefinition> Hotkeys => _hotkeys;
+
+    // Translates Avalonia's native modifier flags into the UI-independent HotkeyModifiers used
+    // by AnimationEditor.Core.Hotkeys. Command unifies Control (Windows/Linux) and Meta (macOS).
+    private static HotkeyModifiers ToHotkeyModifiers(KeyModifiers modifiers)
+    {
+        var result = HotkeyModifiers.None;
+        if (modifiers.HasFlag(KeyModifiers.Shift)) result |= HotkeyModifiers.Shift;
+        if (modifiers.HasFlag(KeyModifiers.Alt)) result |= HotkeyModifiers.Alt;
+        if (modifiers.HasFlag(KeyModifiers.Control) || modifiers.HasFlag(KeyModifiers.Meta))
+            result |= HotkeyModifiers.Command;
+        return result;
+    }
+
+    private List<HotkeyDefinition> BuildHotkeyDefinitions()
+    {
+        const HotkeyModifiers Command = HotkeyModifiers.Command;
+        const HotkeyModifiers Shift   = HotkeyModifiers.Shift;
+        const HotkeyModifiers Alt     = HotkeyModifiers.Alt;
+
+        return new List<HotkeyDefinition>
+        {
+            new()
+            {
+                Id = "copy", Description = "Copy", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("C", Command) },
+                ShouldSkip = IsTextInputFocused,
+                Action = () => _ = HandleCopyAsync(),
+            },
+            new()
+            {
+                Id = "cut", Description = "Cut", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("X", Command) },
+                ShouldSkip = IsTextInputFocused,
+                Action = () => _ = HandleCutAsync(),
+            },
+            new()
+            {
+                Id = "paste", Description = "Paste", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("V", Command) },
+                ShouldSkip = IsTextInputFocused,
+                Action = () => _ = HandlePasteAsync(),
+            },
+            new()
+            {
+                Id = "duplicate", Description = "Duplicate", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("D", Command) },
+                ShouldSkip = IsTextInputFocused,
+                Action = HandleDuplicate,
+            },
+            new()
+            {
+                Id = "delete", Description = "Delete", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("Delete") },
+                ShouldSkip = IsTextInputFocused,
+                Action = HandleDelete,
+            },
+            new()
+            {
+                Id = "rename", Description = "Rename", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("F2") },
+                Action = HandleRenameHotkey,
+            },
+            new()
+            {
+                Id = "toggle-diagnostics", Description = "Toggle Render Diagnostics", Category = "View",
+                Gestures = new[] { new HotkeyGesture("F3") },
+                Action = ToggleDiagnostics,
+            },
+            new()
+            {
+                Id = "undo", Description = "Undo", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("Z", Command, Forbidden: Shift) },
+                Action = () => _undoManager.Undo(),
+            },
+            new()
+            {
+                Id = "redo", Description = "Redo", Category = "Edit",
+                Gestures = new[]
+                {
+                    new HotkeyGesture("Y", Command),
+                    new HotkeyGesture("Z", Command | Shift, Forbidden: Alt),
+                },
+                Action = () => _undoManager.Redo(),
+            },
+            new()
+            {
+                Id = "toggle-play-pause", Description = "Play / Pause Preview", Category = "Playback",
+                Gestures = new[] { new HotkeyGesture("Space") },
+                // Let a focused button receive Space to activate itself rather than hijacking it.
+                ShouldSkip = () => IsTextInputFocused() || FocusManager?.GetFocusedElement() is Button,
+                Action = () => PreviewCtrl.TogglePlayPause(),
+            },
+            new()
+            {
+                Id = "move-up", Description = "Move Selected Chain/Frame Up", Category = "Tree",
+                Gestures = new[] { new HotkeyGesture("Up", Alt) },
+                Action = () => HandleReorderHotkey(-1),
+            },
+            new()
+            {
+                Id = "move-down", Description = "Move Selected Chain/Frame Down", Category = "Tree",
+                Gestures = new[] { new HotkeyGesture("Down", Alt) },
+                Action = () => HandleReorderHotkey(+1),
+            },
+        };
+    }
+
+    // F2: prefer the tree's SelectedItem, fall back to _selectedState when the tree has
+    // temporarily lost focus (e.g. immediately after ALT+arrow reorder, where focus shifts
+    // before our Background-priority re-focus post runs).
+    private void HandleRenameHotkey()
+    {
+        var vm = AnimTree.SelectedItem as TreeNodeVm
+              ?? (_selectedState.SelectedShape is { } ss
+                      ? TreeBuilder.FindNodeForData(_treeRoots, ss) : null)
+              ?? (_selectedState.SelectedFrame is { } sf
+                      ? TreeBuilder.FindNodeForData(_treeRoots, sf) : null)
+              ?? (_selectedState.SelectedChain is { } sc
+                      ? TreeBuilder.FindNodeForData(_treeRoots, sc) : null);
+
+        if (vm is null) return;
+
+        // Frame nodes are intentionally not renameable: a frame's identity is its index, so its
+        // label is the computed positional "Frame N" (see TreeBuilder).
+        if (vm.Data is AnimationChainSave chain)
+            BeginInlineRename(vm, chain.Name);
+        else if (vm.Data is AARectSave rect)
+            BeginInlineRename(vm, rect.Name);
+        else if (vm.Data is CircleSave circle)
+            BeginInlineRename(vm, circle.Name);
+    }
+
+    private void HandleReorderHotkey(int delta)
+    {
+        _altMenuActivationSuppressor.ArmFromAltArrowReorder();
+        _appCommands.HandleReorder(delta);
+        // Restore focus to the tree — reorder can cause Avalonia to shift focus away, which
+        // would let F2 hit the wrong target for a subsequent rename.
+        Dispatcher.UIThread.Post(() => AnimTree.Focus(), DispatcherPriority.Background);
+        if (_selectedState.SelectedFrame is not null)
+            ShowStatusMessage("Frame labels updated to reflect new positions");
+    }
+
+    // Sets each menu item's InputGesture text from the matching registry entry's DisplayText,
+    // so the menu can never show a shortcut a keypress doesn't actually trigger (issue #632).
+    // MenuNew/MenuLoad/MenuSave and the zoom shortcuts keep their hand-authored XAML text — they
+    // have no KeyDown-driven implementation to derive from.
+    private void ApplyHotkeyMenuGestureText()
+    {
+        SetMenuGesture(MenuUndo, "undo");
+        SetMenuGesture(MenuRedo, "redo");
+        SetMenuGesture(MenuCopy, "copy");
+        SetMenuGesture(MenuCut, "cut");
+        SetMenuGesture(MenuPaste, "paste");
+        SetMenuGesture(MenuDuplicate, "duplicate");
+        SetMenuGesture(MenuShowDiagnostics, "toggle-diagnostics");
+    }
+
+    private void SetMenuGesture(MenuItem item, string hotkeyId) =>
+        item.InputGesture = KeyGesture.Parse(_hotkeys.First(h => h.Id == hotkeyId).DisplayText);
 
     private void WireKeyboard()
     {
+        _hotkeys = BuildHotkeyDefinitions();
+        ApplyHotkeyMenuGestureText();
+
         // Use Tunnel routing so we intercept keys before child controls (e.g. the TreeView,
         // which handles Up/Down for navigation and would mark the event Handled before the
         // default Bubble-phase KeyDown fires).
@@ -5073,103 +5238,12 @@ public partial class MainWindow : Window
         {
             if (e.Handled) return;
 
-            if (e.Key == Key.C && HasCommandModifier(e.KeyModifiers))
-            {
-                if (IsTextInputFocused()) return;
-                e.Handled = true;
-                _ = HandleCopyAsync();
-            }
-            else if (e.Key == Key.X && HasCommandModifier(e.KeyModifiers))
-            {
-                if (IsTextInputFocused()) return;
-                e.Handled = true;
-                _ = HandleCutAsync();
-            }
-            else if (e.Key == Key.V && HasCommandModifier(e.KeyModifiers))
-            {
-                if (IsTextInputFocused()) return;
-                e.Handled = true;
-                _ = HandlePasteAsync();
-            }
-            else if (e.Key == Key.D && HasCommandModifier(e.KeyModifiers))
-            {
-                if (IsTextInputFocused()) return;
-                e.Handled = true;
-                HandleDuplicate();
-            }
-            else if (e.Key == Key.Delete)
-            {
-                if (IsTextInputFocused()) return;
-                e.Handled = true;
-                HandleDelete();
-            }
-            else if (e.Key == Key.F2)
-            {
-                e.Handled = true;
-                // Prefer the tree's SelectedItem, fall back to _selectedState when the tree
-                // has temporarily lost focus (e.g. immediately after ALT+arrow reorder, where
-                // focus shifts before our Background-priority re-focus post runs).
-                var vm = AnimTree.SelectedItem as TreeNodeVm
-                      ?? (_selectedState.SelectedShape is { } ss
-                              ? TreeBuilder.FindNodeForData(_treeRoots, ss) : null)
-                      ?? (_selectedState.SelectedFrame is { } sf
-                              ? TreeBuilder.FindNodeForData(_treeRoots, sf) : null)
-                      ?? (_selectedState.SelectedChain is { } sc
-                              ? TreeBuilder.FindNodeForData(_treeRoots, sc) : null);
+            var match = HotkeyRegistry.FindMatch(_hotkeys, e.Key.ToString(), ToHotkeyModifiers(e.KeyModifiers));
+            if (match is null) return;
+            if (match.ShouldSkip?.Invoke() == true) return;
 
-                if (vm is not null)
-                {
-                    // Frame nodes are intentionally not renameable: a frame's identity is its
-                    // index, so its label is the computed positional "Frame N" (see TreeBuilder).
-                    if (vm.Data is AnimationChainSave chain)
-                        BeginInlineRename(vm, chain.Name);
-                    else if (vm.Data is AARectSave rect)
-                        BeginInlineRename(vm, rect.Name);
-                    else if (vm.Data is CircleSave circle)
-                        BeginInlineRename(vm, circle.Name);
-                }
-                // F2 is rename-only. Render diagnostics moved to F3 / Help ▸ Show Render Diagnostics
-                // (the old F2 fallback was unreachable — a tree node is essentially always selected).
-            }
-            else if (e.Key == Key.F3)
-            {
-                e.Handled = true;
-                ToggleDiagnostics();
-            }
-            else if (e.Key == Key.Z && HasCommandModifier(e.KeyModifiers) &&
-                     !e.KeyModifiers.HasFlag(KeyModifiers.Shift))
-            {
-                e.Handled = true;
-                _undoManager.Undo();
-            }
-            else if ((e.Key == Key.Y && HasCommandModifier(e.KeyModifiers)) ||
-                     (e.Key == Key.Z && (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) ||
-                                         e.KeyModifiers == (KeyModifiers.Meta    | KeyModifiers.Shift))))
-            {
-                e.Handled = true;
-                _undoManager.Redo();
-            }
-            else if (e.Key == Key.Space)
-            {
-                if (IsTextInputFocused()) return;
-                // Let a focused button receive Space to activate itself rather than hijacking it.
-                if (FocusManager?.GetFocusedElement() is Button) return;
-                e.Handled = true;
-                PreviewCtrl.TogglePlayPause();
-            }
-            else if ((e.Key == Key.Up || e.Key == Key.Down) &&
-                     e.KeyModifiers.HasFlag(KeyModifiers.Alt))
-            {
-                e.Handled = true;
-                _altMenuActivationSuppressor.ArmFromAltArrowReorder();
-                int delta = e.Key == Key.Up ? -1 : +1;
-                _appCommands.HandleReorder(delta);
-                // Restore focus to the tree — reorder can cause Avalonia to shift focus away, which
-                // would let F2 hit the wrong target for a subsequent rename.
-                Dispatcher.UIThread.Post(() => AnimTree.Focus(), DispatcherPriority.Background);
-                if (_selectedState.SelectedFrame is not null)
-                    ShowStatusMessage("Frame labels updated to reflect new positions");
-            }
+            e.Handled = true;
+            match.Action();
         }), RoutingStrategies.Tunnel);
 
         // Avalonia activates the title-bar menu on Alt KeyUp. Alt+Arrow reorder handles only

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyDefinition.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyDefinition.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.Hotkeys;
+
+/// <summary>
+/// A single hotkey: one or more equivalent <see cref="Gestures"/> (e.g. Redo accepts both
+/// Ctrl+Y and Ctrl+Shift+Z), the action it runs, and the metadata a menu or shortcuts panel
+/// needs to display it. <see cref="ShouldSkip"/> lets a hotkey opt out at dispatch time — e.g.
+/// Copy/Paste/Delete must not fire while a TextBox has focus — without a separate guard table.
+/// </summary>
+public sealed class HotkeyDefinition
+{
+    public required string Id { get; init; }
+    public required string Description { get; init; }
+    public required string Category { get; init; }
+    public required IReadOnlyList<HotkeyGesture> Gestures { get; init; }
+    public required Action Action { get; init; }
+    public Func<bool>? ShouldSkip { get; init; }
+
+    public bool Matches(string keyName, HotkeyModifiers pressed) =>
+        Gestures.Any(g => g.Matches(keyName, pressed));
+
+    /// <summary>
+    /// Display text for the primary (first) gesture, e.g. <c>"Ctrl+Z"</c>. Used to drive
+    /// <c>MenuItem.InputGesture</c> so the menu can never show a shortcut this hotkey doesn't
+    /// actually respond to.
+    /// </summary>
+    public string DisplayText => Format(Gestures[0]);
+
+    private static string Format(HotkeyGesture gesture)
+    {
+        var parts = new List<string>(4);
+        if (gesture.Required.HasFlag(HotkeyModifiers.Command)) parts.Add("Ctrl");
+        if (gesture.Required.HasFlag(HotkeyModifiers.Shift)) parts.Add("Shift");
+        if (gesture.Required.HasFlag(HotkeyModifiers.Alt)) parts.Add("Alt");
+        parts.Add(gesture.KeyName);
+        return string.Join("+", parts);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyGesture.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyGesture.cs
@@ -1,0 +1,20 @@
+namespace AnimationEditor.Core.Hotkeys;
+
+/// <summary>
+/// One key + modifier combination that can trigger a hotkey. A modifier absent from both
+/// <see cref="Required"/> and <see cref="Forbidden"/> is ignored, so e.g. a gesture requiring
+/// only <see cref="HotkeyModifiers.Command"/> still matches with Shift also held — mirroring the
+/// original hand-written if/else chain this was extracted from (Ctrl+Shift+C still copies).
+/// </summary>
+public readonly record struct HotkeyGesture(
+    string KeyName,
+    HotkeyModifiers Required = HotkeyModifiers.None,
+    HotkeyModifiers Forbidden = HotkeyModifiers.None)
+{
+    /// <param name="keyName">The pressed key's name (e.g. an Avalonia <c>Key</c>'s <c>ToString()</c>).</param>
+    /// <param name="pressed">The modifiers held down when <paramref name="keyName"/> was pressed.</param>
+    public bool Matches(string keyName, HotkeyModifiers pressed) =>
+        keyName == KeyName
+        && (pressed & Required) == Required
+        && (pressed & Forbidden) == HotkeyModifiers.None;
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyModifiers.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyModifiers.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace AnimationEditor.Core.Hotkeys;
+
+/// <summary>
+/// UI-framework-independent modifier flags for hotkey matching. <see cref="Command"/> unifies
+/// the platform command modifier — Control on Windows/Linux, Meta (⌘) on macOS — into one flag,
+/// so a gesture that requires <see cref="Command"/> matches either without caring which OS it's
+/// running on. Callers translate the host UI framework's native modifier enum into this one.
+/// </summary>
+[Flags]
+public enum HotkeyModifiers
+{
+    None    = 0,
+    Shift   = 1 << 0,
+    Alt     = 1 << 1,
+    Command = 1 << 2,
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyRegistry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/HotkeyRegistry.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.Hotkeys;
+
+/// <summary>
+/// Pure dispatch logic over a list of <see cref="HotkeyDefinition"/>s. Kept UI-independent so
+/// "does this keypress match this registry entry" is unit-testable without a window.
+/// </summary>
+public static class HotkeyRegistry
+{
+    /// <summary>
+    /// Returns the first definition whose gestures match, or <c>null</c>. Definitions are
+    /// checked in list order — first-match-wins, mirroring the original if/else chain.
+    /// </summary>
+    public static HotkeyDefinition? FindMatch(
+        IEnumerable<HotkeyDefinition> hotkeys, string keyName, HotkeyModifiers pressed) =>
+        hotkeys.FirstOrDefault(h => h.Matches(keyName, pressed));
+
+    /// <summary>
+    /// Gestures shared by two different definitions — a sign one hotkey would silently shadow
+    /// the other, since only the first-listed definition would ever fire for that keypress.
+    /// </summary>
+    public static IReadOnlyList<(HotkeyGesture Gesture, string FirstId, string SecondId)> FindDuplicateGestures(
+        IReadOnlyList<HotkeyDefinition> hotkeys)
+    {
+        var duplicates = new List<(HotkeyGesture, string, string)>();
+        for (int i = 0; i < hotkeys.Count; i++)
+            for (int j = i + 1; j < hotkeys.Count; j++)
+                foreach (var gesture in hotkeys[i].Gestures)
+                    if (hotkeys[j].Gestures.Contains(gesture))
+                        duplicates.Add((gesture, hotkeys[i].Id, hotkeys[j].Id));
+        return duplicates;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
@@ -1,0 +1,218 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.Hotkeys;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #632: hotkeys are now dispatched through a shared registry (BuildHotkeyDefinitions)
+/// instead of a hand-written if/else chain. These cover the branches that had no prior
+/// KeyPress-simulation coverage — Undo/Redo (both Redo gestures), F3, Space and Alt+Up reorder —
+/// to prove the refactor preserved their behavior. Copy/Cut/Paste/Duplicate/Delete's text-input
+/// focus gating already has coverage in CopyPasteFocusGateTests/DuplicateShortcutTests.
+/// </summary>
+public class HotkeyDispatchTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static TreeNodeVm SeedAndSelect(MainWindow window, object data, string header)
+    {
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+        var vm = new TreeNodeVm { Header = header, Data = data };
+        roots.Add(vm);
+        tree.SelectedItems!.Add(vm);
+        tree.Focus();
+        Dispatcher.UIThread.RunJobs();
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void CtrlZ_AfterDeletingChain_RestoresChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            SeedAndSelect(window, chain, "Walk");
+
+            window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+
+            window.KeyPress(Key.Z, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlY_AfterUndoingDelete_ReDeletesChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            SeedAndSelect(window, chain, "Walk");
+
+            window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.None, null);
+            window.KeyPress(Key.Z, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Single(ctx.ProjectManager.AnimationChainListSave!.AnimationChains); // restored
+
+            window.KeyPress(Key.Y, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>Redo's second gesture (Ctrl+Shift+Z) must behave identically to Ctrl+Y.</summary>
+    [AvaloniaFact]
+    public void CtrlShiftZ_AfterUndoingDelete_ReDeletesChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            SeedAndSelect(window, chain, "Walk");
+
+            window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.None, null);
+            window.KeyPress(Key.Z, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Single(ctx.ProjectManager.AnimationChainListSave!.AnimationChains); // restored
+
+            window.KeyPress(Key.Z, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void F3_TogglesRenderDiagnosticsOnBothPanels()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            Assert.False(wireframe.DiagnosticsEnabled);
+            Assert.False(preview.DiagnosticsEnabled);
+
+            window.KeyPress(Key.F3, RawInputModifiers.None, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(wireframe.DiagnosticsEnabled);
+            Assert.True(preview.DiagnosticsEnabled);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Space_TreeFocused_TogglesPreviewPlayback()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            SeedAndSelect(window, chain, "Walk");
+            ctx.SelectedState.SelectedChain = chain;
+
+            // Selecting a chain auto-plays its preview, so Space (a toggle) pauses it first.
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            Assert.True(preview.IsPlaying);
+
+            window.KeyPress(Key.Space, RawInputModifiers.None, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(preview.IsPlaying);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void AltUp_SecondChainSelected_MovesItAboveFirst()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var first = new AnimationChainSave { Name = "First" };
+            var second = new AnimationChainSave { Name = "Second" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(first);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(second);
+            SeedAndSelect(window, second, "Second");
+
+            window.KeyPress(Key.Up, RawInputModifiers.Alt, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Same(second, ctx.ProjectManager.AnimationChainListSave!.AnimationChains[0]);
+            Assert.Same(first, ctx.ProjectManager.AnimationChainListSave!.AnimationChains[1]);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>Guards against two hotkeys silently shadowing one another as the registry grows.</summary>
+    [AvaloniaFact]
+    public void Hotkeys_ProductionRegistry_HasNoDuplicateGestures()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var duplicates = HotkeyRegistry.FindDuplicateGestures(window.Hotkeys.ToList());
+
+            Assert.Empty(duplicates);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Menu InputGesture text is generated from the registry (ApplyHotkeyMenuGestureText), so it
+    /// can never drift from what the KeyDown handler dispatches — the bug this issue fixes.
+    /// </summary>
+    [AvaloniaFact]
+    public void MenuUndo_InputGesture_MatchesCtrlZDispatchedByKeyDown()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var menuUndo = window.FindControl<MenuItem>("MenuUndo")!;
+
+            Assert.Equal(new KeyGesture(Key.Z, KeyModifiers.Control), menuUndo.InputGesture);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyDefinitionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyDefinitionTests.cs
@@ -1,0 +1,57 @@
+using AnimationEditor.Core.Hotkeys;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class HotkeyDefinitionTests
+{
+    [Fact]
+    public void DisplayText_CommandOnlyGesture_ReturnsCtrlPrefixedText()
+    {
+        var hotkey = new HotkeyDefinition
+        {
+            Id = "undo",
+            Description = "Undo",
+            Category = "Edit",
+            Gestures = new[] { new HotkeyGesture("Z", HotkeyModifiers.Command, Forbidden: HotkeyModifiers.Shift) },
+            Action = () => { },
+        };
+
+        Assert.Equal("Ctrl+Z", hotkey.DisplayText);
+    }
+
+    [Fact]
+    public void DisplayText_MultipleGestures_UsesFirstGestureOnly()
+    {
+        // Redo displays "Ctrl+Y" on the menu even though Ctrl+Shift+Z also triggers it.
+        var hotkey = new HotkeyDefinition
+        {
+            Id = "redo",
+            Description = "Redo",
+            Category = "Edit",
+            Gestures = new[]
+            {
+                new HotkeyGesture("Y", HotkeyModifiers.Command),
+                new HotkeyGesture("Z", HotkeyModifiers.Command | HotkeyModifiers.Shift, Forbidden: HotkeyModifiers.Alt),
+            },
+            Action = () => { },
+        };
+
+        Assert.Equal("Ctrl+Y", hotkey.DisplayText);
+    }
+
+    [Fact]
+    public void DisplayText_NoModifiers_ReturnsKeyNameOnly()
+    {
+        var hotkey = new HotkeyDefinition
+        {
+            Id = "toggle-diagnostics",
+            Description = "Toggle Render Diagnostics",
+            Category = "View",
+            Gestures = new[] { new HotkeyGesture("F3") },
+            Action = () => { },
+        };
+
+        Assert.Equal("F3", hotkey.DisplayText);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyGestureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyGestureTests.cs
@@ -1,0 +1,49 @@
+using AnimationEditor.Core.Hotkeys;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class HotkeyGestureTests
+{
+    [Fact]
+    public void Matches_RequiredModifierPresentPlusUnrelatedModifier_ReturnsTrue()
+    {
+        // Ctrl+Shift+C still triggers Copy — Shift is neither required nor forbidden.
+        var gesture = new HotkeyGesture("C", Required: HotkeyModifiers.Command);
+
+        bool result = gesture.Matches("C", HotkeyModifiers.Command | HotkeyModifiers.Shift);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Matches_ForbiddenModifierPresent_ReturnsFalse()
+    {
+        // Ctrl+Shift+Z must not match Undo, since Undo forbids Shift (it's Redo's gesture).
+        var gesture = new HotkeyGesture("Z", Required: HotkeyModifiers.Command, Forbidden: HotkeyModifiers.Shift);
+
+        bool result = gesture.Matches("Z", HotkeyModifiers.Command | HotkeyModifiers.Shift);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Matches_KeyNameDiffers_ReturnsFalse()
+    {
+        var gesture = new HotkeyGesture("C", Required: HotkeyModifiers.Command);
+
+        bool result = gesture.Matches("V", HotkeyModifiers.Command);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Matches_RequiredModifierMissing_ReturnsFalse()
+    {
+        var gesture = new HotkeyGesture("C", Required: HotkeyModifiers.Command);
+
+        bool result = gesture.Matches("C", HotkeyModifiers.None);
+
+        Assert.False(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyRegistryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HotkeyRegistryTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using AnimationEditor.Core.Hotkeys;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class HotkeyRegistryTests
+{
+    private static HotkeyDefinition MakeDefinition(string id, params HotkeyGesture[] gestures) =>
+        new()
+        {
+            Id = id,
+            Description = id,
+            Category = "Edit",
+            Gestures = gestures,
+            Action = () => { },
+        };
+
+    [Fact]
+    public void FindDuplicateGestures_TwoDefinitionsShareAGesture_ReturnsThePair()
+    {
+        var shared = new HotkeyGesture("Z", HotkeyModifiers.Command);
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("undo", shared),
+            MakeDefinition("some-other-z-command", shared),
+        };
+
+        var duplicates = HotkeyRegistry.FindDuplicateGestures(hotkeys);
+
+        Assert.Single(duplicates);
+        Assert.Equal("undo", duplicates[0].FirstId);
+        Assert.Equal("some-other-z-command", duplicates[0].SecondId);
+    }
+
+    [Fact]
+    public void FindDuplicateGestures_NoOverlap_ReturnsEmpty()
+    {
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("copy", new HotkeyGesture("C", HotkeyModifiers.Command)),
+            MakeDefinition("undo", new HotkeyGesture("Z", HotkeyModifiers.Command, Forbidden: HotkeyModifiers.Shift)),
+            MakeDefinition("redo",
+                new HotkeyGesture("Y", HotkeyModifiers.Command),
+                new HotkeyGesture("Z", HotkeyModifiers.Command | HotkeyModifiers.Shift, Forbidden: HotkeyModifiers.Alt)),
+        };
+
+        var duplicates = HotkeyRegistry.FindDuplicateGestures(hotkeys);
+
+        Assert.Empty(duplicates);
+    }
+
+    [Fact]
+    public void FindMatch_RedoSecondGesture_CtrlShiftZ_ReturnsRedoNotUndo()
+    {
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("undo", new HotkeyGesture("Z", HotkeyModifiers.Command, Forbidden: HotkeyModifiers.Shift)),
+            MakeDefinition("redo",
+                new HotkeyGesture("Y", HotkeyModifiers.Command),
+                new HotkeyGesture("Z", HotkeyModifiers.Command | HotkeyModifiers.Shift, Forbidden: HotkeyModifiers.Alt)),
+        };
+
+        var match = HotkeyRegistry.FindMatch(hotkeys, "Z", HotkeyModifiers.Command | HotkeyModifiers.Shift);
+
+        Assert.NotNull(match);
+        Assert.Equal("redo", match!.Id);
+    }
+
+    [Fact]
+    public void FindMatch_FirstDefinitionMatches_StopsBeforeLaterDefinitions()
+    {
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("copy", new HotkeyGesture("C", HotkeyModifiers.Command)),
+            MakeDefinition("copy-again", new HotkeyGesture("C", HotkeyModifiers.Command)),
+        };
+
+        var match = HotkeyRegistry.FindMatch(hotkeys, "C", HotkeyModifiers.Command);
+
+        Assert.Equal("copy", match!.Id);
+    }
+
+    [Fact]
+    public void FindMatch_NoDefinitionMatches_ReturnsNull()
+    {
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("copy", new HotkeyGesture("C", HotkeyModifiers.Command)),
+        };
+
+        var match = HotkeyRegistry.FindMatch(hotkeys, "V", HotkeyModifiers.Command);
+
+        Assert.Null(match);
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the hand-written if/else chain in `MainWindow`'s global `KeyDown` handler with a `HotkeyDefinition`/`HotkeyGesture` registry in `AnimationEditor.Core.Hotkeys`.
- The same registry drives `MenuItem.InputGesture` text (`ApplyHotkeyMenuGestureText`), so the menu can no longer show a shortcut that the KeyDown handler doesn't actually dispatch — the drift the issue describes.
- Gesture matching (`HotkeyGesture.Matches`) is pure and UI-independent, unit-tested in `AnimationEditor.Core.Tests` without any Avalonia window.
- Pure refactor — no new hotkeys, no behavior change to Copy/Cut/Paste/Duplicate/Delete/Rename(F2)/Toggle Diagnostics(F3)/Undo/Redo/Play-Pause(Space)/Reorder(Alt+Up/Down).
- `MenuNew`/`MenuLoad`/`MenuSave` and the zoom shortcuts (`Ctrl+OemPlus` etc.) keep their hand-authored XAML `InputGesture` text — they were never backed by a real `KeyDown` branch (confirmed by grep), so there's nothing to centralize for them yet.

Closes #632

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1584 passed (12 new: gesture matching, duplicate-gesture detection, display-text formatting)
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 662 passed (8 new: Undo/Redo both gestures/F3/Space/Alt+Up reorder + no-duplicate-gestures on the real production registry + menu InputGesture matches dispatch)
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 0 warnings, 0 errors (including the browser/WASM target)