### PR TITLE
Upgrade KernSmith.MonoGameGum/KniGum to 0.16.*

### DIFF
--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="Apos.Shapes" Version="$(AposShapesVersion)" />
     <PackageReference Include="Gum.MonoGame" Version="2026.7.9.1-preview.1" />
     <PackageReference Include="Gum.Shapes.MonoGame" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="KernSmith.MonoGameGum" Version="0.13.*" />
+    <PackageReference Include="KernSmith.MonoGameGum" Version="0.16.*" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -86,7 +86,7 @@
     <PackageReference Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
     <PackageReference Include="Gum.KNI" Version="2026.7.9.1-preview.1" />
     <PackageReference Include="Gum.Shapes.KNI" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="KernSmith.KniGum" Version="0.13.*" />
+    <PackageReference Include="KernSmith.KniGum" Version="0.16.*" />
     <PackageReference Include="KNI.Extended" Version="6.0.0" />
     <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
     <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />


### PR DESCRIPTION
## Summary
- Bumps `KernSmith.MonoGameGum` and `KernSmith.KniGum` from `0.13.*` to `0.16.*` (resolves to 0.16.0, released today).
- Release notes for 0.14.0–0.16.0 show no breaking API changes affecting `KernSmithFontCreator` / `InMemoryFontCreator` wiring.

## Test plan
- [x] `dotnet build src/FlatRedBall2.csproj -f net10.0` — builds clean (MonoGame/desktop backend)
- [x] `dotnet build src/FlatRedBall2.csproj -f net8.0` — builds clean (KNI/web backend)
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1173/1173 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)