### PR TITLE
Animation Editor: keyboard shortcuts reference tab (closes #633, #634)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1103,7 +1103,21 @@
                     <!-- Keyboard Shortcuts reference (#633/#634) — hidden until toggled on from the
                          Help menu via ToggleableSidebarTab. Real content (sourced from the hotkey
                          registry, #632) lands in #634; this is the toggle mechanism's first consumer. -->
-                    <TabItem x:Name="ShortcutsTab" Header="Shortcuts" IsVisible="False">
+                    <TabItem x:Name="ShortcutsTab" IsVisible="False">
+                        <TabItem.Header>
+                            <!-- Close affordances mirror the file-tab-strip's ✕ button + middle-click
+                                 (RebuildTabStrip), so both closeable-tab surfaces behave the same way. -->
+                            <Grid x:Name="ShortcutsTabHeader" ColumnDefinitions="Auto,Auto">
+                                <TextBlock x:Name="ShortcutsTabLabel" Grid.Column="0" Text="Shortcuts" VerticalAlignment="Center" />
+                                <Button x:Name="ShortcutsTabCloseButton" Grid.Column="1"
+                                        Content="✕" FontSize="9" Width="16" Height="16" Padding="0"
+                                        Margin="4,0,0,0"
+                                        Background="Transparent" BorderThickness="0"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        ToolTip.Tip="Close" />
+                            </Grid>
+                        </TabItem.Header>
                         <TextBlock Margin="8" FontSize="11" TextWrapping="Wrap"
                                    Foreground="{DynamicResource InkMid}"
                                    Text="Keyboard shortcuts reference will appear here." />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1101,8 +1101,9 @@
                     </TabItem>
 
                     <!-- Keyboard Shortcuts reference (#633/#634) — hidden until toggled on from the
-                         Help menu via ToggleableSidebarTab. Real content (sourced from the hotkey
-                         registry, #632) lands in #634; this is the toggle mechanism's first consumer. -->
+                         Help menu via ToggleableSidebarTab. Content is sourced from the hotkey
+                         registry (#632, RefreshShortcutsPanel) so it can't drift from what a
+                         keypress actually does. -->
                     <TabItem x:Name="ShortcutsTab" IsVisible="False">
                         <TabItem.Header>
                             <!-- Close affordances mirror the file-tab-strip's ✕ button + middle-click
@@ -1118,9 +1119,32 @@
                                         ToolTip.Tip="Close" />
                             </Grid>
                         </TabItem.Header>
-                        <TextBlock Margin="8" FontSize="11" TextWrapping="Wrap"
-                                   Foreground="{DynamicResource InkMid}"
-                                   Text="Keyboard shortcuts reference will appear here." />
+                        <ScrollViewer Background="{DynamicResource BgPanel}">
+                            <ItemsControl x:Name="ShortcutsList" Margin="8">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="appModels:HotkeyCategoryVm">
+                                        <StackPanel Margin="0,0,0,10">
+                                            <TextBlock Text="{Binding Category}" FontSize="11" FontWeight="Bold"
+                                                       Foreground="{DynamicResource Ink}" Margin="0,0,0,4" />
+                                            <ItemsControl ItemsSource="{Binding Hotkeys}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="appModels:HotkeyEntryVm">
+                                                        <Grid ColumnDefinitions="*,Auto" Margin="0,1">
+                                                            <TextBlock Grid.Column="0" Text="{Binding Description}"
+                                                                       FontSize="11"
+                                                                       Foreground="{DynamicResource InkMid}" />
+                                                            <TextBlock Grid.Column="1" Text="{Binding Gesture}"
+                                                                       FontSize="11"
+                                                                       Foreground="{DynamicResource Ink}" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </TabItem>
                 </TabControl>
             </Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -141,6 +141,8 @@
                         <!-- InputGesture set in code from the hotkey registry — see note above. -->
                         <MenuItem Header="Show _Render Diagnostics" x:Name="MenuShowDiagnostics"
                                   ToggleType="CheckBox" />
+                        <MenuItem Header="_Keyboard Shortcuts" x:Name="MenuShowShortcuts"
+                                  ToggleType="CheckBox" />
                         <MenuItem Header="View _Log"      x:Name="MenuViewLog" />
                         <MenuItem Header="_About"         x:Name="MenuAbout" />
                     </MenuItem>
@@ -1096,6 +1098,15 @@
                                 </ListBox.ItemTemplate>
                             </ListBox>
                         </Grid>
+                    </TabItem>
+
+                    <!-- Keyboard Shortcuts reference (#633/#634) — hidden until toggled on from the
+                         Help menu via ToggleableSidebarTab. Real content (sourced from the hotkey
+                         registry, #632) lands in #634; this is the toggle mechanism's first consumer. -->
+                    <TabItem x:Name="ShortcutsTab" Header="Shortcuts" IsVisible="False">
+                        <TextBlock Margin="8" FontSize="11" TextWrapping="Wrap"
+                                   Foreground="{DynamicResource InkMid}"
+                                   Text="Keyboard shortcuts reference will appear here." />
                     </TabItem>
                 </TabControl>
             </Grid>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -5311,9 +5311,15 @@ public partial class MainWindow : Window
             .GroupBy(h => h.Category)
             .Select(g => new Models.HotkeyCategoryVm(
                 g.Key,
-                g.Select(h => new Models.HotkeyEntryVm(h.Description, h.DisplayText)).ToList()))
+                g.Select(h => new Models.HotkeyEntryVm(h.Description, FormatGestureForDisplay(h))).ToList()))
             .ToList();
     }
+
+    // HotkeyDefinition.DisplayText must keep Avalonia's Key enum names verbatim (e.g. "OemPlus")
+    // since SetMenuGesture feeds it to KeyGesture.Parse, which only recognizes real Key names.
+    // This panel has no such constraint, so swap in words a user would actually recognize.
+    private static string FormatGestureForDisplay(HotkeyDefinition hotkey) =>
+        hotkey.DisplayText.Replace("OemPlus", "Plus").Replace("OemMinus", "Minus");
 
     private void WireKeyboard()
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -5303,10 +5303,23 @@ public partial class MainWindow : Window
     private void SetMenuGesture(MenuItem item, string hotkeyId) =>
         item.InputGesture = KeyGesture.Parse(_hotkeys.First(h => h.Id == hotkeyId).DisplayText);
 
+    // Sourced from the same registry the KeyDown dispatch and menu gesture text use (#632), so
+    // this list can never drift from what a keypress actually does (#634).
+    private void RefreshShortcutsPanel()
+    {
+        ShortcutsList.ItemsSource = _hotkeys
+            .GroupBy(h => h.Category)
+            .Select(g => new Models.HotkeyCategoryVm(
+                g.Key,
+                g.Select(h => new Models.HotkeyEntryVm(h.Description, h.DisplayText)).ToList()))
+            .ToList();
+    }
+
     private void WireKeyboard()
     {
         _hotkeys = BuildHotkeyDefinitions();
         ApplyHotkeyMenuGestureText();
+        RefreshShortcutsPanel();
 
         // Use Tunnel routing so we intercept keys before child controls (e.g. the TreeView,
         // which handles Up/Down for navigation and would mark the event Handled before the

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1795,6 +1795,7 @@ public partial class MainWindow : Window
         HistoryUndoButton.Click += (_, _) => _undoManager.Undo();
         HistoryRedoButton.Click += (_, _) => _undoManager.Redo();
         MenuShowHistory.Click   += (_, _) => SelectHistoryTab();
+        _ = new Helpers.ToggleableSidebarTab(SidebarTabs, ShortcutsTab, InspectorTab, MenuShowShortcuts);
 
         MenuWireframeZoomIn.Click  += (_, _) => WireframeZoom.StepUp();
         MenuWireframeZoomOut.Click += (_, _) => WireframeZoom.StepDown();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1795,7 +1795,16 @@ public partial class MainWindow : Window
         HistoryUndoButton.Click += (_, _) => _undoManager.Undo();
         HistoryRedoButton.Click += (_, _) => _undoManager.Redo();
         MenuShowHistory.Click   += (_, _) => SelectHistoryTab();
-        _ = new Helpers.ToggleableSidebarTab(SidebarTabs, ShortcutsTab, InspectorTab, MenuShowShortcuts);
+        var shortcutsTabToggle = new Helpers.ToggleableSidebarTab(SidebarTabs, ShortcutsTab, InspectorTab, MenuShowShortcuts);
+        ShortcutsTabCloseButton.Click += (_, _) => shortcutsTabToggle.Hide();
+        ShortcutsTabHeader.PointerReleased += (_, args) =>
+        {
+            if (args.GetCurrentPoint(ShortcutsTabHeader).Properties.PointerUpdateKind == PointerUpdateKind.MiddleButtonReleased)
+            {
+                shortcutsTabToggle.Hide();
+                args.Handled = true;
+            }
+        };
 
         MenuWireframeZoomIn.Click  += (_, _) => WireframeZoom.StepUp();
         MenuWireframeZoomOut.Click += (_, _) => WireframeZoom.StepDown();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HotkeyEntryVm.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Models/HotkeyEntryVm.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AnimationEditor.App.Models;
+
+/// <summary>View model for a single row in the Keyboard Shortcuts panel.</summary>
+/// <param name="Description">Human-readable description of the action.</param>
+/// <param name="Gesture">Display text for the gesture, e.g. <c>"Ctrl+Z"</c>.</param>
+internal sealed record HotkeyEntryVm(string Description, string Gesture);
+
+/// <summary>A category header plus its rows, e.g. "Edit" grouping Copy/Cut/Paste/Undo/Redo.</summary>
+internal sealed record HotkeyCategoryVm(string Category, IReadOnlyList<HotkeyEntryVm> Hotkeys);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/ToggleableSidebarTab.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/ToggleableSidebarTab.cs
@@ -39,7 +39,8 @@ internal sealed class ToggleableSidebarTab
         _menuItem.IsChecked = true;
     }
 
-    private void Hide()
+    /// <summary>Hides the tab, e.g. from a close button or middle-click on the tab header.</summary>
+    public void Hide()
     {
         _tab.IsVisible = false;
         if (ReferenceEquals(_tabs.SelectedItem, _tab))

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/ToggleableSidebarTab.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/ToggleableSidebarTab.cs
@@ -1,0 +1,49 @@
+using Avalonia.Controls;
+
+namespace AnimationEditor.App.Helpers;
+
+/// <summary>
+/// Wires a hidden-by-default sidebar <see cref="TabItem"/> to a checkable <see cref="MenuItem"/>:
+/// clicking the menu item shows and selects the tab, clicking it again hides the tab (falling back
+/// to another tab if it was selected) and keeps the menu item's checkmark in sync throughout.
+/// </summary>
+internal sealed class ToggleableSidebarTab
+{
+    private readonly TabControl _tabs;
+    private readonly TabItem _tab;
+    private readonly TabItem _fallbackTab;
+    private readonly MenuItem _menuItem;
+
+    public ToggleableSidebarTab(TabControl tabs, TabItem tab, TabItem fallbackTab, MenuItem menuItem)
+    {
+        _tabs = tabs;
+        _tab = tab;
+        _fallbackTab = fallbackTab;
+        _menuItem = menuItem;
+
+        _tab.IsVisible = false;
+        _menuItem.IsChecked = false;
+        _menuItem.Click += (_, _) => Toggle();
+    }
+
+    private void Toggle()
+    {
+        if (_tab.IsVisible) Hide();
+        else Show();
+    }
+
+    private void Show()
+    {
+        _tab.IsVisible = true;
+        _tabs.SelectedItem = _tab;
+        _menuItem.IsChecked = true;
+    }
+
+    private void Hide()
+    {
+        _tab.IsVisible = false;
+        if (ReferenceEquals(_tabs.SelectedItem, _tab))
+            _tabs.SelectedItem = _fallbackTab;
+        _menuItem.IsChecked = false;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using AnimationEditor.App.Models;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -186,6 +188,28 @@ public class SidebarTabsTests
             Assert.False(tab.IsVisible);
             Assert.Same(inspector, tabs.SelectedItem);
             Assert.False(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ShortcutsList_OnLaunch_IsPopulatedFromTheHotkeyRegistry()
+    {
+        // #634: content is sourced from the same registry the KeyDown dispatch uses (#632), so
+        // it can never drift from what a keypress actually does.
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var list = window.FindControl<ItemsControl>("ShortcutsList")!;
+            var categories = ((IEnumerable<HotkeyCategoryVm>)list.ItemsSource!).ToList();
+
+            var undo = categories.SelectMany(c => c.Hotkeys).First(h => h.Description == "Undo");
+            Assert.Equal("Ctrl+Z", undo.Gesture);
+
+            int totalRows = categories.Sum(c => c.Hotkeys.Count);
+            Assert.Equal(window.Hotkeys.Count, totalRows);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
@@ -65,4 +65,64 @@ public class SidebarTabsTests
         }
         finally { window.Close(); }
     }
+
+    [AvaloniaFact]
+    public void ShortcutsTab_OnLaunch_IsHiddenAndMenuUnchecked()
+    {
+        // #633: the Shortcuts tab is a hidden-by-default toggleable tab, not always visible like
+        // Inspector/History/Files.
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var tab = window.FindControl<TabItem>("ShortcutsTab")!;
+            var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
+            Assert.False(tab.IsVisible);
+            Assert.False(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void MenuShowShortcuts_ClickedOnce_ShowsAndSelectsShortcutsTabAndChecksMenu()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
+            menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs")!;
+            var tab = window.FindControl<TabItem>("ShortcutsTab")!;
+            Assert.True(tab.IsVisible);
+            Assert.Same(tab, tabs.SelectedItem);
+            Assert.True(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void MenuShowShortcuts_ClickedTwice_HidesShortcutsTabAndFallsBackToInspector()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
+            menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+            menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs")!;
+            var tab = window.FindControl<TabItem>("ShortcutsTab")!;
+            var inspector = window.FindControl<TabItem>("InspectorTab")!;
+            Assert.False(tab.IsVisible);
+            Assert.Same(inspector, tabs.SelectedItem);
+            Assert.False(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
@@ -1,6 +1,8 @@
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Xunit;
@@ -115,6 +117,68 @@ public class SidebarTabsTests
             var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
             menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
             menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs")!;
+            var tab = window.FindControl<TabItem>("ShortcutsTab")!;
+            var inspector = window.FindControl<TabItem>("InspectorTab")!;
+            Assert.False(tab.IsVisible);
+            Assert.Same(inspector, tabs.SelectedItem);
+            Assert.False(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ShortcutsTabCloseButton_Clicked_HidesShortcutsTabAndFallsBackToInspector()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
+            menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+
+            var closeButton = window.FindControl<Button>("ShortcutsTabCloseButton")!;
+            closeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent) { Source = closeButton });
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs")!;
+            var tab = window.FindControl<TabItem>("ShortcutsTab")!;
+            var inspector = window.FindControl<TabItem>("InspectorTab")!;
+            Assert.False(tab.IsVisible);
+            Assert.Same(inspector, tabs.SelectedItem);
+            Assert.False(menu.IsChecked);
+        }
+        finally { window.Close(); }
+    }
+
+    // Raises a middle-button-release directly on the header, rather than simulating a physical
+    // click through the window: the header only exists once ToggleableSidebarTab makes the tab
+    // visible mid-test, and the headless compositor's hit-test scene lags behind that late
+    // layout change, so a coordinate-based click can miss the freshly-shown control. Raising the
+    // routed event directly still exercises the same handler a real middle-click would invoke.
+    private static void RaiseMiddleClick(Control target)
+    {
+        var pointer = new Pointer(0, PointerType.Mouse, isPrimary: true);
+        var properties = new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.MiddleButtonReleased);
+        var args = new PointerReleasedEventArgs(
+            target, pointer, target, new Point(0, 0), 0, properties, KeyModifiers.None, MouseButton.Middle);
+        target.RaiseEvent(args);
+    }
+
+    [AvaloniaFact]
+    public void ShortcutsTabHeader_MiddleClicked_HidesShortcutsTabAndFallsBackToInspector()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var menu = window.FindControl<MenuItem>("MenuShowShortcuts")!;
+            menu.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent) { Source = menu });
+
+            var header = window.FindControl<Control>("ShortcutsTabHeader")!;
+            RaiseMiddleClick(header);
 
             var tabs = window.FindControl<TabControl>("SidebarTabs")!;
             var tab = window.FindControl<TabItem>("ShortcutsTab")!;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SidebarTabsTests.cs
@@ -208,6 +208,13 @@ public class SidebarTabsTests
             var undo = categories.SelectMany(c => c.Hotkeys).First(h => h.Description == "Undo");
             Assert.Equal("Ctrl+Z", undo.Gesture);
 
+            // #632's registry names these keys "OemPlus"/"OemMinus" (Avalonia's Key enum, needed
+            // so MenuItem.InputGesture stays parseable) — the panel spells them out instead.
+            var zoomIn = categories.SelectMany(c => c.Hotkeys).First(h => h.Description == "Zoom In (Focused Panel)");
+            Assert.Equal("Ctrl+Plus", zoomIn.Gesture);
+            var zoomOut = categories.SelectMany(c => c.Hotkeys).First(h => h.Description == "Zoom Out (Focused Panel)");
+            Assert.Equal("Ctrl+Minus", zoomOut.Gesture);
+
             int totalRows = categories.Sum(c => c.Hotkeys.Count);
             Assert.Equal(window.Hotkeys.Count, totalRows);
         }


### PR DESCRIPTION
## Summary
- #633 originally targeted extracting History's "docked, closeable panel" pattern for reuse. That pattern was superseded by #544 — History is now a plain, always-visible tab in `SidebarTabs`, with no close button or menu-disable logic left to extract. Confirmed with @vchelaru: the real need is a way to show/hide an individual sidebar **tab** from a menu item, for a Keyboard Shortcuts reference tab. History itself is not made closeable.
- Adds `ToggleableSidebarTab`, wiring a hidden-by-default `TabItem` to a checkable `MenuItem` (`ToggleType="CheckBox"`, same idiom as `MenuShowDiagnostics`): clicking shows+selects the tab and checks the menu item; clicking again (or the tab's ✕ button, or middle-clicking the tab header — mirroring the existing file-tab-strip's close affordances) hides it, falls back to Inspector, and unchecks the menu item.
- Wires it to a new "Shortcuts" tab + `Help > Keyboard Shortcuts` menu item.
- **#634**: populates that tab with real content. `#632`'s `HotkeyDefinition` registry already carried `Description`/`Category`/`DisplayText` for every hotkey, so `RefreshShortcutsPanel` just groups the existing registry by category and binds it — the list can never drift from what a keypress actually does, since it's sourced from the same registry the `KeyDown` dispatch and menu gesture text use.
- Updated #633's issue body to describe the actual current design instead of the stale docked-panel premise.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests` — 679 passed, 0 failed
- [x] New tests in `SidebarTabsTests.cs`: hidden-by-default on launch, show/select/check on menu click, hide/fallback/uncheck on second click, close via ✕ button, close via middle-click, and Shortcuts list content matches the hotkey registry

Closes #633
Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)