### PR TITLE
Animation Editor: anchor major grid-line pattern to texture origin, not viewport

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
@@ -184,21 +184,25 @@ public class TextureViewport : Control, IZoomTarget
             float originX = s.PanX;
             float originY = s.PanY;
 
-            float FirstLine(float origin, float viewMin)
+            // n = how many grid steps this line sits from the texture origin (PanX/PanY). The
+            // major/minor pattern must key off n, not off "which line is first visible" — the
+            // latter shifts the pattern's phase every time the camera pans (#701).
+            (float pos, int n) FirstLine(float origin, float viewMin)
             {
-                float n = MathF.Ceiling((viewMin - origin) / step);
-                return origin + n * step;
+                int n = (int)MathF.Ceiling((viewMin - origin) / step);
+                return (origin + n * step, n);
             }
 
-            int index = 0;
-            for (float x = FirstLine(originX, viewL); x <= viewR; x += step, index++)
-                canvas.DrawLine(x, viewT, x, viewB,
-                    index % MajorGridLineInterval == 0 ? majorPaint : minorPaint);
+            // C#'s % can return negative for negative n; fold it into [0, interval).
+            bool IsMajor(int n) => ((n % MajorGridLineInterval) + MajorGridLineInterval) % MajorGridLineInterval == 0;
 
-            index = 0;
-            for (float y = FirstLine(originY, viewT); y <= viewB; y += step, index++)
-                canvas.DrawLine(viewL, y, viewR, y,
-                    index % MajorGridLineInterval == 0 ? majorPaint : minorPaint);
+            var (xStart, xIndex) = FirstLine(originX, viewL);
+            for (float x = xStart; x <= viewR; x += step, xIndex++)
+                canvas.DrawLine(x, viewT, x, viewB, IsMajor(xIndex) ? majorPaint : minorPaint);
+
+            var (yStart, yIndex) = FirstLine(originY, viewT);
+            for (float y = yStart; y <= viewB; y += step, yIndex++)
+                canvas.DrawLine(viewL, y, viewR, y, IsMajor(yIndex) ? majorPaint : minorPaint);
 
             // Keep textureDest referenced so callers/tests that pass it stay valid; the full-
             // viewport pass supersedes the old texture-only clip.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -218,6 +218,36 @@ public class GridRenderTests
         finally { System.IO.Directory.Delete(dir, true); }
     }
 
+    /// <summary>
+    /// Issue #701: the major-line pattern (every 4th line brighter) must stay anchored to the
+    /// texture origin (PanX/PanY), not to whichever line happens to be first visible. With
+    /// gridSize=8, majors sit at texture-space multiples of 32. Panning the camera by -16 (a
+    /// half-major, non-multiple-of-32 offset) moves the texture origin off past the left edge:
+    /// screen x=0 now maps to texture x=16 (minor) and screen x=16 maps to texture x=32 (major).
+    /// Before the fix, the emphasis index reset to 0 at the first visible line (screen x=0),
+    /// so x=0 was wrongly marked major and x=16 wrongly marked minor.
+    /// </summary>
+    [AvaloniaFact]
+    public void Grid_PannedCamera_MajorLinePatternStaysAnchoredToTextureOrigin()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, dir) = BuildCtrl(ctx);
+        try
+        {
+            ctrl.SetGrid(true, 8);
+            ctrl.SetCamera(-16, -16, 1);   // shift origin by half a major interval
+            using var bm = ctrl.RenderToBitmap(64, 64);
+
+            int atZero = ScanMaxRed(bm, centerX: 0, y: 4);
+            int atSixteen = ScanMaxRed(bm, centerX: 16, y: 4);
+
+            Assert.True(atSixteen > atZero,
+                $"Major line should land at screen x=16 (texture x=32, a multiple of the major interval), " +
+                $"not x=0 (texture x=16): atSixteen={atSixteen}, atZero={atZero}");
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
     // ── Visual: guard cases ───────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Every 4th grid line ("major") was marked by an index that reset to 0 at whichever line happened to be first visible on screen, so panning/zooming the camera shifted which lines were emphasized.
- Fixed so the major/minor pattern derives from the line's offset from the texture origin (PanX/PanY) — i.e. the sprite's top-left corner — so it never shifts as the camera moves.

## Test plan
- Added `Grid_PannedCamera_MajorLinePatternStaysAnchoredToTextureOrigin` (fails on old code, passes on new).
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 707 passed.
- Full solution test run — 1 unrelated pre-existing flake (`DeleteCircle` recovery-file contention under parallel test execution), confirmed passes in isolation and is unrelated to this change.

Closes #701