### PR TITLE
Fix Magic Wand selection off-by-one on right/bottom edge

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/FloodFillBoundsCalculator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/FloodFillBoundsCalculator.cs
@@ -25,8 +25,12 @@ public static class FloodFillBoundsCalculator
     /// </param>
     /// <param name="minX">Inclusive left edge of the bounding box.</param>
     /// <param name="minY">Inclusive top edge of the bounding box.</param>
-    /// <param name="maxX">Inclusive right edge of the bounding box.</param>
-    /// <param name="maxY">Inclusive bottom edge of the bounding box.</param>
+    /// <param name="maxX">
+    ///   Exclusive right edge of the bounding box (one past the last opaque column),
+    ///   matching the min-inclusive/max-exclusive convention used elsewhere in this
+    ///   codebase (e.g. grid snapping, <c>AppCommands.AddFrameFromPixelBounds</c>).
+    /// </param>
+    /// <param name="maxY">Exclusive bottom edge of the bounding box (one past the last opaque row).</param>
     /// <returns>
     ///   <c>true</c> if at least one pixel was flooded (i.e. the seed was opaque
     ///   and in-bounds); <c>false</c> otherwise.
@@ -71,6 +75,8 @@ public static class FloodFillBoundsCalculator
             stack.Push((x,     y + 1));
         }
 
-        return maxX >= minX;
+        bool found = maxX >= minX;
+        if (found) { maxX += 1; maxY += 1; }
+        return found;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectableImage.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectableImage.cs
@@ -18,7 +18,10 @@ public sealed class InspectableImage
 
     /// <summary>
     /// BFS flood fill from (<paramref name="startX"/>, <paramref name="startY"/>)
-    /// across contiguous opaque pixels. Returns the bounding box in texture pixel coords.
+    /// across contiguous opaque pixels. Returns the bounding box in texture pixel coords,
+    /// with <paramref name="maxX"/>/<paramref name="maxY"/> exclusive (one past the last
+    /// opaque column/row), matching the min-inclusive/max-exclusive convention used
+    /// elsewhere in this codebase.
     /// If the start pixel is transparent (or out of bounds) all out params are
     /// <c>int.MinValue / int.MaxValue</c> sentinels — check <c>maxX >= minX</c>.
     /// </summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -1627,6 +1627,23 @@ public class WireframeControl : TextureViewport
     }
 
     /// <summary>
+    /// Test-only: simulates a Magic Wand Ctrl+click at the given screen position,
+    /// mirroring the Ctrl+click branch in <see cref="OnEditPointerPressed"/>.
+    /// Fires <see cref="FrameCreatedFromRegion"/> with the flood-fill's pixel bounds.
+    /// No-op when magic-wand mode is off, the bitmap is null, or the clicked pixel is transparent.
+    /// </summary>
+    public void SimulateWandCtrlClick(float screenX, float screenY)
+    {
+        if (!_isMagicWandMode || _bitmap is null || _inspectableImage is null) return;
+        var world = ScreenToTexture(screenX, screenY);
+        _inspectableImage.GetOpaqueWandBounds(
+            (int)world.X, (int)world.Y,
+            out int minX, out int minY, out int maxX, out int maxY);
+        if (maxX >= minX && maxY >= minY)
+            FrameCreatedFromRegion?.Invoke(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
     /// Builds a cross-hair "+" cursor and returns a <see cref="Cursor"/>
     /// with its hot-spot at the centre pixel.  Called once by <see cref="_addFrameCursorLazy"/>.
     /// </summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeMagicWandModeTests.cs
@@ -22,6 +22,12 @@ namespace AnimationEditor.App.Tests;
 /// 2. A double-click via <see cref="WireframeControl.SimulateWandDoubleClick"/> while a
 ///    hover preview is active applies the preview rect to the selected frame and fires
 ///    <see cref="WireframeControl.FrameRegionChanged"/>.
+///
+/// 3. The hover-preview rect itself lands exactly on the flood-filled island's bounds
+///    (issue #577 — right/bottom must be exclusive, not one pixel short).
+///
+/// 4. Ctrl+click create-frame-from-wand-bounds also lands exactly on the island's bounds
+///    (same issue #577 fix, different call site).
 /// </summary>
 public class WireframeMagicWandModeTests
 {
@@ -174,7 +180,10 @@ public class WireframeMagicWandModeTests
             Assert.NotNull(changedFrame);
             Assert.Same(frame, changedFrame);
 
-            const float Eps = 1.5f / 64f;   // 1.5 pixel tolerance in UV space
+            // Sub-pixel tolerance only (float rounding), not a whole-pixel fudge factor —
+            // a 1-pixel tolerance here would mask the off-by-one bug from issue #577
+            // where RightCoordinate/BottomCoordinate landed one pixel short.
+            const float Eps = 0.25f / 64f;
             Assert.True(Math.Abs(frame.LeftCoordinate   - IslandMin / 64f) < Eps,
                 $"LeftCoordinate expected ≈{IslandMin}/64 but was {frame.LeftCoordinate}");
             Assert.True(Math.Abs(frame.TopCoordinate    - IslandMin / 64f) < Eps,
@@ -187,7 +196,84 @@ public class WireframeMagicWandModeTests
         finally { Directory.Delete(dir, recursive: true); }
     }
 
-    // ── Test 3: toolbar toggle-off falls back to Move mode ────────────────────
+    // ── Test 3: hover preview rect is pixel-exact ─────────────────────────────
+
+    /// <summary>
+    /// Regression test for issue #577: the hover-preview outline (what the user visually
+    /// sees while hovering in Magic Wand mode) must land exactly on the opaque island's
+    /// bounds, with <see cref="SKRect.Right"/>/<see cref="SKRect.Bottom"/> one pixel past
+    /// the last opaque column/row — not on the last opaque pixel itself.
+    /// </summary>
+    [AvaloniaFact]
+    public void WandMode_HoverPreview_RectIsExclusiveOnRightAndBottom()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            const int IslandMin = 20, IslandMax = 40;
+            var png = WriteRegionPng(dir, IslandMin, IslandMin, IslandMax, IslandMax);
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.RefreshFrames();
+            ctrl.SetCamera(0, 0, 1);
+            ctrl.IsMagicWandMode = true;
+
+            // Hover at screen (30,30) → texture pixel (30,30), inside the island.
+            var (showPreview, previewRect) = ctrl.GetPreviewStateForScreenPoint(30f, 30f);
+
+            Assert.True(showPreview);
+            Assert.Equal(new SKRect(IslandMin, IslandMin, IslandMax, IslandMax), previewRect);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── Test 4: Ctrl+click create-frame-from-wand-bounds is pixel-exact ───────
+
+    /// <summary>
+    /// Regression test for issue #577: the wand's flood-fill bounds must be exclusive
+    /// on the right/bottom (one past the last opaque column/row), not inclusive.
+    /// Ctrl+click at a pixel inside a well-defined opaque island via
+    /// <see cref="WireframeControl.SimulateWandCtrlClick"/> must fire
+    /// <see cref="WireframeControl.FrameCreatedFromRegion"/> with bounds that land exactly
+    /// on the island edges — previously maxX/maxY were one pixel short.
+    /// </summary>
+    [AvaloniaFact]
+    public void WandMode_CtrlClick_FiresFrameCreatedFromRegion_WithExclusiveBounds()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            const int IslandMin = 20, IslandMax = 40;
+            var png = WriteRegionPng(dir, IslandMin, IslandMin, IslandMax, IslandMax);
+
+            var chain = new AnimationChainSave { Name = "Test" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            var ctrl = ctx.CreateWireframeControl();
+            ctrl.LoadTexture(png);
+            ctrl.RefreshFrames();
+            ctrl.SetCamera(0, 0, 1);
+            ctrl.IsMagicWandMode = true;
+
+            (int minX, int minY, int maxX, int maxY)? received = null;
+            ctrl.FrameCreatedFromRegion += (x0, y0, x1, y1) => received = (x0, y0, x1, y1);
+
+            // Ctrl+click at screen (30,30) → texture pixel (30,30), inside the island.
+            ctrl.SimulateWandCtrlClick(30f, 30f);
+
+            Assert.NotNull(received);
+            Assert.Equal((IslandMin, IslandMin, IslandMax, IslandMax), received!.Value);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── Test 5: toolbar toggle-off falls back to Move mode ────────────────────
 
     /// <summary>
     /// Regression test for issue #575: clicking the Magic Wand toolbar toggle a second

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FloodFillBoundsCalculatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FloodFillBoundsCalculatorTests.cs
@@ -23,7 +23,7 @@ public class FloodFillBoundsCalculatorTests
             1, 1, 3, 3, Pixels(px, 3), out int l, out int t, out int r, out int b);
         Assert.True(ok);
         Assert.Equal(1, l); Assert.Equal(1, t);
-        Assert.Equal(1, r); Assert.Equal(1, b);
+        Assert.Equal(2, r); Assert.Equal(2, b); // exclusive: one past the single opaque column/row
     }
 
     // ── Rectangular region ────────────────────────────────────────────────────
@@ -44,7 +44,7 @@ public class FloodFillBoundsCalculatorTests
             2, 2, 5, 5, Pixels(px, 5), out int l, out int t, out int r, out int b);
         Assert.True(ok);
         Assert.Equal(1, l); Assert.Equal(1, t);
-        Assert.Equal(3, r); Assert.Equal(3, b);
+        Assert.Equal(4, r); Assert.Equal(4, b); // exclusive: one past the last opaque column/row (3)
     }
 
     // ── Transparent seed ─────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ public class FloodFillBoundsCalculatorTests
             0, 0, 5, 1, Pixels(px, 5), out int l, out _, out int r, out _);
         Assert.True(ok);
         Assert.Equal(0, l);
-        Assert.Equal(1, r); // must NOT reach x=3 or x=4
+        Assert.Equal(2, r); // exclusive: one past x=1; must NOT reach x=3 or x=4
     }
 
     // ── Entire bitmap opaque ──────────────────────────────────────────────────
@@ -109,7 +109,7 @@ public class FloodFillBoundsCalculatorTests
             0, 0, 4, 4, (x, y) => true, out int l, out int t, out int r, out int b);
         Assert.True(ok);
         Assert.Equal(0, l); Assert.Equal(0, t);
-        Assert.Equal(3, r); Assert.Equal(3, b);
+        Assert.Equal(4, r); Assert.Equal(4, b); // exclusive: one past the last column/row (3), i.e. the bitmap width/height
     }
 
     // ── L-shaped region ──────────────────────────────────────────────────────
@@ -134,7 +134,7 @@ public class FloodFillBoundsCalculatorTests
             0, 0, 4, 4, Pixels(px, 4), out int l, out int t, out int r, out int b);
         Assert.True(ok);
         Assert.Equal(0, l); Assert.Equal(0, t);
-        Assert.Equal(3, r); Assert.Equal(3, b);
+        Assert.Equal(4, r); Assert.Equal(4, b); // exclusive: one past the last column/row (3)
     }
 
     // ── 1×1 bitmap ───────────────────────────────────────────────────────────
@@ -146,6 +146,6 @@ public class FloodFillBoundsCalculatorTests
             0, 0, 1, 1, (x, y) => true, out int l, out int t, out int r, out int b);
         Assert.True(ok);
         Assert.Equal(0, l); Assert.Equal(0, t);
-        Assert.Equal(0, r); Assert.Equal(0, b);
+        Assert.Equal(1, r); Assert.Equal(1, b); // exclusive: one past the single opaque pixel
     }
 }


### PR DESCRIPTION
## Summary
- `FloodFillBoundsCalculator.TryGetBounds` returned *inclusive* `maxX`/`maxY`, but every consumer (hover preview rect, Ctrl+click create-frame, double-click apply-to-frame) treated them as *exclusive* — matching the convention used elsewhere in the codebase (grid snapping, `AppCommands.AddFrameFromPixelBounds`).
- Fixed at the source, per the issue's preferred approach: the calculator now returns exclusive bounds (`maxX`/`maxY` incremented by 1). All three consumer call sites in `WireframeControl.cs` needed no changes — they were passing the (buggy) inclusive value straight through as if exclusive, so making the source exclusive fixes them for free.
- Updated `FloodFillBoundsCalculatorTests` to the new exclusive semantics.
- Added two new regression tests in `WireframeMagicWandModeTests.cs`: one asserting the hover-preview `SKRect` lands exactly on the island bounds, one asserting Ctrl+click's `FrameCreatedFromRegion` fires with exact exclusive bounds.
- Tightened the existing double-click test's UV tolerance from 1.5px to 0.25px — the looser tolerance was masking this exact 1px bug.

Closes #577

## Test plan
- [x] `AnimationEditor.Core.Tests` — 1587 passed (incl. updated `FloodFillBoundsCalculatorTests`)
- [x] `AnimationEditor.App.Tests` — 686 passed (incl. new `WireframeMagicWandModeTests` cases)
- [x] `AnimationEditor.Views.Tests` — 47 passed