### PR TITLE
Add template-xnb-sync landmine to shaders skill

### DIFF
--- a/frb-skills/shaders/SKILL.md
+++ b/frb-skills/shaders/SKILL.md
@@ -16,6 +16,8 @@ FlatRedBall2 ships precompiled `.xnb` shaders for its built-in Apos.Shapes depen
 
 Projects import `AposShapesPrecompiled.props` to use these instead of compiling from source. Unknown platforms fall back to normal Apos.Shapes shader compilation.
 
+**These xnbs are duplicated in a second place: the dotnet templates' build folders** — `templates/frb2-desktop/build/` and `templates/frb2-multiplatform/build/` (each has a `DesktopGL/`; multiplatform also `BlazorGL/`), plus a copy of `AposShapesPrecompiled.props`. Any edit to a `src/PrecompiledShaders/<platform>/apos-shapes.xnb` must be copied byte-for-byte into the matching template folder(s). `TemplatePackageReferenceTests` fails CI on drift — run it after touching an xnb. This is invariant for *any* xnb change; the `AposShapes.props` rebuild checklist frames the sync under a version bump, but it isn't bump-specific.
+
 The package version is centralized in `$(AposShapesVersion)` (`src/PrecompiledShaders/AposShapes.props`), imported by the engine. Apos.Shapes ships only `buildTransitive` assets, so both the version and the `SkipAposShapeContent` precompiled-XNB skip flow identically whether the package is referenced directly or transitively — sample Desktop projects inherit it from the engine and don't pin it. Re-adding a per-sample pin only reintroduces the drift `NU1605` then fails the build on; bump the prop instead.
 
 ### Version Guard


### PR DESCRIPTION
Follow-up to #663 / #667.

While patching the precompiled DesktopGL `apos-shapes.xnb` in #667, I updated only the engine copy (`src/PrecompiledShaders/`) and missed the byte-identical duplicates in the dotnet templates' `build/` folders. `TemplatePackageReferenceTests` caught it in CI.

**Root cause:** the `shaders` skill documents xnbs as living only in `src/PrecompiledShaders/` and never mentions the template `build/` copies, and the sync step in `AposShapes.props` is framed as part of a "version bump" checklist — so a one-off patch didn't trigger it.

**Fix:** a landmine in the `shaders` skill naming the second location and the enforcing test, framed as an invariant for *any* xnb change (not just a version bump), so a future agent mirrors the copies and runs the test locally instead of discovering the drift in CI.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
