### PR TITLE
Extract shared "leaving tab" capture couplet into Core TabController (#714)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -56,6 +56,7 @@ public partial class MainWindow : Window
 
     private AppSettingsModel _appSettings = new();
     private readonly TabManager _tabManager = new();
+    private readonly TabController _tabController;
 
     // ── Tab drag state ────────────────────────────────────────────────────────
     private TabEntry? _dragTab;
@@ -189,6 +190,10 @@ public partial class MainWindow : Window
         _pendingCutState = pendingCutState;
         _thumbnailService = thumbnailService;
         _fileAssociation = fileAssociation;
+        // Desktop renders the tree with its own _treeRoots collection, so the controller
+        // reads expand state from there (browser reads its AnimationTreeControl instead).
+        _tabController = new TabController(_undoManager, _appCommands,
+            () => TreeBuilder.CaptureExpandState(_treeRoots));
 
         InitializeComponent();
 
@@ -468,9 +473,7 @@ public partial class MainWindow : Window
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab is { Kind: TabKind.Achx })
         {
-            leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
-            _appCommands.CaptureTabEditorState(leavingTab);
-            CaptureTreeExpandStateForLeavingTab(leavingTab);
+            _tabController.CaptureLeavingTab(leavingTab);
             SaveCompanionFile();
         }
 
@@ -598,9 +601,7 @@ public partial class MainWindow : Window
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab is { Kind: TabKind.Achx })
         {
-            leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
-            _appCommands.CaptureTabEditorState(leavingTab);
-            CaptureTreeExpandStateForLeavingTab(leavingTab);
+            _tabController.CaptureLeavingTab(leavingTab);
         }
 
         // PNG tabs bypass the animation-editor machinery entirely.
@@ -3171,15 +3172,6 @@ public partial class MainWindow : Window
     /// steps land in separate dispatcher jobs. Contrast with <see cref="RefreshTreeView"/>,
     /// which diff-updates and preserves each chain's collapse state across edits.
     /// </summary>
-    /// <summary>
-    /// Snapshots the tree's current expand state (including frame nodes with shape children,
-    /// which have no other persistence) onto <paramref name="leavingTab"/> so it survives the
-    /// full rebuild that reactivating a tab triggers (see <see cref="RebuildTreeView"/>). Call
-    /// immediately after <c>_appCommands.CaptureTabEditorState</c> at every "leaving tab" site (#687).
-    /// </summary>
-    private void CaptureTreeExpandStateForLeavingTab(TabEntry leavingTab) =>
-        leavingTab.CachedTreeExpandState = TreeBuilder.CaptureExpandState(_treeRoots);
-
     private void RebuildTreeView(IReadOnlyList<string> expandedChainNames)
     {
         _suppressTreeSelectionHandling = true;
@@ -4614,9 +4606,7 @@ public partial class MainWindow : Window
         var leavingTab = _tabManager.ActiveTab;
         if (leavingTab is { Kind: TabKind.Achx })
         {
-            leavingTab.UndoSnapshot = _undoManager.TakeSnapshot();
-            _appCommands.CaptureTabEditorState(leavingTab);
-            CaptureTreeExpandStateForLeavingTab(leavingTab);
+            _tabController.CaptureLeavingTab(leavingTab);
         }
 
         // If there is already a file open that hasn't been registered as a tab yet,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -215,6 +215,10 @@ public partial class App : Application
         // controls are independent of each other and of PreviewControl -- any of the three can
         // drive ISelectedState, and the others react via SelectionChanged.
         var animationTree = new AnimationTreeControl();
+        // Browser renders the tree with AnimationTreeControl, so the controller reads expand
+        // state from there (desktop reads its own _treeRoots collection instead).
+        var tabController = new TabController(undoManager, appCommands,
+            () => animationTree.CaptureExpandState());
         var inspector = new InspectorControl();
         inspector.InitializeServices(selectedState);
         inspector.EnableEditing(appCommands, textureName =>
@@ -596,12 +600,7 @@ public partial class App : Application
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
             {
-                appCommands.CaptureTabEditorState(leaving);
-                leaving.UndoSnapshot = undoManager.TakeSnapshot();
-                // #687: snapshot tree expand state (including frame nodes with shape children,
-                // which have no other persistence) so it survives the InitializeServices rebuild
-                // below when the user switches back to this tab.
-                leaving.CachedTreeExpandState = animationTree.CaptureExpandState();
+                tabController.CaptureLeavingTab(leaving);
             }
 
             tabManager.Activate(target.Path);
@@ -624,8 +623,7 @@ public partial class App : Application
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
             {
-                appCommands.CaptureTabEditorState(leaving);
-                leaving.UndoSnapshot = undoManager.TakeSnapshot();
+                tabController.CaptureLeavingTab(leaving);
             }
 
             tabManager.OpenOrFocus(new FilePath(displayName), displayName);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabController.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabController.cs
@@ -1,0 +1,47 @@
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.Models
+{
+    /// <summary>
+    /// Host-agnostic orchestration of the Animation Editor's open tabs, shared by the desktop
+    /// and browser hosts. Currently owns the "leaving tab" capture couplet; broader
+    /// tab-switch/close sequencing migrates here incrementally (issue #714).
+    /// </summary>
+    public sealed class TabController
+    {
+        private readonly IUndoManager _undoManager;
+        private readonly IAppCommands _appCommands;
+        private readonly Func<Dictionary<object, bool>> _captureTreeExpandState;
+
+        /// <param name="captureTreeExpandState">
+        /// Host callback returning the live tree's current expand state. Kept as a callback
+        /// because the two hosts render the tree with different controls (desktop reads its
+        /// <c>_treeRoots</c>; browser reads its <c>AnimationTreeControl</c>).
+        /// </param>
+        public TabController(
+            IUndoManager undoManager,
+            IAppCommands appCommands,
+            Func<Dictionary<object, bool>> captureTreeExpandState)
+        {
+            _undoManager = undoManager;
+            _appCommands = appCommands;
+            _captureTreeExpandState = captureTreeExpandState;
+        }
+
+        /// <summary>
+        /// Snapshots everything the tab being deactivated needs to restore later — its undo
+        /// history, in-memory editor model + selection, and tree expand state (including frame
+        /// nodes with shape children, which have no other persistence, #687). Call at every
+        /// "leaving tab" site so no site can silently drop one of the three and reintroduce #687.
+        /// </summary>
+        public void CaptureLeavingTab(TabEntry leaving)
+        {
+            leaving.UndoSnapshot = _undoManager.TakeSnapshot();
+            _appCommands.CaptureTabEditorState(leaving);
+            leaving.CachedTreeExpandState = _captureTreeExpandState();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabControllerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabControllerTests.cs
@@ -1,0 +1,40 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Verifies the shared "leaving tab" capture couplet lives in one place so neither host can
+/// drop one of the three captured pieces and reintroduce #687 (lost tree expand state).
+/// </summary>
+public class TabControllerTests
+{
+    private sealed class StubCommand : IUndoableCommand
+    {
+        public string Description => "Stub";
+        public bool Do() => true;
+        public void Undo() { }
+    }
+
+    [Fact]
+    public void CaptureLeavingTab_CapturesUndoEditorAndTreeExpandState()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        TestHelpers.MakeChain(ctx.Acls, "Idle");
+        // A recorded command makes the undo snapshot non-trivial, proving it was captured.
+        ctx.UndoManager.Execute(new StubCommand());
+
+        var expandState = new Dictionary<object, bool> { [new object()] = true };
+        var controller = new TabController(ctx.UndoManager, ctx.AppCommands, () => expandState);
+        var tab = new TabEntry(new FilePath(""));
+
+        controller.CaptureLeavingTab(tab);
+
+        Assert.Single(tab.UndoSnapshot!.UndoStack);           // undo history captured
+        Assert.NotNull(tab.CachedEditorModel);                // in-memory editor model captured
+        Assert.Same(expandState, tab.CachedTreeExpandState);  // #687 tree expand state captured
+    }
+}


### PR DESCRIPTION
First small step toward #714 (shared app-shell orchestration between desktop and browser hosts).

## What
Extracts the duplicated "leaving tab" capture couplet — snapshot undo history, capture editor model+selection, capture tree expand state — into a new host-agnostic `AnimationEditor.Core.Models.TabController.CaptureLeavingTab`. Both hosts now call it instead of open-coding the three captures at every tab-switch/open site.

The tree-expand-state capture is the #687 fix; it had to be added in both hosts (fixed twice in #713) exactly because the sequence lived inline per host. One host-specific bit remains — reading the live tree — passed as a callback (desktop reads `_treeRoots`, browser reads its `AnimationTreeControl`).

## Scope
Deliberately small (user asked for a small step). This is the capture half only; the broader tab-switch/close/rebuild sequencing migrates to `TabController` incrementally in follow-ups.

## Notes
- Browser's open-new-tab path previously captured only undo + editor state, **not** tree expand — routing it through `CaptureLeavingTab` closes that latent #687-style gap.
- Re-attaches a mis-placed XML doc block onto desktop `RebuildTreeView`.
- The browser tab sequence is now unit-testable in Core for the first time.

## Tests
- New `Core.Tests/TabControllerTests` asserts all three pieces are captured together.
- All green: 1626 Core + 708 App (incl. desktop #687 / per-tab-undo regression tests). Both hosts build with 0 warnings.

Part of #714 (first step) — the issue stays open for the remaining sequencing extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)