### PR TITLE
Scan object-layer rectangle/polygon objects in GenerateCollisionFromClass

### DIFF
--- a/frb-skills/tmx/SKILL.md
+++ b/frb-skills/tmx/SKILL.md
@@ -51,7 +51,7 @@ This covers `.tmx`, `.tsx`, and `.png` files in the `Content/Tiled/` directory.
 Read `.claude/templates/Tiled/StandardTileset.tsx` for the full list of tile IDs and their Classes. The tileset's `firstgid` is 1, so **GID in CSV = tile id + 1**. GID 0 means empty (no tile). GID 1 is `SolidCollision` — used in virtually every game as the primary wall/floor/ceiling tile.
 
 Tiles fall into two categories:
-- **Collision tiles** (e.g., `SolidCollision`, `JumpThroughCollision`) — place on tile layers, consumed by `GenerateCollisionFromClass`.
+- **Collision tiles** (e.g., `SolidCollision`, `JumpThroughCollision`) — place on tile layers, consumed by `GenerateCollisionFromClass`. Hand-drawn rectangle/polygon `<object>`s on an object layer with a matching Class are consumed too (see "Collision from an object layer" below) — useful for a boundary shape that doesn't align to the stamp grid.
 - **Entity marker tiles** (e.g., `Coin`, `PlayerSpawn`, `Boss`, `BreakableCollision`) — place on object layers for precise per-entity placement, or paint them on regular tile layers for grid-aligned bulk spawns (e.g., rows of breakable bricks). Either way, `map.CreateEntities()` finds both and by default removes the source tile after spawning so it doesn't double-draw under the entity (opt out with `removeSourceTiles: false`). See the `levels` skill for the API.
 
 ## Layer Conventions
@@ -145,6 +145,10 @@ Adjacent sub-cell rects participate in `SolidSides` seam suppression: if two sub
 **Current limitations:**
 - `<ellipse>` and polyline collision objects are ignored — only `<polygon>` and plain `<object>` rectangles are honored.
 - Only one `<polygon>` per tile is supported. Authoring a second polygon on the same tile throws `InvalidOperationException` at load time — merge the shapes into a single polygon in Tiled instead. (Rectangles have no such limit.)
+
+### Collision from an object layer
+
+`GenerateCollisionFromClass`/`GenerateCollisionFromProperty` (the all-layers form, i.e. no `layerName` argument) also match `<object>` rectangles and polygons on any object layer whose own Class/property matches — not just tile objects. Each matched shape is positioned relative to whichever grid cell contains its center, same as a tileset tile's sub-cell `<object>`s, so **it must fit within roughly one cell** to be found by broad-phase collision queries; it does not need to be grid-aligned within that cell. Rotated objects (`rotation` attribute) throw `InvalidOperationException` at load time — remove rotation in Tiled. Passing an explicit `layerName` restricts the scan to a single **tile** layer and skips object layers entirely.
 
 ### Add an object layer for entity spawns
 

--- a/frb-skills/tmx/SKILL.md
+++ b/frb-skills/tmx/SKILL.md
@@ -148,7 +148,10 @@ Adjacent sub-cell rects participate in `SolidSides` seam suppression: if two sub
 
 ### Collision from an object layer
 
-`GenerateCollisionFromClass`/`GenerateCollisionFromProperty` (the all-layers form, i.e. no `layerName` argument) also match `<object>` rectangles and polygons on any object layer whose own Class/property matches — not just tile objects. Each matched shape is positioned relative to whichever grid cell contains its center, same as a tileset tile's sub-cell `<object>`s, so **it must fit within roughly one cell** to be found by broad-phase collision queries; it does not need to be grid-aligned within that cell. Rotated objects (`rotation` attribute) throw `InvalidOperationException` at load time — remove rotation in Tiled. Passing an explicit `layerName` restricts the scan to a single **tile** layer and skips object layers entirely.
+`GenerateCollisionFromClass`/`GenerateCollisionFromProperty` (the all-layers form, i.e. no `layerName` argument) also match `<object>` rectangles and polygons on any object layer whose own Class/property matches — not just tile objects. Passing an explicit `layerName` restricts the scan to a single **tile** layer and skips object layers entirely.
+
+- **Rectangles** support any position, size, and `rotation` that's an exact multiple of 90 — the rect stays axis-aligned (just reoriented/swapped) and is clipped against the grid, so it can span any number of cells and doesn't need to be grid-aligned at all. This is the recommended way to author a hand-drawn collision boundary that doesn't match the tile grid (a wall, a boss-arena floor, an irregular pit).
+- **Rotated rectangles at other angles, and all polygons,** are positioned relative to whichever grid cell contains their center (same convention as a tileset tile's sub-cell `<object>`s) and **must fit within roughly one cell** to be found by broad-phase collision queries — Tiled rotates around the object's own `(x,y)`, not its bounding-box center, so don't assume a rotated shape's world position matches a naive center-based mental model.
 
 ### Add an object layer for entity spawns
 

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -79,6 +79,7 @@ public class TileMap
 
     private readonly record struct TrackedCollection(
         Func<TilemapTileData, bool> Predicate,
+        Func<TilemapObject, bool>? ObjectPredicate,
         string? LayerName,
         TileShapes Collection);
 
@@ -271,17 +272,23 @@ public class TileMap
 
     /// <summary>
     /// Generates a <see cref="TileShapes"/> from tiles whose
-    /// <see cref="TilemapTileData.Class"/> matches <paramref name="className"/>.
+    /// <see cref="TilemapTileData.Class"/> matches <paramref name="className"/>. Also matches
+    /// rectangle and polygon objects on any object layer whose own <see cref="TilemapObject.Class"/>
+    /// matches — but only when <paramref name="layerName"/> is <c>null</c> (see below).
     /// </summary>
-    /// <param name="className">The tile class to match (case-insensitive).</param>
+    /// <param name="className">The tile/object class to match (case-insensitive).</param>
     /// <param name="layerName">
-    /// If specified, restricts the search to this layer. If <c>null</c> (default),
-    /// scans all tile layers.
+    /// If specified, restricts the search to a single <b>tile</b> layer by name — object layers
+    /// are not matched in this mode. If <c>null</c> (default), scans all tile layers plus all
+    /// object layers.
     /// </param>
     public TileShapes GenerateCollisionFromClass(string className, string? layerName = null)
     {
         Func<TilemapTileData, bool> predicate = td =>
             string.Equals(td.Class, className, StringComparison.OrdinalIgnoreCase);
+        Func<TilemapObject, bool>? objectPredicate = layerName == null
+            ? obj => string.Equals(obj.Class, className, StringComparison.OrdinalIgnoreCase)
+            : null;
 
         TileShapes tsc = layerName != null
             ? TileMapCollisions.GenerateFromClass(_tilemap, GetInternalLayer(layerName), className, _x, _y)
@@ -289,29 +296,35 @@ public class TileMap
 
         tsc.Name = className;
 
-        _trackedCollections.Add(new TrackedCollection(predicate, layerName, tsc));
+        _trackedCollections.Add(new TrackedCollection(predicate, objectPredicate, layerName, tsc));
         return tsc;
     }
 
     /// <summary>
     /// Generates a <see cref="TileShapes"/> from tiles that have a custom
-    /// property named <paramref name="propertyName"/>.
+    /// property named <paramref name="propertyName"/>. Also matches rectangle and polygon
+    /// objects on any object layer with a matching property — but only when
+    /// <paramref name="layerName"/> is <c>null</c> (see below).
     /// </summary>
     /// <param name="propertyName">The custom property to match (presence only, value ignored).</param>
     /// <param name="layerName">
-    /// If specified, restricts the search to this layer. If <c>null</c> (default),
-    /// scans all tile layers.
+    /// If specified, restricts the search to a single <b>tile</b> layer by name — object layers
+    /// are not matched in this mode. If <c>null</c> (default), scans all tile layers plus all
+    /// object layers.
     /// </param>
     public TileShapes GenerateCollisionFromProperty(string propertyName, string? layerName = null)
     {
         Func<TilemapTileData, bool> predicate = td =>
             td.Properties.TryGetValue(propertyName, out _);
+        Func<TilemapObject, bool>? objectPredicate = layerName == null
+            ? obj => obj.Properties.TryGetValue(propertyName, out _)
+            : null;
 
         TileShapes tsc = layerName != null
             ? TileMapCollisions.GenerateFromProperty(_tilemap, GetInternalLayer(layerName), propertyName, _x, _y)
             : TileMapCollisions.GenerateFromProperty(_tilemap, propertyName, _x, _y);
 
-        _trackedCollections.Add(new TrackedCollection(predicate, layerName, tsc));
+        _trackedCollections.Add(new TrackedCollection(predicate, objectPredicate, layerName, tsc));
         return tsc;
     }
 
@@ -700,7 +713,7 @@ public class TileMap
                     _tilemap, GetInternalLayer(tracked.LayerName), tracked.Predicate, tracked.Collection);
             else
                 TileMapCollisions.RegenerateInto(
-                    _tilemap, tracked.Predicate, tracked.Collection);
+                    _tilemap, tracked.Predicate, tracked.ObjectPredicate!, tracked.Collection);
         }
 
         // Refresh the renderer's vertex cache so the visual update is visible next frame.

--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -10,6 +10,10 @@ namespace FlatRedBall2.Tiled;
 /// <summary>
 /// Generates a <see cref="TileShapes"/> from a <see cref="TilemapTileLayer"/>
 /// by matching tiles on their <see cref="TilemapTileData.Class"/> attribute or a custom property.
+/// The all-layers overloads (<see cref="GenerateFromClass(Tilemap, string, float, float)"/>,
+/// <see cref="GenerateFromProperty(Tilemap, string, float, float)"/>) also match rectangle and
+/// polygon objects on any <see cref="TilemapObjectLayer"/> — the single-layer overloads are
+/// tile-layer only.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,6 +25,15 @@ namespace FlatRedBall2.Tiled;
 /// <para>
 /// Tile matching uses the tileset metadata from <see cref="Tilemap.Tilesets"/>. Only tiles with a
 /// non-zero global ID that pass the predicate produce collision rectangles.
+/// </para>
+/// <para>
+/// Object matching checks <see cref="TilemapRectangleObject"/> and <see cref="TilemapPolygonObject"/>
+/// entries directly — tile objects (Tiled's "Insert Tile" tool) are not matched; use
+/// <see cref="TileMap.CreateEntities"/> for those. Each matched object is positioned relative to
+/// whichever grid cell contains its center, the same convention used for per-tile
+/// <see cref="TilemapTileData.CollisionObjects"/> — an object must fit within roughly one cell to
+/// be found by broad-phase collision queries. Rotated objects (<c>Rotation != 0</c>) throw
+/// <see cref="InvalidOperationException"/> rather than silently producing wrong geometry.
 /// </para>
 /// </remarks>
 public static class TileMapCollisions
@@ -102,7 +115,8 @@ public static class TileMapCollisions
         float mapY = 0f)
     {
         return GenerateFromAllLayers(tilemap, mapX, mapY,
-            tileData => string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase));
+            tileData => string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase),
+            obj => string.Equals(obj.Class, className, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -128,7 +142,8 @@ public static class TileMapCollisions
         float mapY = 0f)
     {
         return GenerateFromAllLayers(tilemap, mapX, mapY,
-            tileData => tileData.Properties.TryGetValue(propertyName, out _));
+            tileData => tileData.Properties.TryGetValue(propertyName, out _),
+            obj => obj.Properties.TryGetValue(propertyName, out _));
     }
 
     /// <summary>
@@ -147,16 +162,31 @@ public static class TileMapCollisions
 
     /// <summary>
     /// All-layers variant of <see cref="RegenerateInto(Tilemap, TilemapTileLayer, Func{TilemapTileData, bool}, TileShapes)"/>.
+    /// Also re-scans object layers using <paramref name="objectPredicate"/>.
     /// </summary>
     internal static void RegenerateInto(
         Tilemap tilemap,
         Func<TilemapTileData, bool> predicate,
+        Func<TilemapObject, bool> objectPredicate,
         TileShapes target)
     {
+        // target.X/Y were set from mapX/mapY by the original Generate call; mapY (the map's top
+        // edge) is recovered from target.Y (the bottom edge) since object conversion needs the
+        // top-edge convention. See GenerateFromAllLayers.
+        float mapX = target.X;
+        float mapY = target.Y + tilemap.Height * tilemap.TileHeight;
+
         foreach (var layer in tilemap.Layers)
         {
-            if (layer is TilemapTileLayer tileLayer)
-                AddMatchingTiles(tilemap, tileLayer, predicate, target);
+            switch (layer)
+            {
+                case TilemapTileLayer tileLayer:
+                    AddMatchingTiles(tilemap, tileLayer, predicate, target);
+                    break;
+                case TilemapObjectLayer objectLayer:
+                    AddMatchingObjects(objectLayer, mapX, mapY, objectPredicate, target);
+                    break;
+            }
         }
     }
 
@@ -189,27 +219,118 @@ public static class TileMapCollisions
         Tilemap tilemap,
         float mapX,
         float mapY,
-        Func<TilemapTileData, bool> predicate)
+        Func<TilemapTileData, bool> tilePredicate,
+        Func<TilemapObject, bool> objectPredicate)
     {
-        // Use the first tile layer's dimensions for the collection grid.
-        // All tile layers in a Tiled map share the same tile dimensions.
         var collection = new TileShapes
         {
             X = mapX,
+            // Map-level height, not a per-layer height — must be set before any object layer is
+            // processed (object layers may appear before tile layers in Tiled's layer order).
+            Y = mapY - tilemap.Height * tilemap.TileHeight,
             GridSize = tilemap.TileWidth
         };
 
         foreach (var layer in tilemap.Layers)
         {
-            if (layer is not TilemapTileLayer tileLayer)
-                continue;
-
-            // Set Y based on this layer's height (should be consistent across layers).
-            collection.Y = mapY - tileLayer.Height * tilemap.TileHeight;
-            AddMatchingTiles(tilemap, tileLayer, predicate, collection);
+            switch (layer)
+            {
+                case TilemapTileLayer tileLayer:
+                    AddMatchingTiles(tilemap, tileLayer, tilePredicate, collection);
+                    break;
+                case TilemapObjectLayer objectLayer:
+                    AddMatchingObjects(objectLayer, mapX, mapY, objectPredicate, collection);
+                    break;
+            }
         }
 
         return collection;
+    }
+
+    /// <summary>
+    /// Scans rectangle and polygon objects on <paramref name="layer"/> and adds a collision shape
+    /// for each whose <see cref="TilemapObject.Class"/> or properties satisfy
+    /// <paramref name="predicate"/>. Each shape is positioned relative to whichever grid cell
+    /// contains its center — the same convention used for per-tile <see cref="TilemapTileData.CollisionObjects"/>.
+    /// Tile objects (placed with Tiled's "Insert Tile" tool) are not matched here — use
+    /// <see cref="TileMap.CreateEntities"/> for those.
+    /// </summary>
+    private static void AddMatchingObjects(
+        TilemapObjectLayer layer,
+        float mapX,
+        float mapY,
+        Func<TilemapObject, bool> predicate,
+        TileShapes collection)
+    {
+        foreach (var obj in layer.Objects)
+        {
+            if (!predicate(obj)) continue;
+
+            switch (obj)
+            {
+                case TilemapRectangleObject rectObj:
+                    AddRectangleObject(rectObj, mapX, mapY, collection);
+                    break;
+                case TilemapPolygonObject polyObj:
+                    AddPolygonObject(polyObj, mapX, mapY, collection);
+                    break;
+            }
+        }
+    }
+
+    private static void AddRectangleObject(TilemapRectangleObject rectObj, float mapX, float mapY, TileShapes collection)
+    {
+        ThrowIfRotated(rectObj);
+
+        float w = rectObj.Size.X;
+        float h = rectObj.Size.Y;
+        // Tiled rect: top-left (Position.X, Position.Y), Y-down from map top-left.
+        float worldCenterX = mapX + rectObj.Position.X + w / 2f;
+        float worldCenterY = mapY - (rectObj.Position.Y + h / 2f);
+
+        var (col, row) = collection.GetCellAt(new Vector2(worldCenterX, worldCenterY));
+        var cellCenter = collection.GetCellWorldPosition(col, row);
+
+        collection.AddRectangleTileAtCell(col, row,
+            worldCenterX - cellCenter.X, worldCenterY - cellCenter.Y, w, h);
+    }
+
+    private static void AddPolygonObject(TilemapPolygonObject polyObj, float mapX, float mapY, TileShapes collection)
+    {
+        if (polyObj.Points == null || polyObj.Points.Length < 3) return;
+        ThrowIfRotated(polyObj);
+
+        var worldPoints = new List<Vector2>(polyObj.Points.Length);
+        float sumX = 0f, sumY = 0f;
+        foreach (var p in polyObj.Points)
+        {
+            XnaVec2 tiled = polyObj.Position + p;
+            float wx = mapX + tiled.X;
+            float wy = mapY - tiled.Y;
+            worldPoints.Add(new Vector2(wx, wy));
+            sumX += wx;
+            sumY += wy;
+        }
+
+        // Owning cell is the polygon's average-point centroid — there's no single "position"
+        // corner to key off, unlike a rectangle's top-left.
+        var centroid = new Vector2(sumX / worldPoints.Count, sumY / worldPoints.Count);
+        var (col, row) = collection.GetCellAt(centroid);
+        var cellCenter = collection.GetCellWorldPosition(col, row);
+
+        var localPoints = new List<Vector2>(worldPoints.Count);
+        foreach (var p in worldPoints)
+            localPoints.Add(p - cellCenter);
+
+        collection.AddPolygonTileAtCell(col, row, Polygon.FromPoints(localPoints));
+    }
+
+    private static void ThrowIfRotated(TilemapObject obj)
+    {
+        if (obj.Rotation != 0f)
+            throw new InvalidOperationException(
+                $"Tiled object '{obj.Name}' (Class '{obj.Class}') has Rotation={obj.Rotation}, " +
+                "which is not supported for collision generation. Remove rotation in Tiled.");
     }
 
     private static void AddMatchingTiles(

--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -29,11 +29,16 @@ namespace FlatRedBall2.Tiled;
 /// <para>
 /// Object matching checks <see cref="TilemapRectangleObject"/> and <see cref="TilemapPolygonObject"/>
 /// entries directly — tile objects (Tiled's "Insert Tile" tool) are not matched; use
-/// <see cref="TileMap.CreateEntities"/> for those. Each matched object is positioned relative to
-/// whichever grid cell contains its center, the same convention used for per-tile
-/// <see cref="TilemapTileData.CollisionObjects"/> — an object must fit within roughly one cell to
-/// be found by broad-phase collision queries. Rotated objects (<c>Rotation != 0</c>) throw
-/// <see cref="InvalidOperationException"/> rather than silently producing wrong geometry.
+/// <see cref="TileMap.CreateEntities"/> for those.
+/// </para>
+/// <para>
+/// Rectangle objects support any position, size, and rotation that's an exact multiple of 90
+/// degrees — the rectangle stays axis-aligned (just reoriented) and is clipped against the grid,
+/// so it can span any number of cells and doesn't need to be grid-aligned. Rectangles at an
+/// arbitrary (non-90-degree-multiple) angle, and all polygon objects, are instead positioned
+/// relative to whichever grid cell contains their center (the same convention used for per-tile
+/// <see cref="TilemapTileData.CollisionObjects"/>) — these must fit within roughly one cell to be
+/// found by broad-phase collision queries.
 /// </para>
 /// </remarks>
 public static class TileMapCollisions
@@ -278,59 +283,155 @@ public static class TileMapCollisions
         }
     }
 
+    // Tiled rotates an object clockwise around its own (x,y) position (verified against
+    // MonoGame.Extended's OrientedBoundingBox2D.GetCorners() — NOT the object's bounding-box
+    // center). A rotation that's an exact multiple of 90 degrees keeps a rectangle axis-aligned
+    // (just reoriented/swapped), so it's still emitted as a plain rect — any other angle can't be
+    // an AARect and becomes a polygon instead.
     private static void AddRectangleObject(TilemapRectangleObject rectObj, float mapX, float mapY, TileShapes collection)
     {
-        ThrowIfRotated(rectObj);
-
         float w = rectObj.Size.X;
         float h = rectObj.Size.Y;
-        // Tiled rect: top-left (Position.X, Position.Y), Y-down from map top-left.
-        float worldCenterX = mapX + rectObj.Position.X + w / 2f;
-        float worldCenterY = mapY - (rectObj.Position.Y + h / 2f);
+        XnaVec2[] local = { new(0, 0), new(w, 0), new(w, h), new(0, h) };
+        var worldCorners = new Vector2[4];
+        for (int i = 0; i < 4; i++)
+        {
+            var (rx, ry) = RotateAroundOrigin(local[i].X, local[i].Y, rectObj.Rotation);
+            worldCorners[i] = new Vector2(
+                mapX + rectObj.Position.X + rx,
+                mapY - (rectObj.Position.Y + ry));
+        }
 
-        var (col, row) = collection.GetCellAt(new Vector2(worldCenterX, worldCenterY));
-        var cellCenter = collection.GetCellWorldPosition(col, row);
-
-        collection.AddRectangleTileAtCell(col, row,
-            worldCenterX - cellCenter.X, worldCenterY - cellCenter.Y, w, h);
+        if (TryGetAxisAlignedBounds(worldCorners, out float left, out float right, out float bottom, out float top))
+            AddClippedRectangleAcrossCells(left, right, bottom, top, collection);
+        else
+            AddPolygonFromWorldPoints(worldCorners, collection);
     }
 
     private static void AddPolygonObject(TilemapPolygonObject polyObj, float mapX, float mapY, TileShapes collection)
     {
         if (polyObj.Points == null || polyObj.Points.Length < 3) return;
-        ThrowIfRotated(polyObj);
 
-        var worldPoints = new List<Vector2>(polyObj.Points.Length);
-        float sumX = 0f, sumY = 0f;
-        foreach (var p in polyObj.Points)
+        var worldPoints = new Vector2[polyObj.Points.Length];
+        for (int i = 0; i < polyObj.Points.Length; i++)
         {
-            XnaVec2 tiled = polyObj.Position + p;
-            float wx = mapX + tiled.X;
-            float wy = mapY - tiled.Y;
-            worldPoints.Add(new Vector2(wx, wy));
-            sumX += wx;
-            sumY += wy;
+            var p = polyObj.Points[i];
+            var (rx, ry) = RotateAroundOrigin(p.X, p.Y, polyObj.Rotation);
+            worldPoints[i] = new Vector2(
+                mapX + polyObj.Position.X + rx,
+                mapY - (polyObj.Position.Y + ry));
         }
 
-        // Owning cell is the polygon's average-point centroid — there's no single "position"
-        // corner to key off, unlike a rectangle's top-left.
-        var centroid = new Vector2(sumX / worldPoints.Count, sumY / worldPoints.Count);
+        AddPolygonFromWorldPoints(worldPoints, collection);
+    }
+
+    // Rotates a Tiled-local point (Y-down) by 'rotationRadians' clockwise around the origin.
+    // Rotations within a small tolerance of an exact 90-degree multiple snap to integer
+    // transforms instead of using sin/cos — this keeps axis-alignment detection
+    // (TryGetAxisAlignedBounds) from being defeated by trig floating-point noise at exactly the
+    // angles (0/90/180/270) that matter most for staying a plain AARect.
+    private static (float x, float y) RotateAroundOrigin(float x, float y, float rotationRadians)
+    {
+        const float snapEps = 1e-4f;
+        float quarterTurns = rotationRadians / (MathF.PI / 2f);
+        int rounded = (int)MathF.Round(quarterTurns);
+        if (MathF.Abs(quarterTurns - rounded) < snapEps)
+        {
+            return ((rounded % 4 + 4) % 4) switch
+            {
+                1 => (-y, x),
+                2 => (-x, -y),
+                3 => (y, -x),
+                _ => (x, y),
+            };
+        }
+
+        float cos = MathF.Cos(rotationRadians);
+        float sin = MathF.Sin(rotationRadians);
+        return (x * cos - y * sin, x * sin + y * cos);
+    }
+
+    // True if the four corners form an axis-aligned rectangle — every corner's X matches either
+    // the min or max X (and likewise for Y). Any rotation that's a multiple of 90 degrees
+    // satisfies this; arbitrary angles don't.
+    private static bool TryGetAxisAlignedBounds(Vector2[] corners,
+        out float left, out float right, out float bottom, out float top)
+    {
+        const float eps = 1e-3f;
+        left = right = corners[0].X;
+        bottom = top = corners[0].Y;
+        foreach (var c in corners)
+        {
+            if (c.X < left) left = c.X;
+            if (c.X > right) right = c.X;
+            if (c.Y < bottom) bottom = c.Y;
+            if (c.Y > top) top = c.Y;
+        }
+
+        foreach (var c in corners)
+        {
+            bool xOk = MathF.Abs(c.X - left) < eps || MathF.Abs(c.X - right) < eps;
+            bool yOk = MathF.Abs(c.Y - bottom) < eps || MathF.Abs(c.Y - top) < eps;
+            if (!xOk || !yOk) return false;
+        }
+        return true;
+    }
+
+    // Clips an axis-aligned world-space rectangle against the grid, emitting one sub-cell rect
+    // per overlapped cell via the existing multi-rect-per-cell AddRectangleTileAtCell. Handles any
+    // size/position — including spanning many cells and not being grid-aligned — because existing
+    // SolidSides seam suppression already merges adjacent clipped pieces into one continuous
+    // surface.
+    private static void AddClippedRectangleAcrossCells(
+        float left, float right, float bottom, float top, TileShapes collection)
+    {
+        const float eps = 1e-4f;
+        int colMin = (int)MathF.Floor((left - collection.X) / collection.GridSize);
+        int colMax = (int)MathF.Floor((right - collection.X) / collection.GridSize - eps);
+        int rowMin = (int)MathF.Floor((bottom - collection.Y) / collection.GridSize);
+        int rowMax = (int)MathF.Floor((top - collection.Y) / collection.GridSize - eps);
+
+        for (int col = colMin; col <= colMax; col++)
+        {
+            for (int row = rowMin; row <= rowMax; row++)
+            {
+                float cellLeft = collection.X + col * collection.GridSize;
+                float cellBottom = collection.Y + row * collection.GridSize;
+                float clippedLeft = MathF.Max(left, cellLeft);
+                float clippedRight = MathF.Min(right, cellLeft + collection.GridSize);
+                float clippedBottom = MathF.Max(bottom, cellBottom);
+                float clippedTop = MathF.Min(top, cellBottom + collection.GridSize);
+
+                float w = clippedRight - clippedLeft;
+                float h = clippedTop - clippedBottom;
+                if (w <= 0f || h <= 0f) continue;
+
+                var cellCenter = collection.GetCellWorldPosition(col, row);
+                float worldCenterX = (clippedLeft + clippedRight) / 2f;
+                float worldCenterY = (clippedBottom + clippedTop) / 2f;
+                collection.AddRectangleTileAtCell(col, row,
+                    worldCenterX - cellCenter.X, worldCenterY - cellCenter.Y, w, h);
+            }
+        }
+    }
+
+    // Places a polygon at whichever single cell contains the average of its world points. Unlike
+    // AddClippedRectangleAcrossCells, this has no multi-cell splitting — the polygon must fit
+    // within roughly one cell to be found by broad-phase collision queries.
+    private static void AddPolygonFromWorldPoints(Vector2[] worldPoints, TileShapes collection)
+    {
+        float sumX = 0f, sumY = 0f;
+        foreach (var p in worldPoints) { sumX += p.X; sumY += p.Y; }
+        var centroid = new Vector2(sumX / worldPoints.Length, sumY / worldPoints.Length);
+
         var (col, row) = collection.GetCellAt(centroid);
         var cellCenter = collection.GetCellWorldPosition(col, row);
 
-        var localPoints = new List<Vector2>(worldPoints.Count);
+        var localPoints = new List<Vector2>(worldPoints.Length);
         foreach (var p in worldPoints)
             localPoints.Add(p - cellCenter);
 
         collection.AddPolygonTileAtCell(col, row, Polygon.FromPoints(localPoints));
-    }
-
-    private static void ThrowIfRotated(TilemapObject obj)
-    {
-        if (obj.Rotation != 0f)
-            throw new InvalidOperationException(
-                $"Tiled object '{obj.Name}' (Class '{obj.Class}') has Rotation={obj.Rotation}, " +
-                "which is not supported for collision generation. Remove rotation in Tiled.");
     }
 
     private static void AddMatchingTiles(

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
@@ -425,6 +425,153 @@ public class TileMapCollisionsTests
             SolidSides.Up | SolidSides.Down | SolidSides.Right);
     }
 
+    // ── Object-layer objects ─────────────────────────────────────────────────
+    // Tiled <object> elements on an object layer (rectangle/polygon tools, not tile stamps)
+    // whose Class matches are converted into collision shapes the same way per-tile
+    // CollisionObjects are: positioned relative to whichever grid cell contains their center.
+
+    private static Tilemap BuildObjectOnlyTilemap(
+        int widthTiles, int heightTiles, int tileSize, TilemapObjectLayer objectLayer)
+    {
+        var tilemap = new Tilemap(
+            name: "test", width: widthTiles, height: heightTiles,
+            tileWidth: tileSize, tileHeight: tileSize,
+            orientation: TilemapOrientation.Orthogonal);
+        tilemap.Layers.Add(objectLayer);
+        return tilemap;
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRectMatchingClass_EmitsRectAtOwningCell()
+    {
+        // 2x2 map, tile size 16. Rect at Tiled (0,0,16,16) — exactly cell (col 0, tmx row 0).
+        // Tsc row = H-1-tmxRow = 2-1-0 = 1.
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)) { Class = "Solid" });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var rects = coll.GetRectangleTilesAtCell(0, 1);
+        rects.Count.ShouldBe(1);
+        rects[0].X.ShouldBe(8f);
+        rects[0].Y.ShouldBe(-8f);
+        rects[0].Width.ShouldBe(16f);
+        rects[0].Height.ShouldBe(16f);
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRectNonMatchingClass_NotEmitted()
+    {
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)) { Class = "Other" });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        coll.GetRectangleTilesAtCell(0, 1).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerPolygonMatchingClass_EmitsPolygonAtOwningCell()
+    {
+        // Same triangle shape as the per-tile polygon test, but authored at Tiled position
+        // (16, 0) on an object layer — expect the same local-point pattern since both paths
+        // convert to Y-up, centered-on-owning-cell.
+        var tri = new XnaVec2[] { new(0, 0), new(16, 16), new(0, 16) };
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapPolygonObject(
+            id: 1, position: new XnaVec2(16, 0), points: tri) { Class = "Solid" });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var poly = coll.GetPolygonTileAtCell(1, 1);
+        poly.ShouldNotBeNull();
+        poly!.Points.Count.ShouldBe(3);
+        poly.Points[0].ShouldBe(new Vector2(-8f, 8f));
+        poly.Points[1].ShouldBe(new Vector2(8f, -8f));
+        poly.Points[2].ShouldBe(new Vector2(-8f, -8f));
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRotatedRect_Throws()
+    {
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16))
+        { Class = "Solid", Rotation = 45f });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        Should.Throw<System.InvalidOperationException>(
+            () => TileMapCollisions.GenerateFromClass(tilemap, "Solid"));
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRotatedPolygon_Throws()
+    {
+        var tri = new XnaVec2[] { new(0, 0), new(16, 16), new(0, 16) };
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapPolygonObject(
+            id: 1, position: new XnaVec2(0, 0), points: tri)
+        { Class = "Solid", Rotation = 30f });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        Should.Throw<System.InvalidOperationException>(
+            () => TileMapCollisions.GenerateFromClass(tilemap, "Solid"));
+    }
+
+    [Fact]
+    public void GenerateFromProperty_ObjectLayerRectWithMatchingProperty_Emitted()
+    {
+        var rectObj = new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16));
+        rectObj.Properties.SetBool("Hazard", true);
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(rectObj);
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromProperty(tilemap, "Hazard");
+
+        coll.GetRectangleTilesAtCell(0, 1).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GenerateFromClass_MixedTileLayerAndObjectLayer_BothEmitted()
+    {
+        // Object layer is added to tilemap.Layers BEFORE the tile layer, to guard against
+        // collection.Y being computed from per-tile-layer height rather than tilemap.Height —
+        // if computed lazily inside the tile-layer branch, an object encountered first would
+        // resolve against Y=0 and land in the wrong cell.
+        var objectLayer = new TilemapObjectLayer("Objects");
+        objectLayer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(16, 16), size: new XnaVec2(16, 16)) { Class = "Solid" });
+
+        var tilemap = new Tilemap(
+            name: "test", width: 2, height: 2, tileWidth: 16, tileHeight: 16,
+            orientation: TilemapOrientation.Orthogonal);
+        tilemap.Layers.Add(objectLayer);
+
+        var tileset = new TilemapTileset(
+            name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(new TilemapTileData(0) { Class = "Solid" });
+        tilemap.Tilesets.Add(tileset);
+
+        var tileLayer = new TilemapTileLayer("Main", 2, 2, 16, 16);
+        tileLayer.SetTile(0, 0, new TilemapTile(globalId: 1));
+        tilemap.Layers.Add(tileLayer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        // Tile at tmx (0,0) -> tsc (0, 1).
+        coll.GetTileAtCell(0, 1).ShouldNotBeNull();
+        // Object rect at Tiled (16,16,16,16) -> tmx cell (col 1, row 1) -> tsc row 0.
+        coll.GetRectangleTilesAtCell(1, 0).Count.ShouldBe(1);
+    }
+
     [Fact]
     public void GenerateFromClass_SubCellRectAdjacentToPolygonTile_SuppressesRectFaceAtShared()
     {

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using FlatRedBall2.Collision;
 using FlatRedBall2.Tiled;
@@ -496,31 +497,134 @@ public class TileMapCollisionsTests
         poly.Points[2].ShouldBe(new Vector2(-8f, -8f));
     }
 
+    // ── Rotation ──────────────────────────────────────────────────────────────
+    // TilemapObject.Rotation is radians (verified against MonoGame.Extended's own
+    // Shape.GetCorners()), and Tiled rotates an object clockwise around its own (x,y) — the
+    // object's stored position, NOT its bounding-box center. For rotations that are exact
+    // multiples of 90 degrees the rectangle stays axis-aligned (just reoriented/swapped) and
+    // is still emitted as a plain rect; other angles become a polygon.
+
     [Fact]
-    public void GenerateFromClass_ObjectLayerRotatedRect_Throws()
+    public void GenerateFromClass_ObjectLayerRect90DegreesRotated_SwapsDimsAndClipsAcrossCells()
+    {
+        // Position (24,0), size (8,24), rotated 90 deg clockwise around (24,0) -> occupies
+        // Tiled-space X:[0,24] Y:[0,8], i.e. world X:[0,24] Y:[-8,0] -- spans grid cols 0 and 1.
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(24, 0), size: new XnaVec2(8, 24))
+        { Class = "Solid", Rotation = MathF.PI / 2f });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var left = coll.GetRectangleTilesAtCell(0, 1);
+        left.Count.ShouldBe(1);
+        left[0].X.ShouldBe(8f);
+        left[0].Y.ShouldBe(-4f);
+        left[0].Width.ShouldBe(16f);
+        left[0].Height.ShouldBe(8f);
+
+        var right = coll.GetRectangleTilesAtCell(1, 1);
+        right.Count.ShouldBe(1);
+        right[0].X.ShouldBe(20f);
+        right[0].Y.ShouldBe(-4f);
+        right[0].Width.ShouldBe(8f);
+        right[0].Height.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRect180DegreesRotated_PivotsAroundPositionNotCenter()
+    {
+        // Position (16,0), size (16,8), rotated 180 deg around (16,0) -> the rect ends up on the
+        // OPPOSITE side of the pivot (world X:[0,16] Y:[0,8]), not the same bounding box as
+        // unrotated (which would be world X:[16,32] Y:[-8,0]). Confirms the pivot is the object's
+        // own position, not its center.
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(16, 0), size: new XnaVec2(16, 8))
+        { Class = "Solid", Rotation = MathF.PI });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var rects = coll.GetRectangleTilesAtCell(0, 2);
+        rects.Count.ShouldBe(1);
+        rects[0].X.ShouldBe(8f);
+        rects[0].Y.ShouldBe(4f);
+        rects[0].Width.ShouldBe(16f);
+        rects[0].Height.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRectArbitraryRotation_EmittedAsFourPointPolygon()
     {
         var layer = new TilemapObjectLayer("Objects");
         layer.AddObject(new TilemapRectangleObject(
             id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16))
-        { Class = "Solid", Rotation = 45f });
-        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+        { Class = "Solid", Rotation = MathF.PI / 4f });
+        var tilemap = BuildObjectOnlyTilemap(1, 1, 16, layer);
 
-        Should.Throw<System.InvalidOperationException>(
-            () => TileMapCollisions.GenerateFromClass(tilemap, "Solid"));
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        coll.GetTileAtCell(0, 0).ShouldBeNull();
+        var poly = coll.GetPolygonTileAtCell(0, 0);
+        poly.ShouldNotBeNull();
+        poly!.Points.Count.ShouldBe(4);
+        const float tol = 0.01f;
+        poly.Points[0].X.ShouldBe(-8f, tol);
+        poly.Points[0].Y.ShouldBe(8f, tol);
+        poly.Points[1].X.ShouldBe(3.3137f, tol);
+        poly.Points[1].Y.ShouldBe(-3.3137f, tol);
+        poly.Points[2].X.ShouldBe(-8f, tol);
+        poly.Points[2].Y.ShouldBe(-14.6274f, tol);
+        poly.Points[3].X.ShouldBe(-19.3137f, tol);
+        poly.Points[3].Y.ShouldBe(-3.3137f, tol);
     }
 
     [Fact]
-    public void GenerateFromClass_ObjectLayerRotatedPolygon_Throws()
+    public void GenerateFromClass_ObjectLayerRectSpansTwoCellsUnrotated_ClipsPerCellPiece()
+    {
+        // Position (8,8), size (24,8) -- spans world X:[8,32] Y:[-16,-8], overlapping cols 0-1.
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(8, 8), size: new XnaVec2(24, 8)) { Class = "Solid" });
+        var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var left = coll.GetRectangleTilesAtCell(0, 1);
+        left.Count.ShouldBe(1);
+        left[0].X.ShouldBe(12f);
+        left[0].Y.ShouldBe(-12f);
+        left[0].Width.ShouldBe(8f);
+        left[0].Height.ShouldBe(8f);
+
+        var right = coll.GetRectangleTilesAtCell(1, 1);
+        right.Count.ShouldBe(1);
+        right[0].X.ShouldBe(24f);
+        right[0].Y.ShouldBe(-12f);
+        right[0].Width.ShouldBe(16f);
+        right[0].Height.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerPolygonRotated90Degrees_PointsRotatedAroundPosition()
     {
         var tri = new XnaVec2[] { new(0, 0), new(16, 16), new(0, 16) };
         var layer = new TilemapObjectLayer("Objects");
         layer.AddObject(new TilemapPolygonObject(
-            id: 1, position: new XnaVec2(0, 0), points: tri)
-        { Class = "Solid", Rotation = 30f });
+            id: 1, position: new XnaVec2(16, 0), points: tri)
+        { Class = "Solid", Rotation = MathF.PI / 2f });
         var tilemap = BuildObjectOnlyTilemap(2, 2, 16, layer);
 
-        Should.Throw<System.InvalidOperationException>(
-            () => TileMapCollisions.GenerateFromClass(tilemap, "Solid"));
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        var poly = coll.GetPolygonTileAtCell(0, 1);
+        poly.ShouldNotBeNull();
+        poly!.Points.Count.ShouldBe(3);
+        poly.Points[0].ShouldBe(new Vector2(8f, 8f));
+        poly.Points[1].ShouldBe(new Vector2(-8f, -8f));
+        poly.Points[2].ShouldBe(new Vector2(-8f, 8f));
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapReloadTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapReloadTests.cs
@@ -384,6 +384,42 @@ public class TileMapReloadTests
     // Multiple tracked TSCs — both registered collections must update on a single reload.
     // ============================================================================================
 
+    // ============================================================================================
+    // Object-layer-sourced collision must survive a reload that only touches tile-layer data.
+    // The object layer itself is unchanged (same object count) in both maps — TryReload proceeds,
+    // and RegenerateInto must re-scan object layers, not just tile layers, or the object-sourced
+    // shape silently disappears from the tracked TileShapes.
+    // ============================================================================================
+
+    [Fact]
+    public void TryReload_ObjectLayerContributesToCollision_SurvivesTileOnlyReload()
+    {
+        Tilemap BuildWithObjectRect((int col, int row, int localId)[] placements)
+        {
+            var map = BuildTilemap(4, 4, 16, new[] { RectTile(0, "Solid") }, placements);
+            var objLayer = new TilemapObjectLayer("Objects");
+            objLayer.AddObject(new TilemapRectangleObject(
+                id: 1, position: new XnaVec2(0, 48), size: new XnaVec2(16, 16)) { Class = "Solid" });
+            map.Layers.Add(objLayer);
+            return map;
+        }
+
+        var oldMap = BuildWithObjectRect(new[] { (0, 0, 0) });
+        var newMap = BuildWithObjectRect(new[] { (0, 0, 0), (2, 2, 0) });
+
+        var tileMap = new TileMap(oldMap);
+        var solid = tileMap.GenerateCollisionFromClass("Solid");
+
+        // Object rect at Tiled (0,48,16,16) -> tmx row 3, col 0 -> tsc row 0.
+        solid.GetRectangleTilesAtCell(0, 0).Count.ShouldBe(1);
+
+        tileMap.TryReload(newMap).ShouldBeTrue();
+
+        solid.GetRectangleTilesAtCell(0, 0).Count.ShouldBe(1);
+        var (c, r) = Tsc(2, 2);
+        solid.GetTileAtCell(c, r).ShouldNotBeNull();
+    }
+
     [Fact]
     public void TryReload_TwoTrackedCollections_BothUpdate()
     {


### PR DESCRIPTION
## Summary
- `TileMapCollisions`' all-layers scan (`GenerateFromClass`/`GenerateFromProperty`) previously only inspected `TilemapTileLayer`s, silently skipping any `TilemapObjectLayer`. Rectangle/polygon objects hand-drawn on an object layer with a matching Class/property were never converted to collision.
- Object-layer `TilemapRectangleObject`/`TilemapPolygonObject` entries are now matched and converted to collision shapes.
- **Rectangles support any position, size, and rotation that's an exact multiple of 90°** — verified empirically that Tiled rotates an object clockwise around its own `(x,y)`, not its bounding-box center (via MonoGame.Extended's `OrientedBoundingBox2D.GetCorners()`). A 90°-multiple rotation keeps the rectangle axis-aligned (just reoriented/swapped dimensions), so it's clipped against the grid and emitted as one sub-cell rect per overlapped cell — this means a rectangle can be any size, unaligned to the grid, and span any number of cells, not just fit in one.
- Arbitrary-angle rotated rectangles and all polygon objects get correct rotated geometry and are placed relative to whichever single grid cell contains their center (same convention as per-tile `CollisionObjects`) — these must fit within roughly one cell for broad-phase collision to find them, a pre-existing constraint of the engine's grid-based `TileShapes`, not something new introduced here.
- `TileMap`'s tracked-collection/reload path (`TryReloadFrom` → `TryReload` → `RegenerateInto`) is updated so object-layer-sourced shapes are rebuilt (not silently dropped) on in-place reload.
- Passing an explicit `layerName` to `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` still restricts the scan to a single **tile** layer (unchanged) — object layers are only included in the default all-layers scan.
- Updated the `tmx` skill with the capability split and the rotation-pivot gotcha.

## Scope notes
- Tile objects (Tiled's "Insert Tile" tool) on an object layer are **not** matched by collision generation — those are for entity spawning via `TileMap.CreateEntities`. Only rectangle/polygon objects are collision sources.
- General polygon-vs-grid clipping (arbitrary concave polygons spanning multiple cells) is out of scope — a much larger feature (Sutherland-Hodgman-style clipping, handling fragment splitting) that would also need to relax the existing one-polygon-per-cell limit. Polygons keep the one-cell-fit constraint that already applies to tile-based collision polygons today.

## Test plan
- [x] `TileMapCollisionsTests.cs`: matching/non-matching rect Class, matching polygon Class, property-based matching, mixed tile-layer+object-layer in one map (also guards a Y-computation-order bug), 90°-rotated rect (dimension swap + multi-cell clip), 180°-rotated rect (confirms rotation pivots on position, not center), arbitrary-angle rotation → 4-point polygon, unrotated rect spanning two cells (clip logic in isolation), 90°-rotated polygon (points rotate correctly).
- [x] `TileMapReloadTests.cs`: object-layer-sourced collision survives `TryReload` when only tile-layer data changes.
- [x] Full suite: `dotnet test tests/FlatRedBall2.Tests/` — 1109/1109 passed.
- [x] `dotnet build src/FlatRedBall2.csproj` — 0 new warnings, 0 errors.

Closes #640