### PR TITLE
Animation Editor: restore selected frame when switching tabs

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -637,7 +637,7 @@ public partial class MainWindow : Window
         _projectManager.AnimationChainListSave =
             tab.CachedEditorModel ?? new AnimationChainListSave();
         _projectManager.FileName = null;
-        _selectedState.Reset();
+        _appCommands.RestoreTabSelection(tab);
         _undoManager.Clear();
         if (tab.UndoSnapshot != null)
             _undoManager.RestoreSnapshot(tab.UndoSnapshot);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -191,7 +191,7 @@ public partial class App : Application
         // so cached tabs are already correctly "always trusted" here with no code changes needed.
         var tabManager = new TabManager();
         tabManager.OpenOrFocus(new FilePath("sample/player.achx"), "player.achx");
-        TabEditorCache.CaptureFromProject(tabManager.ActiveTab!, projectManager);
+        appCommands.CaptureTabEditorState(tabManager.ActiveTab!);
 
         var preview = new PreviewControl();
         preview.InitializeServices(
@@ -592,7 +592,7 @@ public partial class App : Application
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
             {
-                TabEditorCache.CaptureFromProject(leaving, projectManager);
+                appCommands.CaptureTabEditorState(leaving);
                 leaving.UndoSnapshot = undoManager.TakeSnapshot();
             }
 
@@ -615,12 +615,12 @@ public partial class App : Application
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
             {
-                TabEditorCache.CaptureFromProject(leaving, projectManager);
+                appCommands.CaptureTabEditorState(leaving);
                 leaving.UndoSnapshot = undoManager.TakeSnapshot();
             }
 
             tabManager.OpenOrFocus(new FilePath(displayName), displayName);
-            TabEditorCache.CaptureFromProject(tabManager.ActiveTab!, projectManager);
+            appCommands.CaptureTabEditorState(tabManager.ActiveTab!);
             undoManager.Clear();
             UpdateUndoRedoButtons();
             RebuildTabStrip();
@@ -1427,13 +1427,13 @@ public partial class App : Application
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
             {
-                TabEditorCache.CaptureFromProject(leaving, projectManager);
+                appCommands.CaptureTabEditorState(leaving);
                 leaving.UndoSnapshot = undoManager.TakeSnapshot();
             }
             appCommands.NewFile();
             var displayName = TabManager.ComputeUntitledDisplayName(tabManager.Tabs.Select(t => t.DisplayName).ToList());
             tabManager.OpenOrFocus(new FilePath($"untitled-{++untitledCounter}"), displayName);
-            TabEditorCache.CaptureFromProject(tabManager.ActiveTab!, projectManager);
+            appCommands.CaptureTabEditorState(tabManager.ActiveTab!);
             undoManager.Clear();
             UpdateUndoRedoButtons();
             animationTree.InitializeServices(selectedState, projectManager.AnimationChainListSave);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -250,8 +250,14 @@ namespace AnimationEditor.Core.CommandsAndState
         }
 
         /// <inheritdoc cref="IAppCommands.CaptureTabEditorState"/>
-        public void CaptureTabEditorState(TabEntry tab) =>
+        public void CaptureTabEditorState(TabEntry tab)
+        {
             TabEditorCache.CaptureFromProject(tab, _pm);
+            tab.CachedSelectedChainName = _selectedState.SelectedChain?.Name;
+            tab.CachedSelectedFrameIndex = _selectedState.SelectedFrame != null
+                ? _selectedState.SelectedChain?.Frames.IndexOf(_selectedState.SelectedFrame)
+                : null;
+        }
 
         /// <inheritdoc cref="IAppCommands.TryActivateTabFromCache"/>
         public bool TryActivateTabFromCache(TabEntry tab)
@@ -263,9 +269,7 @@ namespace AnimationEditor.Core.CommandsAndState
             }
 
             TabEditorCache.ApplyToProject(tab, _pm);
-
-            _selectedState.Reset();
-            _selectedState.SelectedChain = tab.CachedEditorModel?.AnimationChains.FirstOrDefault();
+            RestoreTabSelection(tab);
             // See the comment in FinishLoadIntoEditor: build already-expanded from the
             // companion file so reactivating a tab doesn't flicker collapsed-then-expanded.
             RebuildTreeViewRequested?.Invoke((IReadOnlyList<string>?)_ioManager.TryLoadCompanionSettings(tab.Path.FullPath)?.ExpandedNodes ?? Array.Empty<string>());
@@ -286,8 +290,53 @@ namespace AnimationEditor.Core.CommandsAndState
             if (TryActivateTabFromCache(tab))
                 return;
 
+            // FinishLoadIntoEditor resets selection to the first chain; keep the prior
+            // per-tab selection so we can restore it after the disk load.
+            string? chainName = tab.CachedSelectedChainName;
+            int? frameIndex = tab.CachedSelectedFrameIndex;
+
             await OpenAchxWorkflowAsync(tab.Path.FullPath);
+
+            tab.CachedSelectedChainName = chainName;
+            tab.CachedSelectedFrameIndex = frameIndex;
+            RestoreTabSelection(tab);
             CaptureTabEditorState(tab);
+        }
+
+        /// <inheritdoc cref="IAppCommands.RestoreTabSelection"/>
+        public void RestoreTabSelection(TabEntry tab) =>
+            RestoreSelection(tab.CachedSelectedChainName, tab.CachedSelectedFrameIndex);
+
+        /// <summary>
+        /// Applies chain/frame selection by name and frame index. Sets chain before frame
+        /// because <see cref="ISelectedState.SelectedChain"/> clears the frame.
+        /// </summary>
+        private void RestoreSelection(string? selectedChainName, int? selectedFrameIndex)
+        {
+            _selectedState.Reset();
+            var acls = _pm.AnimationChainListSave;
+            if (acls == null || selectedChainName == null)
+            {
+                if (acls != null)
+                    _selectedState.SelectedChain = acls.AnimationChains.FirstOrDefault();
+                return;
+            }
+
+            var restoredChain = acls.AnimationChains
+                .FirstOrDefault(c => c.Name == selectedChainName);
+            if (restoredChain == null)
+            {
+                _selectedState.SelectedChain = acls.AnimationChains.FirstOrDefault();
+                return;
+            }
+
+            _selectedState.SelectedChain = restoredChain;
+            if (selectedFrameIndex.HasValue &&
+                selectedFrameIndex.Value >= 0 &&
+                selectedFrameIndex.Value < restoredChain.Frames.Count)
+            {
+                _selectedState.SelectedFrame = restoredChain.Frames[selectedFrameIndex.Value];
+            }
         }
 
         public void RefreshTreeNode(AnimationChainSave animationChain) =>
@@ -1734,28 +1783,7 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Clear();
             _undoManager.MarkSaved();
 
-            // Restore selection
-            _selectedState.Reset();
-            var acls = _pm.AnimationChainListSave;
-            if (acls != null && selectedChainName != null)
-            {
-                var restoredChain = acls.AnimationChains
-                    .FirstOrDefault(c => c.Name == selectedChainName);
-                if (restoredChain != null)
-                {
-                    _selectedState.SelectedChain = restoredChain;
-                    if (selectedFrameIndex.HasValue &&
-                        selectedFrameIndex.Value >= 0 &&
-                        selectedFrameIndex.Value < restoredChain.Frames.Count)
-                    {
-                        _selectedState.SelectedFrame = restoredChain.Frames[selectedFrameIndex.Value];
-                    }
-                }
-                else
-                {
-                    _selectedState.SelectedChain = acls.AnimationChains.FirstOrDefault();
-                }
-            }
+            RestoreSelection(selectedChainName, selectedFrameIndex);
 
             // Refresh tree without collapsing (preserves expanded nodes)
             RefreshTreeViewRequested?.Invoke();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -84,7 +84,8 @@ namespace AnimationEditor.Core.CommandsAndState
         void LoadAnimationChain(string fileName);
 
         /// <summary>
-        /// Stores the current project model on <paramref name="tab"/> for later tab switches.
+        /// Stores the current project model and chain/frame selection on <paramref name="tab"/>
+        /// for later tab switches.
         /// </summary>
         void CaptureTabEditorState(TabEntry tab);
 
@@ -100,6 +101,13 @@ namespace AnimationEditor.Core.CommandsAndState
         /// <see cref="OpenAchxWorkflowAsync"/>. Does not restore undo.
         /// </summary>
         Task ActivateTabContentAsync(TabEntry tab);
+
+        /// <summary>
+        /// Restores chain/frame selection from <paramref name="tab"/>'s cached selection fields
+        /// onto the current project model. Call after applying a cached or untitled model that
+        /// does not go through <see cref="TryActivateTabFromCache"/>.
+        /// </summary>
+        void RestoreTabSelection(TabEntry tab);
 
         /// <summary>
         /// Raised after the in-memory project model is loaded or saved from disk so the app

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabEntry.cs
@@ -69,6 +69,19 @@ namespace AnimationEditor.Core.Models
         public DateTime? CachedDiskWriteTimeUtc { get; set; }
 
         /// <summary>
+        /// Name of the selected animation chain when this tab was last deactivated.
+        /// Session-only (not written to <c>.aeproperties</c>).
+        /// </summary>
+        public string? CachedSelectedChainName { get; set; }
+
+        /// <summary>
+        /// Index of the selected frame within <see cref="CachedSelectedChainName"/> when this
+        /// tab was last deactivated, or <c>null</c> when only the chain was selected.
+        /// Session-only (not written to <c>.aeproperties</c>).
+        /// </summary>
+        public int? CachedSelectedFrameIndex { get; set; }
+
+        /// <summary>
         /// The tab label. Returns <see cref="_displayNameOverride"/> when set;
         /// otherwise the filename without directory.
         /// </summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
@@ -28,13 +28,32 @@ public class TabSwitchCacheTests : IDisposable
 
     public void Dispose() => _dir.Dispose();
 
-    private string WriteAchx(string fileName, string chainName)
+    private string WriteAchx(string fileName, string chainName, int frameCount = 0)
     {
         var path = Path.Combine(_dir.Path, fileName);
         var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
-        acls.AnimationChains.Add(new AnimationChainSave { Name = chainName });
+        var chain = new AnimationChainSave { Name = chainName };
+        for (int i = 0; i < frameCount; i++)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = $"tex{i}.png", FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
         acls.Save(path);
         return path;
+    }
+
+    [Fact]
+    public void CaptureTabEditorState_PreservesEditsAcrossCacheRoundTrip()
+    {
+        string path = WriteAchx("edited.achx", "Idle");
+        var tab = new TabEntry(new FilePath(path));
+
+        _pm.LoadAnimationChain(new FilePath(path));
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+
+        _pm.AnimationChainListSave!.AnimationChains[0].Name = "Renamed";
+        _ctx.AppCommands.CaptureTabEditorState(tab);
+
+        TabEditorCache.ApplyToProject(tab, _pm);
+        Assert.Equal("Renamed", _pm.AnimationChainListSave!.AnimationChains[0].Name);
     }
 
     [Fact]
@@ -81,19 +100,32 @@ public class TabSwitchCacheTests : IDisposable
     }
 
     [Fact]
-    public void CaptureTabEditorState_PreservesEditsAcrossCacheRoundTrip()
+    public async Task TryActivateTabFromCache_WithSelectedFrame_RestoresFrameSelection()
     {
-        string path = WriteAchx("edited.achx", "Idle");
-        var tab = new TabEntry(new FilePath(path));
+        const string chainName = "Walk";
+        const int selectedFrameIndex = 1;
 
-        _pm.LoadAnimationChain(new FilePath(path));
-        _ctx.AppCommands.CaptureTabEditorState(tab);
+        string pathA = WriteAchx("a.achx", chainName, frameCount: 3);
+        string pathB = WriteAchx("b.achx", "Run");
+        var tabA = new TabEntry(new FilePath(pathA));
+        var tabB = new TabEntry(new FilePath(pathB));
 
-        _pm.AnimationChainListSave!.AnimationChains[0].Name = "Renamed";
-        _ctx.AppCommands.CaptureTabEditorState(tab);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(pathA);
+        var chain = _pm.AnimationChainListSave!.AnimationChains[0];
+        Assert.Equal(chainName, chain.Name);
+        _ctx.SelectedState.SelectedChain = chain;
+        _ctx.SelectedState.SelectedFrame = chain.Frames[selectedFrameIndex];
+        _ctx.AppCommands.CaptureTabEditorState(tabA);
 
-        TabEditorCache.ApplyToProject(tab, _pm);
-        Assert.Equal("Renamed", _pm.AnimationChainListSave!.AnimationChains[0].Name);
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(pathB);
+        _ctx.AppCommands.CaptureTabEditorState(tabB);
+
+        Assert.True(_ctx.AppCommands.TryActivateTabFromCache(tabA));
+        Assert.Equal(chainName, _ctx.SelectedState.SelectedChain!.Name);
+        Assert.NotNull(_ctx.SelectedState.SelectedFrame);
+        Assert.Same(
+            _ctx.SelectedState.SelectedChain.Frames[selectedFrameIndex],
+            _ctx.SelectedState.SelectedFrame);
     }
 
     private sealed class CountingProjectManager : IProjectManager

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -43,6 +43,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.OpenAchxWorkflowAsync)]              = Category.MutatingNotUndoable, // loads a file; clears the undo stack
         [nameof(IAppCommands.LoadAnimationChain)]                 = Category.MutatingNotUndoable, // loads a file; clears the undo stack
         [nameof(IAppCommands.CaptureTabEditorState)]              = Category.NonMutating,
+        [nameof(IAppCommands.RestoreTabSelection)]                = Category.NonMutating,
         [nameof(IAppCommands.TryActivateTabFromCache)]            = Category.MutatingNotUndoable, // swaps project model; undo restored by app layer
         [nameof(IAppCommands.ActivateTabContentAsync)]            = Category.MutatingNotUndoable, // tab switch load or cache restore
         [nameof(IAppCommands.ReloadAchxFromDisk)]                 = Category.MutatingNotUndoable, // hot-reload; clears the undo stack on success


### PR DESCRIPTION
## Summary
- Persist per-tab chain name + frame index on `TabEntry` and restore it on tab reactivation (same pattern as hot reload).
- Cover cache hits, disk-fallback reactivation, untitled tabs, and Browser tab switches via shared `CaptureTabEditorState` / `RestoreTabSelection`.
- Add `TryActivateTabFromCache_WithSelectedFrame_RestoresFrameSelection` to prove frame selection survives a switch away and back.

Closes #543

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ --filter TabSwitchCacheTests`
- [x] Headless UI screenshot: select Frame 2 → switch to second tab → switch back → Frame 2 still selected
- [ ] Manual: open two `.achx` tabs, select a frame, switch away and back, confirm tree/inspector/timeline keep the frame