### PR TITLE
Automation mode: add record_next_screenshot command

### DIFF
--- a/frb-skills/automation-mode/SKILL.md
+++ b/frb-skills/automation-mode/SKILL.md
@@ -56,6 +56,7 @@ Each command is a JSON object terminated by `\n`. Each response is a JSON object
 | Query all entities | `{"cmd":"query","target":"entities"}` |
 | Query one entity type | `{"cmd":"query","target":"Player"}` |
 | Force a value | `{"cmd":"set","entity":"Player","prop":"X","value":100.0}` |
+| Arm a screenshot | `{"cmd":"record_next_screenshot","path":"out.png"}` |
 | Quit | `{"cmd":"quit"}` |
 
 ### Frame stepping
@@ -102,6 +103,10 @@ Engine.RegisterValueSetter("Player", "Health", v => player.Health = (int)v);
 A registered name takes precedence over reflection — handy when you want a concise view rather than the full property dump.
 
 Providers and setters live on the screen that registered them and disappear on screen exit. The agent can detect a screen change with `query target:"screen"`.
+
+## Capturing Screenshots
+
+`record_next_screenshot path:"out.png"` doesn't capture anything by itself — it arms a pending request. The back buffer for the frame you want isn't rendered until `Draw()` runs, which happens after the command is processed, so capture is deferred to the end of the *next* `Draw()` call. **You must follow it with a `step`** — that step is what actually triggers the `Draw()` that fulfills the request and writes the response (with the captured `frame` echoed back). Arming without a subsequent `step` leaves the request pending indefinitely.
 
 ## Gotchas
 

--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using FlatRedBall2.Input;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
 namespace FlatRedBall2.Automation;
@@ -24,6 +25,10 @@ internal class AutomationMode
     // Game-thread only — no synchronization needed.
     private int _pendingStepCount;
     private bool _stepConsumedThisFrame;
+    // Armed by "record_next_screenshot", consumed by the first Draw() that follows. Screenshots
+    // can't be captured inline like query/set — the back buffer for the frame the caller cares
+    // about isn't rendered until Draw() runs, which happens after ProcessCommand returns.
+    private string? _pendingScreenshotPath;
 
     internal AutomationMode(FlatRedBallService engine, System.IO.TextWriter? output = null)
     {
@@ -128,9 +133,10 @@ internal class AutomationMode
         var command = cmdProp.GetString();
         switch (command)
         {
-            case "input":  ProcessInputCommand(cmd, frame);  break;
-            case "query":  ProcessQueryCommand(cmd, frame);  break;
-            case "set":    ProcessSetCommand(cmd, frame);    break;
+            case "input":                  ProcessInputCommand(cmd, frame);              break;
+            case "query":                  ProcessQueryCommand(cmd, frame);               break;
+            case "set":                    ProcessSetCommand(cmd, frame);                 break;
+            case "record_next_screenshot": ProcessRecordNextScreenshotCommand(cmd, frame); break;
             case "quit":
                 try { _engine.Game.Exit(); }
                 catch (InvalidOperationException) { }
@@ -342,6 +348,61 @@ internal class AutomationMode
         {
             error = $"failed to set {entityName}.{propName}: {ex.Message}";
             return false;
+        }
+    }
+
+    // --- Screenshot capture ---
+
+    private void ProcessRecordNextScreenshotCommand(JsonElement cmd, long frame)
+    {
+        var path = cmd.TryGetProperty("path", out var p) ? p.GetString() : null;
+        if (string.IsNullOrEmpty(path))
+        {
+            WriteResponse(new { ok = false, frame, error = "record_next_screenshot requires a non-empty 'path'" });
+            return;
+        }
+        _pendingScreenshotPath = path;
+    }
+
+    /// <summary>
+    /// Pops the armed screenshot request, if any. Pure state-machine logic — no
+    /// <see cref="GraphicsDevice"/> dependency — kept separate from <see cref="FulfillPendingScreenshot"/>
+    /// so it can be unit tested without a real graphics device.
+    /// </summary>
+    internal bool TryConsumePendingScreenshot(out string? path)
+    {
+        path = _pendingScreenshotPath;
+        _pendingScreenshotPath = null;
+        return path != null;
+    }
+
+    /// <summary>
+    /// Captures the just-rendered back buffer to disk as a PNG and responds, if a screenshot is
+    /// pending. Must be called from the end of <see cref="FlatRedBallService.Draw"/> — the back
+    /// buffer only reflects the current frame once Draw has finished writing to it.
+    /// </summary>
+    internal void FulfillPendingScreenshot(GraphicsDevice gd, long frame)
+    {
+        if (!TryConsumePendingScreenshot(out var path)) return;
+
+        try
+        {
+            var pp = gd.PresentationParameters;
+            int width = pp.BackBufferWidth;
+            int height = pp.BackBufferHeight;
+            var backBuffer = new Microsoft.Xna.Framework.Color[width * height];
+            gd.GetBackBufferData(backBuffer);
+
+            using var texture = new Texture2D(gd, width, height);
+            texture.SetData(backBuffer);
+            using var stream = System.IO.File.Create(path!);
+            texture.SaveAsPng(stream, width, height);
+
+            WriteResponse(new { ok = true, frame, result = new { path } });
+        }
+        catch (Exception ex)
+        {
+            WriteResponse(new { ok = false, frame, error = $"screenshot failed: {ex.Message}" });
         }
     }
 

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -1106,6 +1106,7 @@ public class FlatRedBallService
 
 #if DEBUG
         _automationMode?.FlushStepResponse(Time.CurrentFrame);
+        _automationMode?.FulfillPendingScreenshot(gd, Time.CurrentFrame);
 #endif
 
         _frameProfile.DrawTotalMs = ProfileClock.Ms(drawStart, System.Diagnostics.Stopwatch.GetTimestamp());

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
@@ -458,3 +458,48 @@ public class AutomationModeReflectionTests
         output.ToString().Trim().ShouldContain("\"custom\":\"view\"");
     }
 }
+
+// --- AutomationMode screenshot ---
+
+public class AutomationModeScreenshotTests
+{
+    [Fact]
+    public void ProcessLine_RecordNextScreenshotCommand_ArmsPendingRequestWithoutImmediateResponse()
+    {
+        var output = new StringWriter();
+        var mode = new AutomationMode(new FlatRedBallService(), output);
+
+        mode.ProcessLine("{\"cmd\":\"record_next_screenshot\",\"path\":\"out.png\"}");
+        mode.TryAdvanceFrame(0);
+
+        output.ToString().ShouldBeEmpty();
+        mode.TryConsumePendingScreenshot(out var path).ShouldBeTrue();
+        path.ShouldBe("out.png");
+    }
+
+    [Fact]
+    public void ProcessLine_RecordNextScreenshotCommand_MissingPath_WritesErrorAndDoesNotArm()
+    {
+        var output = new StringWriter();
+        var mode = new AutomationMode(new FlatRedBallService(), output);
+
+        mode.ProcessLine("{\"cmd\":\"record_next_screenshot\"}");
+        mode.TryAdvanceFrame(0);
+
+        output.ToString().ShouldContain("\"ok\":false");
+        mode.TryConsumePendingScreenshot(out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryConsumePendingScreenshot_CalledTwice_OnlyFiresOnce()
+    {
+        var mode = new AutomationMode(new FlatRedBallService(), new StringWriter());
+        mode.ProcessLine("{\"cmd\":\"record_next_screenshot\",\"path\":\"out.png\"}");
+        mode.TryAdvanceFrame(0);
+
+        mode.TryConsumePendingScreenshot(out _);
+        var second = mode.TryConsumePendingScreenshot(out _);
+
+        second.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `record_next_screenshot` to automation mode's NDJSON protocol: arms a pending screenshot request instead of capturing inline, since the back buffer for the target frame isn't rendered until `Draw()` runs (which happens after `ProcessCommand`).
- `FulfillPendingScreenshot` is called from the end of `Draw()`, next to the existing `FlushStepResponse` hook, and captures/encodes/writes the PNG once the frame has actually rendered — echoing the captured `frame` number in the response.
- Requires a `step` after `record_next_screenshot` to actually trigger the capture; documented in the `automation-mode` skill's new "Capturing Screenshots" section and the protocol table.

## Design notes
A single inline `screenshot` command (processed like `query`/`set`) was considered and rejected: tracing `TryAdvanceFrame`'s queue-drain logic (it `break`s on the first `step` it finds) showed a same-batch `screenshot`+`step` pairing doesn't reliably capture the intended frame — the pending flag ends up waiting on whatever unrelated future `step` shows up, capturing an unpredictable frame. Splitting into an explicit arm (`record_next_screenshot`) + flush (`step`) makes the actual mechanics honest in the protocol instead of hidden behind a command name that implies synchronous capture.

## Test plan
- `TryConsumePendingScreenshot` (the pending-request state machine) is unit tested headlessly in `AutomationModeScreenshotTests` — arms without an immediate response, rejects a missing `path`, and only fires once.
- The `GetBackBufferData` → PNG encode → file write path needs a real `GraphicsDevice`, which the test project can't construct headlessly (same constraint as `ContentLoaderTextureTests`). That's the untested wiring layer per this repo's TDD discipline — the testable core (arm/consume ordering) is covered, and the residue is a thin, mechanical MonoGame call sequence.
- `dotnet build src/FlatRedBall2.csproj` — clean (pre-existing unrelated warnings only).
- `dotnet test tests/FlatRedBall2.Tests/` — 1114/1114 passing.

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)