### PR TITLE
Add web (browser) link to Animation Editor download table

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Each sample is a complete runnable game built on the engine — open the source 
 | macOS (Apple Silicon) | [AnimationEditor-osx-arm64.zip](https://github.com/vchelaru/FlatRedBall2/releases/latest/download/AnimationEditor-osx-arm64.zip) |
 | macOS (Intel) | [AnimationEditor-osx-x64.zip](https://github.com/vchelaru/FlatRedBall2/releases/latest/download/AnimationEditor-osx-x64.zip) |
 | Linux (x64) | [AnimationEditor-linux-x64.tar.gz](https://github.com/vchelaru/FlatRedBall2/releases/latest/download/AnimationEditor-linux-x64.tar.gz) |
+| Web (browser, no install) | [Try it online](https://vchelaru.github.io/FlatRedBall2/AnimationEditor/) |
 
-The links above always resolve to the latest published release. Older versions are on the [Releases page](https://github.com/vchelaru/FlatRedBall2/releases).
+The downloads above always resolve to the latest published release. The web version is deployed manually and may lag behind; older release downloads are on the [Releases page](https://github.com/vchelaru/FlatRedBall2/releases).
 
 Binaries are unsigned. Windows SmartScreen will warn on first run ("More info" → "Run anyway"); macOS Gatekeeper will refuse to open directly — right-click the executable, choose Open, then confirm.
 


### PR DESCRIPTION
## Summary
- Adds a "Web (browser, no install)" row to the Animation Editor table in README.md, linking to the GitHub Pages deploy (https://vchelaru.github.io/FlatRedBall2/AnimationEditor/) from `deploy-animation-editor-web.yml`.
- Notes that the web build is deployed manually (`workflow_dispatch`) and may lag the source, unlike the binary downloads which always resolve to the latest release.

## Test plan
- [x] Docs-only change; no build/test impact.