### PR TITLE
Tests: fix nullable-reference warnings in tween/GumHud tests

### DIFF
--- a/tests/FlatRedBall2.Tests/GumHudTests.cs
+++ b/tests/FlatRedBall2.Tests/GumHudTests.cs
@@ -169,8 +169,9 @@ public class GumHudTests
         entity.IsVisible = false;
 
         var renderable = (IAttachable)screen.GumRenderables[0];
-        renderable.Parent.ShouldBe(entity);
-        renderable.Parent.IsAbsoluteVisible.ShouldBeFalse();
+        var parent = renderable.Parent;
+        parent.ShouldBe(entity);
+        parent!.IsAbsoluteVisible.ShouldBeFalse();
     }
 
     // EntityVisualsRoot is the screen-level root that entity-attached Gum visuals are parented

--- a/tests/FlatRedBall2.Tests/Tweening/EntityColorTweenTests.cs
+++ b/tests/FlatRedBall2.Tests/Tweening/EntityColorTweenTests.cs
@@ -120,7 +120,7 @@ public class EntityColorTweenTests
         var entity = factory.Create();
 
         Should.Throw<ArgumentNullException>(() =>
-            entity.Tween((Action<Color>)null, Color.Black, Color.White, TimeSpan.FromSeconds(1)));
+            entity.Tween((Action<Color>)null!, Color.Black, Color.White, TimeSpan.FromSeconds(1)));
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Tweening/EntityVector2TweenTests.cs
+++ b/tests/FlatRedBall2.Tests/Tweening/EntityVector2TweenTests.cs
@@ -66,6 +66,6 @@ public class EntityVector2TweenTests
         var entity = factory.Create();
 
         Should.Throw<ArgumentNullException>(() =>
-            entity.Tween((Action<Vector2>)null, Vector2.Zero, Vector2.One, TimeSpan.FromSeconds(1)));
+            entity.Tween((Action<Vector2>)null!, Vector2.Zero, Vector2.One, TimeSpan.FromSeconds(1)));
     }
 }


### PR DESCRIPTION
## Summary
- Mechanical fix for the three CS8600/CS8625/CS8602 nullable-reference warnings called out in #704.
- `EntityVector2TweenTests`/`EntityColorTweenTests`: suppress the intentional-null-setter test argument with `!`.
- `GumHudTests.cs`: capture `renderable.Parent` into a local so the compiler can see it's guarded by the preceding `ShouldBe` assertion.

## Test plan
- [x] `dotnet build tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj` — the three target warnings are gone (two unrelated `Line.cs` cref warnings remain, out of scope).
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1172 passed, 0 failed.

Closes #704