### PR TITLE
Animation Editor: toggle visibility of user-placed guides

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
+++ b/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
@@ -191,7 +191,8 @@
 | PL05 | Loop animation | Wraps from last frame back to first |
 | PL06 | Preview flip H/V | Applies chain-level flip to preview |
 | PL07 | Onion skin | When a single frame is pinned, renders the previous frame at 50% alpha behind it; wraps index for the first frame; toggled by `OnionSkinToggle` |
-| PL08 | Preview guides overlay | Toggles rendering of horizontal/vertical guide lines (from `AESettingsSave`) over the preview canvas; controlled by `ShowGuidesCheck` |
+| PL08a | Origin crosshair overlay | Toggles a fixed crosshair through world origin (0,0) over the preview canvas; controlled by `ShowOriginCheck` |
+| PL08b | User-placed guides visibility (#689) | Toggles rendering/hit-testing of user-placed horizontal/vertical guide lines (persisted in `AESettingsSave`); controlled by `ShowUserGuidesCheck`, only shown once a guide exists; placing a new guide while hidden reveals them all again (matches Photoshop) |
 | PL09 | Preview zoom | Independent zoom combo (10%–400%) for the preview panel via `PreviewZoomCombo` and mouse wheel; `SetZoomPercent` clamps to 0.05×–32× |
 | PL10 | Preview pan | Middle-click or Alt+left-click drag pans the preview viewport; uses dedicated camera (`_panX`/`_panY`) shared with zoom-toward computation |
 | PL11 | Preview sprite alignment | Combo in preview toolbar: Center (FRB default), TopLeft, TopRight, BottomLeft, BottomRight, etc.; changes the anchor point used when positioning the animated sprite's `RelativeX/Y` offset in the preview panel |

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1340,11 +1340,29 @@
                                     <TextBlock Text="Onion Skin" VerticalAlignment="Center" />
                                 </StackPanel>
                             </ToggleButton>
-                            <ToggleButton x:Name="ShowGuidesCheck"
+                            <ToggleButton x:Name="ShowOriginCheck"
                                           Height="26"
                                           Foreground="{DynamicResource Ink}"
                                           VerticalAlignment="Center"
                                           Margin="4,0,4,0"
+                                          ToolTip.Tip="Show origin crosshair">
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <svg:Svg Width="16" Height="16"
+                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconCrosshair.svg"
+                                             CurrentColor="{DynamicResource IconInk}"
+                                             VerticalAlignment="Center" />
+                                    <TextBlock Text="Origin" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </ToggleButton>
+                            <!-- Only shown once the user has placed at least one guide (#689) —
+                                 see UpdateGuideToggleVisibility in MainWindow.axaml.cs. -->
+                            <ToggleButton x:Name="ShowUserGuidesCheck"
+                                          Height="26"
+                                          Foreground="{DynamicResource Ink}"
+                                          VerticalAlignment="Center"
+                                          Margin="0,0,4,0"
+                                          IsVisible="False"
+                                          IsChecked="True"
                                           ToolTip.Tip="Show guides">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
                                     <svg:Svg Width="16" Height="16"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -146,6 +146,7 @@ public partial class MainWindow : Window
     private bool _suppressTreeSelectionHandling;
     private bool _suppressCompanionSave;
     private bool _suppressInterpolateSync;
+    private bool _suppressGuideVisibilitySync;
     private readonly AltMenuActivationSuppressor _altMenuActivationSuppressor = new();
     private System.Threading.CancellationTokenSource? _toastCts;
 
@@ -2057,8 +2058,17 @@ public partial class MainWindow : Window
         OnionSkinToggle.IsCheckedChanged += (_, _) =>
             PreviewCtrl.ShowOnionSkin = OnionSkinToggle.IsChecked == true;
 
-        ShowGuidesCheck.IsCheckedChanged += (_, _) =>
-            PreviewCtrl.ShowGuides = ShowGuidesCheck.IsChecked == true;
+        ShowOriginCheck.IsCheckedChanged += (_, _) =>
+            PreviewCtrl.ShowOrigin = ShowOriginCheck.IsChecked == true;
+
+        ShowUserGuidesCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (_suppressGuideVisibilitySync) return;
+            PreviewCtrl.ShowUserGuides = ShowUserGuidesCheck.IsChecked == true;
+        };
+        // PreviewControl auto-reveals guides when a new one is added while hidden (#689);
+        // resync the toolbar toggle and its visibility (only shown once a guide exists).
+        PreviewCtrl.GuidesChanged += UpdateGuideToggleVisibility;
 
         InterpolateToggle.IsCheckedChanged += (_, _) =>
         {
@@ -2101,6 +2111,22 @@ public partial class MainWindow : Window
         PreviewHScroll.Scroll += OnPreviewScrollEnded;
         PreviewVScroll.Scroll += OnPreviewScrollEnded;
         PreviewCtrl.ViewChanged += RefreshPreviewScrollBars;
+
+        UpdateGuideToggleVisibility();
+    }
+
+    /// <summary>
+    /// Shows the "Guides" toggle only once at least one guide has been placed (#689), and
+    /// mirrors its checked state to <see cref="PreviewControl.ShowUserGuides"/> — including
+    /// after the control auto-reveals guides on creation, which happens without going through
+    /// this toggle's own click handler.
+    /// </summary>
+    private void UpdateGuideToggleVisibility()
+    {
+        ShowUserGuidesCheck.IsVisible = PreviewCtrl.HGuideCount > 0 || PreviewCtrl.VGuideCount > 0;
+        _suppressGuideVisibilitySync = true;
+        ShowUserGuidesCheck.IsChecked = PreviewCtrl.ShowUserGuides;
+        _suppressGuideVisibilitySync = false;
     }
 
     private void OnPreviewScrollValueChanged(bool horizontal)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -731,7 +731,7 @@ public partial class App : Application
         };
 
         // Phase 5 (#622): view/canvas polish. Every toggle here is already-built, already-tested
-        // control state (PreviewControl.ShowOnionSkin/InterpolateOffsets/ShowGuides,
+        // control state (PreviewControl.ShowOnionSkin/InterpolateOffsets/ShowOrigin/ShowUserGuides,
         // TextureViewport.DiagnosticsEnabled/SetZoomPercent/SetGrid) that MainWindow exposes via
         // its own toolbar controls on desktop -- this is the same wiring, minus persistence
         // (zoom%/grid-size/guide positions live in the desktop-only .aeproperties companion file,
@@ -766,17 +766,42 @@ public partial class App : Application
         interpolateButton.Click += (_, _) => preview.InterpolateOffsets = interpolateButton.IsChecked == true;
 
         // Ruler-click-drag-to-create/move/right-click-to-remove guides is entirely self-contained
-        // inside PreviewControl's own pointer handlers (present since Phase 1's wiring) --
-        // ShowGuides only toggles the origin crosshair overlay; guides themselves always render
-        // once created, with or without this toggle.
-        var showGuidesButton = new ToggleButton
+        // inside PreviewControl's own pointer handlers (present since Phase 1's wiring).
+        var showOriginButton = new ToggleButton
         {
             Height = 26, MinHeight = 0, Padding = new Thickness(10, 0),
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(4, 0, 4, 0),
+            Content = IconLabel("IconCrosshair", "Origin"),
+        };
+        showOriginButton.Click += (_, _) => preview.ShowOrigin = showOriginButton.IsChecked == true;
+
+        // Only shown once the user has placed at least one guide (#689); mirrors the checked
+        // state to PreviewControl.ShowUserGuides, including the auto-reveal-on-create case,
+        // which happens without going through this button's own click handler.
+        var showUserGuidesButton = new ToggleButton
+        {
+            Height = 26, MinHeight = 0, Padding = new Thickness(10, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
+            IsVisible = false,
+            IsChecked = true,
             Content = IconLabel("IconGuides", "Guides"),
         };
-        showGuidesButton.Click += (_, _) => preview.ShowGuides = showGuidesButton.IsChecked == true;
+        bool suppressGuideVisibilitySync = false;
+        showUserGuidesButton.Click += (_, _) =>
+        {
+            if (suppressGuideVisibilitySync) return;
+            preview.ShowUserGuides = showUserGuidesButton.IsChecked == true;
+        };
+        void UpdateGuideToggleVisibility()
+        {
+            showUserGuidesButton.IsVisible = preview.HGuideCount > 0 || preview.VGuideCount > 0;
+            suppressGuideVisibilitySync = true;
+            showUserGuidesButton.IsChecked = preview.ShowUserGuides;
+            suppressGuideVisibilitySync = false;
+        }
+        preview.GuidesChanged += UpdateGuideToggleVisibility;
 
         var diagnosticsButton = new ToggleButton { Content = "Diagnostics (F3)", IsVisible = false };
         void ApplyDiagnostics(bool on)
@@ -995,7 +1020,8 @@ public partial class App : Application
             Children =
             {
                 onionSkinButton,
-                showGuidesButton,
+                showOriginButton,
+                showUserGuidesButton,
                 interpolateButton,
                 ToolbarDivider(),
                 previewZoomLabel,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconCrosshair.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconCrosshair.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="6"/>
+  <line x1="12" y1="1" x2="12" y2="6"/>
+  <line x1="12" y1="18" x2="12" y2="23"/>
+  <line x1="1" y1="12" x2="6" y2="12"/>
+  <line x1="18" y1="12" x2="23" y2="12"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -111,7 +111,8 @@ public class PreviewControl : Control, IZoomTarget
 
     // -- Settings --------------------------------------------------------------
     private bool _showOnionSkin;
-    private bool _showGuides;
+    private bool _showOrigin;
+    private bool _showUserGuides = true;
     private bool _interpolateOffsets;
 
     // -- Pan drag --------------------------------------------------------------
@@ -188,11 +189,27 @@ public class PreviewControl : Control, IZoomTarget
         set { _showOnionSkin = value; InvalidateVisual(); }
     }
 
-    public bool ShowGuides
+    /// <summary>Toggles the origin crosshair overlay — unrelated to user-placed guides, see <see cref="ShowUserGuides"/>.</summary>
+    public bool ShowOrigin
     {
-        get => _showGuides;
-        set { _showGuides = value; InvalidateVisual(); }
+        get => _showOrigin;
+        set { _showOrigin = value; InvalidateVisual(); }
     }
+
+    /// <summary>
+    /// Toggles visibility of user-placed ruler guides. Placing a new guide while this is
+    /// <c>false</c> sets it back to <c>true</c> (matches Photoshop) so guides never pile up
+    /// unseen. Does not affect guide hit-testing: a hidden guide cannot be dragged or
+    /// right-click-removed, since there's nothing on screen to target.
+    /// </summary>
+    public bool ShowUserGuides
+    {
+        get => _showUserGuides;
+        set { _showUserGuides = value; InvalidateVisual(); }
+    }
+
+    /// <summary>Fires whenever a guide is added, removed, or bulk-replaced via <see cref="SetGuides"/>.</summary>
+    public event Action? GuidesChanged;
 
     /// <summary>
     /// When <c>true</c>, the displayed sprite position eases between consecutive frames'
@@ -505,7 +522,7 @@ public class PreviewControl : Control, IZoomTarget
         if (IsGroupPreviewActive)
         {
             return new RenderSnapshot(
-                null, null, _zoom, _panX, _panY, _showGuides, null, null, width, height,
+                null, null, _zoom, _panX, _panY, _showOrigin, _showUserGuides, null, null, width, height,
                 _appState!.OffsetMultiplier,
                 _hGuides.ToArray(), _vGuides.ToArray(),
                 _draggedGuideIdx, _draggingHGuide,
@@ -545,7 +562,7 @@ public class PreviewControl : Control, IZoomTarget
         var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
 
         return new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
-                                  _showGuides, texPath, onionPath, width, height,
+                                  _showOrigin, _showUserGuides, texPath, onionPath, width, height,
                                   _appState!.OffsetMultiplier,
                                   _hGuides.ToArray(), _vGuides.ToArray(),
                                   _draggedGuideIdx, _draggingHGuide,
@@ -773,10 +790,22 @@ public class PreviewControl : Control, IZoomTarget
     }
 
     /// <summary>Test-only: adds a horizontal guide at the given world-Y coordinate.</summary>
-    public void AddHGuide(float worldY) { _hGuides.Add(worldY); InvalidateVisual(); }
+    public void AddHGuide(float worldY) { _hGuides.Add(worldY); OnGuideAdded(); }
 
     /// <summary>Test-only: adds a vertical guide at the given world-X coordinate.</summary>
-    public void AddVGuide(float worldX) { _vGuides.Add(worldX); InvalidateVisual(); }
+    public void AddVGuide(float worldX) { _vGuides.Add(worldX); OnGuideAdded(); }
+
+    /// <summary>
+    /// Common bookkeeping for every guide-creation path (ruler click, <see cref="AddHGuide"/>/
+    /// <see cref="AddVGuide"/>, <see cref="SimulateAddHGuide"/>/<see cref="SimulateAddVGuide"/>):
+    /// reveals guides if they were hidden and notifies listeners the guide set changed.
+    /// </summary>
+    private void OnGuideAdded()
+    {
+        _showUserGuides = true;
+        InvalidateVisual();
+        GuidesChanged?.Invoke();
+    }
 
     /// <summary>Test-only: returns the number of user-created horizontal guides.</summary>
     public int HGuideCount => _hGuides.Count;
@@ -1176,7 +1205,7 @@ public class PreviewControl : Control, IZoomTarget
     internal void SimulateAddHGuide(float screenY, float controlHeight)
     {
         _hGuides.Add(SnapToPixel(ScreenToWorldY(screenY, controlHeight)));
-        InvalidateVisual();
+        OnGuideAdded();
     }
 
     /// <summary>
@@ -1187,7 +1216,7 @@ public class PreviewControl : Control, IZoomTarget
     internal void SimulateAddVGuide(float screenX, float controlWidth)
     {
         _vGuides.Add(SnapToPixel(ScreenToWorldX(screenX, controlWidth)));
-        InvalidateVisual();
+        OnGuideAdded();
     }
 
     /// <summary>
@@ -1241,6 +1270,7 @@ public class PreviewControl : Control, IZoomTarget
         _vGuides.Clear();
         _vGuides.AddRange(vGuides);
         InvalidateVisual();
+        GuidesChanged?.Invoke();
     }
 
     /// <summary>
@@ -1258,7 +1288,7 @@ public class PreviewControl : Control, IZoomTarget
     /// user-placed guides. Returns <c>null</c> when no guide is nearby.
     /// </summary>
     public StandardCursorType? GetGuideCursorAt(float px, float py)
-        => GuideCursorResolver.CursorTypeAt(px, py,
+        => !_showUserGuides ? null : GuideCursorResolver.CursorTypeAt(px, py,
             _hGuides.ToArray(), _vGuides.ToArray(),
             _panX, _panY, _zoom,
             (float)Bounds.Width, (float)Bounds.Height);
@@ -1350,7 +1380,7 @@ public class PreviewControl : Control, IZoomTarget
     /// </summary>
     private bool TryRemoveGuideAt(float px, float py)
     {
-        if (px < RulerSize || py < RulerSize) return false;
+        if (!_showUserGuides || px < RulerSize || py < RulerSize) return false;
 
         const float hitPx = 4f;
         for (int i = 0; i < _hGuides.Count; i++)
@@ -1359,6 +1389,7 @@ public class PreviewControl : Control, IZoomTarget
             {
                 _hGuides.RemoveAt(i);
                 InvalidateVisual();
+                GuidesChanged?.Invoke();
                 return true;
             }
         }
@@ -1368,6 +1399,7 @@ public class PreviewControl : Control, IZoomTarget
             {
                 _vGuides.RemoveAt(i);
                 InvalidateVisual();
+                GuidesChanged?.Invoke();
                 return true;
             }
         }
@@ -1763,7 +1795,7 @@ public class PreviewControl : Control, IZoomTarget
             _draggedGuideIdx = _hGuides.Count - 1;
             _draggingHGuide  = true;
             e.Pointer.Capture(this);
-            InvalidateVisual();
+            OnGuideAdded();
             return;
         }
 
@@ -1775,30 +1807,34 @@ public class PreviewControl : Control, IZoomTarget
             _draggedGuideIdx = _vGuides.Count - 1;
             _draggingHGuide  = false;
             e.Pointer.Capture(this);
-            InvalidateVisual();
+            OnGuideAdded();
             return;
         }
 
-        // Click near existing guide ΓåÆ drag it
-        const float hitPx = 4f;
-        for (int i = 0; i < _hGuides.Count; i++)
+        // Click near existing guide ΓåÆ drag it. Skipped while guides are hidden — there's
+        // nothing on screen to target, so a click here falls through to shape drag/select.
+        if (_showUserGuides)
         {
-            if (MathF.Abs(py - WorldToScreenY(_hGuides[i])) < hitPx)
+            const float hitPx = 4f;
+            for (int i = 0; i < _hGuides.Count; i++)
             {
-                _draggedGuideIdx = i;
-                _draggingHGuide  = true;
-                e.Pointer.Capture(this);
-                return;
+                if (MathF.Abs(py - WorldToScreenY(_hGuides[i])) < hitPx)
+                {
+                    _draggedGuideIdx = i;
+                    _draggingHGuide  = true;
+                    e.Pointer.Capture(this);
+                    return;
+                }
             }
-        }
-        for (int i = 0; i < _vGuides.Count; i++)
-        {
-            if (MathF.Abs(px - WorldToScreenX(_vGuides[i])) < hitPx)
+            for (int i = 0; i < _vGuides.Count; i++)
             {
-                _draggedGuideIdx = i;
-                _draggingHGuide  = false;
-                e.Pointer.Capture(this);
-                return;
+                if (MathF.Abs(px - WorldToScreenX(_vGuides[i])) < hitPx)
+                {
+                    _draggedGuideIdx = i;
+                    _draggingHGuide  = false;
+                    e.Pointer.Capture(this);
+                    return;
+                }
             }
         }
 
@@ -1935,6 +1971,7 @@ public class PreviewControl : Control, IZoomTarget
                     _hGuides.RemoveAt(_draggedGuideIdx);
                 else
                     _vGuides.RemoveAt(_draggedGuideIdx);
+                GuidesChanged?.Invoke();
             }
             _draggedGuideIdx = -1;
             InvalidateVisual();
@@ -1973,7 +2010,8 @@ public class PreviewControl : Control, IZoomTarget
         AnimationFrameSave? OnionFrame,
         float  Zoom,
         float  PanX, float PanY,
-        bool   ShowGuides,
+        bool   ShowOrigin,
+        bool   ShowUserGuides,
         string? TexturePath,
         string? OnionTexturePath,
         float  Width, float Height,
@@ -2059,8 +2097,8 @@ public class PreviewControl : Control, IZoomTarget
             }
         }
 
-        // Origin crosshair (toggled by ShowGuides)
-        if (s.ShowGuides)
+        // Origin crosshair (toggled by ShowOrigin)
+        if (s.ShowOrigin)
         {
             using var gp = new SKPaint
             {
@@ -2073,7 +2111,7 @@ public class PreviewControl : Control, IZoomTarget
         }
 
         // User-created guide lines
-        if (s.HGuides.Length > 0 || s.VGuides.Length > 0)
+        if (s.ShowUserGuides && (s.HGuides.Length > 0 || s.VGuides.Length > 0))
         {
             using var guidePaint = new SKPaint
             {
@@ -2163,7 +2201,7 @@ public class PreviewControl : Control, IZoomTarget
         }
 
         // Dragged guide value label - drawn last so it stays on top of shapes.
-        if (s.DraggedGuideIdx >= 0)
+        if (s.ShowUserGuides && s.DraggedGuideIdx >= 0)
         {
             using var dragLabelFont = new SKFont { Size = 11f };
             using var dragLabelPaint = new SKPaint
@@ -2255,23 +2293,26 @@ public class PreviewControl : Control, IZoomTarget
         }
 
         // Draw guide value labels on the ruler edge
-        using var guideTickPaint = new SKPaint
+        if (s.ShowUserGuides)
         {
-            Color       = palette.GuideLine.WithAlpha(200),
-            StrokeWidth = 1f,
-            IsAntialias = false
-        };
-        foreach (float wy in s.HGuides)
-        {
-            float sy = cy + wy * s.Zoom;
-            if (sy >= RulerSize && sy <= s.Height)
-                canvas.DrawLine(0, sy, RulerSize, sy, guideTickPaint);
-        }
-        foreach (float wx in s.VGuides)
-        {
-            float sx = cx + wx * s.Zoom;
-            if (sx >= RulerSize && sx <= s.Width)
-                canvas.DrawLine(sx, 0, sx, RulerSize, guideTickPaint);
+            using var guideTickPaint = new SKPaint
+            {
+                Color       = palette.GuideLine.WithAlpha(200),
+                StrokeWidth = 1f,
+                IsAntialias = false
+            };
+            foreach (float wy in s.HGuides)
+            {
+                float sy = cy + wy * s.Zoom;
+                if (sy >= RulerSize && sy <= s.Height)
+                    canvas.DrawLine(0, sy, RulerSize, sy, guideTickPaint);
+            }
+            foreach (float wx in s.VGuides)
+            {
+                float sx = cx + wx * s.Zoom;
+                if (sx >= RulerSize && sx <= s.Width)
+                    canvas.DrawLine(sx, 0, sx, RulerSize, guideTickPaint);
+            }
         }
 
         // Ruler border lines

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideRightClickRemoveTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GuideRightClickRemoveTests.cs
@@ -41,7 +41,7 @@ public class GuideRightClickRemoveTests
     private static PreviewControl MakeArrangedControl(TestServices ctx)
     {
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowUserGuides = true;
         // Arrange to a known size so GetCenterX/Y match the 64×64 render size.
         ctrl.Measure(new Size(64, 64));
         ctrl.Arrange(new Rect(0, 0, 64, 64));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/OriginCrosshairPanTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/OriginCrosshairPanTests.cs
@@ -10,10 +10,12 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests that the guide crosshair in <see cref="PreviewControl"/> is correctly
-/// positioned relative to pan offsets.
+/// Tests that the origin crosshair in <see cref="PreviewControl"/> is correctly
+/// positioned relative to pan offsets. Not to be confused with user-placed guides
+/// (<see cref="PreviewControl.ShowUserGuides"/>) — this is the unrelated fixed
+/// crosshair through world origin (0,0), toggled by <see cref="PreviewControl.ShowOrigin"/>.
 ///
-/// The guide implementation draws:
+/// The crosshair draws:
 ///   Vertical line   at cx = (Width-20)/2  + 20 + PanX
 ///   Horizontal line at cy = (Height-20)/2 + 20 + PanY
 ///
@@ -21,10 +23,10 @@ namespace AnimationEditor.App.Tests;
 ///   – vertical line tests sample at y=25 (well above cy=42 at default pan)
 ///   – horizontal line tests sample at x=25 (well left of cx=42 at default pan)
 ///
-/// Guide colour: SKColor(100, 200, 100, 160) → over background (30,30,30)
+/// Crosshair colour: SKColor(100, 200, 100, 160) → over background (30,30,30)
 ///   blended G ≈ 137 >> background G=30, so Green > Red is a solid assertion.
 /// </summary>
-public class GuidePanTests
+public class OriginCrosshairPanTests
 {
     private static TestServices ResetSingletons() {
         var ctx = TestHelpers.BuildServices();
@@ -47,54 +49,54 @@ public class GuidePanTests
         File.WriteAllBytes(path, data.ToArray());
     }
 
-    // ── ShowGuides = false ────────────────────────────────────────────────────
+    // ── ShowOrigin = false ────────────────────────────────────────────────────
 
     /// <summary>
-    /// When ShowGuides is false the crosshair must not appear at all.
+    /// When ShowOrigin is false the crosshair must not appear at all.
     /// With no chain set the canvas is pure background (30,30,30).
-    /// The guide would raise Green significantly; without it Green ≈ 30.
+    /// The crosshair would raise Green significantly; without it Green ≈ 30.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_HiddenWhenShowGuidesFalse_NoCrosshairAtCenter()
+    public void Origin_HiddenWhenShowOriginFalse_NoCrosshairAtCenter()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = false;
+        ctrl.ShowOrigin = false;
 
         using var bm = ctrl.RenderToBitmap(64, 64);
 
-        // Default pan → guide would be at (42, 42); verify it is not green
+        // Default pan → crosshair would be at (42, 42); verify it is not green
         var px = bm.GetPixel(32, 10);   // sample off the horizontal axis
         Assert.True(px.Green <= px.Red + 10,
-            $"ShowGuides=false: no green crosshair expected; G={px.Green} R={px.Red}");
+            $"ShowOrigin=false: no green crosshair expected; G={px.Green} R={px.Red}");
     }
 
     // ── Default pan: crosshair at canvas centre ───────────────────────────────
 
     /// <summary>
-    /// With default pan (0,0) the vertical guide is at x = (Width-20)/2+20 = 42 and
-    /// the horizontal guide is at y = (Height-20)/2+20 = 42.
+    /// With default pan (0,0) the vertical line is at x = (Width-20)/2+20 = 42 and
+    /// the horizontal line is at y = (Height-20)/2+20 = 42.
     /// Sampling at y=25 isolates the vertical line from the horizontal crossing.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_DefaultPan_VerticalLineAtCenterX()
+    public void Origin_DefaultPan_VerticalLineAtCenterX()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
 
         using var bm = ctrl.RenderToBitmap(64, 64);
 
-        var guidePixel = bm.GetPixel(42, 25);    // on the vertical line
-        var offPixel   = bm.GetPixel(25, 25);    // off the vertical line
+        var crosshairPixel = bm.GetPixel(42, 25);    // on the vertical line
+        var offPixel       = bm.GetPixel(25, 25);    // off the vertical line
 
-        Assert.True(guidePixel.Green > guidePixel.Red,
-            $"Vertical guide at x=42 should be green-dominant; G={guidePixel.Green} R={guidePixel.Red}");
+        Assert.True(crosshairPixel.Green > crosshairPixel.Red,
+            $"Vertical line at x=42 should be green-dominant; G={crosshairPixel.Green} R={crosshairPixel.Red}");
         Assert.True(offPixel.Green <= offPixel.Red + 10,
-            $"Off-guide pixel (25,25) should be background, not green; G={offPixel.Green} R={offPixel.Red}");
+            $"Off-line pixel (25,25) should be background, not green; G={offPixel.Green} R={offPixel.Red}");
     }
 
-    // ── PanX shifts the vertical guide ───────────────────────────────────────
+    // ── PanX shifts the vertical line ───────────────────────────────────────
 
     /// <summary>
     /// SetPan(16, 0) → cx = 42 + 16 = 58.
@@ -102,11 +104,11 @@ public class GuidePanTests
     /// Sampling at y=25 avoids the horizontal line (which remains at y=42).
     /// </summary>
     [AvaloniaFact]
-    public void Guide_PanX16_VerticalLineShiftsToX48()
+    public void Origin_PanX16_VerticalLineShiftsToX48()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         ctrl.SetPan(16f, 0f);
 
         using var bm = ctrl.RenderToBitmap(64, 64);
@@ -115,9 +117,9 @@ public class GuidePanTests
         var atOldPos = bm.GetPixel(42, 25);   // old (default) vertical line position
 
         Assert.True(atNewPos.Green > atNewPos.Red,
-            $"Vertical guide should be at x=58 after PanX=16; G={atNewPos.Green} R={atNewPos.Red}");
+            $"Vertical line should be at x=58 after PanX=16; G={atNewPos.Green} R={atNewPos.Red}");
         Assert.True(atOldPos.Green <= atOldPos.Red + 10,
-            $"Old vertical-guide position x=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
+            $"Old vertical-line position x=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
     }
 
     /// <summary>
@@ -125,11 +127,11 @@ public class GuidePanTests
     /// The vertical line shifts left.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_PanXNeg8_VerticalLineShiftsToX24()
+    public void Origin_PanXNeg8_VerticalLineShiftsToX24()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         ctrl.SetPan(-8f, 0f);
 
         using var bm = ctrl.RenderToBitmap(64, 64);
@@ -138,12 +140,12 @@ public class GuidePanTests
         var atOldPos = bm.GetPixel(42, 25);
 
         Assert.True(atNewPos.Green > atNewPos.Red,
-            $"Vertical guide should be at x=34 after PanX=-8; G={atNewPos.Green} R={atNewPos.Red}");
+            $"Vertical line should be at x=34 after PanX=-8; G={atNewPos.Green} R={atNewPos.Red}");
         Assert.True(atOldPos.Green <= atOldPos.Red + 10,
-            $"Old vertical-guide position x=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
+            $"Old vertical-line position x=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
     }
 
-    // ── PanY shifts the horizontal guide ─────────────────────────────────────
+    // ── PanY shifts the horizontal line ─────────────────────────────────────
 
     /// <summary>
     /// SetPan(0, 16) → cy = 42 + 16 = 58.
@@ -151,11 +153,11 @@ public class GuidePanTests
     /// Sampling at x=25 avoids the vertical line (which remains at x=42).
     /// </summary>
     [AvaloniaFact]
-    public void Guide_PanY16_HorizontalLineShiftsToY48()
+    public void Origin_PanY16_HorizontalLineShiftsToY48()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         ctrl.SetPan(0f, 16f);
 
         using var bm = ctrl.RenderToBitmap(64, 64);
@@ -164,9 +166,9 @@ public class GuidePanTests
         var atOldPos = bm.GetPixel(25, 42);
 
         Assert.True(atNewPos.Green > atNewPos.Red,
-            $"Horizontal guide should be at y=58 after PanY=16; G={atNewPos.Green} R={atNewPos.Red}");
+            $"Horizontal line should be at y=58 after PanY=16; G={atNewPos.Green} R={atNewPos.Red}");
         Assert.True(atOldPos.Green <= atOldPos.Red + 10,
-            $"Old horizontal-guide position y=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
+            $"Old horizontal-line position y=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
     }
 
     /// <summary>
@@ -174,11 +176,11 @@ public class GuidePanTests
     /// The horizontal line shifts up.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_PanYNeg8_HorizontalLineShiftsToY24()
+    public void Origin_PanYNeg8_HorizontalLineShiftsToY24()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         ctrl.SetPan(0f, -8f);
 
         using var bm = ctrl.RenderToBitmap(64, 64);
@@ -187,30 +189,29 @@ public class GuidePanTests
         var atOldPos = bm.GetPixel(25, 42);
 
         Assert.True(atNewPos.Green > atNewPos.Red,
-            $"Horizontal guide should be at y=34 after PanY=-8; G={atNewPos.Green} R={atNewPos.Red}");
+            $"Horizontal line should be at y=34 after PanY=-8; G={atNewPos.Green} R={atNewPos.Red}");
         Assert.True(atOldPos.Green <= atOldPos.Red + 10,
-            $"Old horizontal-guide position y=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
+            $"Old horizontal-line position y=42 should now be background; G={atOldPos.Green} R={atOldPos.Red}");
     }
 
-    // ── Guide visible over a texture frame ───────────────────────────────────
+    // ── Crosshair visible over a texture frame ───────────────────────────────
 
     /// <summary>
-    /// When a dark frame is rendered and guides are enabled the guide line
-    /// is drawn on top and should be detectably greener than an adjacent
-    /// off-guide pixel at the same row.
+    /// When a dark frame is rendered and the crosshair is enabled it is drawn on top
+    /// and should be detectably greener than an adjacent off-line pixel at the same row.
     ///
-    /// Uses a dark-blue texture so the guide's green channel stands out
+    /// Uses a dark-blue texture so the crosshair's green channel stands out
     /// even after blending over the frame.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_WithDarkTexture_CrosshairIsGreenDominantOverFrame()
+    public void Origin_WithDarkTexture_CrosshairIsGreenDominantOverFrame()
     {
         var ctx = ResetSingletons();
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
-            // Dark blue texture so guide green channel is distinguishable
+            // Dark blue texture so crosshair green channel is distinguishable
             WritePng(Path.Combine(dir, "dark.png"), new SKColor(0, 0, 60), size: 16);
             ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
 
@@ -227,16 +228,16 @@ public class GuidePanTests
             ctx.SelectedState.SelectedFrame = frame;
 
             var ctrl = ctx.CreatePreviewControl();
-            ctrl.ShowGuides = true;
+            ctrl.ShowOrigin = true;
 
             using var bm = ctrl.RenderToBitmap(64, 64);
 
-            // Vertical guide at x=42; sample inside the frame at y=38 (above horizontal crossing y=42)
-            var guideOverFrame = bm.GetPixel(42, 38);
-            var offGuide       = bm.GetPixel(47, 38);  // 5 px to the right, same row
+            // Vertical line at x=42; sample inside the frame at y=38 (above horizontal crossing y=42)
+            var crosshairOverFrame = bm.GetPixel(42, 38);
+            var offCrosshair       = bm.GetPixel(47, 38);  // 5 px to the right, same row
 
-            Assert.True(guideOverFrame.Green > offGuide.Green,
-                $"Guide pixel should be greener than off-guide pixel; guide G={guideOverFrame.Green} offGuide G={offGuide.Green}");
+            Assert.True(crosshairOverFrame.Green > offCrosshair.Green,
+                $"Crosshair pixel should be greener than off-line pixel; crosshair G={crosshairOverFrame.Green} offCrosshair G={offCrosshair.Green}");
         }
         finally
         {
@@ -255,11 +256,11 @@ public class GuidePanTests
     /// Old positions (42,25) and (25,42) should be background.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_PanXY8_BothLinesShiftToNewPosition()
+    public void Origin_PanXY8_BothLinesShiftToNewPosition()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         ctrl.SetPan(8f, 8f);
 
         using var bm = ctrl.RenderToBitmap(64, 64);
@@ -270,34 +271,34 @@ public class GuidePanTests
         var horzOld  = bm.GetPixel(25, 42);
 
         Assert.True(vertNew.Green > vertNew.Red,
-            $"Vertical guide at x=50; G={vertNew.Green} R={vertNew.Red}");
+            $"Vertical line at x=50; G={vertNew.Green} R={vertNew.Red}");
         Assert.True(horzNew.Green > horzNew.Red,
-            $"Horizontal guide at y=50; G={horzNew.Green} R={horzNew.Red}");
+            $"Horizontal line at y=50; G={horzNew.Green} R={horzNew.Red}");
         Assert.True(vertOld.Green <= vertOld.Red + 10,
             $"Old x=42 should be background; G={vertOld.Green} R={vertOld.Red}");
         Assert.True(horzOld.Green <= horzOld.Red + 10,
             $"Old y=42 should be background; G={horzOld.Green} R={horzOld.Red}");
     }
 
-    // ── Guide toggle: on → off → on restores same pixels ─────────────────────
+    // ── Crosshair toggle: on → off → on restores same pixels ─────────────────
 
     /// <summary>
-    /// Toggling ShowGuides off and back on should produce an identical bitmap
-    /// to the original ShowGuides=true render.
+    /// Toggling ShowOrigin off and back on should produce an identical bitmap
+    /// to the original ShowOrigin=true render.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_ToggleOffThenOn_ProducesIdenticalBitmap()
+    public void Origin_ToggleOffThenOn_ProducesIdenticalBitmap()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
 
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         using var bmOn1 = ctrl.RenderToBitmap(64, 64);
 
-        ctrl.ShowGuides = false;
+        ctrl.ShowOrigin = false;
         using var bmOff = ctrl.RenderToBitmap(64, 64);
 
-        ctrl.ShowGuides = true;
+        ctrl.ShowOrigin = true;
         using var bmOn2 = ctrl.RenderToBitmap(64, 64);
 
         // bmOn1 and bmOn2 must be identical
@@ -306,14 +307,14 @@ public class GuidePanTests
             for (int y = 0; y < 64 && allSame; y++)
                 allSame = bmOn1.GetPixel(x, y) == bmOn2.GetPixel(x, y);
 
-        Assert.True(allSame, "ShowGuides=true after toggle-off should produce same bitmap as before toggle");
+        Assert.True(allSame, "ShowOrigin=true after toggle-off should produce same bitmap as before toggle");
 
-        // bmOn1 and bmOff must differ (the guide pixels)
+        // bmOn1 and bmOff must differ (the crosshair pixels)
         bool anyDiff = false;
         for (int x = 0; x < 64 && !anyDiff; x++)
             for (int y = 0; y < 64 && !anyDiff; y++)
                 anyDiff = bmOn1.GetPixel(x, y) != bmOff.GetPixel(x, y);
 
-        Assert.True(anyDiff, "ShowGuides=false must produce a different bitmap than ShowGuides=true");
+        Assert.True(anyDiff, "ShowOrigin=false must produce a different bitmap than ShowOrigin=true");
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/OriginCrosshairPersistenceAcrossChainSwitchTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/OriginCrosshairPersistenceAcrossChainSwitchTests.cs
@@ -11,19 +11,17 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests that verify the guide crosshair in <see cref="PreviewControl"/>
-/// persists when the user switches between animation chains.
+/// Tests that verify the origin crosshair in <see cref="PreviewControl"/>
+/// persists when the user switches between animation chains. Not to be confused
+/// with user-placed guides — this covers the fixed crosshair through world origin
+/// (0,0), toggled by <see cref="PreviewControl.ShowOrigin"/>.
 ///
-/// Tutorial doc step:
-///   "Now that we have a guide which represents the ground we can select the
-///    other animation to see how it lines up."
-///
-/// The guide position is stored in <c>_panX/_panY</c> on <c>PreviewControl</c>.
+/// The crosshair position is stored in <c>_panX/_panY</c> on <c>PreviewControl</c>.
 /// <c>OnSelectionChanged</c> only calls <c>_playback.SetChain</c> and
-/// <c>InvalidateVisual</c> — it does NOT reset pan — so the guide MUST
+/// <c>InvalidateVisual</c> — it does NOT reset pan — so the crosshair MUST
 /// remain at the same pixel position after a chain switch.
 /// </summary>
-public class GuidePersistenceAcrossChainSwitchTests
+public class OriginCrosshairPersistenceAcrossChainSwitchTests
 {
     private static TestServices ResetSingletons() {
         var ctx = TestHelpers.BuildServices();
@@ -48,17 +46,17 @@ public class GuidePersistenceAcrossChainSwitchTests
         return path;
     }
 
-    // ── Guide stays at same X after chain switch ──────────────────────────────
+    // ── Crosshair stays at same X after chain switch ──────────────────────────
 
     /// <summary>
-    /// After setting PanX=+8 (guide vertical line at x = 42+8 = 50), switching
-    /// from "Idle" to "Run" must NOT move the guide — it must still be at x=50.
+    /// After setting PanX=+8 (crosshair vertical line at x = 42+8 = 50), switching
+    /// from "Idle" to "Run" must NOT move the crosshair — it must still be at x=50.
     ///
     /// The test uses two empty chains so any pixel difference between the two
-    /// renders is only due to guide position or texture content, not frame drawing.
+    /// renders is only due to crosshair position or texture content, not frame drawing.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_AfterChainSwitch_VerticalLineRemainsAtSameX()
+    public void Origin_AfterChainSwitch_VerticalLineRemainsAtSameX()
     {
         var ctx = ResetSingletons();
 
@@ -68,8 +66,8 @@ public class GuidePersistenceAcrossChainSwitchTests
         ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
-        ctrl.SetPan(8f, 0f); // vertical guide at x = (Width-20)/2+20+8 = 50
+        ctrl.ShowOrigin = true;
+        ctrl.SetPan(8f, 0f); // vertical line at x = (Width-20)/2+20+8 = 50
 
         ctx.SelectedState.SelectedChain = chainIdle;
         Dispatcher.UIThread.RunJobs();
@@ -79,24 +77,24 @@ public class GuidePersistenceAcrossChainSwitchTests
         Dispatcher.UIThread.RunJobs();
         using var bmRun = ctrl.RenderToBitmap(64, 64);
 
-        // Both renders must show the vertical guide at x=50 (green-dominant)
-        var idleGuidePixel = bmIdle.GetPixel(50, 25);
-        var runGuidePixel  = bmRun.GetPixel(50, 25);
-        var runOldPixel    = bmRun.GetPixel(42, 25);   // x=42 is old default centre
+        // Both renders must show the vertical line at x=50 (green-dominant)
+        var idlePixel   = bmIdle.GetPixel(50, 25);
+        var runPixel    = bmRun.GetPixel(50, 25);
+        var runOldPixel = bmRun.GetPixel(42, 25);   // x=42 is old default centre
 
-        Assert.True(idleGuidePixel.Green > idleGuidePixel.Red,
-            $"Idle: guide should be at x=50; G={idleGuidePixel.Green} R={idleGuidePixel.Red}");
-        Assert.True(runGuidePixel.Green > runGuidePixel.Red,
-            $"Run: guide must persist at x=50 after chain switch; G={runGuidePixel.Green} R={runGuidePixel.Red}");
+        Assert.True(idlePixel.Green > idlePixel.Red,
+            $"Idle: crosshair should be at x=50; G={idlePixel.Green} R={idlePixel.Red}");
+        Assert.True(runPixel.Green > runPixel.Red,
+            $"Run: crosshair must persist at x=50 after chain switch; G={runPixel.Green} R={runPixel.Red}");
         Assert.True(runOldPixel.Green <= runOldPixel.Red + 10,
-            $"Run: x=42 (old default) should NOT have guide; G={runOldPixel.Green} R={runOldPixel.Red}");
+            $"Run: x=42 (old default) should NOT have crosshair; G={runOldPixel.Green} R={runOldPixel.Red}");
     }
 
     /// <summary>
-    /// Same verification for the horizontal guide (PanY=+8 → guide at y=40).
+    /// Same verification for the horizontal line (PanY=+8 → line at y=40).
     /// </summary>
     [AvaloniaFact]
-    public void Guide_AfterChainSwitch_HorizontalLineRemainsAtSameY()
+    public void Origin_AfterChainSwitch_HorizontalLineRemainsAtSameY()
     {
         var ctx = ResetSingletons();
 
@@ -106,8 +104,8 @@ public class GuidePersistenceAcrossChainSwitchTests
         ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
-        ctrl.SetPan(0f, 8f); // horizontal guide at y = (Height-20)/2+20+8 = 50
+        ctrl.ShowOrigin = true;
+        ctrl.SetPan(0f, 8f); // horizontal line at y = (Height-20)/2+20+8 = 50
 
         ctx.SelectedState.SelectedChain = chainIdle;
         Dispatcher.UIThread.RunJobs();
@@ -120,19 +118,19 @@ public class GuidePersistenceAcrossChainSwitchTests
         var atOldY = bmRun.GetPixel(25, 42);
 
         Assert.True(atNewY.Green > atNewY.Red,
-            $"Horizontal guide should still be at y=50 after chain switch; G={atNewY.Green} R={atNewY.Red}");
+            $"Horizontal line should still be at y=50 after chain switch; G={atNewY.Green} R={atNewY.Red}");
         Assert.True(atOldY.Green <= atOldY.Red + 10,
-            $"y=42 (old default) should not have guide; G={atOldY.Green} R={atOldY.Red}");
+            $"y=42 (old default) should not have crosshair; G={atOldY.Green} R={atOldY.Red}");
     }
 
-    // ── Guide stays across multiple switches ──────────────────────────────────
+    // ── Crosshair stays across multiple switches ──────────────────────────────
 
     /// <summary>
     /// Switching chains multiple times (Idle→Run→Idle→Run) must not drift the
-    /// guide position. After four switches guide must be at the original offset.
+    /// crosshair position. After four switches it must be at the original offset.
     /// </summary>
     [AvaloniaFact]
-    public void Guide_MultipleChainSwitches_GuideDoesNotDrift()
+    public void Origin_MultipleChainSwitches_CrosshairDoesNotDrift()
     {
         var ctx = ResetSingletons();
 
@@ -142,8 +140,8 @@ public class GuidePersistenceAcrossChainSwitchTests
         ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
         var ctrl = ctx.CreatePreviewControl();
-        ctrl.ShowGuides = true;
-        ctrl.SetPan(8f, 8f); // guide at (50, 50)
+        ctrl.ShowOrigin = true;
+        ctrl.SetPan(8f, 8f); // crosshair at (50, 50)
 
         for (int i = 0; i < 4; i++)
         {
@@ -152,29 +150,29 @@ public class GuidePersistenceAcrossChainSwitchTests
         }
 
         using var bm = ctrl.RenderToBitmap(64, 64);
-        var vertGuide = bm.GetPixel(50, 25);  // vertical line at x=50
-        var horzGuide = bm.GetPixel(25, 50);  // horizontal line at y=50
+        var vertLine = bm.GetPixel(50, 25);  // vertical line at x=50
+        var horzLine = bm.GetPixel(25, 50);  // horizontal line at y=50
 
-        Assert.True(vertGuide.Green > vertGuide.Red,
-            $"After 4 switches vertical guide must still be at x=50; G={vertGuide.Green} R={vertGuide.Red}");
-        Assert.True(horzGuide.Green > horzGuide.Red,
-            $"After 4 switches horizontal guide must still be at y=50; G={horzGuide.Green} R={horzGuide.Red}");
+        Assert.True(vertLine.Green > vertLine.Red,
+            $"After 4 switches vertical line must still be at x=50; G={vertLine.Green} R={vertLine.Red}");
+        Assert.True(horzLine.Green > horzLine.Red,
+            $"After 4 switches horizontal line must still be at y=50; G={horzLine.Green} R={horzLine.Red}");
     }
 
-    // ── Guide persists with textured chains ───────────────────────────────────
+    // ── Crosshair persists with textured chains ────────────────────────────────
 
     /// <summary>
     /// Stronger test: both chains have textures. Even when the texture content
-    /// differs between chains, the guide must appear at the same pixel after the switch.
+    /// differs between chains, the crosshair must appear at the same pixel after the switch.
     ///
     /// Chain A (Idle): first chain.
     /// Chain B (Run):  second chain.
-    /// Guide: vertical at x=40 (PanX=+8 on 64×64 canvas).
+    /// Crosshair: vertical at x=40 (PanX=+8 on 64×64 canvas).
     /// After switching to Run, pixel at (40, 10) must still be green-dominant
-    /// (the guide rendered at that position).
+    /// (the crosshair rendered at that position).
     /// </summary>
     [AvaloniaFact]
-    public void Guide_WithTexturedChains_PersistsAfterSwitch()
+    public void Origin_WithTexturedChains_PersistsAfterSwitch()
     {
         var ctx = ResetSingletons();
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -187,8 +185,8 @@ public class GuidePersistenceAcrossChainSwitchTests
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainRun);
 
             var ctrl = ctx.CreatePreviewControl();
-            ctrl.ShowGuides = true;
-            ctrl.SetPan(8f, 0f); // vertical guide at x = 42+8 = 50
+            ctrl.ShowOrigin = true;
+            ctrl.SetPan(8f, 0f); // vertical line at x = 42+8 = 50
 
             // Select Idle chain
             ctx.SelectedState.SelectedChain = chainIdle;
@@ -200,14 +198,14 @@ public class GuidePersistenceAcrossChainSwitchTests
             Dispatcher.UIThread.RunJobs();
             using var bmRun = ctrl.RenderToBitmap(64, 64);
 
-            // Guide must appear at x=50 in BOTH renders (pan was not reset)
-            var idleGuide = bmIdle.GetPixel(50, 25);
-            var runGuide  = bmRun.GetPixel(50, 25);
+            // Crosshair must appear at x=50 in BOTH renders (pan was not reset)
+            var idlePixel = bmIdle.GetPixel(50, 25);
+            var runPixel  = bmRun.GetPixel(50, 25);
 
-            Assert.True(idleGuide.Green > idleGuide.Red,
-                $"Guide at x=50 must appear with Idle chain; G={idleGuide.Green} R={idleGuide.Red}");
-            Assert.True(runGuide.Green > runGuide.Red,
-                $"Guide at x=50 must persist after switching to Run; G={runGuide.Green} R={runGuide.Red}");
+            Assert.True(idlePixel.Green > idlePixel.Red,
+                $"Crosshair at x=50 must appear with Idle chain; G={idlePixel.Green} R={idlePixel.Red}");
+            Assert.True(runPixel.Green > runPixel.Red,
+                $"Crosshair at x=50 must persist after switching to Run; G={runPixel.Green} R={runPixel.Red}");
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewControlShowUserGuidesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewControlShowUserGuidesTests.cs
@@ -1,0 +1,128 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreviewControl.ShowUserGuides"/> — the toggle that hides/shows
+/// user-placed ruler guides (distinct from <see cref="PreviewControl.ShowOrigin"/>, which
+/// controls the unrelated origin crosshair).
+/// </summary>
+public class PreviewControlShowUserGuidesTests
+{
+    private static TestServices ResetSingletons() {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier             = 1f;
+        return ctx;
+    }
+
+    private static PreviewControl MakeArrangedControl(TestServices ctx)
+    {
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.Measure(new Size(64, 64));
+        ctrl.Arrange(new Rect(0, 0, 64, 64));
+        return ctrl;
+    }
+
+    [AvaloniaFact]
+    public void GetGuideCursorAt_GuidesHidden_ReturnsNull()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = MakeArrangedControl(ctx);
+        ctrl.AddHGuide(0f);   // world Y=0 → screen Y=42
+        ctrl.ShowUserGuides = false;
+
+        var cursor = ctrl.GetGuideCursorAt(30f, 42f);
+
+        Assert.Null(cursor);
+    }
+
+    [AvaloniaFact]
+    public void GuidesChanged_OnAddHGuide_Fires()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = ctx.CreatePreviewControl();
+        int fireCount = 0;
+        ctrl.GuidesChanged += () => fireCount++;
+
+        ctrl.AddHGuide(5f);
+
+        Assert.Equal(1, fireCount);
+    }
+
+    [AvaloniaFact]
+    public void ShowUserGuides_DefaultsToTrue()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = ctx.CreatePreviewControl();
+
+        Assert.True(ctrl.ShowUserGuides);
+    }
+
+    /// <summary>
+    /// A hidden guide must render identically to having no guide at all — not just
+    /// "less visible" but fully absent from the canvas.
+    /// </summary>
+    [AvaloniaFact]
+    public void ShowUserGuides_False_GuideLineNotRenderedInBitmap()
+    {
+        var ctx = ResetSingletons();
+        var ctrlBaseline = ctx.CreatePreviewControl();
+        using var bmBaseline = ctrlBaseline.RenderToBitmap(64, 64);
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SetGuides(hGuides: new[] { 0f }, vGuides: new[] { 0f });
+        ctrl.ShowUserGuides = false;
+        using var bmHidden = ctrl.RenderToBitmap(64, 64);
+
+        bool allSame = true;
+        for (int x = 0; x < 64 && allSame; x++)
+            for (int y = 0; y < 64 && allSame; y++)
+                allSame = bmBaseline.GetPixel(x, y) == bmHidden.GetPixel(x, y);
+
+        Assert.True(allSame, "ShowUserGuides=false must render identically to having no guides at all");
+    }
+
+    /// <summary>
+    /// Matches Photoshop: placing a new guide while existing guides are hidden reveals
+    /// them all again, so the user never silently stacks up guides they can't see.
+    /// </summary>
+    [AvaloniaFact]
+    public void ShowUserGuides_FalseThenAddHGuide_AutoRevealsGuides()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.ShowUserGuides = false;
+
+        ctrl.AddHGuide(0f);
+
+        Assert.True(ctrl.ShowUserGuides);
+    }
+
+    [AvaloniaFact]
+    public void SimulateRightClick_GuidesHidden_DoesNotRemoveGuide()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = MakeArrangedControl(ctx);
+        ctrl.AddHGuide(0f);   // world Y=0 → screen Y=42
+        ctrl.ShowUserGuides = false;
+
+        bool removed = ctrl.SimulateRightClick(30f, 42f);
+
+        Assert.False(removed);
+        Assert.Equal(1, ctrl.HGuideCount);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
@@ -500,20 +500,20 @@ public class VisualRenderTests
     }
 
     /// <summary>
-    /// ShowGuides draws a 1 px green cross-hair through the canvas centre.
-    /// Sampling the intersection pixel proves the agent can detect guide lines
-    /// rendered over a plain background.
+    /// ShowOrigin draws a 1 px green cross-hair through the canvas centre.
+    /// Sampling the intersection pixel proves the agent can detect the origin
+    /// crosshair rendered over a plain background.
     ///
-    /// Math (guide = SKColor(100,200,100,160) over background SKColor(30,30,30)):
+    /// Math (crosshair = SKColor(100,200,100,160) over background SKColor(30,30,30)):
     ///   R≈74, G≈137, B≈74  →  green channel is clearly dominant.
     /// </summary>
     [AvaloniaFact]
-    public void PreviewGuides_DrawGreenCrossHairAtCenter()
+    public void ShowOrigin_DrawGreenCrossHairAtCenter()
     {
         var ctx = ResetSingletons();
         var ctrl = ctx.CreatePreviewControl();
         ctrl.PauseAutoPlayback();
-        ctrl.ShowGuides = true;   // no chain; guides are drawn over dark background
+        ctrl.ShowOrigin = true;   // no chain; crosshair is drawn over dark background
 
         using var bm = ctrl.RenderToBitmap(64, 64);
 


### PR DESCRIPTION
## Summary
- Adds `PreviewControl.ShowUserGuides` to hide/show user-placed ruler guides in the preview panel; a hidden guide renders identically to no guide at all and can't be dragged or right-click-removed (nothing on screen to target).
- Renames the existing `ShowGuides`/"Guides" toggle to `ShowOrigin`/"Origin" — it actually controlled an unrelated origin crosshair, not user guides. This freed up "Guides" for the real feature and removes a pre-existing naming collision (mirrored in both the desktop `MainWindow` toolbar and the Browser/WASM toolbar).
- Placing a new guide while guides are hidden auto-reveals them all (matches Photoshop), so guides never silently pile up unseen.
- The "Guides" toggle only appears in the toolbar once at least one guide has been placed.

## Test plan
- [x] New unit tests in `PreviewControlShowUserGuidesTests.cs` (default-true, hidden-guide render, auto-reveal-on-add, hit-test suppression while hidden, `GuidesChanged` event)
- [x] Renamed/updated pre-existing crosshair tests (`OriginCrosshairPanTests.cs`, `OriginCrosshairPersistenceAcrossChainSwitchTests.cs`, `VisualRenderTests.cs`) to the new `ShowOrigin` name
- [x] Full Animation Editor solution build + test suite green (`AnimationEditor.App.Tests`, `.Core.Tests`, `.Views.Tests`, `.DocScreenshots` all pass individually)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)