### PR TITLE
Animation Editor: allow closing the last open tab

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -264,7 +264,7 @@ public partial class MainWindow : Window
         TabStrip.Children.Clear();
 
         var tabs = _tabManager.Tabs;
-        TabBarBorder.IsVisible = tabs.Count > 1;
+        TabBarBorder.IsVisible = tabs.Count > 0;
 
         foreach (var tab in tabs)
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseLastTabTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseLastTabTests.cs
@@ -1,0 +1,113 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Verifies the last remaining tab can be closed (issue #608): the tab bar's close
+/// affordance must stay reachable at a single open tab, and closing it must land the
+/// editor back in a fresh, untitled, unsaved state.
+/// </summary>
+public class CloseLastTabTests
+{
+    private static string WriteAchx(string dir, string fileName, params string[] chainNames)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        foreach (var name in chainNames)
+        {
+            var chain = new AnimationChainSave { Name = name };
+            chain.Frames.Add(new AnimationFrameSave { TextureName = name + ".png", FrameLength = 0.1f });
+            acls.AnimationChains.Add(chain);
+        }
+        acls.Save(path);
+        return path;
+    }
+
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    private static void CloseTab(MainWindow window, TabEntry tab)
+    {
+        var method = typeof(MainWindow)
+            .GetMethod("CloseTab", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(window, [tab]);
+    }
+
+    [AvaloniaFact]
+    public async System.Threading.Tasks.Task SingleOpenTab_TabBarShowsCloseAffordance()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => System.Threading.Tasks.Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pathA = WriteAchx(dir, "a.achx", "Walk");
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+
+            var tabManager = GetTabManager(window);
+            Assert.Single(tabManager.Tabs);
+
+            var tabBar = window.FindControl<Border>("TabBarBorder");
+            Assert.NotNull(tabBar);
+            Assert.True(tabBar!.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async System.Threading.Tasks.Task ClosingLastTab_ReturnsToFreshUnsavedState()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => System.Threading.Tasks.Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pathA = WriteAchx(dir, "a.achx", "Walk");
+            await window.OpenFileAsTab(pathA);
+            Dispatcher.UIThread.RunJobs();
+
+            var tabManager = GetTabManager(window);
+            var tabA = tabManager.Tabs.First(t => t.Path == new FilePath(pathA));
+
+            CloseTab(window, tabA);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(tabManager.Tabs);
+            Assert.Null(ctx.ProjectManager.FileName);
+
+            var tabBar = window.FindControl<Border>("TabBarBorder");
+            Assert.NotNull(tabBar);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `RebuildTabStrip` collapsed the entire tab bar (including every tab's close button) once only one tab remained (`tabs.Count > 1`), making the last tab's close affordance unreachable.
- Changed the visibility check to `tabs.Count > 0` so the bar — and its close button — stays visible down to a single tab.
- The "all tabs closed → fresh empty document" path in `CloseTab`'s `else` branch already worked correctly and is now reachable; `SaveTabsToSettings` already excludes the resulting Untitled sentinel tab, so nothing gets persisted/restored on next launch.

Closes #608

## Test plan
- [x] New `[AvaloniaFact]` tests in `CloseLastTabTests.cs`:
  - `SingleOpenTab_TabBarShowsCloseAffordance` — fails before the fix (tab bar hidden at count 1), passes after.
  - `ClosingLastTab_ReturnsToFreshUnsavedState` — confirms closing the last tab empties `_tabManager.Tabs` and resets `ProjectManager.FileName` to null.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 683 passed, 0 failed.
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — clean, 0 warnings/errors.