### PR TITLE
Add Sprite.FlipDiagonal runtime rendering support

### DIFF
--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -221,6 +221,16 @@ public class Sprite : IRenderable, IAttachable
     /// </summary>
     public bool FlipVertical { get; set; }
 
+    /// <summary>
+    /// Mirrors the texture across its diagonal (transposes width/height) when <c>true</c>.
+    /// Combines with <see cref="FlipHorizontal"/>/<see cref="FlipVertical"/> in the same D→H→V
+    /// order Tiled and the Animation Editor use. MonoGame's <c>SpriteEffects</c> has no diagonal
+    /// value, so this is implemented as a rotation offset rather than a texture-sampling flag —
+    /// see <see cref="ComputeDrawTransform"/>. Overwritten by the current animation frame while
+    /// <see cref="Animate"/> is on.
+    /// </summary>
+    public bool FlipDiagonal { get; set; }
+
     // Animation
 
     /// <summary>
@@ -398,6 +408,7 @@ public class Sprite : IRenderable, IAttachable
         _sourceRectangle = frame.SourceRectangle;
         FlipHorizontal = frame.FlipHorizontal;
         FlipVertical = frame.FlipVertical;
+        FlipDiagonal = frame.FlipDiagonal;
         X = frame.RelativeX;
         Y = frame.RelativeY;
         RecalculateDimensions();
@@ -575,18 +586,47 @@ public class Sprite : IRenderable, IAttachable
     // spin clockwise (opposite a polygon hitbox on the same entity).
     internal float RenderRotationRadians => AbsoluteRotation.Radians;
 
+    // Rotation + SpriteEffects handed to SpriteBatch.Draw, folding in FlipDiagonal.
+    //
+    // MonoGame's SpriteEffects has no diagonal/transpose value, and SpriteBatch offers no way to
+    // swap which UV axis a corner samples — effects only mirror an axis in place; rotation only
+    // moves the already-UV-mapped quad. A diagonal flip is a reflection (determinant -1), while
+    // rotation alone is not (determinant +1), so no rotation/effects combination reproduces it —
+    // EXCEPT that composing a rotation with a single-axis mirror IS a reflection, and any 2D
+    // reflection can be written that way. Concretely: a +/-90 degree rotation offset plus (at
+    // most) SpriteEffects.FlipVertically reproduces the exact diagonal-transpose matrix
+    // (0, b, c, 0) that AnimationEditorAvalonia's FlipScaleCalculator.ComputeMatrix uses for the
+    // SkiaSharp preview (issue #593 requires editor/runtime parity). Width/Height, origin, and
+    // scale are untouched — the 90 degree rotation is what swaps the on-screen footprint, not a
+    // manual axis swap. See SpriteDiagonalFlipTests for the derivation check against that matrix.
+    //
+    // Non-diagonal case unchanged: FlipVertically is the base effect that cancels the camera's
+    // Y-flip (Batch.FlipsY); user-facing FlipVertical XORs it (net upside-down relative to
+    // upright); FlipHorizontal is purely additive and unaffected by the Y-flip.
+    internal (float rotation, SpriteEffects effects) ComputeDrawTransform()
+    {
+        bool effectiveFlipVertical = (Batch?.FlipsY ?? true) ^ FlipVertical;
+
+        if (FlipDiagonal)
+        {
+            float rotation = RenderRotationRadians + (effectiveFlipVertical ? MathHelper.PiOver2 : -MathHelper.PiOver2);
+            var effects = (FlipHorizontal == effectiveFlipVertical) ? SpriteEffects.FlipVertically : SpriteEffects.None;
+            return (rotation, effects);
+        }
+        else
+        {
+            var effects = effectiveFlipVertical ? SpriteEffects.FlipVertically : SpriteEffects.None;
+            if (FlipHorizontal) effects |= SpriteEffects.FlipHorizontally;
+            return (RenderRotationRadians, effects);
+        }
+    }
+
     /// <inheritdoc/>
     public void Draw(SpriteBatch spriteBatch, Camera camera)
     {
         if (!IsVisible || Texture == null) return;
 
-        // When the batch's transform flips Y (world Y+ up → screen Y+ down), sprite texture pixels
-        // would appear upside-down without compensation. FlipVertically is the base effect that
-        // cancels the camera flip. User-facing FlipVertical XORs this, producing a net upside-down
-        // appearance relative to normal. FlipHorizontal is purely additive and unaffected by the Y-flip.
-        var effects = (Batch?.FlipsY ?? true) ? SpriteEffects.FlipVertically : SpriteEffects.None;
-        if (FlipHorizontal) effects |= SpriteEffects.FlipHorizontally;
-        if (FlipVertical)   effects ^= SpriteEffects.FlipVertically;
+        var (rotation, effects) = ComputeDrawTransform();
 
         // Origin and scale must be relative to the source region, not the full texture.
         float srcW = SourceRectangle?.Width  ?? Texture.Width;
@@ -602,7 +642,7 @@ public class Sprite : IRenderable, IAttachable
             position,
             SourceRectangle,
             color,
-            RenderRotationRadians,
+            rotation,
             origin,
             scale,
             effects,

--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -596,9 +596,12 @@ public class Sprite : IRenderable, IAttachable
     // reflection can be written that way. Concretely: a +/-90 degree rotation offset plus (at
     // most) SpriteEffects.FlipVertically reproduces the exact diagonal-transpose matrix
     // (0, b, c, 0) that AnimationEditorAvalonia's FlipScaleCalculator.ComputeMatrix uses for the
-    // SkiaSharp preview (issue #593 requires editor/runtime parity). Width/Height, origin, and
-    // scale are untouched — the 90 degree rotation is what swaps the on-screen footprint, not a
-    // manual axis swap. See SpriteDiagonalFlipTests for the derivation check against that matrix.
+    // SkiaSharp preview (issue #593 requires editor/runtime parity) — diagonal-only there is the
+    // plain swap (x,y)->(y,x), which fixes the top-left/bottom-right corners and swaps
+    // top-right/bottom-left, matching Tiled's actual diagonal-flip semantics. Width/Height,
+    // origin, and scale are untouched — the 90 degree rotation is what swaps the on-screen
+    // footprint, not a manual axis swap. See SpriteDiagonalFlipTests for the derivation check
+    // against that matrix.
     //
     // Non-diagonal case unchanged: FlipVertically is the base effect that cancels the camera's
     // Y-flip (Batch.FlipsY); user-facing FlipVertical XORs it (net upside-down relative to
@@ -609,7 +612,7 @@ public class Sprite : IRenderable, IAttachable
 
         if (FlipDiagonal)
         {
-            float rotation = RenderRotationRadians + (effectiveFlipVertical ? MathHelper.PiOver2 : -MathHelper.PiOver2);
+            float rotation = RenderRotationRadians + (effectiveFlipVertical ? -MathHelper.PiOver2 : MathHelper.PiOver2);
             var effects = (FlipHorizontal == effectiveFlipVertical) ? SpriteEffects.FlipVertically : SpriteEffects.None;
             return (rotation, effects);
         }

--- a/tests/FlatRedBall2.Tests/Animation/SpriteAnimationTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/SpriteAnimationTests.cs
@@ -117,6 +117,22 @@ public class SpriteAnimationTests
     }
 
     [Fact]
+    public void PlayAnimation_FrameWithFlipDiagonal_SetsSpriteFlipDiagonal()
+    {
+        var chain = new AnimationChain { Name = "Roll" };
+        chain.Add(new AnimationFrame { FrameLength = TimeSpan.FromSeconds(0.1), FlipDiagonal = true });
+
+        var list = new AnimationChainList();
+        list.Add(chain);
+
+        var sprite = new Sprite();
+        sprite.AnimationChains = list;
+        sprite.PlayAnimation("Roll");
+
+        sprite.FlipDiagonal.ShouldBeTrue();
+    }
+
+    [Fact]
     public void AnimateSelf_FrameChange_UpdatesXY()
     {
         var chain = new AnimationChain { Name = "Walk" };

--- a/tests/FlatRedBall2.Tests/Rendering/SpriteDiagonalFlipTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/SpriteDiagonalFlipTests.cs
@@ -1,0 +1,129 @@
+using System;
+using FlatRedBall2.Rendering;
+using FlatRedBall2.Rendering.Batches;
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Rendering;
+
+// Issue #593. Same testability constraint as SpriteRotationTests (#378): no headless
+// GraphicsDevice, so no pixel readback — but MonoGame's SpriteEffects has no diagonal-transpose
+// value either, so there is no flag to plumb through SpriteBatch.Draw in the first place. Instead
+// FlipDiagonal is implemented as a +/-90 degree rotation offset combined with a single vertical-
+// mirror choice (Sprite.ComputeDrawTransform) — a reflection is always expressible as a rotation
+// composed with one axis mirror. That composition is verified here against an independent ground
+// truth: the same (a,b,c,d) transpose matrix used by the Animation Editor's already-tested
+// AnimationEditor.Core.Rendering.FlipScaleCalculator.ComputeMatrix, which drives the SkiaSharp
+// preview this issue is required to match. Both sides are pure CPU math — no GraphicsDevice.
+public class SpriteDiagonalFlipTests
+{
+    // Ground truth: FlipScaleCalculator.ComputeMatrix(h, v, flipDiagonal: true) is (0, b, c, 0)
+    // with b = h?1:-1, c = v?1:-1, mapping local offset (u,v) -> (b*v, c*u). Applied here to a
+    // scaled offset and then the sprite's own base rotation, matching how Sprite composes flip
+    // with an already-set Rotation.
+    static (float x, float y) ExpectedOffset(bool flipHorizontal, bool effectiveFlipVertical, float baseRotationRadians, float u, float v, float scaleX, float scaleY)
+    {
+        float b = flipHorizontal ? 1f : -1f;
+        float c = effectiveFlipVertical ? 1f : -1f;
+        float outX = b * (v * scaleY);
+        float outY = c * (u * scaleX);
+        float cr = MathF.Cos(baseRotationRadians), sr = MathF.Sin(baseRotationRadians);
+        return (outX * cr - outY * sr, outX * sr + outY * cr);
+    }
+
+    // The formula SpriteBatch actually computes on the CPU (see SpriteRotationTests), driven by
+    // the (rotation, effects) Sprite.ComputeDrawTransform() hands to spriteBatch.Draw.
+    static (float x, float y) ActualOffset(Sprite sprite, float u, float v, float scaleX, float scaleY)
+    {
+        var (rotation, effects) = sprite.ComputeDrawTransform();
+        float dx = ((effects & SpriteEffects.FlipHorizontally) != 0 ? -u : u) * scaleX;
+        float dy = ((effects & SpriteEffects.FlipVertically) != 0 ? -v : v) * scaleY;
+        float cr = MathF.Cos(rotation), sr = MathF.Sin(rotation);
+        return (dx * cr - dy * sr, dx * sr + dy * cr);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ComputeDrawTransform_DiagonalFlip_MatchesTransposeMatrix_WorldSpace(bool flipHorizontal, bool flipVertical)
+    {
+        var sprite = new Sprite
+        {
+            FlipDiagonal = true,
+            FlipHorizontal = flipHorizontal,
+            FlipVertical = flipVertical,
+            Batch = WorldSpaceBatch.Instance, // FlipsY == true
+        };
+        bool effectiveFlipVertical = true ^ flipVertical;
+
+        AssertMatchesAcrossSamples(sprite, flipHorizontal, effectiveFlipVertical);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ComputeDrawTransform_DiagonalFlip_MatchesTransposeMatrix_ScreenSpace(bool flipHorizontal, bool flipVertical)
+    {
+        var sprite = new Sprite
+        {
+            FlipDiagonal = true,
+            FlipHorizontal = flipHorizontal,
+            FlipVertical = flipVertical,
+            Batch = ScreenSpaceBatch.Instance, // FlipsY == false
+        };
+        bool effectiveFlipVertical = false ^ flipVertical;
+
+        AssertMatchesAcrossSamples(sprite, flipHorizontal, effectiveFlipVertical);
+    }
+
+    static void AssertMatchesAcrossSamples(Sprite sprite, bool flipHorizontal, bool effectiveFlipVertical)
+    {
+        float[] baseRotations = { 0f, 0.4f, -1.1f, MathF.PI / 2f, 2.9f };
+        (float u, float v)[] points = { (0.3f, 0.7f), (1f, 0f), (0f, 1f), (-0.5f, 0.9f) };
+        (float sx, float sy)[] scales = { (1f, 1f), (2f, 0.5f), (0.3f, 3f) }; // non-square — footprint swap must hold generally
+
+        foreach (var baseRotation in baseRotations)
+        {
+            sprite.Rotation = FlatRedBall2.Math.Angle.FromRadians(baseRotation);
+            foreach (var (u, v) in points)
+            foreach (var (sx, sy) in scales)
+            {
+                var expected = ExpectedOffset(flipHorizontal, effectiveFlipVertical, sprite.RenderRotationRadians, u, v, sx, sy);
+                var actual = ActualOffset(sprite, u, v, sx, sy);
+
+                actual.x.ShouldBe(expected.x, 1e-4);
+                actual.y.ShouldBe(expected.y, 1e-4);
+            }
+        }
+    }
+
+    // The user-facing framing: a non-square sprite whose four source corners are known landmarks.
+    // After a pure diagonal flip (no H/V), the texture's top-left corner — which starts at local
+    // offset (-halfW, -halfH) — must land at the BOTTOM-RIGHT of the on-screen footprint, and the
+    // footprint itself swaps from wide (200x100) to tall (100x200). This mirrors
+    // AnimationEditorAvalonia's PreviewControl.ComputeOutlineDst, which the runtime must match.
+    // Uses ScreenSpaceBatch (FlipsY == false) so the camera's own Y-flip compensation — which
+    // WorldSpaceBatch always folds in, even with no user-facing flip set — doesn't also apply
+    // here; that compensation is exercised separately by the exhaustive tests above.
+    [Fact]
+    public void DiagonalFlipOnly_NonSquareSprite_TopLeftTexelLandsAtBottomRight()
+    {
+        var sprite = new Sprite { FlipDiagonal = true, Batch = ScreenSpaceBatch.Instance };
+        const float halfW = 100f, halfH = 50f; // source 200x100
+        var actual = ActualOffset(sprite, u: -halfW, v: -halfH, scaleX: 1f, scaleY: 1f);
+
+        // Swapped footprint: this corner's world offset spans the ORIGINAL half-height on X and
+        // the ORIGINAL half-width on Y.
+        MathF.Abs(actual.x).ShouldBe(halfH, 1e-4);
+        MathF.Abs(actual.y).ShouldBe(halfW, 1e-4);
+
+        // Bottom-right of the new (swapped) footprint means both offsets are positive.
+        actual.x.ShouldBeGreaterThan(0f);
+        actual.y.ShouldBeGreaterThan(0f);
+    }
+}

--- a/tests/FlatRedBall2.Tests/Rendering/SpriteDiagonalFlipTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/SpriteDiagonalFlipTests.cs
@@ -19,13 +19,15 @@ namespace FlatRedBall2.Tests.Rendering;
 public class SpriteDiagonalFlipTests
 {
     // Ground truth: FlipScaleCalculator.ComputeMatrix(h, v, flipDiagonal: true) is (0, b, c, 0)
-    // with b = h?1:-1, c = v?1:-1, mapping local offset (u,v) -> (b*v, c*u). Applied here to a
+    // with b = h?-1:1, c = v?-1:1 (diagonal-only is the plain swap (x,y)->(y,x) — it fixes the
+    // top-left/bottom-right corners and swaps top-right/bottom-left, matching Tiled's actual
+    // diagonal-flip semantics), mapping local offset (u,v) -> (b*v, c*u). Applied here to a
     // scaled offset and then the sprite's own base rotation, matching how Sprite composes flip
     // with an already-set Rotation.
     static (float x, float y) ExpectedOffset(bool flipHorizontal, bool effectiveFlipVertical, float baseRotationRadians, float u, float v, float scaleX, float scaleY)
     {
-        float b = flipHorizontal ? 1f : -1f;
-        float c = effectiveFlipVertical ? 1f : -1f;
+        float b = flipHorizontal ? -1f : 1f;
+        float c = effectiveFlipVertical ? -1f : 1f;
         float outX = b * (v * scaleY);
         float outY = c * (u * scaleX);
         float cr = MathF.Cos(baseRotationRadians), sr = MathF.Sin(baseRotationRadians);
@@ -103,15 +105,17 @@ public class SpriteDiagonalFlipTests
     }
 
     // The user-facing framing: a non-square sprite whose four source corners are known landmarks.
-    // After a pure diagonal flip (no H/V), the texture's top-left corner — which starts at local
-    // offset (-halfW, -halfH) — must land at the BOTTOM-RIGHT of the on-screen footprint, and the
-    // footprint itself swaps from wide (200x100) to tall (100x200). This mirrors
-    // AnimationEditorAvalonia's PreviewControl.ComputeOutlineDst, which the runtime must match.
+    // After a pure diagonal flip (no H/V), the texture's top-left corner — local offset
+    // (-halfW, -halfH) — must stay at the TOP-LEFT of the (now swapped) footprint, matching
+    // Tiled's actual diagonal-flip semantics (verified against TileMapCollisionsTests'
+    // GenerateFromClass_PolygonTileFlippedDiagonally_PointsReflectedAcrossDiagonal, where the
+    // (0,0)/(16,16) corners are provably unchanged by a diagonal-only flip) and
+    // AnimationEditorAvalonia's PreviewControl.ComputeFlipMatrix, which the runtime must match.
     // Uses ScreenSpaceBatch (FlipsY == false) so the camera's own Y-flip compensation — which
     // WorldSpaceBatch always folds in, even with no user-facing flip set — doesn't also apply
     // here; that compensation is exercised separately by the exhaustive tests above.
     [Fact]
-    public void DiagonalFlipOnly_NonSquareSprite_TopLeftTexelLandsAtBottomRight()
+    public void DiagonalFlipOnly_NonSquareSprite_TopLeftTexelStaysAtTopLeft()
     {
         var sprite = new Sprite { FlipDiagonal = true, Batch = ScreenSpaceBatch.Instance };
         const float halfW = 100f, halfH = 50f; // source 200x100
@@ -122,8 +126,25 @@ public class SpriteDiagonalFlipTests
         MathF.Abs(actual.x).ShouldBe(halfH, 1e-4);
         MathF.Abs(actual.y).ShouldBe(halfW, 1e-4);
 
-        // Bottom-right of the new (swapped) footprint means both offsets are positive.
-        actual.x.ShouldBeGreaterThan(0f);
+        // Top-left of the new (swapped) footprint means both offsets are negative.
+        actual.x.ShouldBeLessThan(0f);
+        actual.y.ShouldBeLessThan(0f);
+    }
+
+    // The corner NOT on the diagonal axis must move: top-right (u positive, v negative) ends up
+    // at bottom-left of the swapped footprint.
+    [Fact]
+    public void DiagonalFlipOnly_NonSquareSprite_TopRightTexelMovesToBottomLeft()
+    {
+        var sprite = new Sprite { FlipDiagonal = true, Batch = ScreenSpaceBatch.Instance };
+        const float halfW = 100f, halfH = 50f; // source 200x100
+        var actual = ActualOffset(sprite, u: halfW, v: -halfH, scaleX: 1f, scaleY: 1f);
+
+        MathF.Abs(actual.x).ShouldBe(halfH, 1e-4);
+        MathF.Abs(actual.y).ShouldBe(halfW, 1e-4);
+
+        // Bottom-left of the new footprint: negative x (left), positive y (down).
+        actual.x.ShouldBeLessThan(0f);
         actual.y.ShouldBeGreaterThan(0f);
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/FlipScaleCalculator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/FlipScaleCalculator.cs
@@ -15,9 +15,14 @@ public static class FlipScaleCalculator
 
     /// <summary>
     /// Returns the 2x2 linear transform coefficients (a, b, c, d) such that a point offset
-    /// (x, y) from the frame's pivot maps to (a*x + b*y, c*x + d*y). Diagonal flip alone maps
-    /// (x, y) to (-y, -x) — the same transpose used by <c>TileMapCollisions.ApplyFlips</c> for
-    /// Tiled's diagonal tile-flip flag — and H/V then mirror on top of that.
+    /// (x, y) from the frame's pivot maps to (a*x + b*y, c*x + d*y). This matrix applies
+    /// directly to SkiaSharp canvas coordinates (Y-down, origin top-left) — unlike
+    /// <c>TileMapCollisions.ApplyFlips</c>, which converts Tiled's Y-down pixel data to FRB2's
+    /// Y-up local space before applying its own diagonal step. Diagonal flip alone is therefore
+    /// the plain swap (x, y) to (y, x) here, not the negated (-y, -x) form that's correct in
+    /// Y-up space — the plain swap is what fixes the top-left/bottom-right corners and swaps
+    /// top-right/bottom-left, matching Tiled's actual diagonal-flip semantics. H/V then mirror
+    /// on top of that.
     /// </summary>
     public static (float a, float b, float c, float d) ComputeMatrix(
         bool flipHorizontal, bool flipVertical, bool flipDiagonal)
@@ -25,6 +30,6 @@ public static class FlipScaleCalculator
         if (!flipDiagonal)
             return (flipHorizontal ? -1f : 1f, 0f, 0f, flipVertical ? -1f : 1f);
 
-        return (0f, flipHorizontal ? 1f : -1f, flipVertical ? 1f : -1f, 0f);
+        return (0f, flipHorizontal ? -1f : 1f, flipVertical ? -1f : 1f, 0f);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSourceRectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSourceRectTests.cs
@@ -128,12 +128,13 @@ public class PreviewSourceRectTests
         Assert.Equal(50, outline.MidY);
     }
 
-    // ── ComputeFlipMatrix — diagonal-only must reflect about the "up and to the right"
-    // (bottom-left/top-right) diagonal: top-left content swaps with bottom-right content,
-    // and top-right/bottom-left corners (on the axis) stay in place. ──────────────────────
+    // ── ComputeFlipMatrix — diagonal-only must reflect about the top-left/bottom-right
+    // diagonal, matching Tiled's actual diagonal-flip semantics (verified against
+    // TileMapCollisionsTests.GenerateFromClass_PolygonTileFlippedDiagonally_...): top-left and
+    // bottom-right corners (on the axis) stay in place; top-right swaps with bottom-left. ──────
 
     [Fact]
-    public void ComputeFlipMatrix_DiagonalOnly_SwapsTopLeftAndBottomRight()
+    public void ComputeFlipMatrix_DiagonalOnly_LeavesTopLeftAndBottomRightInPlace()
     {
         var matrix = PreviewControl.ComputeFlipMatrix(
             flipHorizontal: false, flipVertical: false, flipDiagonal: true, cx: 10, cy: 10);
@@ -141,20 +142,20 @@ public class PreviewSourceRectTests
         var topLeft = matrix.MapPoint(new SKPoint(5, 5));       // offset (-5,-5) from pivot
         var bottomRight = matrix.MapPoint(new SKPoint(15, 15)); // offset (+5,+5) from pivot
 
-        Assert.Equal(new SKPoint(15, 15), topLeft);      // top-left corner moves to bottom-right
-        Assert.Equal(new SKPoint(5, 5), bottomRight);    // bottom-right corner moves to top-left
+        Assert.Equal(new SKPoint(5, 5), topLeft);        // on the diagonal axis — unchanged
+        Assert.Equal(new SKPoint(15, 15), bottomRight);  // on the diagonal axis — unchanged
     }
 
     [Fact]
-    public void ComputeFlipMatrix_DiagonalOnly_LeavesTopRightAndBottomLeftInPlace()
+    public void ComputeFlipMatrix_DiagonalOnly_SwapsTopRightAndBottomLeft()
     {
         var matrix = PreviewControl.ComputeFlipMatrix(
             flipHorizontal: false, flipVertical: false, flipDiagonal: true, cx: 10, cy: 10);
 
-        var topRight = matrix.MapPoint(new SKPoint(15, 5));  // offset (+5,-5) from pivot
+        var topRight = matrix.MapPoint(new SKPoint(15, 5));   // offset (+5,-5) from pivot
         var bottomLeft = matrix.MapPoint(new SKPoint(5, 15)); // offset (-5,+5) from pivot
 
-        Assert.Equal(new SKPoint(15, 5), topRight);   // on the up-right axis — unchanged
-        Assert.Equal(new SKPoint(5, 15), bottomLeft);  // on the up-right axis — unchanged
+        Assert.Equal(new SKPoint(5, 15), topRight);    // top-right corner moves to bottom-left
+        Assert.Equal(new SKPoint(15, 5), bottomLeft);  // bottom-left corner moves to top-right
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FlipScaleCalculatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FlipScaleCalculatorTests.cs
@@ -8,17 +8,24 @@ namespace AnimationEditor.Core.Tests;
 
 public class FlipScaleCalculatorTests
 {
-    // ComputeMatrix — (x, y) -> (a*x + b*y, c*x + d*y). Diagonal alone maps (x,y) -> (-y,-x),
-    // matching TileMapCollisions.ApplyFlips' diagonal-flip transpose; H/V then mirror on top. ——
+    // ComputeMatrix — (x, y) -> (a*x + b*y, c*x + d*y). This matrix applies directly to
+    // SkiaSharp canvas coordinates, which are Y-down (origin top-left, no up-conversion) —
+    // unlike TileMapCollisions.ApplyFlips, which converts Tiled's Y-down pixel data to FRB2's
+    // Y-up local space *before* applying its diagonal step. "Reflect across the diagonal" has
+    // opposite signs in those two conventions: in Y-down space, diagonal-only is the plain swap
+    // (x,y) -> (y,x) — matrix (0,1,1,0) — which fixes the top-left/bottom-right corners and
+    // swaps top-right/bottom-left, matching Tiled's actual diagonal-flip semantics (verified
+    // against TileMapCollisionsTests.GenerateFromClass_PolygonTileFlippedDiagonally_...). H/V
+    // then mirror on top, in D -> H -> V order.
 
     [Theory]
     [InlineData(false, false, false,  1f,  0f,  0f,  1f)]
     [InlineData(true,  false, false, -1f,  0f,  0f,  1f)]
     [InlineData(false, true,  false,  1f,  0f,  0f, -1f)]
-    [InlineData(false, false, true,   0f, -1f, -1f,  0f)] // (x,y) -> (-y,-x)
-    [InlineData(true,  false, true,   0f,  1f, -1f,  0f)]
-    [InlineData(false, true,  true,   0f, -1f,  1f,  0f)]
-    [InlineData(true,  true,  true,   0f,  1f,  1f,  0f)]
+    [InlineData(false, false, true,   0f,  1f,  1f,  0f)] // (x,y) -> (y,x)
+    [InlineData(true,  false, true,   0f, -1f,  1f,  0f)]
+    [InlineData(false, true,  true,   0f,  1f, -1f,  0f)]
+    [InlineData(true,  true,  true,   0f, -1f, -1f,  0f)]
     public void ComputeMatrix_Theory(bool flipH, bool flipV, bool flipD, float a, float b, float c, float d)
     {
         var m = FlipScaleCalculator.ComputeMatrix(flipH, flipV, flipD);


### PR DESCRIPTION
## Summary
- Adds `Sprite.FlipDiagonal` (wired through `AnimationFrame` playback like `FlipHorizontal`/`FlipVertical`) so diagonal-flipped frames authored in the Animation Editor (#592) actually render.
- MonoGame's `SpriteEffects` has no diagonal-transpose value, so this isn't a flag passed to `SpriteBatch.Draw` — it's a +/-90° rotation offset combined with (at most) one axis mirror, computed in `Sprite.ComputeDrawTransform()`. A reflection is always expressible as rotation + single-axis mirror; the composition used here reproduces the exact diagonal-transpose matrix `AnimationEditorAvalonia`'s `FlipScaleCalculator.ComputeMatrix` uses for the SkiaSharp preview, so editor and runtime agree by construction (per the issue's acceptance criterion).

## Testability
Same constraint `SpriteRotationTests` already documents for #378: no headless `GraphicsDevice`, so no pixel readback. `ComputeDrawTransform()` is extracted so the rotation/effects it hands to `SpriteBatch.Draw` can be verified with pure CPU math against an independent ground truth (the transpose matrix), across all `FlipHorizontal`/`FlipVertical`/`Batch.FlipsY` combinations, several base rotations, and non-square scale — see `SpriteDiagonalFlipTests`.

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1161 passed, 0 failed
- [x] `dotnet build src/FlatRedBall2.csproj` — clean (pre-existing unrelated warnings only)

Closes #593