### PR TITLE
Animation Editor: toggle to show/hide sprite bounding box in preview

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1185,12 +1185,8 @@
                                 BorderThickness="1" CornerRadius="4" ClipToBounds="True"
                                 Height="26" Margin="0,0,2,0" VerticalAlignment="Center">
                             <StackPanel Orientation="Horizontal">
-                                <!-- MinHeight 0 + Padding override (#501-style): Fluent forces a
-                                     ToggleButton min height of ~32 and a vertical Padding that, combined
-                                     with this Border's Height=26 + ClipToBounds, squeezed and clipped
-                                     text descenders (e.g. the "g" in "Magic"). -->
                                 <ToggleButton x:Name="MoveModeToggle"
-                                              Height="26" MinHeight="0" Padding="10,0"
+                                              Classes="toolbarToggle"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="3,0,0,3"
                                               ToolTip.Tip="Move mode — drag handles to resize/move frames">
@@ -1204,7 +1200,7 @@
                                 </ToggleButton>
                                 <Border Width="1" Background="{DynamicResource LineBrush}" />
                                 <ToggleButton x:Name="MagicWandToggle"
-                                              Height="26" MinHeight="0" Padding="10,0"
+                                              Classes="toolbarToggle"
                                               Foreground="{DynamicResource Ink}"
                                               CornerRadius="0,3,3,0"
                                               ToolTip.Tip="Magic Wand mode — hover to preview region; double-click to apply; Ctrl+click to add new frame">
@@ -1224,7 +1220,7 @@
                                 Margin="4,0" VerticalAlignment="Center" />
 
                         <ToggleButton x:Name="SnapToGridCheck"
-                                      Height="26"
+                                      Classes="toolbarToggle"
                                       Foreground="{DynamicResource Ink}"
                                       VerticalAlignment="Center"
                                       Margin="0,0,4,0"
@@ -1329,7 +1325,7 @@
                              convention already used for the property panel's coordinate fields. -->
                         <WrapPanel VerticalAlignment="Center">
                             <ToggleButton x:Name="OnionSkinToggle"
-                                          Height="26"
+                                          Classes="toolbarToggle"
                                           Foreground="{DynamicResource Ink}"
                                           ToolTip.Tip="Show previous frame at 50% alpha">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
@@ -1341,7 +1337,7 @@
                                 </StackPanel>
                             </ToggleButton>
                             <ToggleButton x:Name="ShowOriginCheck"
-                                          Height="26"
+                                          Classes="toolbarToggle"
                                           Foreground="{DynamicResource Ink}"
                                           VerticalAlignment="Center"
                                           Margin="4,0,4,0"
@@ -1355,7 +1351,7 @@
                                 </StackPanel>
                             </ToggleButton>
                             <ToggleButton x:Name="ShowBoundingBoxCheck"
-                                          Height="26"
+                                          Classes="toolbarToggle"
                                           Foreground="{DynamicResource Ink}"
                                           VerticalAlignment="Center"
                                           Margin="0,0,4,0"
@@ -1372,7 +1368,7 @@
                             <!-- Only shown once the user has placed at least one guide (#689) —
                                  see UpdateGuideToggleVisibility in MainWindow.axaml.cs. -->
                             <ToggleButton x:Name="ShowUserGuidesCheck"
-                                          Height="26"
+                                          Classes="toolbarToggle"
                                           Foreground="{DynamicResource Ink}"
                                           VerticalAlignment="Center"
                                           Margin="0,0,4,0"
@@ -1388,7 +1384,7 @@
                                 </StackPanel>
                             </ToggleButton>
                             <ToggleButton x:Name="InterpolateToggle"
-                                          Height="26"
+                                          Classes="toolbarToggle"
                                           Foreground="{DynamicResource Ink}"
                                           VerticalAlignment="Center"
                                           Margin="0,0,4,0"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1354,6 +1354,21 @@
                                     <TextBlock Text="Origin" VerticalAlignment="Center" />
                                 </StackPanel>
                             </ToggleButton>
+                            <ToggleButton x:Name="ShowBoundingBoxCheck"
+                                          Height="26"
+                                          Foreground="{DynamicResource Ink}"
+                                          VerticalAlignment="Center"
+                                          Margin="0,0,4,0"
+                                          IsChecked="True"
+                                          ToolTip.Tip="Show sprite bounding box outline">
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <svg:Svg Width="16" Height="16"
+                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconBoundingBox.svg"
+                                             CurrentColor="{DynamicResource IconInk}"
+                                             VerticalAlignment="Center" />
+                                    <TextBlock Text="Bounding Box" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </ToggleButton>
                             <!-- Only shown once the user has placed at least one guide (#689) —
                                  see UpdateGuideToggleVisibility in MainWindow.axaml.cs. -->
                             <ToggleButton x:Name="ShowUserGuidesCheck"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2066,6 +2066,9 @@ public partial class MainWindow : Window
         ShowOriginCheck.IsCheckedChanged += (_, _) =>
             PreviewCtrl.ShowOrigin = ShowOriginCheck.IsChecked == true;
 
+        ShowBoundingBoxCheck.IsCheckedChanged += (_, _) =>
+            PreviewCtrl.ShowBoundingBox = ShowBoundingBoxCheck.IsChecked == true;
+
         ShowUserGuidesCheck.IsCheckedChanged += (_, _) =>
         {
             if (_suppressGuideVisibilitySync) return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconBoundingBox.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconBoundingBox.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" stroke-dasharray="4,3"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
@@ -91,11 +91,11 @@
                     </WrapPanel>
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <ToggleButton x:Name="FrameFlipHToggle" x:FieldModifier="Public"
-                                      Height="26" MinHeight="0" Padding="10,0" Content="Flip H" />
+                                      Classes="toolbarToggle" Content="Flip H" />
                         <ToggleButton x:Name="FrameFlipVToggle" x:FieldModifier="Public"
-                                      Height="26" MinHeight="0" Padding="10,0" Content="Flip V" />
+                                      Classes="toolbarToggle" Content="Flip V" />
                         <ToggleButton x:Name="FrameFlipDToggle" x:FieldModifier="Public"
-                                      Height="26" MinHeight="0" Padding="10,0" Content="Flip D" />
+                                      Classes="toolbarToggle" Content="Flip D" />
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -113,6 +113,7 @@ public class PreviewControl : Control, IZoomTarget
     private bool _showOnionSkin;
     private bool _showOrigin;
     private bool _showUserGuides = true;
+    private bool _showBoundingBox = true;
     private bool _interpolateOffsets;
 
     // -- Pan drag --------------------------------------------------------------
@@ -206,6 +207,14 @@ public class PreviewControl : Control, IZoomTarget
     {
         get => _showUserGuides;
         set { _showUserGuides = value; InvalidateVisual(); }
+    }
+
+    /// <summary>Toggles the 1-px outline drawn around the rendered sprite. When <c>false</c>,
+    /// only the sprite itself is drawn — no outline around it or the onion-skin frame.</summary>
+    public bool ShowBoundingBox
+    {
+        get => _showBoundingBox;
+        set { _showBoundingBox = value; InvalidateVisual(); }
     }
 
     /// <summary>Fires whenever a guide is added, removed, or bulk-replaced via <see cref="SetGuides"/>.</summary>
@@ -522,7 +531,7 @@ public class PreviewControl : Control, IZoomTarget
         if (IsGroupPreviewActive)
         {
             return new RenderSnapshot(
-                null, null, _zoom, _panX, _panY, _showOrigin, _showUserGuides, null, null, width, height,
+                null, null, _zoom, _panX, _panY, _showOrigin, _showUserGuides, _showBoundingBox, null, null, width, height,
                 _appState!.OffsetMultiplier,
                 _hGuides.ToArray(), _vGuides.ToArray(),
                 _draggedGuideIdx, _draggingHGuide,
@@ -562,7 +571,7 @@ public class PreviewControl : Control, IZoomTarget
         var (frameOffX, frameOffY) = ResolveFrameOffset(chain, displayFrame, selectedFrame is not null);
 
         return new RenderSnapshot(displayFrame, onionFrame, _zoom, _panX, _panY,
-                                  _showOrigin, _showUserGuides, texPath, onionPath, width, height,
+                                  _showOrigin, _showUserGuides, _showBoundingBox, texPath, onionPath, width, height,
                                   _appState!.OffsetMultiplier,
                                   _hGuides.ToArray(), _vGuides.ToArray(),
                                   _draggedGuideIdx, _draggingHGuide,
@@ -2012,6 +2021,7 @@ public class PreviewControl : Control, IZoomTarget
         float  PanX, float PanY,
         bool   ShowOrigin,
         bool   ShowUserGuides,
+        bool   ShowBoundingBox,
         string? TexturePath,
         string? OnionTexturePath,
         float  Width, float Height,
@@ -2073,7 +2083,7 @@ public class PreviewControl : Control, IZoomTarget
 
                 float lcx = cx + layer.OffsetX * s.OffsetMultiplier * s.Zoom;
                 float lcy = cy - layer.OffsetY * s.OffsetMultiplier * s.Zoom;
-                DrawFrameCore(canvas, layer.Frame, layer.Color, limg, lcx, lcy, s.Zoom, alpha: 1.0f);
+                DrawFrameCore(canvas, layer.Frame, layer.Color, limg, lcx, lcy, s.Zoom, alpha: 1.0f, showOutline: s.ShowBoundingBox);
             }
         }
         else
@@ -2084,7 +2094,7 @@ public class PreviewControl : Control, IZoomTarget
             {
                 float ocx = cx + s.OnionFrame.RelativeX * s.OffsetMultiplier * s.Zoom;
                 float ocy = cy - s.OnionFrame.RelativeY * s.OffsetMultiplier * s.Zoom;
-                DrawFrameCore(canvas, s.OnionFrame, s.OnionColor, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f);
+                DrawFrameCore(canvas, s.OnionFrame, s.OnionColor, onionImg, ocx, ocy, s.Zoom, alpha: 0.4f, showOutline: s.ShowBoundingBox);
             }
 
             if (s.Frame is not null &&
@@ -2093,7 +2103,7 @@ public class PreviewControl : Control, IZoomTarget
             {
                 float fcx = cx + s.FrameOffsetX * s.OffsetMultiplier * s.Zoom;
                 float fcy = cy - s.FrameOffsetY * s.OffsetMultiplier * s.Zoom;
-                DrawFrameCore(canvas, s.Frame, s.FrameColor, img, fcx, fcy, s.Zoom, alpha: 1.0f);
+                DrawFrameCore(canvas, s.Frame, s.FrameColor, img, fcx, fcy, s.Zoom, alpha: 1.0f, showOutline: s.ShowBoundingBox);
             }
         }
 
@@ -2362,7 +2372,7 @@ public class PreviewControl : Control, IZoomTarget
 
     private static void DrawFrameCore(
         SKCanvas canvas, AnimationFrameSave frame, ResolvedFrameColor color, SKImage img,
-        float cx, float cy, float zoom, float alpha)
+        float cx, float cy, float zoom, float alpha, bool showOutline = true)
     {
         var (sx, sy, sw, sh) = ComputeSourceRect(frame, img.Width, img.Height);
 
@@ -2401,6 +2411,8 @@ public class PreviewControl : Control, IZoomTarget
         canvas.DrawImage(img, src, dst, sampling, paint);
 
         if (flip) canvas.Restore();
+
+        if (!showOutline) return;
 
         var outlineDst = ComputeOutlineDst(dst, frame.FlipDiagonal, cx, cy);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
@@ -48,6 +48,18 @@
     <Style Selector="Button:disabled">
         <Setter Property="Opacity" Value="0.35" />
     </Style>
+    <!-- Toolbar/inspector text ToggleButtons (Move, Magic Wand, Grid, Onion Skin, Origin,
+         Bounding Box, Guides, Interpolate, Flip H/V/D, ...): FluentTheme's default ToggleButton
+         MinHeight (~32) and vertical Padding clip text descenders (e.g. the "g" in "Magic")
+         once a fixed Height="26" is applied, because the squeeze happens inside the button's
+         own rounded-corner clip. Originally patched per-button (#501/#697-style); centralized
+         here so new toolbar toggles pick it up via Classes="toolbarToggle" instead of repeating
+         the two-setter override. -->
+    <Style Selector="ToggleButton.toolbarToggle">
+        <Setter Property="Height" Value="26"/>
+        <Setter Property="MinHeight" Value="0"/>
+        <Setter Property="Padding" Value="10,0"/>
+    </Style>
     <!-- Icon-based +/- buttons: render SVG from file so path data lives in one place only -->
     <Style Selector="Button.plus">
         <Setter Property="ContentTemplate">

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHandlesAndBorderTests.cs
@@ -442,6 +442,59 @@ public class WireframeHandlesAndBorderTests
         }
     }
 
+    /// <summary>
+    /// <see cref="PreviewControl.ShowBoundingBox"/> set to <c>false</c> suppresses the
+    /// frame outline entirely — the near-border pixel should read as plain background,
+    /// not the brightened outline stroke seen in <c>PreviewFrameBorder_LeftEdge_...</c>.
+    /// </summary>
+    [AvaloniaFact]
+    public void PreviewFrameBorder_ShowBoundingBoxFalse_LeftEdgeNotBrighterThanFarBackground()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = Path.Combine(dir, "dark.png");
+            using (var bmp = new SKBitmap(16, 16)) { bmp.Erase(new SKColor(0, 0, 60)); using var d = bmp.Encode(SKEncodedImageFormat.Png, 100); File.WriteAllBytes(texPath, d.ToArray()); }
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var frame = new AnimationFrameSave
+            {
+                TextureName = "dark.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave()
+            };
+            var chain = new AnimationChainSave { Name = "Test" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+
+            var ctrl = ctx.CreatePreviewControl();
+            ctrl.ShowBoundingBox = false;
+            using var bm = ctrl.RenderToBitmap(64, 64);
+
+            // Same sample points as PreviewFrameBorder_LeftEdge_BrighterThanFarBackground.
+            int maxRNearBorder = Enumerable.Range(33, 3)
+                .Where(x => x >= 0 && x < bm.Width)
+                .Select(x => (int)bm.GetPixel(x, 42).Red)
+                .Max();
+
+            var farBg = bm.GetPixel(22, 42);
+
+            Assert.True(maxRNearBorder <= farBg.Red + 60,
+                $"Frame border should be suppressed when ShowBoundingBox=false; nearMax R={maxRNearBorder} farBg R={farBg.Red}");
+        }
+        finally
+        {
+            ctx.ProjectManager.FileName = string.Empty;
+            ctx.SelectedState.SelectedFrame = null;
+            ctx.SelectedState.SelectedChain = null;
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     // ── Handles hidden when chain (not individual frame) is selected ──────────
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds a "Bounding Box" toolbar toggle to the preview panel, alongside Origin/Guides — default on, matching current behavior.
- When off, the 1-px outline `DrawFrameCore` draws around the rendered sprite (and onion-skin frame) is suppressed; only the sprite is drawn.

## Test plan
- [x] New unit test `PreviewFrameBorder_ShowBoundingBoxFalse_LeftEdgeNotBrighterThanFarBackground` confirms the outline pixel is suppressed when `ShowBoundingBox = false` (mirrors the existing `PreviewFrameBorder_LeftEdge_BrighterThanFarBackground` outline-present test).
- [x] Full `AnimationEditor.App.Tests` suite passes (701/701).

Closes #697