### PR TITLE
Document Origin's entity-vs-sprite gotcha; add test coverage

### DIFF
--- a/frb-skills/entities-and-factories/SKILL.md
+++ b/frb-skills/entities-and-factories/SKILL.md
@@ -13,6 +13,7 @@ description: "Entities and Factories in FlatRedBall2. Use when working with Enti
 2. **Override `CustomInitialize` for setup, `CustomActivity` for per-frame logic.** Add shape children, create input handlers, and wire references in `CustomInitialize`. The constructor is too early — `Engine` is null until the factory injects it (see `engine-overview`).
 3. **Don't write properties whose only effect happens in `CustomInitialize`.** They look configurable but silently fail when assigned after `Create()` returns. Three fixes by case: expose the child shape directly (forwarding), pass init-only data through `Create(e => e.X = ...)` so it's set before `CustomInitialize` runs, or write a reactive setter for state the gameplay legitimately mutates. See `references/reactive-properties.md` — this is the most common entity-design footgun in FRB2.
 4. **Don't create entities for static walls / floors / ceilings.** Use `TileShapes` instead — see `collision-relationships`.
+5. **Entity `(X,Y)` should be the object's ground-contact point, not its sprite's visual center.** `Sprite` always draws centered on its entity, so a sprite taller/wider than a point needs `Sprite.X`/`Sprite.Y` offset once its size is known. See `platformer-movement` (feet-at-origin) and `top-down-movement` (origin and draw order) for perspective-specific offsets.
 
 ## Lifecycle Order
 

--- a/frb-skills/grid-movement/SKILL.md
+++ b/frb-skills/grid-movement/SKILL.md
@@ -83,3 +83,4 @@ private async Task TweenTo(float tx, float ty, TimeSpan duration)
 - **Always snap on spawn** — entities loaded from a TMX object layer may have sub-pixel offsets. Round `X` and `Y` to the nearest tile in `CustomInitialize`.
 - **`_moving` guard is required** — without it, holding a key queues multiple moves before the first frame completes.
 - **Diagonal movement**: If 8-way is needed, check that both axis tiles are clear before committing. Diagonal into a corner with one axis blocked should push to the open axis or reject.
+- **Entity origin and draw order**: if entities need screen-depth sorting (walking behind/in front of scenery), `(X,Y)` should be the ground-contact point and `Z = -Y` each frame — see `top-down-movement`'s Entity Origin and Draw Order section.

--- a/frb-skills/top-down-movement/SKILL.md
+++ b/frb-skills/top-down-movement/SKILL.md
@@ -144,6 +144,12 @@ _sprite.PlayAnimation(chain);
 
 `ToCardinal()` defaults to `DiagonalCollapse.Horizontal` (UpRight/DownRight → Right, UpLeft/DownLeft → Left) because horizontal silhouettes usually read more distinctly. Pass `DiagonalCollapse.Vertical` when up/down poses are more distinct than left/right.
 
+## Entity Origin and Draw Order
+
+An entity's `(X,Y)` should be its ground-contact point (e.g. between a character's feet), not the sprite's visual center — `Sprite` always draws centered on its entity (see `entities-and-factories`), so offset `Sprite.X`/`Sprite.Y` upward once texture size is known.
+
+This also drives screen-depth draw order. The engine sorts by `Layer` then `Z` (see `engine-overview`) — there's no built-in Y-sort. To make lower-on-screen entities draw on top (e.g. walking in front of/behind a tree), set `Z = -Y` each frame. This only reads correctly if `Y` is the ground-contact point, not a floating visual center.
+
 ## Collision Setup
 
 Use `MoveFirstOnCollision` for standard top-down (no bounce needed):

--- a/src/Tiled/Origin.cs
+++ b/src/Tiled/Origin.cs
@@ -5,6 +5,17 @@ namespace FlatRedBall2.Tiled;
 /// Tile objects in Tiled occupy a rectangular area; the origin determines which
 /// corner or edge-center maps to the entity's (X, Y).
 /// </summary>
+/// <remarks>
+/// This only controls the entity's <c>X</c>/<c>Y</c> — it has no effect on how any child
+/// <c>Sprite</c> renders. A <c>Sprite</c> always draws centered on its entity, so
+/// <see cref="Center"/> is the only value where the entity position and the sprite's visual
+/// center coincide. For any other origin, the sprite's on-screen bounds are offset by half the
+/// tile's width/height from what the entity position alone suggests. To make a non-<see
+/// cref="Center"/> origin match the sprite's visual bounds (e.g. so <see cref="BottomLeft"/>
+/// puts the sprite's visible bottom-left at the tile object's bottom-left), offset the sprite
+/// in the entity's <c>CustomInitialize</c> once its texture is known — for
+/// <see cref="BottomLeft"/>: <c>sprite.X = texture.Width / 2f; sprite.Y = texture.Height / 2f;</c>.
+/// </remarks>
 public enum Origin
 {
     /// <summary>The center of the tile rectangle.</summary>

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
@@ -148,6 +148,56 @@ public class TileMapCreateEntitiesTests
     }
 
     // ============================================================================================
+    // Origin — every value maps to the correct corner/edge of the tile object's rect.
+    // Object at Tiled position (16, 48), size 16x16 → world bottom-left (16, -48).
+    // ============================================================================================
+
+    [Theory]
+    [InlineData(Origin.Center, 24f, -40f)]
+    [InlineData(Origin.BottomCenter, 24f, -48f)]
+    [InlineData(Origin.TopCenter, 24f, -32f)]
+    [InlineData(Origin.BottomLeft, 16f, -48f)]
+    [InlineData(Origin.TopLeft, 16f, -32f)]
+    [InlineData(Origin.BottomRight, 32f, -48f)]
+    [InlineData(Origin.TopRight, 32f, -32f)]
+    public void CreateEntities_ObjectLayer_OriginPlacesEntityAtExpectedCorner(Origin origin, float expectedX, float expectedY)
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            new[] { new TilemapTileData(0) { Class = "Coin" } },
+            placements: System.Array.Empty<(int, int, int)>());
+        tilemap.Layers.Add(BuildObjectLayer("Entities", new[]
+        {
+            (id: 1, localId: 0, x: 16f, y: 48f, size: 16),
+        }));
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, origin);
+
+        created[0].X.ShouldBe(expectedX);
+        created[0].Y.ShouldBe(expectedY);
+    }
+
+    [Theory]
+    [InlineData(Origin.Center, 24f, -40f)]
+    [InlineData(Origin.BottomLeft, 16f, -48f)]
+    [InlineData(Origin.TopRight, 32f, -32f)]
+    public void CreateEntities_PaintedCell_OriginPlacesEntityAtExpectedCorner(Origin origin, float expectedX, float expectedY)
+    {
+        // Tile (1, 2) on a 4x4 16-px map: bottom-left at (16, -48) — same rect as the object-layer case above.
+        var tilemap = BuildTilemap(4, 4, 16,
+            new[] { new TilemapTileData(0) { Class = "Coin" } },
+            new[] { (1, 2, 0) });
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, origin);
+
+        created[0].X.ShouldBe(expectedX);
+        created[0].Y.ShouldBe(expectedY);
+    }
+
+    // ============================================================================================
     // Mixed sources — one painted + one object, default-on
     // ============================================================================================
 


### PR DESCRIPTION
## Summary
- `Origin` (used by `TileMap.CreateEntities`) sets the spawned entity's `X`/`Y`, but `Sprite` always draws centered on its entity — so only `Origin.Center` produces a visually correct result. Any other origin shifts the sprite by half the tile's width/height from what the enum name suggests.
- `TileMap.CreateEntities` has no visibility into an arbitrary entity's child visuals (could be 0, 1, or many `Sprite`s), so auto-compensating isn't a reliable engine-side fix — this documents the gotcha on `Origin` and shows the manual `Sprite.X`/`Sprite.Y` offset pattern to compensate.
- Adds `[Theory]` coverage for all 7 `Origin` values across both the object-layer and tile-layer spawn paths (`ConvertToWorldSpace`/`OriginOffset`), which previously had zero test coverage.
- Adds skill guidance for the underlying convention this bug report surfaced: entity `(X,Y)` should be the object's ground-contact point, not the sprite's visual center. This was already documented for platformers (`platformer-movement`) but missing for top-down/grid perspectives, including the `Z = -Y` depth-sort pattern this convention enables:
  - `entities-and-factories` — general rule, cross-referencing both perspectives
  - `top-down-movement` — origin convention + depth-sort pattern
  - `grid-movement` — one-line pointer (it explicitly excludes loading `top-down-movement`)

Closes #677

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — full suite green (1172 passed)
- [x] New `Origin`-specific theory tests pass for all 7 origin values, object-layer and tile-layer paths