### PR TITLE
Fix flaky UndoCoverageRosterTests recovery-file race

### DIFF
--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
@@ -34,6 +34,10 @@ internal sealed class TestServices
         SelectedState     = new SelectedState(ProjectManager);
         AppState          = new AppState(ApplicationEvents, SelectedState);
         IoManager         = new IoManager(AppState);
+        // Each instance gets its own recovery path so concurrent test classes never
+        // race on the shared default temp file (see issue #703).
+        IoManager.RecoveryFilePath = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "AnimationEditorCoreTests", $"recovery_{Guid.NewGuid():N}.achx");
         ObjectFinder      = new ObjectFinder(ProjectManager);
         UndoManager       = new UndoManager();
         AppCommands       = new AppCommands(ProjectManager, SelectedState, ApplicationEvents,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestServicesRecoveryPathTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestServicesRecoveryPathTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Guards against the shared-recovery-file-path race (issue #703): every
+/// <see cref="TestServices"/> instance must get its own <c>RecoveryFilePath</c>
+/// so concurrent test classes never write to the same temp file.
+/// </summary>
+public class TestServicesRecoveryPathTests
+{
+    [Fact]
+    public void TwoInstances_GetDifferentRecoveryFilePaths()
+    {
+        var first = TestHelpers.SetupFreshAcls();
+        var second = TestHelpers.SetupFreshAcls();
+
+        Assert.NotEqual(first.IoManager.RecoveryFilePath, second.IoManager.RecoveryFilePath);
+    }
+
+    [Fact]
+    public void RecoveryFilePath_IsNotTheSharedDefaultTempPath()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+
+        var sharedDefault = Path.Combine(Path.GetTempPath(), "AnimationEditor_Recovery.achx");
+
+        Assert.NotEqual(sharedDefault, ctx.IoManager.RecoveryFilePath);
+    }
+}


### PR DESCRIPTION
## Summary
- `TestServices` (shared per-test service builder in `AnimationEditor.Core.Tests`) built every test's `IoManager` with the fixed default `RecoveryFilePath`, so concurrent xUnit test classes racing through `WriteRecoveryFile` could collide on the same `.tmp` file and throw `IOException`.
- Fixed by assigning a unique GUID-based recovery path per `TestServices` instance in the constructor, closing off the whole class of collision instead of requiring each new test file to remember to override it (as `AppCommandsRecoveryTests`/`IoManagerRecoveryTests` already did).

## Test plan
- [x] Added `TestServicesRecoveryPathTests` — fails before the fix (two instances shared the same path / matched the hardcoded shared default), passes after.
- [x] `dotnet test tests/AnimationEditor.Core.Tests` — 1622 passed.
- [x] Full-solution `dotnet test AnimationEditorAvalonia.slnx` run twice clean (no IOException).

Closes #703