### PR TITLE
Audit Animation Editor undo/redo description clarity

### DIFF
--- a/.claude/skills/animation-editor-browser-verify/SKILL.md
+++ b/.claude/skills/animation-editor-browser-verify/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: animation-editor-browser-verify
+description: >-
+  Visual proof on Animation Editor WASM without shipping demo hooks. Triggers:
+  browser History screenshot, WasmAppHost ports, canvas wait, FeatureDemos.
+---
+
+# Animation Editor — Browser Visual Verify
+
+Use when proving a UI change in **`AnimationEditor.Browser`**. Prefer **desktop DocScreenshots + Core.Tests** when that already covers the behavior — browser capture is optional extra evidence.
+
+Shared drive scripts: **`AnimationEditor.Core.Demo.FeatureDemos`** (internal; InternalsVisibleTo tests/DocScreenshots only).
+
+## Do not pollute shipping App code
+
+**Landmine:** never commit `?demo=` / `FeatureDemos.TryRun` wiring into `App.axaml.cs` `BuildView` (or Desktop `MainWindow`). A query-param backdoor mutates undo state on any deployed build.
+
+Default proof path:
+1. Unit-test labels via Core (`CommandDescriptionTests` / `FeatureDemosTests`).
+2. Desktop History PNGs via DocScreenshots `_ScratchCapture` + `FeatureDemos.TryRun`.
+
+Browser screenshot only if desktop isn't enough: add a **temporary local** `#if DEBUG` hook, capture, **revert before merge**.
+
+## Run and find the real URL
+
+```
+dotnet run --project tools/AnimationEditorAvalonia/src/AnimationEditor.Browser --no-launch-profile --urls "http://127.0.0.1:5420"
+```
+
+WasmAppHost often **ignores** `--urls` and prints `App url: http://127.0.0.1:<ephemeral>/`. Use that host. Port-in-use on launchSettings HTTPS → kill the listener or keep `--no-launch-profile`.
+
+## Wait for load
+
+Avalonia **canvas** — `document.body.innerText` stays empty. Poll `canvas` count ≥ 1 and splash gone, then MCP screenshot. No DOM refs for sidebar tabs.
+
+## After capture
+
+Copy PNGs to `tools/AnimationEditorAvalonia/tests/_out/<feature>/` beside desktop output.

--- a/.claude/skills/animation-editor-screenshots/SKILL.md
+++ b/.claude/skills/animation-editor-screenshots/SKILL.md
@@ -39,4 +39,13 @@ For a one-off request (not a permanent doc-page scenario), hand-edit a scratch f
 
 Iterate fast: `dotnet build tests/AnimationEditor.DocScreenshots/...csproj`, then run the built `.exe -method "AnimationEditor.DocScreenshots._ScratchCapture.Capture"` directly — faster than `dotnet test` for one scenario, and its `Console.WriteLine` output is visible, unlike `dotnet test`'s VSTest adapter which swallows it on failure.
 
-Write output to a **persistent** path, not a temp dir you delete — then open it for the user (`Invoke-Item "<path>"` in PowerShell launches the OS default viewer). Also `Read` the PNG yourself before showing it — catches an empty tree or wrong selection before the user sees it.
+Write output via **`ScreenshotOutput.ResolveFeatureDir("<feature>")`** → `tools/AnimationEditorAvalonia/tests/_out/<feature>/` (not a temp dir you delete). Open with `Invoke-Item`, then `Read` the PNG yourself before showing the user.
+
+## Feature proof (History / undo labels / similar)
+
+When the ask is "prove the panel shows X" — not a unit assert:
+
+1. Put the drive script in **`AnimationEditor.Core.Demo.FeatureDemos`** (internal, test/DocScreenshots only). Call `FeatureDemos.TryRun(...)` from `_ScratchCapture` — do **not** hand-build history rows or fork a second script, and do **not** wire demos into shipping `App`/`MainWindow`.
+2. Drive real **`AppCommands` / `UndoManager.Execute`**. Never assign fake `HistoryEntryVm` text.
+3. Select **History** (`SidebarTabs` → `HistoryTab`), optionally enlarge `LeftPanelGrid` row 2 so more labels fit, capture `window` + `HistoryScrollViewer`, write `labels.txt` from `UndoManager.UndoHistory`.
+4. Optional browser PNG: **`animation-editor-browser-verify`** (temporary local hook only — revert before merge).

--- a/.claude/skills/animation-editor-testing/SKILL.md
+++ b/.claude/skills/animation-editor-testing/SKILL.md
@@ -20,6 +20,12 @@ Default to a plain `[Fact]` against `AnimationEditor.Core` (`AppCommands`, comma
 
 Tests that do need it construct `MainWindow` and drive it with `Dispatcher.UIThread.RunJobs()` between actions — see `WireframePanZoomTests.cs` for the established pattern.
 
+## Undo labels vs screenshots
+
+- **Correctness of a command's `Description`:** assert on the command (or `UndoManager.UndoHistory` after `AppCommands`) in Core.Tests — see `CommandDescriptionTests` / `FeatureDemosTests`.
+- **"Show me the History panel":** DocScreenshots / browser verify — **`animation-editor-screenshots`** and **`animation-editor-browser-verify`**. Those drive the same `FeatureDemos` helpers; they do not replace unit asserts.
+
+Never seed History UI models with hand-written strings to "prove" a label.
 ## Service wiring in tests
 
 Services (`ProjectManager`, `SelectedState`, `AppCommands`, `AppState`, `ApplicationEvents`, `IoManager`, `ObjectFinder`, `UndoManager`) are constructor-injected — no static `Self` accessors, no global state. Production wires them through a `Microsoft.Extensions.DependencyInjection` container in `App.axaml.cs`.

--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -13,7 +13,7 @@ tools/AnimationEditorAvalonia/
 
 > The legacy WinForms version (`FlatRedBall.AnimationEditorForms`) lives in the separate `FlatRedBall` (FRB1) repo at `FRBDK/FlatRedBall.AnimationEditorForms/`. Do **not** edit it for FRB2 issues — that codebase is being replaced. Issues filed in `vchelaru/FlatRedBall2` always refer to the Avalonia version.
 
-For writing tests against the editor — headless Avalonia, service wiring, the `[AvaloniaFact]` deadlock pitfall — see the **`animation-editor-testing`** skill. For generating headless documentation screenshots of the UI, see the **`animation-editor-screenshots`** skill.
+For writing tests against the editor — headless Avalonia, service wiring, the `[AvaloniaFact]` deadlock pitfall — see the **`animation-editor-testing`** skill. For generating headless documentation screenshots of the UI, see the **`animation-editor-screenshots`** skill. For WASM/`?demo=` visual proof in the browser host, see **`animation-editor-browser-verify`**.
 
 ## `.achx` is a general-purpose format — the editor authors, runtimes interpret
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ CLAUDE.local.md
 /.claude/skills/tweening
 /.claude/worktrees
 **/TestResults/
+
+# Animation Editor ad-hoc visual proof screenshots (DocScreenshots / browser capture)
+tools/AnimationEditorAvalonia/tests/_out/

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AnimationEditorTargetFramework Condition="'$(AnimationEditorTargetFramework)' == ''">net10.0</AnimationEditorTargetFramework>
@@ -31,6 +31,9 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>AnimationEditor.Core.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>AnimationEditor.DocScreenshots</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddAxisAlignedRectangleCommand.cs
@@ -11,7 +11,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly ISelectedState _selectedState;
         private readonly AARectSave? _preAddRect;
 
-        public string Description => "Add Rectangle";
+        public string Description { get; }
 
         public AddAxisAlignedRectangleCommand(AARectSave rect, AnimationFrameSave frame,
             IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
@@ -22,6 +22,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             _selectedState = selectedState;
             _preAddRect = selectedState.SelectedRectangle;
+            Description = $"Add {ShapeUndoLabel.FormatForAddDelete(rect)}";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AddCircleCommand.cs
@@ -11,7 +11,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly ISelectedState _selectedState;
         private readonly CircleSave? _preAddCircle;
 
-        public string Description => "Add Circle";
+        public string Description { get; }
 
         public AddCircleCommand(CircleSave circle, AnimationFrameSave frame,
             IAppCommands commands, IApplicationEvents events, ISelectedState selectedState)
@@ -22,6 +22,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             _selectedState = selectedState;
             _preAddCircle = selectedState.SelectedCircle;
+            Description = $"Add {ShapeUndoLabel.FormatForAddDelete(circle)}";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -662,7 +662,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 chains,
                 () => { chains.RemoveAt(idx); chains.Insert(newIdx, chain); },
                 this, _events, RefreshTreeView,
-                delta > 0 ? "Move Animation Down" : "Move Animation Up"));
+                delta > 0
+                    ? $"Move Animation '{chain.Name}' Down"
+                    : $"Move Animation '{chain.Name}' Up"));
         }
 
         /// <inheritdoc cref="IAppCommands.MoveChainToIndex"/>
@@ -684,7 +686,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chains,
                 () => { chains.RemoveAt(currentIndex); chains.Insert(insertAt, chain); },
                 this, _events, RefreshTreeView,
-                "Move Animation"));
+                $"Move Animation '{chain.Name}'"));
         }
 
         /// <inheritdoc cref="IAppCommands.MoveChainsToIndex"/>
@@ -719,7 +721,9 @@ namespace AnimationEditor.Core.CommandsAndState
                         list.Insert(at + i, moved[i]);
                 },
                 this, _events, RefreshTreeView,
-                moved.Length == 1 ? "Move Animation" : $"Move {moved.Length} Animations"));
+                moved.Length == 1
+                    ? $"Move Animation '{moved[0].Name}'"
+                    : $"Move {moved.Length} Animations"));
         }
 
         public void MoveChainToTop(AnimationChainSave chain)
@@ -730,7 +734,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chains,
                 () => { chains.Remove(chain); chains.Insert(0, chain); },
                 this, _events, RefreshTreeView,
-                "Move Animation to Top"));
+                $"Move Animation '{chain.Name}' to Top"));
         }
 
         public void MoveChainToBottom(AnimationChainSave chain)
@@ -741,7 +745,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chains,
                 () => { chains.Remove(chain); chains.Add(chain); },
                 this, _events, RefreshTreeView,
-                "Move Animation to Bottom"));
+                $"Move Animation '{chain.Name}' to Bottom"));
         }
 
         public void MoveFrame(AnimationFrameSave frame, AnimationChainSave chain, int delta)
@@ -753,7 +757,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => { chain.Frames.RemoveAt(idx); chain.Frames.Insert(newIdx, frame); },
                 this, _events, () => RefreshTreeNode(chain),
-                delta > 0 ? "Move Frame Down" : "Move Frame Up"));
+                delta > 0
+                    ? $"Move Frame in '{chain.Name}' Down"
+                    : $"Move Frame in '{chain.Name}' Up"));
         }
 
         public void MoveFrameToTop(AnimationFrameSave frame, AnimationChainSave chain)
@@ -762,7 +768,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => { chain.Frames.Remove(frame); chain.Frames.Insert(0, frame); },
                 this, _events, () => RefreshTreeNode(chain),
-                "Move Frame to Top"));
+                $"Move Frame in '{chain.Name}' to Top"));
         }
 
         public void MoveFrameToBottom(AnimationFrameSave frame, AnimationChainSave chain)
@@ -771,7 +777,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => { chain.Frames.Remove(frame); chain.Frames.Add(frame); },
                 this, _events, () => RefreshTreeNode(chain),
-                "Move Frame to Bottom"));
+                $"Move Frame in '{chain.Name}' to Bottom"));
         }
 
         /// <inheritdoc cref="IAppCommands.MoveFrames"/>
@@ -825,7 +831,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 },
                 this, _events, () => RefreshTreeNode(chain),
                 CountAwareMoveDescription(indices.Count, "Frame", "Frames",
-                    delta > 0 ? "Down" : "Up")));
+                    delta > 0 ? "Down" : "Up", frameContextName: chain.Name)));
         }
 
         /// <inheritdoc cref="IAppCommands.MoveChainsRelative"/>
@@ -870,19 +876,30 @@ namespace AnimationEditor.Core.CommandsAndState
                 },
                 this, _events, RefreshTreeView,
                 CountAwareMoveDescription(indices.Count, "Animation", "Animations",
-                    delta > 0 ? "Down" : "Up")));
+                    delta > 0 ? "Down" : "Up",
+                    itemName: indices.Count == 1 ? list[indices[0]].Name : null)));
         }
 
         /// <summary>
-        /// Undo label for a relative reorder: singular omits the count
-        /// (<c>Move Frame Down</c>), plural includes it (<c>Move 3 Frames Down</c>).
+        /// Undo label for a relative reorder. Plural includes the count
+        /// (<c>Move 3 Frames Down</c>). Singular names the target when known
+        /// (<c>Move Animation 'Walk' Down</c>, <c>Move Frame in 'Walk' Down</c>).
         /// </summary>
         private static string CountAwareMoveDescription(
-            int count, string singularNoun, string pluralNoun, string direction) =>
-            count == 1
-                ? $"Move {singularNoun} {direction}"
-                : $"Move {count} {pluralNoun} {direction}";
+            int count, string singularNoun, string pluralNoun, string direction,
+            string? itemName = null, string? frameContextName = null)
+        {
+            if (count != 1)
+                return $"Move {count} {pluralNoun} {direction}";
 
+            if (frameContextName is not null)
+                return $"Move Frame in '{frameContextName}' {direction}";
+
+            if (itemName is not null)
+                return $"Move {singularNoun} '{itemName}' {direction}";
+
+            return $"Move {singularNoun} {direction}";
+        }
         public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {
             var shapes = frame.ShapesSave?.Shapes;
@@ -895,7 +912,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 shapes,
                 () => { shapes.RemoveAt(idx); shapes.Insert(newIdx, shape); },
                 this, _events, () => RefreshTreeNode(frame),
-                delta > 0 ? "Move Shape Down" : "Move Shape Up"));
+                delta > 0
+                    ? $"Move {ShapeReorderLabel(shape)} Down"
+                    : $"Move {ShapeReorderLabel(shape)} Up"));
         }
 
         public void MoveShapeToTop(object shape, AnimationFrameSave frame)
@@ -906,7 +925,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 shapes,
                 () => { shapes.Remove(shape); shapes.Insert(0, shape); },
                 this, _events, () => RefreshTreeNode(frame),
-                "Move Shape to Top"));
+                $"Move {ShapeReorderLabel(shape)} to Top"));
         }
 
         public void MoveShapeToBottom(object shape, AnimationFrameSave frame)
@@ -917,8 +936,15 @@ namespace AnimationEditor.Core.CommandsAndState
                 shapes,
                 () => { shapes.Remove(shape); shapes.Add(shape); },
                 this, _events, () => RefreshTreeNode(frame),
-                "Move Shape to Bottom"));
+                $"Move {ShapeReorderLabel(shape)} to Bottom"));
         }
+
+        private static string ShapeReorderLabel(object shape) => shape switch
+        {
+            AARectSave r => string.IsNullOrEmpty(r.Name) ? "Rect" : $"Rect '{r.Name}'",
+            CircleSave c => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
+            _ => "Shape",
+        };
 
         /// <summary>
         /// Moves the currently-selected shape, frame, or chain up (<paramref name="delta"/> = -1)
@@ -1022,7 +1048,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => chain.Frames.Reverse(),
                 this, _events, () => RefreshTreeNode(chain),
-                "Invert Frame Order"));
+                $"Invert Frame Order in '{chain.Name}'"));
         }
 
         public void SetAllFrameLengths(AnimationChainSave chain, float frameLength)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -824,7 +824,8 @@ namespace AnimationEditor.Core.CommandsAndState
                         chain.Frames.Add(frame);
                 },
                 this, _events, () => RefreshTreeNode(chain),
-                delta > 0 ? "Move Frames Down" : "Move Frames Up"));
+                CountAwareMoveDescription(indices.Count, "Frame", "Frames",
+                    delta > 0 ? "Down" : "Up")));
         }
 
         /// <inheritdoc cref="IAppCommands.MoveChainsRelative"/>
@@ -868,8 +869,19 @@ namespace AnimationEditor.Core.CommandsAndState
                         list.Add(chain);
                 },
                 this, _events, RefreshTreeView,
-                delta > 0 ? "Move Animations Down" : "Move Animations Up"));
+                CountAwareMoveDescription(indices.Count, "Animation", "Animations",
+                    delta > 0 ? "Down" : "Up")));
         }
+
+        /// <summary>
+        /// Undo label for a relative reorder: singular omits the count
+        /// (<c>Move Frame Down</c>), plural includes it (<c>Move 3 Frames Down</c>).
+        /// </summary>
+        private static string CountAwareMoveDescription(
+            int count, string singularNoun, string pluralNoun, string direction) =>
+            count == 1
+                ? $"Move {singularNoun} {direction}"
+                : $"Move {count} {pluralNoun} {direction}";
 
         public void MoveShape(object shape, AnimationFrameSave frame, int delta)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -939,12 +939,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 $"Move {ShapeReorderLabel(shape)} to Bottom"));
         }
 
-        private static string ShapeReorderLabel(object shape) => shape switch
-        {
-            AARectSave r => string.IsNullOrEmpty(r.Name) ? "Rect" : $"Rect '{r.Name}'",
-            CircleSave c => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
-            _ => "Shape",
-        };
+        private static string ShapeReorderLabel(object shape) => ShapeUndoLabel.Format(shape);
 
         /// <summary>
         /// Moves the currently-selected shape, frame, or chain up (<paramref name="delta"/> = -1)
@@ -1603,7 +1598,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 new PasteChainsCommand(acls, chains, this, _events, _selectedState),
                 new DeleteChainsCommand(sourcesToRemove, acls, this, _events, _selectedState),
             };
-            string desc = chains.Count == 1 ? "Cut Animation" : $"Cut {chains.Count} Animations";
+            string desc = chains.Count == 1
+                ? $"Cut Animation '{(sourcesToRemove.Count > 0 ? sourcesToRemove[0].Name : chains[0].Name)}'"
+                : $"Cut {chains.Count} Animations";
             _undoManager.Execute(new CompositeCommand(cmds, desc));
         }
 
@@ -1626,7 +1623,18 @@ namespace AnimationEditor.Core.CommandsAndState
                 cmds.Add(new DeleteFramesCommand(
                     group.Select(x => x.Frame).ToList(), group.Key, this, _events, _selectedState));
             }
-            string desc = frames.Count == 1 ? "Cut Frame" : $"Cut {frames.Count} Frames";
+            string desc;
+            if (frames.Count == 1)
+            {
+                var sourceChain = sourcesToRemove.Count > 0
+                    ? _objectFinder.GetAnimationChainContaining(sourcesToRemove[0])
+                    : null;
+                desc = $"Cut Frame in '{(sourceChain ?? targetChain).Name}'";
+            }
+            else
+            {
+                desc = $"Cut {frames.Count} Frames";
+            }
             _undoManager.Execute(new CompositeCommand(cmds, desc));
         }
 
@@ -1660,7 +1668,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 new PasteShapesCommand(targetFrame, clones, this, _events, _selectedState),
             };
             cmds.AddRange(deleteCmds);
-            string desc = clones.Count == 1 ? "Cut Shape" : $"Cut {clones.Count} Shapes";
+            string desc = clones.Count == 1
+                ? $"Cut {ShapeUndoLabel.Format(sourcesToRemove.Count > 0 ? sourcesToRemove[0] : clones[0])}"
+                : $"Cut {clones.Count} Shapes";
             _undoManager.Execute(new CompositeCommand(cmds, desc));
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameRegionChangedCommand.cs
@@ -61,8 +61,8 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
                 }
             }
             return isChainDrag
-                ? $"Drag Chain ({snapshots.Count} frames)"
-                : $"Edit {snapshots.Count} Frame Regions";
+                ? $"Move {snapshots.Count} Frames"
+                : $"Edit {snapshots.Count} Frames";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteChainsCommand.cs
@@ -31,7 +31,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             _selectedState = selectedState;
             Description = chains.Count == 1
-                ? $"Delete '{chains[0].Name}'"
+                ? $"Delete Animation '{chains[0].Name}'"
                 : $"Delete {chains.Count} Animations";
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DeleteFramesCommand.cs
@@ -30,7 +30,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands = commands;
             _events = events;
             _selectedState = selectedState;
-            Description = frames.Count == 1 ? "Delete Frame" : $"Delete {frames.Count} Frames";
+            Description = frames.Count == 1
+                ? $"Delete Frame in '{chain.Name}'"
+                : $"Delete {frames.Count} Frames";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateChainsCommand.cs
@@ -38,7 +38,9 @@ internal sealed class DuplicateChainsCommand : IUndoableCommand
         _events = events;
         _selectedState = selectedState;
         _preSelection = new List<object>(_selectedState.SelectedNodes);
-        Description = _copies.Length == 1 ? "Duplicate Animation" : $"Duplicate {_copies.Length} Animations";
+            Description = _copies.Length == 1
+                ? $"Duplicate Animation '{_sources[0].Name}'"
+                : $"Duplicate {_copies.Length} Animations";
     }
 
     public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateShapesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/DuplicateShapesCommand.cs
@@ -32,7 +32,9 @@ internal sealed class DuplicateShapesCommand : IUndoableCommand
         _events = events;
         _selectedState = selectedState;
         _preSelection = new List<object>(_selectedState.SelectedNodes);
-        Description = _copies.Length == 1 ? "Duplicate Shape" : $"Duplicate {_copies.Length} Shapes";
+        Description = _copies.Length == 1
+            ? $"Duplicate {ShapeUndoLabel.Format(_copies[0])}"
+            : $"Duplicate {_copies.Length} Shapes";
     }
 
     public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/FlipCommand.cs
@@ -30,12 +30,15 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _commands = commands;
             _events = events;
             _refresh = refresh;
-            Description = axis switch
+            string axisLabel = axis switch
             {
-                FlipAxis.Horizontal => "Flip Horizontal",
-                FlipAxis.Vertical => "Flip Vertical",
-                _ => "Flip Diagonal",
+                FlipAxis.Horizontal => "Horizontal",
+                FlipAxis.Vertical => "Vertical",
+                _ => "Diagonal",
             };
+            Description = frames.Count == 1
+                ? $"Flip {axisLabel}"
+                : $"Flip {frames.Count} Frames {axisLabel}";
         }
 
         public bool Do() { Toggle(); return true; }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFramesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFramesCommand.cs
@@ -53,7 +53,7 @@ internal sealed class MoveFramesCommand : IUndoableCommand
         bool sameChain = ReferenceEquals(sourceChain, targetChain);
         Description = (frames.Count, sameChain) switch
         {
-            (1, true) => "Move Frame",
+            (1, true) => $"Move Frame in '{sourceChain.Name}'",
             (_, true) => $"Move {frames.Count} Frames",
             (1, false) => $"Move Frame to '{targetChain.Name}'",
             _ => $"Move {frames.Count} Frames to '{targetChain.Name}'",

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveShapeCommand.cs
@@ -31,14 +31,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events   = events;
         }
 
-        public string Description => $"Move {ShapeLabel(_shape)}";
-
-        private static string ShapeLabel(object shape) => shape switch
-        {
-            AARectSave r  => string.IsNullOrEmpty(r.Name) ? "Rect"   : $"Rect '{r.Name}'",
-            CircleSave c  => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
-            _             => "Shape"
-        };
+        public string Description => $"Move {ShapeUndoLabel.Format(_shape)}";
 
         public bool Do() { Apply(_newX, _newY); return true; }
         public void Undo() => Apply(_oldX, _oldY);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteChainsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteChainsCommand.cs
@@ -41,7 +41,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _selectedState = selectedState;
             _preSelection = new List<object>(selectedState.SelectedNodes);
             _anchorChains = selectedState.SelectedChains;
-            Description = chains.Count == 1 ? "Paste Animation" : $"Paste {chains.Count} Animations";
+            Description = chains.Count == 1
+                ? $"Paste Animation '{chains[0].Name}'"
+                : $"Paste {chains.Count} Animations";
         }
 
         public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteShapesCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PasteShapesCommand.cs
@@ -32,7 +32,9 @@ internal sealed class PasteShapesCommand : IUndoableCommand
         _events = events;
         _selectedState = selectedState;
         _preSelection = new List<object>(_selectedState.SelectedNodes);
-        Description = _shapes.Length == 1 ? "Paste Shape" : $"Paste {_shapes.Length} Shapes";
+        Description = _shapes.Length == 1
+            ? $"Paste {ShapeUndoLabel.Format(_shapes[0])}"
+            : $"Paste {_shapes.Length} Shapes";
     }
 
     public bool Do()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ResizeShapeCommand.cs
@@ -35,14 +35,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events    = events;
         }
 
-        public string Description => $"Resize {ShapeLabel(_shape)}";
-
-        private static string ShapeLabel(object shape) => shape switch
-        {
-            AARectSave r  => string.IsNullOrEmpty(r.Name) ? "Rect"   : $"Rect '{r.Name}'",
-            CircleSave c  => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
-            _             => "Shape"
-        };
+        public string Description => $"Resize {ShapeUndoLabel.Format(_shape)}";
 
         public bool Do() { Apply(_newX, _newY, _newParam1, _newParam2); return true; }
         public void Undo() => Apply(_oldX, _oldY, _oldParam1, _oldParam2);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeUndoLabel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/ShapeUndoLabel.cs
@@ -1,0 +1,25 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands;
+
+/// <summary>
+/// Shared undo-label fragment for a collision shape — matches
+/// <c>Move Rect 'Hitbox'</c> / <c>Delete Circle 'X'</c> naming.
+/// </summary>
+internal static class ShapeUndoLabel
+{
+    public static string Format(object shape) => shape switch
+    {
+        AARectSave r => string.IsNullOrEmpty(r.Name) ? "Rect" : $"Rect '{r.Name}'",
+        CircleSave c => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
+        _ => "Shape",
+    };
+
+    /// <summary>Add/Delete wording uses "Rectangle" rather than the shorter "Rect".</summary>
+    public static string FormatForAddDelete(object shape) => shape switch
+    {
+        AARectSave r => string.IsNullOrEmpty(r.Name) ? "Rectangle" : $"Rectangle '{r.Name}'",
+        CircleSave c => string.IsNullOrEmpty(c.Name) ? "Circle" : $"Circle '{c.Name}'",
+        _ => "Shape",
+    };
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/DemoQuery.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/DemoQuery.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace AnimationEditor.Core.Demo;
+
+/// <summary>
+/// Parses <c>?demo=&lt;name&gt;</c> from a URL. For test / temporary local hooks only —
+/// do not wire this into shipping <c>App.BuildView</c>.
+/// </summary>
+internal static class DemoQuery
+{
+    public static string? TryGetDemoName(string pageUrl)
+    {
+        if (string.IsNullOrEmpty(pageUrl)) return null;
+
+        // Uri.TryCreate handles absolute http(s) URLs from Avalonia Browser's location.href.
+        if (!Uri.TryCreate(pageUrl, UriKind.Absolute, out var uri))
+            return null;
+
+        var query = uri.Query;
+        if (string.IsNullOrEmpty(query) || query.Length < 2) return null;
+
+        foreach (var pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            var key = eq < 0 ? pair : pair[..eq];
+            if (!key.Equals("demo", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var value = eq < 0 || eq == pair.Length - 1
+                ? ""
+                : Uri.UnescapeDataString(pair[(eq + 1)..]);
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+
+        return null;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/FeatureDemos.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/FeatureDemos.cs
@@ -1,0 +1,34 @@
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+
+namespace AnimationEditor.Core.Demo;
+
+/// <summary>
+/// Named demos for visual / history verification (DocScreenshots, Core.Tests).
+/// Add new demos here — do not fork drive scripts per host, and do not call from
+/// shipping Browser/Desktop <c>App</c> entry points.
+/// </summary>
+internal static class FeatureDemos
+{
+    public const string UndoLabels = "undo-labels";
+
+    /// <summary>
+    /// Runs <paramref name="demoName"/> if registered. <paramref name="textureName"/> is the
+    /// relative texture used when the demo adds frames (desktop fixtures vs browser sample).
+    /// </summary>
+    public static bool TryRun(
+        string demoName,
+        AppCommands commands,
+        UndoManager undoManager,
+        IApplicationEvents events,
+        string textureName)
+    {
+        if (demoName.Equals(UndoLabels, StringComparison.OrdinalIgnoreCase))
+        {
+            UndoLabelsDemo.Run(commands, undoManager, events, textureName);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/UndoLabelsDemo.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Demo/UndoLabelsDemo.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.Demo;
+
+/// <summary>
+/// Drives one instance of each #534 undo-label convention through real
+/// <see cref="AppCommands"/> / <see cref="UndoManager.Execute"/> (not fake history rows).
+/// Shared by DocScreenshots and Core.Tests — not invoked from shipping app hosts.
+/// </summary>
+internal static class UndoLabelsDemo
+{
+    public static void Run(
+        AppCommands cmds,
+        UndoManager undo,
+        IApplicationEvents events,
+        string textureName)
+    {
+        var walk = cmds.AddAnimationChainWithName("Walk")!;
+        for (int i = 0; i < 5; i++)
+            cmds.AddFrame(walk, textureName);
+
+        var run = cmds.AddAnimationChainWithName("Run")!;
+        for (int i = 0; i < 3; i++)
+            cmds.AddFrame(run, textureName);
+
+        var idle = cmds.AddAnimationChainWithName("Idle")!;
+        cmds.AddFrame(idle, textureName);
+
+        var jump = cmds.AddAnimationChainWithName("Jump")!;
+        cmds.AddFrame(jump, textureName);
+
+        var scrap = cmds.AddAnimationChainWithName("Scrap")!;
+        cmds.AddFrame(scrap, textureName);
+
+        // Drop noisy setup Add* entries so History shows only the labels under audit.
+        undo.Clear();
+
+        cmds.MoveFramesRelative(walk.Frames.Take(3).ToList(), walk, +1);
+        cmds.MoveChainsRelative(new[] { walk, run }, +1);
+        cmds.FlipChainHorizontally(walk);
+
+        var bulkFrames = walk.Frames.Take(2).ToList();
+        undo.Execute(new BulkFrameRegionChangedCommand(
+            bulkFrames.Select(f => new BulkFrameRegionChangedCommand.FrameSnapshot(
+                f,
+                f.LeftCoordinate, f.TopCoordinate, f.RightCoordinate, f.BottomCoordinate,
+                f.LeftCoordinate + 0.05f, f.TopCoordinate + 0.05f,
+                f.RightCoordinate + 0.05f, f.BottomCoordinate + 0.05f)).ToList(),
+            cmds, events));
+
+        undo.Execute(new BulkFrameRegionChangedCommand(
+            new[]
+            {
+                new BulkFrameRegionChangedCommand.FrameSnapshot(
+                    walk.Frames[0],
+                    walk.Frames[0].LeftCoordinate, walk.Frames[0].TopCoordinate,
+                    walk.Frames[0].RightCoordinate, walk.Frames[0].BottomCoordinate,
+                    walk.Frames[0].LeftCoordinate + 0.02f, walk.Frames[0].TopCoordinate,
+                    walk.Frames[0].RightCoordinate + 0.02f, walk.Frames[0].BottomCoordinate),
+                new BulkFrameRegionChangedCommand.FrameSnapshot(
+                    walk.Frames[1],
+                    walk.Frames[1].LeftCoordinate, walk.Frames[1].TopCoordinate,
+                    walk.Frames[1].RightCoordinate, walk.Frames[1].BottomCoordinate,
+                    walk.Frames[1].LeftCoordinate + 0.08f, walk.Frames[1].TopCoordinate + 0.03f,
+                    walk.Frames[1].RightCoordinate + 0.08f, walk.Frames[1].BottomCoordinate + 0.03f),
+            },
+            cmds, events));
+
+        cmds.MoveChain(idle, +1);
+        cmds.MoveChainToTop(jump);
+        cmds.MoveFrame(walk.Frames[0], walk, +1);
+        cmds.MoveFrameToTop(walk.Frames[^1], walk);
+        cmds.MoveFrames(new[] { walk.Frames[0] }, walk, walk, insertIndex: 2);
+        cmds.InvertFrameOrder(run);
+
+        cmds.DuplicateChains(new[] { idle });
+        var pasteChain = new AnimationChainSave { Name = "PastedWalk" };
+        pasteChain.Frames.Add(AnimationCloneHelper.CloneFrame(walk.Frames[0]));
+        cmds.PasteChains(new[] { pasteChain });
+
+        var shapeFrame = walk.Frames[0];
+        cmds.AddAxisAlignedRectangle(shapeFrame);
+        cmds.AddCircle(shapeFrame);
+
+        var rect = shapeFrame.ShapesSave!.AARectSaves.First();
+        var circle = shapeFrame.ShapesSave!.CircleSaves.First();
+        rect.Name = "Hitbox";
+        circle.Name = "Hurtbox";
+
+        cmds.AddAxisAlignedRectangle(shapeFrame);
+        shapeFrame.ShapesSave!.AARectSaves.Last().Name = "Other";
+
+        cmds.MoveShape(rect, shapeFrame, +1);
+        cmds.DuplicateShape(rect);
+
+        var pasteCircle = (CircleSave)AnimationCloneHelper.CloneShape(circle)!;
+        pasteCircle.Name = "HurtboxPaste";
+        cmds.PasteShapes(shapeFrame, Array.Empty<AARectSave>(), new[] { pasteCircle });
+
+        var cutSource = shapeFrame.ShapesSave!.AARectSaves.First(r => r.Name == "Other");
+        var cutClone = (AARectSave)AnimationCloneHelper.CloneShape(cutSource)!;
+        cmds.PasteShapesCut(shapeFrame, new[] { cutClone }, [], new[] { (object)cutSource }, shapeFrame);
+
+        var cutFrameSrc = scrap.Frames[0];
+        cmds.PasteFramesCut(walk, new[] { AnimationCloneHelper.CloneFrame(cutFrameSrc) },
+            insertIndex: null, sourcesToRemove: new[] { cutFrameSrc });
+
+        var cutAnimClone = AnimationCloneHelper.CloneChain(scrap);
+        cutAnimClone.Name = "Scrap";
+        cmds.PasteChainsCut(new[] { cutAnimClone }, new[] { scrap });
+
+        var doomed = cmds.AddAnimationChainWithName("Doomed")!;
+        cmds.AddFrame(doomed, textureName);
+        cmds.DeleteFrames(new List<AnimationFrameSave> { doomed.Frames[0] });
+        cmds.DeleteAnimationChains(new List<AnimationChainSave> { doomed });
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
@@ -12,6 +12,36 @@ namespace AnimationEditor.Core.Tests;
 [Collection("SequentialSingletons")]
 public class CommandDescriptionTests
 {
+    // ── AddCircleCommand / AddAxisAlignedRectangleCommand ─────────────────────
+
+    [Fact]
+    public void AddAxisAlignedRectangleCommand_Description_IncludesName()
+    {
+        var expected = "Add Rectangle 'Hitbox'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var rect = new AARectSave { Name = "Hitbox" };
+        chain.Frames[0].ShapesSave = new ShapesSave();
+        var cmd = new AddAxisAlignedRectangleCommand(
+            rect, chain.Frames[0], ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void AddCircleCommand_Description_IncludesName()
+    {
+        var expected = "Add Circle 'Hurtbox'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var circle = new CircleSave { Name = "Hurtbox" };
+        chain.Frames[0].ShapesSave = new ShapesSave();
+        var cmd = new AddCircleCommand(
+            circle, chain.Frames[0], ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
     // ── BulkFrameRegionChangedCommand ─────────────────────────────────────────
 
     [Fact]
@@ -91,6 +121,52 @@ public class CommandDescriptionTests
         Assert.Equal(expected, cmd.Description);
     }
 
+    // ── Cut (CompositeCommand via AppCommands) ────────────────────────────────
+
+    [Fact]
+    public void CutAnimation_Description_Single_IncludesName()
+    {
+        var expected = "Cut Animation 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var walk = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        TestHelpers.MakeChain(ctx.Acls, "Run");
+        var pasted = new AnimationChainSave { Name = "Walk" };
+
+        ctx.AppCommands.PasteChainsCut(new[] { pasted }, new[] { walk });
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void CutFrame_Description_Single_IncludesChainName()
+    {
+        var expected = "Cut Frame in 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var f0 = chain.Frames[0];
+        var pasted = TestHelpers.MakeFrame();
+
+        ctx.AppCommands.PasteFramesCut(chain, new[] { pasted }, insertIndex: 2, sourcesToRemove: new[] { f0 });
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void CutShape_Description_Single_IncludesShapeName()
+    {
+        var expected = "Cut Rect 'Hitbox'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        frame.ShapesSave!.Shapes.Add(rect);
+        var pasted = new AARectSave { Name = "Hitbox" };
+
+        ctx.AppCommands.PasteShapesCut(frame, new[] { pasted }, [], new[] { rect }, frame);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
     // ── DeleteChainsCommand / DeleteFramesCommand ─────────────────────────────
 
     [Fact]
@@ -135,6 +211,20 @@ public class CommandDescriptionTests
     }
 
     [Fact]
+    public void DuplicateShapesCommand_Description_Single_IncludesShapeName()
+    {
+        var expected = "Duplicate Rect 'Hitbox'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var copy = new AARectSave { Name = "Hitbox" };
+        var cmd = new DuplicateShapesCommand(
+            chain.Frames[0], new[] { copy },
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
     public void PasteChainsCommand_Description_SingleChain_IncludesName()
     {
         var expected = "Paste Animation 'Walk'";
@@ -142,6 +232,20 @@ public class CommandDescriptionTests
         var chain = new AnimationChainSave { Name = "Walk" };
         var cmd = new PasteChainsCommand(
             ctx.Acls, new[] { chain },
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void PasteShapesCommand_Description_Single_IncludesShapeName()
+    {
+        var expected = "Paste Circle 'Hurtbox'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var copy = new CircleSave { Name = "Hurtbox" };
+        var cmd = new PasteShapesCommand(
+            chain.Frames[0], new[] { copy },
             ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
 
         Assert.Equal(expected, cmd.Description);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
@@ -1,95 +1,23 @@
 using AnimationEditor.Core.CommandsAndState.Commands;
 using FlatRedBall2.Animation.Content;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
 
+/// <summary>
+/// Undo/redo label conventions (issue #534): imperative tense, Title Case nouns,
+/// singular omits the count, plural includes it.
+/// </summary>
+[Collection("SequentialSingletons")]
 public class CommandDescriptionTests
 {
-    // ── FrameRegionChangedCommand ─────────────────────────────────────────────
-
-    [Fact]
-    public void FrameRegionChangedCommand_Description_PositionChangedSizeUnchanged_ReturnsMove()
-    {
-        var frame = new AnimationFrameSave();
-        // Move: same size (0.5x0.5), just shifted
-        var cmd = new FrameRegionChangedCommand(frame,
-            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
-            aL: 0.1f, aT: 0.1f, aR: 0.6f, aB: 0.6f,
-            commands: null!, events: null!);
-
-        Assert.Equal("Move Frame", cmd.Description);
-    }
-
-    [Fact]
-    public void FrameRegionChangedCommand_Description_SizeChanged_ReturnsResize()
-    {
-        var frame = new AnimationFrameSave();
-        // Resize: width changed from 0.5 to 0.4
-        var cmd = new FrameRegionChangedCommand(frame,
-            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
-            aL: 0f,   aT: 0f,   aR: 0.4f, aB: 0.5f,
-            commands: null!, events: null!);
-
-        Assert.Equal("Resize Frame", cmd.Description);
-    }
-
     // ── BulkFrameRegionChangedCommand ─────────────────────────────────────────
 
     [Fact]
-    public void BulkFrameRegionChangedCommand_Description_SingleFramePositionOnly_ReturnsMove()
+    public void BulkFrameRegionChangedCommand_Description_MultiFrameDifferentDeltas_ReturnsEditWithCount()
     {
-        var snapshots = new[]
-        {
-            new BulkFrameRegionChangedCommand.FrameSnapshot(
-                new AnimationFrameSave(),
-                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
-                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f)
-        };
-        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
-
-        Assert.Equal("Move Frame", cmd.Description);
-    }
-
-    [Fact]
-    public void BulkFrameRegionChangedCommand_Description_SingleFrameSizeChanged_ReturnsResize()
-    {
-        var snapshots = new[]
-        {
-            new BulkFrameRegionChangedCommand.FrameSnapshot(
-                new AnimationFrameSave(),
-                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
-                AL: 0f, AT: 0f, AR: 0.4f, AB: 0.5f)
-        };
-        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
-
-        Assert.Equal("Resize Frame", cmd.Description);
-    }
-
-    [Fact]
-    public void BulkFrameRegionChangedCommand_Description_MultiFrameSameDelta_ReturnsDragChain()
-    {
-        // Both frames move by (+0.1, +0.1) with same size — chain drag
-        var snapshots = new[]
-        {
-            new BulkFrameRegionChangedCommand.FrameSnapshot(
-                new AnimationFrameSave(),
-                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
-                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f),
-            new BulkFrameRegionChangedCommand.FrameSnapshot(
-                new AnimationFrameSave(),
-                BL: 0.5f, BT: 0f, BR: 1.0f, BB: 0.5f,
-                AL: 0.6f, AT: 0.1f, AR: 1.1f, AB: 0.6f)
-        };
-        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
-
-        Assert.Equal("Drag Chain (2 frames)", cmd.Description);
-    }
-
-    [Fact]
-    public void BulkFrameRegionChangedCommand_Description_MultiFrameDifferentDeltas_ReturnsEditRegions()
-    {
-        // Three frames with different translation deltas — handle drag
+        var expected = "Edit 3 Frames";
         var snapshots = new[]
         {
             new BulkFrameRegionChangedCommand.FrameSnapshot(
@@ -107,41 +35,236 @@ public class CommandDescriptionTests
         };
         var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
 
-        Assert.Equal("Edit 3 Frame Regions", cmd.Description);
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_MultiFrameSameDelta_ReturnsMoveWithCount()
+    {
+        var expected = "Move 2 Frames";
+        // Both frames move by (+0.1, +0.1) with same size — uniform drag
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f),
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0.5f, BT: 0f, BR: 1.0f, BB: 0.5f,
+                AL: 0.6f, AT: 0.1f, AR: 1.1f, AB: 0.6f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_SingleFramePositionOnly_ReturnsMove()
+    {
+        var expected = "Move Frame";
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0.1f, AT: 0.1f, AR: 0.6f, AB: 0.6f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void BulkFrameRegionChangedCommand_Description_SingleFrameSizeChanged_ReturnsResize()
+    {
+        var expected = "Resize Frame";
+        var snapshots = new[]
+        {
+            new BulkFrameRegionChangedCommand.FrameSnapshot(
+                new AnimationFrameSave(),
+                BL: 0f, BT: 0f, BR: 0.5f, BB: 0.5f,
+                AL: 0f, AT: 0f, AR: 0.4f, AB: 0.5f)
+        };
+        var cmd = new BulkFrameRegionChangedCommand(snapshots, commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    // ── FlipCommand ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FlipCommand_Description_MultipleFrames_IncludesCount()
+    {
+        var expected = "Flip 3 Frames Horizontal";
+        var frames = new[]
+        {
+            new AnimationFrameSave(),
+            new AnimationFrameSave(),
+            new AnimationFrameSave(),
+        };
+        var cmd = new FlipCommand(frames, FlipAxis.Horizontal, commands: null!, events: null!, refresh: () => { });
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void FlipCommand_Description_SingleFrame_OmitsCount()
+    {
+        var expected = "Flip Vertical";
+        var frames = new[] { new AnimationFrameSave() };
+        var cmd = new FlipCommand(frames, FlipAxis.Vertical, commands: null!, events: null!, refresh: () => { });
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    // ── FrameRegionChangedCommand ─────────────────────────────────────────────
+
+    [Fact]
+    public void FrameRegionChangedCommand_Description_PositionChangedSizeUnchanged_ReturnsMove()
+    {
+        var expected = "Move Frame";
+        var frame = new AnimationFrameSave();
+        // Move: same size (0.5x0.5), just shifted
+        var cmd = new FrameRegionChangedCommand(frame,
+            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
+            aL: 0.1f, aT: 0.1f, aR: 0.6f, aB: 0.6f,
+            commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void FrameRegionChangedCommand_Description_SizeChanged_ReturnsResize()
+    {
+        var expected = "Resize Frame";
+        var frame = new AnimationFrameSave();
+        // Resize: width changed from 0.5 to 0.4
+        var cmd = new FrameRegionChangedCommand(frame,
+            bL: 0f,   bT: 0f,   bR: 0.5f, bB: 0.5f,
+            aL: 0f,   aT: 0f,   aR: 0.4f, aB: 0.5f,
+            commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    // ── MoveChainsRelative / MoveFramesRelative (AppCommands → ReorderCommand) ─
+
+    [Fact]
+    public void MoveChainsRelative_Description_MultipleChains_IncludesCount()
+    {
+        var expected = "Move 2 Animations Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var a = TestHelpers.MakeChain(ctx.Acls, "A");
+        var b = TestHelpers.MakeChain(ctx.Acls, "B");
+        TestHelpers.MakeChain(ctx.Acls, "C");
+
+        ctx.AppCommands.MoveChainsRelative(new[] { a, b }, +1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveChainsRelative_Description_SingleChain_OmitsCount()
+    {
+        var expected = "Move Animation Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var a = TestHelpers.MakeChain(ctx.Acls, "A");
+        TestHelpers.MakeChain(ctx.Acls, "B");
+
+        ctx.AppCommands.MoveChainsRelative(new[] { a }, +1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveFramesCommand_Description_MultipleSameChain_IncludesCount()
+    {
+        var expected = "Move 3 Frames";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 4);
+        var frames = chain.Frames.Take(3).ToArray();
+        var cmd = new MoveFramesCommand(
+            frames, chain, chain, insertIndex: 3,
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void MoveFramesCommand_Description_SingleSameChain_OmitsCount()
+    {
+        var expected = "Move Frame";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var cmd = new MoveFramesCommand(
+            new[] { chain.Frames[0] }, chain, chain, insertIndex: 1,
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void MoveFramesRelative_Description_MultipleFrames_IncludesCount()
+    {
+        var expected = "Move 3 Frames Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 5);
+        var frames = chain.Frames.Take(3).ToArray();
+
+        ctx.AppCommands.MoveFramesRelative(frames, chain, +1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveFramesRelative_Description_SingleFrame_OmitsCount()
+    {
+        var expected = "Move Frame Up";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var frame = chain.Frames[1];
+
+        ctx.AppCommands.MoveFramesRelative(new[] { frame }, chain, -1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
     }
 
     // ── SetFrameTextureNameCommand ─────────────────────────────────────────────
 
     [Fact]
-    public void SetFrameTextureNameCommand_Description_NewNameSet_ShowsFilename()
-    {
-        var frame = new AnimationFrameSave();
-        var cmd = new SetFrameTextureNameCommand(frame,
-            oldName: null, newName: TestPaths.Abs("textures", "sprite.png"),
-            commands: null!, events: null!);
-
-        Assert.Equal("Set Texture: sprite.png", cmd.Description);
-    }
-
-    [Fact]
-    public void SetFrameTextureNameCommand_Description_NewNameNullOldNameSet_ShowsOldFilename()
-    {
-        var frame = new AnimationFrameSave();
-        var cmd = new SetFrameTextureNameCommand(frame,
-            oldName: TestPaths.Abs("textures", "old.png"), newName: null,
-            commands: null!, events: null!);
-
-        Assert.Equal("Set Texture: old.png", cmd.Description);
-    }
-
-    [Fact]
     public void SetFrameTextureNameCommand_Description_BothNull_ReturnsSetTexture()
     {
+        var expected = "Set Texture";
         var frame = new AnimationFrameSave();
         var cmd = new SetFrameTextureNameCommand(frame,
             oldName: null, newName: null,
             commands: null!, events: null!);
 
-        Assert.Equal("Set Texture", cmd.Description);
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void SetFrameTextureNameCommand_Description_NewNameNullOldNameSet_ShowsOldFilename()
+    {
+        var expected = "Set Texture: old.png";
+        var frame = new AnimationFrameSave();
+        var cmd = new SetFrameTextureNameCommand(frame,
+            oldName: TestPaths.Abs("textures", "old.png"), newName: null,
+            commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void SetFrameTextureNameCommand_Description_NewNameSet_ShowsFilename()
+    {
+        var expected = "Set Texture: sprite.png";
+        var frame = new AnimationFrameSave();
+        var cmd = new SetFrameTextureNameCommand(frame,
+            oldName: null, newName: TestPaths.Abs("textures", "sprite.png"),
+            commands: null!, events: null!);
+
+        Assert.Equal(expected, cmd.Description);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandDescriptionTests.cs
@@ -91,6 +91,62 @@ public class CommandDescriptionTests
         Assert.Equal(expected, cmd.Description);
     }
 
+    // ── DeleteChainsCommand / DeleteFramesCommand ─────────────────────────────
+
+    [Fact]
+    public void DeleteChainsCommand_Description_SingleChain_IncludesName()
+    {
+        var expected = "Delete Animation 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var cmd = new DeleteChainsCommand(
+            new[] { chain }, ctx.Acls, ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void DeleteFramesCommand_Description_SingleFrame_IncludesChainName()
+    {
+        var expected = "Delete Frame in 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var cmd = new DeleteFramesCommand(
+            new[] { chain.Frames[0] }, chain, ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    // ── DuplicateChainsCommand / PasteChainsCommand ───────────────────────────
+
+    [Fact]
+    public void DuplicateChainsCommand_Description_SingleChain_IncludesName()
+    {
+        var expected = "Duplicate Animation 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var source = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var copy = new AnimationChainSave { Name = "Walk Copy" };
+        var cmd = new DuplicateChainsCommand(
+            ctx.Acls,
+            new[] { (source, copy) },
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void PasteChainsCommand_Description_SingleChain_IncludesName()
+    {
+        var expected = "Paste Animation 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var cmd = new PasteChainsCommand(
+            ctx.Acls, new[] { chain },
+            ctx.AppCommands, ctx.ApplicationEvents, ctx.SelectedState);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
     // ── FlipCommand ───────────────────────────────────────────────────────────
 
     [Fact]
@@ -148,7 +204,45 @@ public class CommandDescriptionTests
         Assert.Equal(expected, cmd.Description);
     }
 
-    // ── MoveChainsRelative / MoveFramesRelative (AppCommands → ReorderCommand) ─
+    // ── InvertFrameOrder / MoveChain / MoveFrame / shape reorder ──────────────
+
+    [Fact]
+    public void InvertFrameOrder_Description_IncludesChainName()
+    {
+        var expected = "Invert Frame Order in 'Walk'";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+
+        ctx.AppCommands.InvertFrameOrder(chain);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveChain_Description_IncludesName()
+    {
+        var expected = "Move Animation 'A' Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var a = TestHelpers.MakeChain(ctx.Acls, "A");
+        TestHelpers.MakeChain(ctx.Acls, "B");
+
+        ctx.AppCommands.MoveChain(a, +1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveChainToTop_Description_IncludesName()
+    {
+        var expected = "Move Animation 'B' to Top";
+        var ctx = TestHelpers.SetupFreshAcls();
+        TestHelpers.MakeChain(ctx.Acls, "A");
+        var b = TestHelpers.MakeChain(ctx.Acls, "B");
+
+        ctx.AppCommands.MoveChainToTop(b);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
 
     [Fact]
     public void MoveChainsRelative_Description_MultipleChains_IncludesCount()
@@ -165,14 +259,26 @@ public class CommandDescriptionTests
     }
 
     [Fact]
-    public void MoveChainsRelative_Description_SingleChain_OmitsCount()
+    public void MoveChainsRelative_Description_SingleChain_IncludesName()
     {
-        var expected = "Move Animation Down";
+        var expected = "Move Animation 'A' Down";
         var ctx = TestHelpers.SetupFreshAcls();
         var a = TestHelpers.MakeChain(ctx.Acls, "A");
         TestHelpers.MakeChain(ctx.Acls, "B");
 
         ctx.AppCommands.MoveChainsRelative(new[] { a }, +1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveFrame_Description_IncludesChainName()
+    {
+        var expected = "Move Frame in 'Walk' Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+
+        ctx.AppCommands.MoveFrame(chain.Frames[0], chain, +1);
 
         Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
     }
@@ -192,9 +298,9 @@ public class CommandDescriptionTests
     }
 
     [Fact]
-    public void MoveFramesCommand_Description_SingleSameChain_OmitsCount()
+    public void MoveFramesCommand_Description_SingleSameChain_IncludesChainName()
     {
-        var expected = "Move Frame";
+        var expected = "Move Frame in 'Walk'";
         var ctx = TestHelpers.SetupFreshAcls();
         var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
         var cmd = new MoveFramesCommand(
@@ -218,14 +324,30 @@ public class CommandDescriptionTests
     }
 
     [Fact]
-    public void MoveFramesRelative_Description_SingleFrame_OmitsCount()
+    public void MoveFramesRelative_Description_SingleFrame_IncludesChainName()
     {
-        var expected = "Move Frame Up";
+        var expected = "Move Frame in 'Walk' Up";
         var ctx = TestHelpers.SetupFreshAcls();
         var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
         var frame = chain.Frames[1];
 
         ctx.AppCommands.MoveFramesRelative(new[] { frame }, chain, -1);
+
+        Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
+    }
+
+    [Fact]
+    public void MoveShape_Description_IncludesShapeName()
+    {
+        var expected = "Move Rect 'Hitbox' Down";
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        var rect = new AARectSave { Name = "Hitbox" };
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Other" });
+
+        ctx.AppCommands.MoveShape(rect, frame, +1);
 
         Assert.Equal(expected, ctx.UndoManager.UndoHistory[^1].Description);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DemoQueryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/DemoQueryTests.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.Demo;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class DemoQueryTests
+{
+    [Fact]
+    public void TryGetDemoName_NoQuery_ReturnsNull()
+    {
+        string? expected = null;
+        var actual = DemoQuery.TryGetDemoName("http://127.0.0.1:49990/");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryGetDemoName_DemoParamPresent_ReturnsName()
+    {
+        var expected = "undo-labels";
+        var actual = DemoQuery.TryGetDemoName(
+            "http://127.0.0.1:49990/?demo=undo-labels");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryGetDemoName_DemoAmongOtherParams_ReturnsName()
+    {
+        var expected = "undo-labels";
+        var actual = DemoQuery.TryGetDemoName(
+            "http://127.0.0.1:49990/?arg=--urls&demo=undo-labels&x=1");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryGetDemoName_EmptyDemoValue_ReturnsNull()
+    {
+        string? expected = null;
+        var actual = DemoQuery.TryGetDemoName("http://127.0.0.1:49990/?demo=");
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FeatureDemosTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/FeatureDemosTests.cs
@@ -1,0 +1,34 @@
+using AnimationEditor.Core.Demo;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class FeatureDemosTests
+{
+    [Fact]
+    public void TryRun_UnknownName_ReturnsFalse()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var ran = FeatureDemos.TryRun(
+            "does-not-exist", ctx.AppCommands, ctx.UndoManager, ctx.ApplicationEvents, "tex.png");
+
+        Assert.False(ran);
+        Assert.Empty(ctx.UndoManager.UndoHistory);
+    }
+
+    [Fact]
+    public void TryRun_UndoLabels_RecordsCountAwareAndNamedEntries()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var ran = FeatureDemos.TryRun(
+            FeatureDemos.UndoLabels, ctx.AppCommands, ctx.UndoManager, ctx.ApplicationEvents, "tex.png");
+
+        Assert.True(ran);
+        var labels = ctx.UndoManager.UndoHistory.Select(c => c.Description).ToList();
+        Assert.Contains("Move 3 Frames Down", labels);
+        Assert.Contains("Move Animation 'Idle' Down", labels);
+        Assert.Contains("Delete Animation 'Doomed'", labels);
+        Assert.Contains(labels, l => l.StartsWith("Move Rect 'Hitbox'"));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/ScreenshotOutput.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/ScreenshotOutput.cs
@@ -1,0 +1,23 @@
+using System.IO;
+
+namespace AnimationEditor.DocScreenshots;
+
+/// <summary>
+/// Stable on-disk folder for ad-hoc feature-proof screenshots
+/// (<c>tools/AnimationEditorAvalonia/tests/_out/&lt;feature&gt;/</c>).
+/// </summary>
+internal static class ScreenshotOutput
+{
+    /// <summary>
+    /// Resolves <c>tests/_out/&lt;featureName&gt;</c> relative to the DocScreenshots project
+    /// (four levels up from the test exe under <c>bin/Debug/netX/</c>).
+    /// </summary>
+    public static string ResolveFeatureDir(string featureName)
+    {
+        var testsRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var dir = Path.Combine(testsRoot, "_out", featureName);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/_ScratchCapture.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/_ScratchCapture.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Linq;
+using AnimationEditor.App;
+using AnimationEditor.Core.Demo;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.DocScreenshots;
+
+/// <summary>
+/// Ad-hoc visual proof template: drive a <see cref="FeatureDemos"/> scenario through
+/// real <c>AppCommands</c>, open History, capture PNGs + <c>labels.txt</c> under
+/// <see cref="ScreenshotOutput"/>.
+/// </summary>
+public class _ScratchCapture
+{
+    [AvaloniaFact]
+    public void CaptureHistoryLabels_UndoLabelsDemo()
+    {
+        var outputDir = ScreenshotOutput.ResolveFeatureDir("issue-534-history");
+
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => System.Threading.Tasks.Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Width = 1400;
+        window.Height = 1000;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            ScenarioFixtures.UseCharacterSheetProject(ctx);
+            ctx.ProjectManager.AnimationChainListSave ??= new AnimationChainListSave();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(FeatureDemos.TryRun(
+                FeatureDemos.UndoLabels,
+                ctx.AppCommands,
+                ctx.UndoManager,
+                ctx.ApplicationEvents,
+                "characters.png"));
+
+            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs();
+
+            EnlargeHistoryPanel(window);
+            SelectHistoryTab(window);
+            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs();
+
+            var labelsPath = Path.Combine(outputDir, "labels.txt");
+            File.WriteAllLines(labelsPath,
+                ctx.UndoManager.UndoHistory.Select((c, i) => $"{i + 1}. {c.Description}"));
+
+            var scroll = window.FindControl<ScrollViewer>("HistoryScrollViewer")
+                ?? throw new InvalidOperationException("HistoryScrollViewer not found");
+
+            ScreenshotCapture.Capture(window, Path.Combine(outputDir, "01-window-history-tab.png"));
+
+            scroll.Offset = new Vector(0, 0);
+            Dispatcher.UIThread.RunJobs();
+            ScreenshotCapture.Capture(scroll, Path.Combine(outputDir, "02-history-top.png"));
+
+            double extent = scroll.Extent.Height;
+            double viewport = scroll.Viewport.Height;
+            if (extent > viewport + 1)
+            {
+                scroll.Offset = new Vector(0, Math.Max(0, (extent - viewport) / 2));
+                Dispatcher.UIThread.RunJobs();
+                ScreenshotCapture.Capture(scroll, Path.Combine(outputDir, "03-history-mid.png"));
+
+                scroll.Offset = new Vector(0, Math.Max(0, extent - viewport));
+                Dispatcher.UIThread.RunJobs();
+                ScreenshotCapture.Capture(scroll, Path.Combine(outputDir, "04-history-bottom.png"));
+            }
+
+            Assert.True(File.Exists(labelsPath));
+            Assert.True(ctx.UndoManager.UndoHistory.Count >= 15);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static void SelectHistoryTab(MainWindow window)
+    {
+        var tabs = window.FindControl<TabControl>("SidebarTabs")
+            ?? throw new InvalidOperationException("SidebarTabs not found");
+        var history = window.FindControl<TabItem>("HistoryTab")
+            ?? throw new InvalidOperationException("HistoryTab not found");
+        tabs.SelectedItem = history;
+    }
+
+    private static void EnlargeHistoryPanel(MainWindow window)
+    {
+        if (window.FindControl<Grid>("LeftPanelGrid") is { } left
+            && left.RowDefinitions.Count >= 3)
+        {
+            left.RowDefinitions[0].Height = new GridLength(1, GridUnitType.Star);
+            left.RowDefinitions[2].Height = new GridLength(4, GridUnitType.Star);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Makes Animation Editor undo/redo `Description` strings consistent: plural ops include counts (`Move 3 Frames Down`), singular ops quote the target name (`Delete Animation 'Doomed'`, `Cut Rect 'Other'`), imperative Title Case throughout.
- Adds shared `ShapeUndoLabel` plus Core tests covering the conventions.
- Adds an internal `FeatureDemos` harness (DocScreenshots / tests only — not wired into shipping Browser `App`) and gitignores `tools/AnimationEditorAvalonia/tests/_out/` so local History proof PNGs stay out of the repo.

Closes #534

Follow-up for true UI-driven WASM verification (no code demos): #690

## Test plan

- [ ] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/`
- [ ] Spot-check History after multi-frame reorder, singular rename/delete, and shape add/cut — labels match the new conventions
- [ ] Confirm no `?demo=` / `FeatureDemos.TryRun` wiring in `AnimationEditor.Browser` `App.axaml.cs`
