### PR TITLE
Fix Gum popups (ComboBox dropdown, MenuItem submenu, ListBox popups) never rendering or receiving input

### DIFF
--- a/.claude/skills/sample-project-setup/SKILL.md
+++ b/.claude/skills/sample-project-setup/SKILL.md
@@ -17,11 +17,11 @@ How to create a new sample project (`.csproj`) under `samples/`. Follow this che
 
 ### 1. Create the directory and `.csproj`
 
-Copy the structure from an existing sample (e.g., `PlatformerSample`). The minimal `.csproj`:
+Copy the structure from an existing sample (e.g., `AnimationChainSample`). The minimal `.csproj`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\src\PrecompiledShaders\AposShapesPrecompiled.props" />
+  <Import Project="..\..\src\PrecompiledShaders\AposShapesPrecompiled.props" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -63,7 +63,7 @@ Without this file, the first build fails with **"Cannot find a manifest file"** 
 
 Copy from any existing sample:
 ```
-samples/PlatformerSample/.config/dotnet-tools.json  →  samples/YourSample/.config/dotnet-tools.json
+samples/AnimationChainSample/.config/dotnet-tools.json  →  samples/YourSample/.config/dotnet-tools.json
 ```
 
 Content (do not modify versions):

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -490,6 +490,12 @@ public class FlatRedBallService
         // This covers controls added via AddToRoot() as well as screen-specific GumRenderables,
         // which are abandoned with the old Screen object.
         _gum.Root.Children.Clear();
+        // PopupRoot/ModalRoot (ComboBox dropdowns, MenuItem submenus, ListBox popups) are global
+        // Gum Forms roots, not owned by any Screen — clear them too so a popup left open when the
+        // screen changed doesn't bleed into the new screen. Null before FormsUtilities.Initialize
+        // has run (see the _game != null wiring below).
+        _gum.PopupRoot?.Children.Clear();
+        _gum.ModalRoot?.Children.Clear();
 
         // Apply the screen's preferred display settings. Camera properties always apply;
         // window properties (size, resizing) only apply on Start to avoid mid-game window pops.
@@ -518,6 +524,16 @@ public class FlatRedBallService
         CurrentScreen = screen;
         screen.CustomInitialize();
         screen.InvokeInitialized();
+
+        if (_game != null)
+        {
+            // Wired in last so PopupRoot/ModalRoot draw on top of any overlay visuals
+            // CustomInitialize just added — draw order follows GumRenderables insertion order
+            // (see Screen.DrawOverlay). ModalRoot is added after PopupRoot so a modal blocks
+            // (draws over) an open popup, matching Gum's own "modal is always topmost" intent.
+            screen.AddOverlayRoot(_gum.PopupRoot!);
+            screen.AddOverlayRoot(_gum.ModalRoot!);
+        }
 
         // Snap every CameraControllingEntity to its target now that CustomInitialize has
         // wired up Targets. Without this, frame 1's lazy-spawn tick runs against the camera's
@@ -1076,6 +1092,15 @@ public class FlatRedBallService
             // in canvas pixels are not clipped/culled by the parent's bounds.
             CurrentScreen.EntityVisualsRoot.Width  = pp.BackBufferWidth;
             CurrentScreen.EntityVisualsRoot.Height = pp.BackBufferHeight;
+            // PopupRoot/ModalRoot are also sized here rather than left to Gum's own
+            // FormsUtilities.Update (which sizes them from the GraphicalUiElement.CanvasWidth/
+            // Height global): FRB2 never updates that global on resize under its own camera
+            // pipeline (see the _gum.CanvasWidth/Height comment above), so relying on it would
+            // leave popups stale-sized after a window resize.
+            _gum.PopupRoot.Width  = pp.BackBufferWidth;
+            _gum.PopupRoot.Height = pp.BackBufferHeight;
+            _gum.ModalRoot.Width  = pp.BackBufferWidth;
+            _gum.ModalRoot.Height = pp.BackBufferHeight;
             CurrentScreen.DrawOverlay(_spriteBatch, RenderDiagnostics, _overlayCamera);
         }
 

--- a/src/Screen.cs
+++ b/src/Screen.cs
@@ -307,6 +307,21 @@ public class Screen : ILifecycleEvents
     /// <summary>Removes a Forms control previously added with <see cref="AddOverlay(FrameworkElement, Layer?)"/>.</summary>
     public void RemoveOverlay(FrameworkElement element) => RemoveOverlay(element.Visual);
 
+    /// <summary>
+    /// Registers an existing Gum root as a screen-level overlay without reparenting it. Unlike
+    /// <see cref="AddOverlay(GraphicalUiElement, Layer?)"/> (which parents a leaf visual under
+    /// <see cref="OverlayRoot"/>), <paramref name="root"/> is drawn as-is — used for Gum Forms'
+    /// global <c>PopupRoot</c>/<c>ModalRoot</c>, which must stay unparented for Gum's own Forms
+    /// code to treat them as top-level roots.
+    /// </summary>
+    internal void AddOverlayRoot(GraphicalUiElement root, Layer? layer = null)
+    {
+        var renderable = new GumRenderable(root) { Layer = layer ?? Layer, IsOverlay = true };
+        _gumRenderables.Add(renderable);
+        _gumByVisual[root] = renderable;
+        _renderList.Add(renderable);
+    }
+
     // ---------- Entity-attached visuals ----------
 
     private GraphicalUiElement? _entityVisualsRoot;

--- a/tests/FlatRedBall2.Tests/GumHudTests.cs
+++ b/tests/FlatRedBall2.Tests/GumHudTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FlatRedBall2.Rendering;
 using Gum.Wireframe;
 using Gum.GueDeriving;
@@ -73,6 +74,43 @@ public class GumHudTests
         var renderable = screen.GumRenderables[0];
         // Overlay renderables are drawn in a post-camera pass, never inside the per-camera loop.
         renderable.ShouldDrawForCamera(screen.Cameras[0]).ShouldBeFalse();
+    }
+
+    // AddOverlayRoot wires up Gum Forms' global PopupRoot/ModalRoot (ComboBox dropdowns, MenuItem
+    // submenus, ListBox popups) so they actually draw — see issue #656. Unlike AddOverlay, the
+    // passed-in root must NOT be reparented under Screen.OverlayRoot: PopupRoot/ModalRoot are
+    // independent top-level Gum roots that Gum's own Forms code expects to remain unparented.
+
+    [Fact]
+    public void AddOverlayRoot_RootRegisteredAsOverlay_NotParentedUnderOverlayRoot()
+    {
+        var screen = new TestScreen();
+        var popupRoot = new ContainerRuntime();
+
+        screen.AddOverlayRoot(popupRoot);
+
+        screen.GumRenderables.ShouldContain(r => r.Visual == popupRoot);
+        screen.OverlayRoot.Children.ShouldNotContain(popupRoot);
+        var renderable = screen.GumRenderables.First(r => r.Visual == popupRoot);
+        renderable.ShouldDrawForCamera(screen.Cameras[0]).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddOverlayRoot_CalledAfterAddOverlay_DrawnAfterEarlierOverlayVisual()
+    {
+        // Draw order follows GumRenderables insertion order (see Screen.DrawOverlay) — popups
+        // must be wired in after a screen's own overlay visuals so they render on top.
+        var screen = new TestScreen();
+        var overlayVisual = new ContainerRuntime();
+        var popupRoot = new ContainerRuntime();
+        screen.AddOverlay(overlayVisual);
+
+        screen.AddOverlayRoot(popupRoot);
+
+        var renderables = screen.GumRenderables.ToList();
+        var overlayIndex = renderables.FindIndex(r => r.Visual == overlayVisual);
+        var popupIndex = renderables.FindIndex(r => r.Visual == popupRoot);
+        popupIndex.ShouldBeGreaterThan(overlayIndex);
     }
 
     // Engine-created Gum roots (Camera.UiRoot, Screen.OverlayRoot) are full-canvas-sized


### PR DESCRIPTION
## Summary
- FRB2 never wraps Gum Forms' global `PopupRoot`/`ModalRoot` (ComboBox dropdown, MenuItem submenu, ListBox popup) in a `GumRenderable`, so nothing ever draws them — FRB2 draws each Gum visual explicitly and never invokes Gum's own full-tree render pass.
- They also leaked across screen transitions since only `_gum.Root.Children` was cleared, not the popup roots.
- `Screen.AddOverlayRoot` registers an existing Gum root (not a leaf visual) as a screen-level overlay without reparenting it — required because `PopupRoot`/`ModalRoot` must stay unparented for Gum's own Forms code to treat them as top-level roots (unlike `AddOverlay`, which parents a visual under `OverlayRoot`).
- `FlatRedBallService.ActivateScreen` wires both roots in right after `CustomInitialize()` (so popups draw on top of a screen's own `AddOverlay` visuals, `ModalRoot` last so a modal blocks an open popup), sizes them to the back buffer each frame in `Draw()` (Gum's own sizing relies on a canvas-size global FRB2 deliberately never updates under its own resize pipeline), and clears their children on every screen transition.

## Investigation note
Traced this against the actual Gum source (not just the issue's static analysis) before implementing. One correction to the issue's root-cause writeup: cursor/click dispatch for popups already worked without any engine change — `Gum.MonoGameGum.Forms.FormsUtilities.Update` special-cases `PopupRoot`/`ModalRoot` into its input list regardless of which roots FRB2 passes in, so `LastEventRoots` already includes them. Only **rendering** and **resize-safe sizing** needed engine-side wiring; adding the roots to FRB2's per-frame update list turned out to be unnecessary (Gum already funnels their children through `DoUiActivityRecursively` unconditionally for `ModalRoot` and whenever they're absent from the passed roots for `PopupRoot`).

## Test plan
- New `GumHudTests`: `AddOverlayRoot_RootRegisteredAsOverlay_NotParentedUnderOverlayRoot`, `AddOverlayRoot_CalledAfterAddOverlay_DrawnAfterEarlierOverlayVisual` — cover the testable core (parenting + draw-order) without a `GraphicsDevice`.
- **Untested wiring**: the `FlatRedBallService.Initialize`/`Draw` call sites (the `_game != null` branches that call `AddOverlayRoot` with the real `_gum.PopupRoot`/`ModalRoot`, and the back-buffer sizing in `Draw()`) require a real `GraphicsDevice` and aren't exercised by the headless test project — consistent with the rest of `Draw()`/`ActivateScreen`'s game-dependent code, none of which has direct unit coverage today.
- `dotnet test tests/FlatRedBall2.Tests/` — full suite green (1111 passed).
- Not yet manually verified in a running game with an open `ComboBox`/`MenuItem` (no GraphicsDevice in this environment) — worth a manual pass before merge.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)