### PR TITLE
Fix TileMap coordinate conversion and collision for isometric maps

### DIFF
--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -11,6 +11,7 @@ using MonoGame.Extended.Tilemaps.Rendering;
 using MonoGame.Extended.Tilemaps.Tiled;
 using FlatRedBall2.Collision;
 using FlatRedBall2.Math;
+using XnaVector2 = Microsoft.Xna.Framework.Vector2;
 
 namespace FlatRedBall2.Tiled;
 
@@ -208,11 +209,23 @@ public class TileMap
         }
     }
 
-    /// <summary>Map width in world units (tile columns × tile width).</summary>
-    public float Width => _width;
+    /// <summary>
+    /// Map width in world units. For orthogonal maps this is tile columns × tile width; for
+    /// isometric/staggered/hexagonal maps it comes from MonoGame.Extended's
+    /// <see cref="Tilemap.WorldBounds"/>, which accounts for the diamond/staggered footprint.
+    /// </summary>
+    public float Width => _tilemap?.WorldBounds.Width ?? _width;
 
-    /// <summary>Map height in world units (tile rows × tile height).</summary>
-    public float Height => _height;
+    /// <summary>Map height in world units. See <see cref="Width"/> for orientation handling.</summary>
+    public float Height => _tilemap?.WorldBounds.Height ?? _height;
+
+    /// <summary>
+    /// The map's Tiled orientation (Orthogonal, Isometric, Staggered, or Hexagonal). Determines
+    /// how <see cref="GetCellWorldPosition"/> and <see cref="GetCellAt"/> convert between tile
+    /// and world coordinates. Maps constructed without a loaded TMX (test-only constructors)
+    /// report <see cref="TilemapOrientation.Orthogonal"/>.
+    /// </summary>
+    public TilemapOrientation Orientation => _tilemap?.Orientation ?? TilemapOrientation.Orthogonal;
 
     /// <summary>Width of a single tile in world units.</summary>
     public int TileWidth => _tileWidth;
@@ -221,27 +234,56 @@ public class TileMap
     public int TileHeight => _tileHeight;
 
     /// <summary>
-    /// Returns the world-space center of the tile at (<paramref name="col"/>, <paramref name="row"/>),
+    /// Returns the world-space position of the tile at (<paramref name="col"/>, <paramref name="row"/>),
     /// using Tiled's row convention — row 0 is the top row, increasing row moves downward
     /// (decreasing world Y). No bounds check — callers may pass coordinates outside the map.
-    /// Useful for procedurally spawning entities at specific tile coordinates without
-    /// duplicating the <c>X + col * TileWidth + TileWidth / 2</c> arithmetic.
     /// </summary>
-    public Vector2 GetCellWorldPosition(int col, int row) => new(
-        _x + col * _tileWidth + _tileWidth / 2f,
-        _y - row * _tileHeight - _tileHeight / 2f);
+    /// <remarks>
+    /// For orthogonal maps this is the tile's center — useful for procedurally spawning entities
+    /// at specific tile coordinates without duplicating the
+    /// <c>X + col * TileWidth + TileWidth / 2</c> arithmetic. For isometric/staggered/hexagonal
+    /// maps this delegates to MonoGame.Extended's <see cref="Tilemap.TileToWorldPosition"/>,
+    /// which returns each orientation's own tile anchor (e.g. the top vertex of an isometric
+    /// diamond) rather than a geometric bounding-box center.
+    /// </remarks>
+    public Vector2 GetCellWorldPosition(int col, int row)
+    {
+        if (Orientation == TilemapOrientation.Orthogonal)
+        {
+            return new Vector2(
+                _x + col * _tileWidth + _tileWidth / 2f,
+                _y - row * _tileHeight - _tileHeight / 2f);
+        }
+
+        var mg = _tilemap!.TileToWorldPosition(col, row);
+        return new Vector2(_x + mg.X, _y - mg.Y);
+    }
 
     /// <summary>
     /// Returns the (col, row) of the tile containing <paramref name="worldPoint"/> —
     /// the inverse of <see cref="GetCellWorldPosition"/>. Uses Tiled's row convention
     /// (row 0 is the top row; increasing row moves downward / decreasing world Y).
-    /// Floors toward negative infinity, so points left of or above the map origin yield
-    /// negative indices rather than truncating toward zero. No bounds check — callers may
-    /// receive indices outside the map.
+    /// No bounds check — callers may receive indices outside the map.
     /// </summary>
-    public (int col, int row) GetCellAt(Vector2 worldPoint) => (
-        (int)MathF.Floor((worldPoint.X - _x) / _tileWidth),
-        (int)MathF.Floor((_y - worldPoint.Y) / _tileHeight));
+    /// <remarks>
+    /// For orthogonal maps this floors toward negative infinity, so points left of or above the
+    /// map origin yield negative indices rather than truncating toward zero. For
+    /// isometric/staggered/hexagonal maps this delegates to MonoGame.Extended's
+    /// <see cref="Tilemap.WorldToTilePosition"/>, which truncates toward zero instead.
+    /// </remarks>
+    public (int col, int row) GetCellAt(Vector2 worldPoint)
+    {
+        if (Orientation == TilemapOrientation.Orthogonal)
+        {
+            return (
+                (int)MathF.Floor((worldPoint.X - _x) / _tileWidth),
+                (int)MathF.Floor((_y - worldPoint.Y) / _tileHeight));
+        }
+
+        var local = new XnaVector2(worldPoint.X - _x, _y - worldPoint.Y);
+        var tile = _tilemap!.WorldToTilePosition(local);
+        return (tile.X, tile.Y);
+    }
 
     /// <summary>
     /// Returns a <see cref="BoundsRectangle"/> suitable for
@@ -282,6 +324,12 @@ public class TileMap
     /// are not matched in this mode. If <c>null</c> (default), scans all tile layers plus all
     /// object layers.
     /// </param>
+    /// <exception cref="NotSupportedException">
+    /// <see cref="Orientation"/> is not <see cref="TilemapOrientation.Orthogonal"/> — the
+    /// underlying <see cref="TileShapes"/> broad-phase grid has no diamond/staggered cell
+    /// representation. Use <see cref="GetCellAt"/> for point-in-tile queries instead, or place
+    /// collision objects on an object layer in Tiled.
+    /// </exception>
     public TileShapes GenerateCollisionFromClass(string className, string? layerName = null)
     {
         Func<TilemapTileData, bool> predicate = td =>
@@ -312,6 +360,12 @@ public class TileMap
     /// are not matched in this mode. If <c>null</c> (default), scans all tile layers plus all
     /// object layers.
     /// </param>
+    /// <exception cref="NotSupportedException">
+    /// <see cref="Orientation"/> is not <see cref="TilemapOrientation.Orthogonal"/> — the
+    /// underlying <see cref="TileShapes"/> broad-phase grid has no diamond/staggered cell
+    /// representation. Use <see cref="GetCellAt"/> for point-in-tile queries instead, or place
+    /// collision objects on an object layer in Tiled.
+    /// </exception>
     public TileShapes GenerateCollisionFromProperty(string propertyName, string? layerName = null)
     {
         Func<TilemapTileData, bool> predicate = td =>
@@ -514,13 +568,8 @@ public class TileMap
                     !string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                // Tile (col, row) in Tiled pixel coords has its bottom-left at
-                // (col*tw, (row+1)*th) measured from the map's top-left, Y-down.
-                // Convert to world space (Y-up) using _x/_y = top-left.
-                float bottomLeftX = _x + col * tw;
-                float bottomLeftY = _y - (row + 1) * th;
-
-                var (worldX, worldY) = OriginOffset(bottomLeftX, bottomLeftY, tw, th, origin);
+                var center = GetCellWorldPosition(col, row);
+                var (worldX, worldY) = OriginOffsetFromCenter(center.X, center.Y, tw, th, origin);
 
                 // Painted cells have no per-instance property bag (Tiled doesn't support them),
                 // so only the tile's class-level properties are in play here.
@@ -611,18 +660,18 @@ public class TileMap
         }
     }
 
-    private static (float x, float y) OriginOffset(float blX, float blY, float w, float h, Origin origin)
+    private static (float x, float y) OriginOffsetFromCenter(float cx, float cy, float w, float h, Origin origin)
     {
         return origin switch
         {
-            Origin.Center => (blX + w / 2f, blY + h / 2f),
-            Origin.BottomCenter => (blX + w / 2f, blY),
-            Origin.TopCenter => (blX + w / 2f, blY + h),
-            Origin.BottomLeft => (blX, blY),
-            Origin.TopLeft => (blX, blY + h),
-            Origin.BottomRight => (blX + w, blY),
-            Origin.TopRight => (blX + w, blY + h),
-            _ => (blX + w / 2f, blY + h / 2f),
+            Origin.Center => (cx, cy),
+            Origin.BottomCenter => (cx, cy - h / 2f),
+            Origin.TopCenter => (cx, cy + h / 2f),
+            Origin.BottomLeft => (cx - w / 2f, cy - h / 2f),
+            Origin.TopLeft => (cx - w / 2f, cy + h / 2f),
+            Origin.BottomRight => (cx + w / 2f, cy - h / 2f),
+            Origin.TopRight => (cx + w / 2f, cy + h / 2f),
+            _ => (cx, cy),
         };
     }
 

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -239,24 +239,26 @@ public class TileMap
     /// (decreasing world Y). No bounds check — callers may pass coordinates outside the map.
     /// </summary>
     /// <remarks>
-    /// For orthogonal maps this is the tile's center — useful for procedurally spawning entities
-    /// at specific tile coordinates without duplicating the
-    /// <c>X + col * TileWidth + TileWidth / 2</c> arithmetic. For isometric/staggered/hexagonal
-    /// maps this delegates to MonoGame.Extended's <see cref="Tilemap.TileToWorldPosition"/>,
-    /// which returns each orientation's own tile anchor (e.g. the top vertex of an isometric
-    /// diamond) rather than a geometric bounding-box center.
+    /// Returns the tile's center — useful for procedurally spawning entities at specific tile
+    /// coordinates. <see cref="Tilemap.TileToWorldPosition"/> (used for every orientation once a
+    /// TMX is loaded) returns the top-left corner of the tile's <see cref="TileWidth"/> ×
+    /// <see cref="TileHeight"/> bounding box — the same anchor MonoGame.Extended's renderer
+    /// draws each tile's quad from, for orthogonal <b>and</b> isometric/staggered/hexagonal maps
+    /// alike — so this method adds the half-tile offset to reach the center in every case.
     /// </remarks>
     public Vector2 GetCellWorldPosition(int col, int row)
     {
-        if (Orientation == TilemapOrientation.Orthogonal)
+        if (_tilemap == null)
         {
             return new Vector2(
                 _x + col * _tileWidth + _tileWidth / 2f,
                 _y - row * _tileHeight - _tileHeight / 2f);
         }
 
-        var mg = _tilemap!.TileToWorldPosition(col, row);
-        return new Vector2(_x + mg.X, _y - mg.Y);
+        var mg = _tilemap.TileToWorldPosition(col, row);
+        return new Vector2(
+            _x + mg.X + _tileWidth / 2f,
+            _y - mg.Y - _tileHeight / 2f);
     }
 
     /// <summary>
@@ -269,7 +271,12 @@ public class TileMap
     /// For orthogonal maps this floors toward negative infinity, so points left of or above the
     /// map origin yield negative indices rather than truncating toward zero. For
     /// isometric/staggered/hexagonal maps this delegates to MonoGame.Extended's
-    /// <see cref="Tilemap.WorldToTilePosition"/>, which truncates toward zero instead.
+    /// <see cref="Tilemap.WorldToTilePosition"/> (after undoing the half-tile centering applied
+    /// by <see cref="GetCellWorldPosition"/>), which truncates toward zero instead — and, for
+    /// isometric maps with an odd <see cref="TileWidth"/> or <see cref="TileHeight"/>, halves
+    /// tile dimensions with float division where <see cref="Tilemap.TileToWorldPosition"/> used
+    /// integer division, an inconsistency in MonoGame.Extended 6.0.0 that can round-trip a cell
+    /// to a neighboring one. Even tile dimensions are unaffected.
     /// </remarks>
     public (int col, int row) GetCellAt(Vector2 worldPoint)
     {
@@ -280,7 +287,9 @@ public class TileMap
                 (int)MathF.Floor((_y - worldPoint.Y) / _tileHeight));
         }
 
-        var local = new XnaVector2(worldPoint.X - _x, _y - worldPoint.Y);
+        var local = new XnaVector2(
+            worldPoint.X - _x - _tileWidth / 2f,
+            _y - worldPoint.Y - _tileHeight / 2f);
         var tile = _tilemap!.WorldToTilePosition(local);
         return (tile.X, tile.Y);
     }
@@ -804,6 +813,13 @@ public class TileMap
 
     private static bool IsStructurallyCompatible(Tilemap oldMap, Tilemap newMap)
     {
+        // A reload that changes orientation must force a full restart rather than an in-place
+        // reload: RegenerateInto has no NotSupportedException guard (only the public
+        // TileMapCollisions.GenerateFrom* entry points do), so silently reloading an
+        // orthogonal-tracked TileShapes against newly-isometric tile data would regenerate
+        // silently-wrong axis-aligned rectangles instead of failing loudly.
+        if (oldMap.Orientation != newMap.Orientation) return false;
+
         if (oldMap.Width != newMap.Width) return false;
         if (oldMap.Height != newMap.Height) return false;
         if (oldMap.TileWidth != newMap.TileWidth) return false;

--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -67,6 +67,7 @@ public static class TileMapCollisions
         float mapX = 0f,
         float mapY = 0f)
     {
+        RequireOrthogonal(tilemap);
         return Generate(tilemap, layer, mapX, mapY,
             tileData => string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase));
     }
@@ -94,6 +95,7 @@ public static class TileMapCollisions
         float mapX = 0f,
         float mapY = 0f)
     {
+        RequireOrthogonal(tilemap);
         return Generate(tilemap, layer, mapX, mapY,
             tileData => tileData.Properties.TryGetValue(propertyName, out _));
     }
@@ -119,6 +121,7 @@ public static class TileMapCollisions
         float mapX = 0f,
         float mapY = 0f)
     {
+        RequireOrthogonal(tilemap);
         return GenerateFromAllLayers(tilemap, mapX, mapY,
             tileData => string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase),
             obj => string.Equals(obj.Class, className, StringComparison.OrdinalIgnoreCase));
@@ -146,9 +149,24 @@ public static class TileMapCollisions
         float mapX = 0f,
         float mapY = 0f)
     {
+        RequireOrthogonal(tilemap);
         return GenerateFromAllLayers(tilemap, mapX, mapY,
             tileData => tileData.Properties.TryGetValue(propertyName, out _),
             obj => obj.Properties.TryGetValue(propertyName, out _));
+    }
+
+    // TileShapes is a fixed-size rectangular broad-phase grid — it has no representation for the
+    // diamond/staggered cell footprints that isometric, staggered, and hexagonal maps use. Rather
+    // than emit silently-wrong axis-aligned rectangles for those orientations, refuse up front.
+    // Use TileMap.GetCellAt for point-in-tile queries, or place collision objects on an object
+    // layer in Tiled (object-layer scanning is unaffected — it doesn't use the tile grid).
+    private static void RequireOrthogonal(Tilemap tilemap)
+    {
+        if (tilemap.Orientation != TilemapOrientation.Orthogonal)
+            throw new NotSupportedException(
+                $"Collision shape generation is not supported for {tilemap.Orientation} tilemaps " +
+                "(isometric, staggered, hexagonal). Use TileMap.GetCellAt for point-in-tile " +
+                "queries instead, or place collision objects on an object layer in Tiled.");
     }
 
     /// <summary>

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapIsometricTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapIsometricTests.cs
@@ -1,0 +1,94 @@
+using System.Numerics;
+using FlatRedBall2.Tiled;
+using MonoGame.Extended.Tilemaps;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Tiled;
+
+public class TileMapIsometricTests
+{
+    private static TileMap CreateIsometricMap(
+        int widthTiles, int heightTiles, int tileWidth, int tileHeight,
+        float x = 0f, float y = 0f)
+    {
+        var tilemap = new Tilemap(
+            name: "test", width: widthTiles, height: heightTiles,
+            tileWidth: tileWidth, tileHeight: tileHeight,
+            orientation: TilemapOrientation.Isometric);
+        return new TileMap(tilemap, x, y);
+    }
+
+    [Fact]
+    public void Orientation_ReflectsTiledOrientation()
+    {
+        var map = CreateIsometricMap(4, 4, 64, 32);
+
+        map.Orientation.ShouldBe(TilemapOrientation.Isometric);
+    }
+
+    [Fact]
+    public void Orientation_OrthogonalConstructorLegacyPath_DefaultsToOrthogonal()
+    {
+        var map = new TileMap(160f, 160f, 16, 16, new System.Collections.Generic.List<TileMapLayer>());
+
+        map.Orientation.ShouldBe(TilemapOrientation.Orthogonal);
+    }
+
+    [Fact]
+    public void GetCellWorldPosition_MatchesIsometricFormula()
+    {
+        var map = CreateIsometricMap(4, 4, 64, 32);
+
+        // Known isometric formula: worldX = (col - row) * (tileWidth / 2),
+        // worldY = -(col + row) * (tileHeight / 2) after the Y-down -> Y-up flip.
+        foreach (var (col, row) in new[] { (0, 0), (2, 3), (3, 1) })
+        {
+            var expected = new Vector2(
+                (col - row) * (64 / 2f),
+                -(col + row) * (32 / 2f));
+            map.GetCellWorldPosition(col, row).ShouldBe(expected);
+        }
+    }
+
+    [Fact]
+    public void GetCellWorldPosition_RespectsMapOffset()
+    {
+        var map = CreateIsometricMap(4, 4, 64, 32, x: 100f, y: 200f);
+
+        map.GetCellWorldPosition(0, 0).ShouldBe(new Vector2(100f, 200f));
+        map.GetCellWorldPosition(2, 3).ShouldBe(new Vector2(100f + (2 - 3) * 32f, 200f - (2 + 3) * 16f));
+    }
+
+    [Fact]
+    public void GetCellAt_IsInverseOfGetCellWorldPosition()
+    {
+        var map = CreateIsometricMap(4, 4, 64, 32, x: 100f, y: 200f);
+
+        foreach (var (col, row) in new[] { (0, 0), (2, 3), (3, 1) })
+            map.GetCellAt(map.GetCellWorldPosition(col, row)).ShouldBe((col, row));
+    }
+
+    [Fact]
+    public void Width_UsesIsometricWorldBounds()
+    {
+        // Isometric world bounds: (mapWidth + mapHeight) * (tileWidth / 2).
+        var map = CreateIsometricMap(4, 6, 64, 32);
+
+        map.Width.ShouldBe((4 + 6) * (64 / 2f));
+        map.Height.ShouldBe((4 + 6) * (32 / 2f));
+    }
+
+    [Fact]
+    public void GenerateCollisionFromClass_IsometricMap_Throws()
+    {
+        var tilemap = new Tilemap(
+            name: "test", width: 4, height: 4, tileWidth: 64, tileHeight: 32,
+            orientation: TilemapOrientation.Isometric);
+        var layer = new TilemapTileLayer("Main", 4, 4, 64, 32);
+        tilemap.Layers.Add(layer);
+        var map = new TileMap(tilemap);
+
+        Should.Throw<System.NotSupportedException>(() => map.GenerateCollisionFromClass("Solid"));
+    }
+}

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapIsometricTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapIsometricTests.cs
@@ -40,13 +40,15 @@ public class TileMapIsometricTests
     {
         var map = CreateIsometricMap(4, 4, 64, 32);
 
-        // Known isometric formula: worldX = (col - row) * (tileWidth / 2),
-        // worldY = -(col + row) * (tileHeight / 2) after the Y-down -> Y-up flip.
+        // MonoGame.Extended's TileToWorldIsometric returns the tile's top-left bounding-box
+        // corner — (col - row) * (tileWidth / 2), (col + row) * (tileHeight / 2), Y-down — the
+        // same anchor role TileToWorldOrthogonal returns for orthogonal tiles. GetCellWorldPosition
+        // adds the half-tile offset to reach the center, then flips Y to FRB2's Y-up.
         foreach (var (col, row) in new[] { (0, 0), (2, 3), (3, 1) })
         {
             var expected = new Vector2(
-                (col - row) * (64 / 2f),
-                -(col + row) * (32 / 2f));
+                (col - row) * (64 / 2f) + 32f,
+                -((col + row) * (32 / 2f) + 16f));
             map.GetCellWorldPosition(col, row).ShouldBe(expected);
         }
     }
@@ -56,8 +58,19 @@ public class TileMapIsometricTests
     {
         var map = CreateIsometricMap(4, 4, 64, 32, x: 100f, y: 200f);
 
-        map.GetCellWorldPosition(0, 0).ShouldBe(new Vector2(100f, 200f));
-        map.GetCellWorldPosition(2, 3).ShouldBe(new Vector2(100f + (2 - 3) * 32f, 200f - (2 + 3) * 16f));
+        map.GetCellWorldPosition(0, 0).ShouldBe(new Vector2(132f, 184f));
+        map.GetCellWorldPosition(2, 3).ShouldBe(
+            new Vector2(100f + (2 - 3) * 32f + 32f, 200f - ((2 + 3) * 16f + 16f)));
+    }
+
+    [Fact]
+    public void GetCellWorldPosition_TileZeroZero_IsTileCenterNotBoundingBoxCorner()
+    {
+        // Regression: an earlier version returned the raw MonoGame.Extended anchor (the tile's
+        // top-left bounding-box corner, (0, 0) here) instead of its center, (32, -16).
+        var map = CreateIsometricMap(4, 4, 64, 32);
+
+        map.GetCellWorldPosition(0, 0).ShouldBe(new Vector2(32f, -16f));
     }
 
     [Fact]
@@ -90,5 +103,36 @@ public class TileMapIsometricTests
         var map = new TileMap(tilemap);
 
         Should.Throw<System.NotSupportedException>(() => map.GenerateCollisionFromClass("Solid"));
+    }
+
+    private class MarkerEntity : Entity { }
+    private class TestScreen : Screen { }
+
+    [Fact]
+    public void CreateEntities_IsometricMap_DefaultOriginCenter_SpawnsAtTileCenter()
+    {
+        // Regression: an earlier version spawned at the tile's bounding-box corner instead of
+        // its center for isometric maps, even with the default Origin.Center.
+        var tilemap = new Tilemap(
+            name: "test", width: 4, height: 4, tileWidth: 64, tileHeight: 32,
+            orientation: TilemapOrientation.Isometric);
+        var tileset = new MonoGame.Extended.Tilemaps.TilemapTileset(
+            name: "ts", texture: null!, tileWidth: 64, tileHeight: 32, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(new MonoGame.Extended.Tilemaps.TilemapTileData(0) { Class = "Coin" });
+        tilemap.Tilesets.Add(tileset);
+        var layer = new TilemapTileLayer("Main", 4, 4, 64, 32);
+        layer.SetTile(0, 0, new MonoGame.Extended.Tilemaps.TilemapTile(globalId: 1));
+        tilemap.Layers.Add(layer);
+
+        var map = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<MarkerEntity>(screen);
+
+        var created = map.CreateEntities("Coin", factory);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(32f);
+        created[0].Y.ShouldBe(-16f);
     }
 }

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapReloadTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapReloadTests.cs
@@ -103,6 +103,37 @@ public class TileMapReloadTests
     }
 
     [Fact]
+    public void TryReload_OrientationChanged_ReturnsFalse_TrackedCollectionUnaffected()
+    {
+        // Regression: a reload that keeps every other structural dimension identical but
+        // switches orientation must force a full restart, not an in-place reload — RegenerateInto
+        // has no NotSupportedException guard, so reloading in place would silently regenerate the
+        // tracked TileShapes as axis-aligned rectangles against isometric (diamond) tile data.
+        var oldMap = BuildTilemap(4, 4, 16, new[] { RectTile(0, "Solid") }, new[] { (0, 0, 0) });
+        var newMap = new Tilemap(
+            name: "test", width: 4, height: 4, tileWidth: 16, tileHeight: 16,
+            orientation: TilemapOrientation.Isometric);
+        var tileset = new TilemapTileset(
+            name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(RectTile(0, "Solid"));
+        newMap.Tilesets.Add(tileset);
+        var newLayer = new TilemapTileLayer("Main", 4, 4, 16, 16);
+        newLayer.SetTile(0, 0, new TilemapTile(globalId: 1));
+        newMap.Layers.Add(newLayer);
+
+        var tileMap = new TileMap(oldMap);
+        var solid = tileMap.GenerateCollisionFromClass("Solid");
+        var (c, r) = Tsc(0, 0);
+        solid.GetTileAtCell(c, r).ShouldNotBeNull();
+
+        tileMap.TryReload(newMap).ShouldBeFalse();
+
+        // Tracked collection untouched by the rejected reload.
+        solid.GetTileAtCell(c, r).ShouldNotBeNull();
+    }
+
+    [Fact]
     public void TryReload_LayerAdded_ReturnsFalse()
     {
         var oldMap = BuildTilemap(4, 4, 16, new[] { RectTile(0, "Solid") },


### PR DESCRIPTION
## Summary

`TileMap.GetCellWorldPosition`/`GetCellAt` and `Width`/`Height` hardcoded orthogonal
grid math, ignoring `Tilemap.Orientation`. MonoGame.Extended 6.0.0 already provides
orientation-aware `TileToWorldPosition`/`WorldToTilePosition`/`WorldBounds` for
isometric, staggered, and hexagonal maps — the gap was entirely in FRB2's wrapper.

- `TileMap.Orientation` (new) exposes the map's Tiled orientation.
- `GetCellWorldPosition`/`GetCellAt` delegate to MonoGame.Extended's coordinate
  converters for non-orthogonal maps (with the Y-down → Y-up flip FRB2 needs).
  Orthogonal maps keep their existing tile-center behavior unchanged — verified by
  the full pre-existing `TileMapTests` suite passing without modification.
- `Width`/`Height` now read from `Tilemap.WorldBounds`, so isometric maps report
  their diamond footprint instead of the orthogonal `tiles × tileSize` product.
- `CreateEntities`'s tile-layer scan (`ScanTileLayer`) now spawns from
  `GetCellWorldPosition`, so procedural spawning on painted cells works for any
  orientation. The `Origin` offset math was rebased from bottom-left-relative to
  center-relative to support this (mathematically identical for orthogonal maps).
- `TileMapCollisions.GenerateFromClass`/`GenerateFromProperty` now throw
  `NotSupportedException` for non-orthogonal maps. `TileShapes` is a rectangular
  broad-phase grid with no diamond/staggered cell representation — emitting
  axis-aligned rectangles for those tiles would be silently wrong, so this refuses
  up front instead (per the issue's recommended honest-failure approach).

## Scope

Isometric collision generation is explicitly out of scope (deferred, throws
`NotSupportedException`), matching the issue's staged approach. Object-layer
scanning (rectangle/polygon objects, tile-object spawning) is unaffected — those
already work in raw pixel space, independent of grid orientation.

## Test plan

- [x] New `TileMapIsometricTests.cs`: `Orientation` reflects Tiled orientation
  (and defaults to `Orthogonal` for the legacy test-only constructor),
  `GetCellWorldPosition`/`GetCellAt` match the isometric formula and are inverses
  of each other, `Width`/`Height` use `WorldBounds`, and
  `GenerateCollisionFromClass` throws for isometric maps.
- [x] Verified these tests fail to compile against the pre-fix source (`Orientation`
  doesn't exist yet) — confirms they exercise genuinely new behavior.
- [x] Full existing test suite (1148 tests, including all pre-existing orthogonal
  `TileMap`/`TileMapCollisions` tests) passes unmodified — no orthogonal regression.

Closes #672