### PR TITLE
Animation Editor: wire up New/Load/Save and zoom keyboard shortcuts

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -84,10 +84,13 @@
                       VerticalAlignment="Center"
                       Margin="4,0">
                     <MenuItem Header="_File">
-                        <MenuItem Header="_New"          x:Name="MenuNew"    InputGesture="Ctrl+N" />
-                        <MenuItem Header="_Load..."       x:Name="MenuLoad"   InputGesture="Ctrl+L" />
+                        <!-- InputGesture text for New/Load/Save is set in code from the hotkey
+                             registry (MainWindow.ApplyHotkeyMenuGestureText, issue #638) so it
+                             can never drift from what the KeyDown handler actually does. -->
+                        <MenuItem Header="_New"          x:Name="MenuNew" />
+                        <MenuItem Header="_Load..."       x:Name="MenuLoad" />
                         <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
-                        <MenuItem Header="_Save"          x:Name="MenuSave"   InputGesture="Ctrl+S" />
+                        <MenuItem Header="_Save"          x:Name="MenuSave" />
                         <MenuItem Header="Save _As..."    x:Name="MenuSaveAs" />
                         <MenuItem Header="_Export">
                             <MenuItem Header="_PixiJS..." x:Name="MenuExportPixiJs" />
@@ -113,11 +116,17 @@
                         <MenuItem Header="_Settings…" x:Name="MenuSettings" />
                     </MenuItem>
                     <MenuItem Header="_View">
-                        <MenuItem Header="Wireframe _Zoom In"   InputGesture="Ctrl+OemPlus" />
-                        <MenuItem Header="Wireframe Zoom _Out"  InputGesture="Ctrl+OemMinus" />
+                        <!-- InputGesture text for the four zoom items is set in code from the
+                             hotkey registry (see note above) — issue #638. Wireframe and preview
+                             zoom are deliberately on different gestures (plain Ctrl+Oem vs.
+                             Ctrl+Shift+Oem), each forbidding the other's modifier, so a future
+                             app-wide zoom feature can claim its own gesture (e.g. bare Ctrl+Plus/
+                             Minus or Ctrl+0) without colliding with either pane zoom. -->
+                        <MenuItem Header="Wireframe _Zoom In"   x:Name="MenuWireframeZoomIn" />
+                        <MenuItem Header="Wireframe Zoom _Out"  x:Name="MenuWireframeZoomOut" />
                         <Separator />
-                        <MenuItem Header="Preview Zoom _In"     InputGesture="Ctrl+Shift+OemPlus" />
-                        <MenuItem Header="Preview Zoom O_ut"    InputGesture="Ctrl+Shift+OemMinus" />
+                        <MenuItem Header="Preview Zoom _In"     x:Name="MenuPreviewZoomIn" />
+                        <MenuItem Header="Preview Zoom O_ut"    x:Name="MenuPreviewZoomOut" />
                         <Separator />
                         <MenuItem Header="Show _History" x:Name="MenuShowHistory" />
                         <Separator />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -117,11 +117,12 @@
                     </MenuItem>
                     <MenuItem Header="_View">
                         <!-- InputGesture text for the four zoom items is set in code from the
-                             hotkey registry (see note above) — issue #638. Wireframe and preview
-                             zoom are deliberately on different gestures (plain Ctrl+Oem vs.
-                             Ctrl+Shift+Oem), each forbidding the other's modifier, so a future
-                             app-wide zoom feature can claim its own gesture (e.g. bare Ctrl+Plus/
-                             Minus or Ctrl+0) without colliding with either pane zoom. -->
+                             hotkey registry (see note above) — issue #638. Clicking a menu item
+                             always zooms that specific panel; Ctrl+Plus/Minus is one shared,
+                             focus-contextual gesture (whichever panel is focused), so both
+                             Wireframe/Preview Zoom In (and Out) truthfully show the same shortcut
+                             text — see MainWindow.FocusedPanelZoom. Ctrl+Shift+Plus/Minus is
+                             reserved, unclaimed, for a future app-wide zoom feature. -->
                         <MenuItem Header="Wireframe _Zoom In"   x:Name="MenuWireframeZoomIn" />
                         <MenuItem Header="Wireframe Zoom _Out"  x:Name="MenuWireframeZoomOut" />
                         <Separator />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -5193,9 +5193,10 @@ public partial class MainWindow : Window
                 Gestures = new[] { new HotkeyGesture("S", Command) },
                 Action = () => OnSaveClick(null, null!),
             },
-            // Ctrl+Plus/Minus zooms whichever panel (wireframe or preview) currently has keyboard
-            // focus — not a fixed pane — because requiring the user to first click away from a
-            // panel to reach a different zoom gesture is its own source of confusion. Forbidden:
+            // Ctrl+Plus/Minus zooms whichever panel (wireframe, preview, or the PNG diff pane)
+            // currently has keyboard focus — not a fixed pane — because requiring the user to
+            // first click away from a panel to reach a different zoom gesture is its own source
+            // of confusion. Forbidden:
             // Shift is reserved now, before anything claims it, so that a future app-wide zoom on
             // Ctrl+Shift+Plus/Minus is a pure addition later rather than a retrofit that has to
             // come back and defensively exclude Shift from these two entries after the fact. This
@@ -5220,13 +5221,14 @@ public partial class MainWindow : Window
     }
 
     // Resolves which pane's ZoomControl the panel-zoom-in/out hotkeys should drive: whichever of
-    // WireframeCtrl/PreviewCtrl currently owns keyboard focus (or is an ancestor of the focused
-    // element), else null when neither does (e.g. the tree or a text field is focused instead).
+    // WireframeCtrl/PreviewCtrl/PngPane currently owns keyboard focus (or is an ancestor of the
+    // focused element), else null when none does (e.g. the tree or a text field is focused instead).
     private ZoomControl? FocusedPanelZoom()
     {
         if (FocusManager?.GetFocusedElement() is not Control focused) return null;
         if (focused == WireframeCtrl || WireframeCtrl.IsVisualAncestorOf(focused)) return WireframeZoom;
         if (focused == PreviewCtrl || PreviewCtrl.IsVisualAncestorOf(focused)) return PreviewZoom;
+        if (focused == PngPane || PngPane.IsVisualAncestorOf(focused)) return PngZoom;
         return null;
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
-﻿using AnimationEditor.App.Services;
+﻿using AnimationEditor.App.Controls;
+using AnimationEditor.App.Services;
 using AnimationEditor.App.Theming;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
@@ -5192,37 +5193,41 @@ public partial class MainWindow : Window
                 Gestures = new[] { new HotkeyGesture("S", Command) },
                 Action = () => OnSaveClick(null, null!),
             },
-            // Wireframe and preview zoom deliberately sit on different gestures (Forbidden:Shift
-            // keeps Ctrl+Shift+Oem from also matching the wireframe entry) rather than sharing one
-            // gesture disambiguated by a suppression flag — the Gum tool's app-wide vs. per-pane
-            // zoom hotkeys took that shared-gesture path and it required a bug fix (double-zoom)
-            // plus a hand-threaded bool at every call site. Keeping the two pane zooms on distinct
-            // gestures also leaves bare Ctrl+Plus/Minus free for a future app-wide zoom feature.
+            // Ctrl+Plus/Minus zooms whichever panel (wireframe or preview) currently has keyboard
+            // focus — not a fixed pane — because requiring the user to first click away from a
+            // panel to reach a different zoom gesture is its own source of confusion. Forbidden:
+            // Shift is reserved now, before anything claims it, so that a future app-wide zoom on
+            // Ctrl+Shift+Plus/Minus is a pure addition later rather than a retrofit that has to
+            // come back and defensively exclude Shift from these two entries after the fact. This
+            // is the shape of disambiguation the Gum tool's app-wide vs. per-pane zoom hotkeys
+            // never had — they shared one gesture and were split apart only after a double-zoom
+            // bug, via a hand-threaded suppression flag at every call site.
             new()
             {
-                Id = "wireframe-zoom-in", Description = "Wireframe Zoom In", Category = "View",
+                Id = "panel-zoom-in", Description = "Zoom In (Focused Panel)", Category = "View",
                 Gestures = new[] { new HotkeyGesture("OemPlus", Command, Forbidden: Shift) },
-                Action = () => WireframeZoom.StepUp(),
+                ShouldSkip = () => FocusedPanelZoom() is null,
+                Action = () => FocusedPanelZoom()!.StepUp(),
             },
             new()
             {
-                Id = "wireframe-zoom-out", Description = "Wireframe Zoom Out", Category = "View",
+                Id = "panel-zoom-out", Description = "Zoom Out (Focused Panel)", Category = "View",
                 Gestures = new[] { new HotkeyGesture("OemMinus", Command, Forbidden: Shift) },
-                Action = () => WireframeZoom.StepDown(),
-            },
-            new()
-            {
-                Id = "preview-zoom-in", Description = "Preview Zoom In", Category = "View",
-                Gestures = new[] { new HotkeyGesture("OemPlus", Command | Shift) },
-                Action = () => PreviewZoom.StepUp(),
-            },
-            new()
-            {
-                Id = "preview-zoom-out", Description = "Preview Zoom Out", Category = "View",
-                Gestures = new[] { new HotkeyGesture("OemMinus", Command | Shift) },
-                Action = () => PreviewZoom.StepDown(),
+                ShouldSkip = () => FocusedPanelZoom() is null,
+                Action = () => FocusedPanelZoom()!.StepDown(),
             },
         };
+    }
+
+    // Resolves which pane's ZoomControl the panel-zoom-in/out hotkeys should drive: whichever of
+    // WireframeCtrl/PreviewCtrl currently owns keyboard focus (or is an ancestor of the focused
+    // element), else null when neither does (e.g. the tree or a text field is focused instead).
+    private ZoomControl? FocusedPanelZoom()
+    {
+        if (FocusManager?.GetFocusedElement() is not Control focused) return null;
+        if (focused == WireframeCtrl || WireframeCtrl.IsVisualAncestorOf(focused)) return WireframeZoom;
+        if (focused == PreviewCtrl || PreviewCtrl.IsVisualAncestorOf(focused)) return PreviewZoom;
+        return null;
     }
 
     // F2: prefer the tree's SelectedItem, fall back to _selectedState when the tree has
@@ -5275,10 +5280,12 @@ public partial class MainWindow : Window
         SetMenuGesture(MenuNew, "new");
         SetMenuGesture(MenuLoad, "load");
         SetMenuGesture(MenuSave, "save");
-        SetMenuGesture(MenuWireframeZoomIn, "wireframe-zoom-in");
-        SetMenuGesture(MenuWireframeZoomOut, "wireframe-zoom-out");
-        SetMenuGesture(MenuPreviewZoomIn, "preview-zoom-in");
-        SetMenuGesture(MenuPreviewZoomOut, "preview-zoom-out");
+        // Wireframe/Preview Zoom In (and Out) share one gesture — it's contextual to whichever
+        // panel has focus — so both menu items truthfully show the same shortcut text.
+        SetMenuGesture(MenuWireframeZoomIn, "panel-zoom-in");
+        SetMenuGesture(MenuWireframeZoomOut, "panel-zoom-out");
+        SetMenuGesture(MenuPreviewZoomIn, "panel-zoom-in");
+        SetMenuGesture(MenuPreviewZoomOut, "panel-zoom-out");
     }
 
     private void SetMenuGesture(MenuItem item, string hotkeyId) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1795,6 +1795,11 @@ public partial class MainWindow : Window
         HistoryRedoButton.Click += (_, _) => _undoManager.Redo();
         MenuShowHistory.Click   += (_, _) => SelectHistoryTab();
 
+        MenuWireframeZoomIn.Click  += (_, _) => WireframeZoom.StepUp();
+        MenuWireframeZoomOut.Click += (_, _) => WireframeZoom.StepDown();
+        MenuPreviewZoomIn.Click    += (_, _) => PreviewZoom.StepUp();
+        MenuPreviewZoomOut.Click   += (_, _) => PreviewZoom.StepDown();
+
         MenuThemeLight.Click  += (_, _) => SetTheme(AppTheme.Light);
         MenuThemeDark.Click   += (_, _) => SetTheme(AppTheme.Dark);
         MenuThemeSystem.Click += (_, _) => SetTheme(AppTheme.System);
@@ -5169,6 +5174,54 @@ public partial class MainWindow : Window
                 Gestures = new[] { new HotkeyGesture("Down", Alt) },
                 Action = () => HandleReorderHotkey(+1),
             },
+            new()
+            {
+                Id = "new", Description = "New", Category = "File",
+                Gestures = new[] { new HotkeyGesture("N", Command) },
+                Action = () => OnNewClick(null, null!),
+            },
+            new()
+            {
+                Id = "load", Description = "Load...", Category = "File",
+                Gestures = new[] { new HotkeyGesture("L", Command) },
+                Action = () => _ = LoadAsync(),
+            },
+            new()
+            {
+                Id = "save", Description = "Save", Category = "File",
+                Gestures = new[] { new HotkeyGesture("S", Command) },
+                Action = () => OnSaveClick(null, null!),
+            },
+            // Wireframe and preview zoom deliberately sit on different gestures (Forbidden:Shift
+            // keeps Ctrl+Shift+Oem from also matching the wireframe entry) rather than sharing one
+            // gesture disambiguated by a suppression flag — the Gum tool's app-wide vs. per-pane
+            // zoom hotkeys took that shared-gesture path and it required a bug fix (double-zoom)
+            // plus a hand-threaded bool at every call site. Keeping the two pane zooms on distinct
+            // gestures also leaves bare Ctrl+Plus/Minus free for a future app-wide zoom feature.
+            new()
+            {
+                Id = "wireframe-zoom-in", Description = "Wireframe Zoom In", Category = "View",
+                Gestures = new[] { new HotkeyGesture("OemPlus", Command, Forbidden: Shift) },
+                Action = () => WireframeZoom.StepUp(),
+            },
+            new()
+            {
+                Id = "wireframe-zoom-out", Description = "Wireframe Zoom Out", Category = "View",
+                Gestures = new[] { new HotkeyGesture("OemMinus", Command, Forbidden: Shift) },
+                Action = () => WireframeZoom.StepDown(),
+            },
+            new()
+            {
+                Id = "preview-zoom-in", Description = "Preview Zoom In", Category = "View",
+                Gestures = new[] { new HotkeyGesture("OemPlus", Command | Shift) },
+                Action = () => PreviewZoom.StepUp(),
+            },
+            new()
+            {
+                Id = "preview-zoom-out", Description = "Preview Zoom Out", Category = "View",
+                Gestures = new[] { new HotkeyGesture("OemMinus", Command | Shift) },
+                Action = () => PreviewZoom.StepDown(),
+            },
         };
     }
 
@@ -5209,9 +5262,7 @@ public partial class MainWindow : Window
     }
 
     // Sets each menu item's InputGesture text from the matching registry entry's DisplayText,
-    // so the menu can never show a shortcut a keypress doesn't actually trigger (issue #632).
-    // MenuNew/MenuLoad/MenuSave and the zoom shortcuts keep their hand-authored XAML text — they
-    // have no KeyDown-driven implementation to derive from.
+    // so the menu can never show a shortcut a keypress doesn't actually trigger (issue #632, #638).
     private void ApplyHotkeyMenuGestureText()
     {
         SetMenuGesture(MenuUndo, "undo");
@@ -5221,6 +5272,13 @@ public partial class MainWindow : Window
         SetMenuGesture(MenuPaste, "paste");
         SetMenuGesture(MenuDuplicate, "duplicate");
         SetMenuGesture(MenuShowDiagnostics, "toggle-diagnostics");
+        SetMenuGesture(MenuNew, "new");
+        SetMenuGesture(MenuLoad, "load");
+        SetMenuGesture(MenuSave, "save");
+        SetMenuGesture(MenuWireframeZoomIn, "wireframe-zoom-in");
+        SetMenuGesture(MenuWireframeZoomOut, "wireframe-zoom-out");
+        SetMenuGesture(MenuPreviewZoomIn, "preview-zoom-in");
+        SetMenuGesture(MenuPreviewZoomOut, "preview-zoom-out");
     }
 
     private void SetMenuGesture(MenuItem item, string hotkeyId) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/AnimationEditor.Views.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/AnimationEditor.Views.csproj
@@ -45,5 +45,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>AnimationEditor.Browser</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>AnimationEditor.Views.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PointerGestures.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PointerGestures.cs
@@ -1,0 +1,20 @@
+using Avalonia.Input;
+
+namespace AnimationEditor.App.Controls;
+
+/// <summary>
+/// Shared pointer-gesture logic for every zoomable/pannable panel (TextureViewport --
+/// wireframe and the PNG diff pane -- and PreviewControl). These controls don't share a base
+/// class (see the "zoom hosts share no base class" landmine), so without a single source of
+/// truth here each one's OnPointerPressed silently re-derives its own copy of "is this a pan"
+/// and can drift from the others -- which is exactly how PreviewControl ended up missing the
+/// unconditional Focus() call that TextureViewport already had (#638 follow-up).
+/// </summary>
+internal static class PointerGestures
+{
+    /// <summary>
+    /// True when a pointer press should start a pan gesture: middle-click, or Alt+left-click.
+    /// </summary>
+    public static bool IsPanGesture(bool isMiddleButtonPressed, bool isLeftButtonPressed, KeyModifiers modifiers) =>
+        isMiddleButtonPressed || (isLeftButtonPressed && modifiers.HasFlag(KeyModifiers.Alt));
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -1726,13 +1726,13 @@ public class PreviewControl : Control, IZoomTarget
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
+        Focus();
         var props = e.GetCurrentPoint(this).Properties;
         var pos   = e.GetPosition(this);
         float px  = (float)pos.X;
         float py  = (float)pos.Y;
 
-        if (props.IsMiddleButtonPressed ||
-            (props.IsLeftButtonPressed && e.KeyModifiers.HasFlag(KeyModifiers.Alt)))
+        if (PointerGestures.IsPanGesture(props.IsMiddleButtonPressed, props.IsLeftButtonPressed, e.KeyModifiers))
         {
             CancelZoomAnimation();   // a pan gesture overrides any in-flight wheel ease
             _isPanning    = true;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
@@ -1009,10 +1009,8 @@ public class TextureViewport : Control, IZoomTarget
 
         var props = e.GetCurrentPoint(this).Properties;
         var pos = e.GetPosition(this);
-        bool isAlt = (e.KeyModifiers & KeyModifiers.Alt) != 0;
 
-        // Middle-mouse or Alt+left → pan
-        if (props.IsMiddleButtonPressed || (props.IsLeftButtonPressed && isAlt))
+        if (PointerGestures.IsPanGesture(props.IsMiddleButtonPressed, props.IsLeftButtonPressed, e.KeyModifiers))
         {
             StartPan(pos);
             e.Pointer.Capture(this);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
@@ -293,20 +293,19 @@ public class HotkeyDispatchTests
     // Clicks the centre of `control` via a real pointer press, so focus-on-click behavior
     // (TextureViewport/PreviewControl.OnPointerPressed calling Focus()) is actually exercised
     // rather than assumed.
-    private static void Click(MainWindow window, Control control)
+    private static void Click(MainWindow window, Control control, MouseButton button = MouseButton.Left)
     {
         var centre = new Point(control.Bounds.Width / 2, control.Bounds.Height / 2);
         var pointInWindow = control.TranslatePoint(centre, window)!.Value;
-        window.MouseDown(pointInWindow, MouseButton.Left);
+        window.MouseDown(pointInWindow, button);
         Dispatcher.UIThread.RunJobs();
     }
 
     /// <summary>
     /// The focus-based panel-zoom hotkeys below depend on clicking a panel actually focusing it.
-    /// PreviewControl (unlike TextureViewport) has no explicit <c>Focus()</c> call in its
-    /// OnPointerPressed — this passes only because Avalonia auto-focuses a Focusable control on
-    /// pointer press by default. Keep this test as a guard against that default ever being
-    /// suppressed (e.g. a future PreviewControl change marking the press event Handled early).
+    /// Left-click specifically also works via Avalonia's default focus-on-primary-click, so this
+    /// alone wouldn't have caught the real gap here — see
+    /// <see cref="MiddleClickingPreviewPanel_GivesItFocus"/> for that regression.
     /// </summary>
     [AvaloniaFact]
     public void ClickingPreviewPanel_GivesItFocus()
@@ -321,6 +320,71 @@ public class HotkeyDispatchTests
             Assert.Same(preview, window.FocusManager?.GetFocusedElement());
         }
         finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Regression for a real gap found in manual testing (#638): Avalonia's default
+    /// focus-on-pointer-press only covers the primary (left) button, so middle-clicking
+    /// PreviewControl's pan gesture never focused it — unlike TextureViewport, which calls
+    /// Focus() unconditionally before branching on which button was pressed. Fixed by giving
+    /// PreviewControl.OnPointerPressed the same explicit, button-independent Focus() call.
+    /// </summary>
+    [AvaloniaFact]
+    public void MiddleClickingPreviewPanel_GivesItFocus()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            Click(window, preview, MouseButton.Middle);
+
+            Assert.Same(preview, window.FocusManager?.GetFocusedElement());
+        }
+        finally { window.Close(); }
+    }
+
+    // A 1×1 transparent PNG — enough to make OpenPngAsTab show a visible, focusable PngPane;
+    // the pan/focus/zoom path under test doesn't depend on the decode succeeding (see PngTabTests).
+    private const string OnePixelPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+    /// <summary>
+    /// The PNG diff pane is a third focus-based zoom target alongside wireframe/preview (#638
+    /// follow-up) — it reuses TextureViewport (same base as wireframe), so it already had correct
+    /// multi-button focus-on-click; only FocusedPanelZoom needed to learn about it.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task CtrlOemPlus_PngPaneFocused_StepsPngZoomOnly()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var pngPath = Path.Combine(dir, "sheet.png");
+        File.WriteAllBytes(pngPath, Convert.FromBase64String(OnePixelPngBase64));
+        var (window, _) = CreateWindow();
+        try
+        {
+            window.OpenPngAsTab(pngPath);
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            Click(window, pngPane);
+
+            window.KeyPress(Key.OemPlus, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1.5f, pngPane.Zoom);
+            Assert.Equal(1f, wireframe.Zoom);
+            Assert.Equal(1f, preview.Zoom);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
@@ -8,7 +8,9 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
+using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -212,6 +214,168 @@ public class HotkeyDispatchTests
             var menuUndo = window.FindControl<MenuItem>("MenuUndo")!;
 
             Assert.Equal(new KeyGesture(Key.Z, KeyModifiers.Control), menuUndo.InputGesture);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── Issue #638: decorative File/View shortcuts wired to real actions ───────
+
+    [AvaloniaFact]
+    public void CtrlN_ClearsTree()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            var vm = SeedAndSelect(window, chain, "Walk");
+            var roots = (ObservableCollection<TreeNodeVm>)window.FindControl<TreeView>("AnimTree")!.ItemsSource!;
+            Assert.Contains(vm, roots);
+
+            window.KeyPress(Key.N, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.DoesNotContain(vm, roots);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlS_WithFileName_WritesFileToDisk()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(dir, "out.achx");
+        Directory.CreateDirectory(dir);
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(
+                new AnimationChainSave { Name = "Idle" });
+            ctx.ProjectManager.FileName = path;
+
+            window.KeyPress(Key.S, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The headless platform's StorageProvider returns no files for a file-open request, so this
+    /// only proves Ctrl+L dispatches to the same load path as clicking MenuLoad without throwing —
+    /// it does not exercise picking and loading a real file (no test in this suite does; loading a
+    /// specific file is covered via LoadAnimationFileAsync directly, see MainWindowMenuFlowTests).
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlL_DoesNotThrow()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            window.KeyPress(Key.L, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Wireframe and preview zoom are deliberately on different gestures (Ctrl+Oem vs.
+    /// Ctrl+Shift+Oem), each forbidding the other's modifier — this is the regression guard for
+    /// the double-zoom bug the Gum tool hit from sharing one gesture between an app-wide and a
+    /// per-pane zoom (disambiguated there only by a hand-threaded suppression flag).
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlOemPlus_StepsWireframeZoomUp_LeavesPreviewUnchanged()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            window.KeyPress(Key.OemPlus, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1.5f, wireframe.Zoom);
+            Assert.Equal(1f, preview.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlOemMinus_StepsWireframeZoomDown_LeavesPreviewUnchanged()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            window.KeyPress(Key.OemMinus, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0.75f, wireframe.Zoom);
+            Assert.Equal(1f, preview.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlShiftOemPlus_StepsPreviewZoomUp_LeavesWireframeUnchanged()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            window.KeyPress(Key.OemPlus, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1.5f, preview.Zoom);
+            Assert.Equal(1f, wireframe.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlShiftOemMinus_StepsPreviewZoomDown_LeavesWireframeUnchanged()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            window.KeyPress(Key.OemMinus, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0.75f, preview.Zoom);
+            Assert.Equal(1f, wireframe.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>Menu InputGesture text for the #638 items now derives from the registry too.</summary>
+    [AvaloniaFact]
+    public void MenuWireframeZoomIn_InputGesture_MatchesCtrlOemPlusDispatchedByKeyDown()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var item = window.FindControl<MenuItem>("MenuWireframeZoomIn")!;
+
+            Assert.Equal(new KeyGesture(Key.OemPlus, KeyModifiers.Control), item.InputGesture);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HotkeyDispatchTests.cs
@@ -2,11 +2,13 @@ using AnimationEditor.App.Controls;
 using AnimationEditor.Core.Hotkeys;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.ObjectModel;
@@ -288,20 +290,52 @@ public class HotkeyDispatchTests
         finally { window.Close(); }
     }
 
+    // Clicks the centre of `control` via a real pointer press, so focus-on-click behavior
+    // (TextureViewport/PreviewControl.OnPointerPressed calling Focus()) is actually exercised
+    // rather than assumed.
+    private static void Click(MainWindow window, Control control)
+    {
+        var centre = new Point(control.Bounds.Width / 2, control.Bounds.Height / 2);
+        var pointInWindow = control.TranslatePoint(centre, window)!.Value;
+        window.MouseDown(pointInWindow, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+    }
+
     /// <summary>
-    /// Wireframe and preview zoom are deliberately on different gestures (Ctrl+Oem vs.
-    /// Ctrl+Shift+Oem), each forbidding the other's modifier — this is the regression guard for
-    /// the double-zoom bug the Gum tool hit from sharing one gesture between an app-wide and a
-    /// per-pane zoom (disambiguated there only by a hand-threaded suppression flag).
+    /// The focus-based panel-zoom hotkeys below depend on clicking a panel actually focusing it.
+    /// PreviewControl (unlike TextureViewport) has no explicit <c>Focus()</c> call in its
+    /// OnPointerPressed — this passes only because Avalonia auto-focuses a Focusable control on
+    /// pointer press by default. Keep this test as a guard against that default ever being
+    /// suppressed (e.g. a future PreviewControl change marking the press event Handled early).
     /// </summary>
     [AvaloniaFact]
-    public void CtrlOemPlus_StepsWireframeZoomUp_LeavesPreviewUnchanged()
+    public void ClickingPreviewPanel_GivesItFocus()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+
+            Click(window, preview);
+
+            Assert.Same(preview, window.FocusManager?.GetFocusedElement());
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Ctrl+Plus/Minus targets whichever panel has focus rather than a fixed pane — clicking into
+    /// wireframe then pressing Ctrl+Plus must zoom only wireframe, never preview.
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlOemPlus_WireframeFocused_StepsWireframeZoomOnly()
     {
         var (window, _) = CreateWindow();
         try
         {
             var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
             var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            Click(window, wireframe);
 
             window.KeyPress(Key.OemPlus, RawInputModifiers.Control, PhysicalKey.None, null);
             Dispatcher.UIThread.RunJobs();
@@ -312,52 +346,18 @@ public class HotkeyDispatchTests
         finally { window.Close(); }
     }
 
+    /// <summary>The same gesture, but with focus on preview instead — zooms preview only.</summary>
     [AvaloniaFact]
-    public void CtrlOemMinus_StepsWireframeZoomDown_LeavesPreviewUnchanged()
+    public void CtrlOemMinus_PreviewFocused_StepsPreviewZoomOnly()
     {
         var (window, _) = CreateWindow();
         try
         {
             var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
             var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            Click(window, preview);
 
             window.KeyPress(Key.OemMinus, RawInputModifiers.Control, PhysicalKey.None, null);
-            Dispatcher.UIThread.RunJobs();
-
-            Assert.Equal(0.75f, wireframe.Zoom);
-            Assert.Equal(1f, preview.Zoom);
-        }
-        finally { window.Close(); }
-    }
-
-    [AvaloniaFact]
-    public void CtrlShiftOemPlus_StepsPreviewZoomUp_LeavesWireframeUnchanged()
-    {
-        var (window, _) = CreateWindow();
-        try
-        {
-            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
-            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
-
-            window.KeyPress(Key.OemPlus, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
-            Dispatcher.UIThread.RunJobs();
-
-            Assert.Equal(1.5f, preview.Zoom);
-            Assert.Equal(1f, wireframe.Zoom);
-        }
-        finally { window.Close(); }
-    }
-
-    [AvaloniaFact]
-    public void CtrlShiftOemMinus_StepsPreviewZoomDown_LeavesWireframeUnchanged()
-    {
-        var (window, _) = CreateWindow();
-        try
-        {
-            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
-            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
-
-            window.KeyPress(Key.OemMinus, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
             Dispatcher.UIThread.RunJobs();
 
             Assert.Equal(0.75f, preview.Zoom);
@@ -366,16 +366,63 @@ public class HotkeyDispatchTests
         finally { window.Close(); }
     }
 
-    /// <summary>Menu InputGesture text for the #638 items now derives from the registry too.</summary>
+    /// <summary>Neither panel focused (tree has it) — Ctrl+Plus is a no-op, not a guess.</summary>
     [AvaloniaFact]
-    public void MenuWireframeZoomIn_InputGesture_MatchesCtrlOemPlusDispatchedByKeyDown()
+    public void CtrlOemPlus_NeitherPanelFocused_DoesNothing()
     {
         var (window, _) = CreateWindow();
         try
         {
-            var item = window.FindControl<MenuItem>("MenuWireframeZoomIn")!;
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            window.FindControl<TreeView>("AnimTree")!.Focus();
 
-            Assert.Equal(new KeyGesture(Key.OemPlus, KeyModifiers.Control), item.InputGesture);
+            window.KeyPress(Key.OemPlus, RawInputModifiers.Control, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1f, wireframe.Zoom);
+            Assert.Equal(1f, preview.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Ctrl+Shift+Plus/Minus is reserved, unclaimed, for a future app-wide zoom feature — it must
+    /// NOT also trigger the focused panel's zoom (Forbidden:Shift on panel-zoom-in/out). This is
+    /// the regression guard for the Gum tool's mistake: its app-wide and per-pane zoom hotkeys
+    /// shared one gesture and were split apart only after a reported double-zoom bug.
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlShiftOemPlus_WireframeFocused_DoesNotStepPanelZoom()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            Click(window, wireframe);
+
+            window.KeyPress(Key.OemPlus, RawInputModifiers.Control | RawInputModifiers.Shift, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1f, wireframe.Zoom);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Menu InputGesture text for the #638 items now derives from the registry — Wireframe and
+    /// Preview Zoom In both show the same gesture text since it's genuinely contextual.
+    /// </summary>
+    [AvaloniaFact]
+    public void WireframeAndPreviewZoomInMenuItems_ShowTheSameSharedGesture()
+    {
+        var (window, _) = CreateWindow();
+        try
+        {
+            var expected = new KeyGesture(Key.OemPlus, KeyModifiers.Control);
+
+            Assert.Equal(expected, window.FindControl<MenuItem>("MenuWireframeZoomIn")!.InputGesture);
+            Assert.Equal(expected, window.FindControl<MenuItem>("MenuPreviewZoomIn")!.InputGesture);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/PointerGesturesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/PointerGesturesTests.cs
@@ -1,0 +1,43 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Input;
+using Xunit;
+
+namespace AnimationEditor.Views.Tests;
+
+/// <summary>
+/// TextureViewport (wireframe + PNG diff pane) and PreviewControl each had their own copy of the
+/// "is this a pan gesture" check. The copies stayed textually identical, but PreviewControl's
+/// pointer-press handling separately forgot the accompanying Focus() call that TextureViewport
+/// had (#638 follow-up) -- a sign the duplication itself was the risk, not just that one bug.
+/// PointerGestures.IsPanGesture is the single source of truth both controls now call.
+/// </summary>
+public class PointerGesturesTests
+{
+    [Fact]
+    public void MiddleButtonPressed_IsPanGesture_RegardlessOfModifiers()
+    {
+        Assert.True(PointerGestures.IsPanGesture(
+            isMiddleButtonPressed: true, isLeftButtonPressed: false, modifiers: KeyModifiers.None));
+    }
+
+    [Fact]
+    public void LeftButtonPressed_WithAlt_IsPanGesture()
+    {
+        Assert.True(PointerGestures.IsPanGesture(
+            isMiddleButtonPressed: false, isLeftButtonPressed: true, modifiers: KeyModifiers.Alt));
+    }
+
+    [Fact]
+    public void LeftButtonPressed_WithoutAlt_IsNotPanGesture()
+    {
+        Assert.False(PointerGestures.IsPanGesture(
+            isMiddleButtonPressed: false, isLeftButtonPressed: true, modifiers: KeyModifiers.None));
+    }
+
+    [Fact]
+    public void RightButtonPressed_IsNotPanGesture()
+    {
+        Assert.False(PointerGestures.IsPanGesture(
+            isMiddleButtonPressed: false, isLeftButtonPressed: false, modifiers: KeyModifiers.None));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `HotkeyRegistry` entries for the decorative shortcuts flagged in #638: `Ctrl+N` (New), `Ctrl+L` (Load), `Ctrl+S` (Save), and a shared **focus-based** `Ctrl+Plus`/`Ctrl+Minus` panel-zoom hotkey covering all three zoom surfaces: wireframe, preview, and the PNG diff pane.
- Menu `InputGesture` text for all File items and both zoom directions now derives from the registry (`ApplyHotkeyMenuGestureText`) instead of hand-authored XAML, so it can never drift from what the keypress actually does — same discipline as #632/#637.
- **Zoom design:** `Ctrl+Plus`/`Ctrl+Minus` zooms whichever panel currently has keyboard focus, rather than a fixed gesture per panel. `Ctrl+Shift+Plus`/`Ctrl+Shift+Minus` is left completely unclaimed, reserved for a possible future app-wide zoom feature. Both panel-zoom gestures keep `Forbidden: Shift` from the start, so that reservation is a pure addition later rather than a retrofit — the disambiguation the Gum tool's app-wide vs. per-pane zoom hotkeys never had; they shared one gesture and were split apart only after a reported double-zoom bug, via a hand-threaded suppression flag at every call site.
- **Fixed a real focus bug found in manual testing:** middle-clicking the preview panel didn't focus it (only left-click did), because `PreviewControl.OnPointerPressed` never called `Focus()` explicitly, unlike `TextureViewport` (shared base of the wireframe and PNG-diff panels), which calls it unconditionally regardless of which button was pressed.
- **Root-caused and unified:** that gap existed because `TextureViewport` and `PreviewControl` are unrelated classes that each independently reimplemented the same pan-gesture detection (middle-click, or Alt+left-click) — textually identical copies that had already silently diverged on the `Focus()` call. Extracted `PointerGestures.IsPanGesture` as the single shared, directly-tested predicate both now call, closing off that class of drift for any future zoomable panel.
- View menu keeps 4 distinct clickable items (clicking "Preview Zoom In" always zooms preview, unconditionally); "Wireframe Zoom In"/"Preview Zoom In" both display the same `Ctrl+OemPlus` gesture text since it's genuinely contextual to focus.

## Test plan
- [x] `CtrlN_ClearsTree`, `CtrlS_WithFileName_WritesFileToDisk`, `CtrlL_DoesNotThrow`.
- [x] `CtrlOemPlus_WireframeFocused_StepsWireframeZoomOnly` / `CtrlOemMinus_PreviewFocused_StepsPreviewZoomOnly` / `CtrlOemPlus_PngPaneFocused_StepsPngZoomOnly` (via simulated pointer clicks) / `CtrlOemPlus_NeitherPanelFocused_DoesNothing`.
- [x] `CtrlShiftOemPlus_WireframeFocused_DoesNotStepPanelZoom` — regression guard for the Gum-style shadowing bug.
- [x] `ClickingPreviewPanel_GivesItFocus` / `MiddleClickingPreviewPanel_GivesItFocus` — the latter is the TDD-driven regression test for the middle-click focus bug (written failing, then fixed).
- [x] `PointerGesturesTests` (new, `AnimationEditor.Views.Tests`) — direct coverage of the extracted `IsPanGesture` predicate's four cases.
- [x] `WireframeAndPreviewZoomInMenuItems_ShowTheSameSharedGesture`.
- [x] `Hotkeys_ProductionRegistry_HasNoDuplicateGestures` (pre-existing) still passes.
- [x] Full `AnimationEditor.App.Tests` suite: 673/673 passing.
- [x] Full `AnimationEditor.Core.Tests` suite: 1584/1584 passing.
- [x] Full `AnimationEditor.Views.Tests` suite: 26/26 passing.

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)