### PR TITLE
Fix EnableAutomationMode being a permanent no-op via NuGet

### DIFF
--- a/frb-skills/automation-mode/SKILL.md
+++ b/frb-skills/automation-mode/SKILL.md
@@ -7,7 +7,7 @@ description: Automation mode in FlatRedBall2. Use when an external agent (AI or 
 
 Automation mode lets an external process control a running game via NDJSON (newline-delimited JSON) over stdin/stdout — one command per line in, one response per line out. The primary use case is AI agents that need to observe and interact with the game the way Playwright interacts with a browser.
 
-**Debug builds only.** `EnableAutomationMode()` is a no-op in Release. This is intentional — automation mode exposes internal state and allows arbitrary value forcing.
+**Debug builds only — gated on your own project's configuration.** `EnableAutomationMode()` is a `[Conditional("DEBUG")]` call: the C# compiler strips the call site entirely when your project builds Release, regardless of how the FlatRedBall2 package itself was built. It's safe to leave the call in unconditionally. This is intentional — automation mode exposes internal state and allows arbitrary value forcing.
 
 ## Setup
 

--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -1,4 +1,3 @@
-#if DEBUG
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -325,7 +324,7 @@ internal class AutomationMode
             return false;
         }
         var inst = factory.EntityInstances[0];
-#pragma warning disable IL2075 // Intentional reflection; DEBUG-only, never runs in AOT deployments.
+#pragma warning disable IL2075 // Intentional reflection; only reachable via EnableAutomationMode, which is compiled out of Release consumer builds and never runs in AOT deployments.
         var p = inst.GetType().GetProperty(propName,
             System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
 #pragma warning restore IL2075
@@ -432,7 +431,7 @@ internal class AutomationMode
     {
         var dict = new Dictionary<string, object?>();
         var t = entity.GetType();
-#pragma warning disable IL2075 // Intentional reflection; DEBUG-only, never runs in AOT deployments.
+#pragma warning disable IL2075 // Intentional reflection; only reachable via EnableAutomationMode, which is compiled out of Release consumer builds and never runs in AOT deployments.
         foreach (var prop in t.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
 #pragma warning restore IL2075
         {
@@ -477,7 +476,7 @@ internal class AutomationMode
 
     private void WriteResponse(object response)
     {
-#pragma warning disable IL2026, IL3050 // Intentional dynamic JSON; DEBUG-only, never runs in AOT deployments.
+#pragma warning disable IL2026, IL3050 // Intentional dynamic JSON; only reachable via EnableAutomationMode, which is compiled out of Release consumer builds and never runs in AOT deployments.
         var json = JsonSerializer.Serialize(response);
 #pragma warning restore IL2026, IL3050
         lock (_output)
@@ -487,4 +486,3 @@ internal class AutomationMode
         }
     }
 }
-#endif

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -952,12 +952,17 @@ public class FlatRedBallService
     /// <summary>The active screen's overlay. Shortcut for <see cref="CurrentScreen"/>.<see cref="Screen.Overlay"/>.</summary>
     public Overlay Overlay => CurrentScreen.Overlay;
 
-#if DEBUG
     private Automation.AutomationMode? _automationMode;
 
     /// <summary>
     /// Activates automation mode when the game is launched with --frb-auto. No-op otherwise.
-    /// Call in Game.Initialize after base.Initialize(). In Release builds this is a no-op.
+    /// Call in Game.Initialize after base.Initialize().
+    /// <para>
+    /// This call site is compiled out entirely in Release builds of <b>your</b> project (via
+    /// <see cref="System.Diagnostics.ConditionalAttribute"/> on "DEBUG") — it is safe to leave
+    /// unconditionally in shipping code. Gating is based on your project's own Debug/Release
+    /// configuration, not FlatRedBall2's.
+    /// </para>
     /// <para>
     /// When automation activates, <see cref="Random"/> is replaced with a deterministic
     /// <see cref="GameRandom"/> so recorded NDJSON runs reproduce exactly.
@@ -969,6 +974,7 @@ public class FlatRedBallService
     /// keeps its default time-based seed. When --frb-auto is present, omitting this
     /// parameter (or passing <c>null</c>) seeds <see cref="Random"/> with <c>0</c>.
     /// </param>
+    [System.Diagnostics.Conditional("DEBUG")]
     public void EnableAutomationMode(int? seed = null)
     {
         if (System.Environment.GetCommandLineArgs().Contains("--frb-auto"))
@@ -999,11 +1005,6 @@ public class FlatRedBallService
     /// </summary>
     public void RegisterValueSetter(string entityName, string propName, Action<double> setter)
         => _automationMode?.RegisterValueSetter(entityName, propName, setter);
-#else
-    public void EnableAutomationMode(int? seed = null) { }
-    public void RegisterStateProvider(string name, Func<object> provider) { }
-    public void RegisterValueSetter(string entityName, string propName, Action<double> setter) { }
-#endif
 
     /// <summary>
     /// Per-frame engine tick. Call from <c>Game.Update</c>. Drives screen transitions, input
@@ -1013,7 +1014,6 @@ public class FlatRedBallService
     public void Update(GameTime gameTime)
     {
         long updateStart = System.Diagnostics.Stopwatch.GetTimestamp();
-#if DEBUG
         if (_automationMode != null)
         {
             if (!_automationMode.TryAdvanceFrame(Time.CurrentFrame))
@@ -1022,7 +1022,6 @@ public class FlatRedBallService
                 return;
             }
         }
-#endif
 
         // Apply pending screen transition at start of frame
         if (_pendingScreenChange != null)
@@ -1197,10 +1196,8 @@ public class FlatRedBallService
             CurrentScreen.DrawOverlay(_spriteBatch, RenderDiagnostics, _overlayCamera);
         }
 
-#if DEBUG
         _automationMode?.FlushStepResponse(Time.CurrentFrame);
         _automationMode?.FulfillPendingScreenshot(gd, Time.CurrentFrame);
-#endif
 
         _frameProfile.DrawTotalMs = ProfileClock.Ms(drawStart, System.Diagnostics.Stopwatch.GetTimestamp());
         _frameProfile.RenderMs = _frameProfile.DrawTotalMs;

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeReleaseBuildTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeReleaseBuildTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Automation;
+
+// Issue #683. Published NuGet packages are packed with `dotnet pack -c Release`, so a build-time
+// `#if DEBUG` around AutomationMode strips the real implementation out of every shipped assembly —
+// EnableAutomationMode() is a permanent no-op for NuGet consumers regardless of their own project's
+// build configuration. The fix keeps the implementation compiled into the engine assembly under
+// both configurations and instead gates the public entry point with [Conditional("DEBUG")], which
+// the C# compiler evaluates against the *caller's* DEBUG symbol at each call site.
+//
+// This builds the real engine assembly in Release and inspects its bytes for the internal
+// StartAutomationMode symbol, which previously only existed in a Debug-configured build of the
+// engine itself.
+public class AutomationModeReleaseBuildTests
+{
+    [Fact]
+    public void ReleaseConfigurationBuild_OfEngineItself_StillContainsAutomationModeImplementation()
+    {
+        var repoRoot = Packaging.TemplatePackageReferenceTests.RepoRootForTests;
+        var csprojPath = Path.Combine(repoRoot, "src", "FlatRedBall2.csproj");
+
+        var outputDir = Path.Combine(Path.GetTempPath(), "frb2-automation-relcheck-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            var startInfo = new ProcessStartInfo(
+                "dotnet",
+                $"build \"{csprojPath}\" -c Release -f net10.0 -o \"{outputDir}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var process = Process.Start(startInfo)!;
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            process.ExitCode.ShouldBe(0, $"Release build of FlatRedBall2.csproj failed:{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+
+            var dllBytes = File.ReadAllBytes(Path.Combine(outputDir, "FlatRedBall2.dll"));
+            var dllText = System.Text.Encoding.Latin1.GetString(dllBytes);
+
+            dllText.Contains("StartAutomationMode").ShouldBeTrue(
+                "AutomationMode's real implementation must be compiled into the engine assembly in " +
+                "Release too — the gate belongs at the EnableAutomationMode call site (via " +
+                "[Conditional(\"DEBUG\")]), evaluated against the consumer's DEBUG symbol, not the " +
+                "engine's own build configuration.");
+        }
+        finally
+        {
+            try { Directory.Delete(outputDir, recursive: true); }
+            catch { /* best-effort temp cleanup */ }
+        }
+    }
+}

--- a/tests/FlatRedBall2.Tests/Automation/AutomationSeedTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationSeedTests.cs
@@ -1,4 +1,3 @@
-#if DEBUG
 using System.IO;
 using FlatRedBall2.Utilities;
 using Shouldly;
@@ -62,4 +61,3 @@ public class AutomationSeedTests
         anyDifferent.ShouldBeTrue();
     }
 }
-#endif


### PR DESCRIPTION
## Summary
- `EnableAutomationMode()` was gated with `#if DEBUG`, which is evaluated at **FlatRedBall2's own** build time — since `publish.yml` always packs with `dotnet pack -c Release`, only the empty stub ever shipped in the NuGet package, making automation mode a permanent no-op for any NuGet consumer regardless of their own project's Debug/Release configuration.
- `AutomationMode`'s real implementation is now compiled unconditionally into the engine assembly (both Debug and Release configs of FlatRedBall2 itself). The public `EnableAutomationMode` entry point is gated with `[Conditional("DEBUG")]` instead — the same pattern `Debug.Assert`/`Debug.WriteLine` use. The compiler strips the call site based on the *caller's* (consumer's) DEBUG symbol, so it now correctly gates on the consumer's own build configuration.
- Updated the `automation-mode` skill doc to describe the corrected (consumer-gated) behavior.

## Test plan
- Added `AutomationModeReleaseBuildTests` — builds `src/FlatRedBall2.csproj` in `-c Release` and asserts the compiled assembly still contains the internal `StartAutomationMode` symbol, which previously only existed in a Debug-configured build of the engine itself. Verified this test fails on the pre-fix code and passes after.
- Manually verified `[Conditional("DEBUG")]` semantics with a throwaway synthetic consumer project: a Release build of the consumer strips the call entirely; a Debug build keeps it.
- `dotnet test tests/FlatRedBall2.Tests/` — 1173 passed.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)