### PR TITLE
Show a "Frame N" hover notch on the wireframe panel

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -223,7 +223,7 @@ public partial class MainWindow : Window
         WireTabBar();
         WireDefaultHandlerBanner();
 
-        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
+        WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState, _objectFinder, msg => ShowStatusMessage(msg, isError: true));
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
         FilesPanel.Initialize(_thumbnailService, this,
             msg => ShowStatusMessage(msg, isError: true), OpenPngAsTab);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -207,7 +207,7 @@ public partial class App : Application
         var wireframe = new WireframeControl();
         wireframe.InitializeServices(
             selectedState, appState, appCommands, applicationEvents,
-            projectManager, undoManager, pendingCutState,
+            projectManager, undoManager, pendingCutState, objectFinder,
             thumbnailService: thumbnailService);
 
         // Phase 1 (#603): read-only browsing of every chain/frame/shape in the loaded file,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Data;
 using AnimationEditor.Core.Rendering;
+using AnimationEditor.Core.ViewModels;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -61,6 +62,15 @@ public class WireframeControl : TextureViewport
         public float? OriginTexX, OriginTexY;
         public List<SKRect> PendingCutFrameBounds = new();
         /// <summary>
+        /// Texture-space bounds of the frame currently under the mouse (#718). Null when
+        /// nothing is hovered. Paired with <see cref="HoverLabel"/>, which is resolved on the
+        /// UI thread in <see cref="BuildSnapshot"/> so the render thread never touches
+        /// <see cref="AnimationFrameSave"/>/<see cref="AnimationChainSave"/> objects.
+        /// </summary>
+        public SKRect? HoverFrameBounds;
+        /// <summary>"Frame N" label for <see cref="HoverFrameBounds"/>; null when nothing is hovered.</summary>
+        public string? HoverLabel;
+        /// <summary>
         /// Selection-outline reveal progress (#542): 0 = full bump, 1 = settled.
         /// Same curve as the PNG diff boxes via <see cref="RevealAnimation"/>.
         /// </summary>
@@ -108,6 +118,12 @@ public class WireframeControl : TextureViewport
             canvas.DrawRect(sr, frameFill);
             canvas.DrawRect(sr, frameStroke);
         }
+
+        // Hover label (#718): a small screen-space notch anchored at the top-left corner of
+        // the hovered frame. Fixed pixel font size (never multiplied by s.Zoom) so it reads the
+        // same size at any zoom level, unlike the frame rects it's attached to.
+        if (s.HoverFrameBounds.HasValue && s.HoverLabel != null)
+            DrawHoverLabel(canvas, SnapToScreen(s.HoverFrameBounds.Value, s), s.HoverLabel);
 
         // Pending-cut frames: dashed orange overlay (distinct from selection blue).
         if (s.PendingCutFrameBounds.Count > 0)
@@ -158,6 +174,35 @@ public class WireframeControl : TextureViewport
             using var dotPaint = new SKPaint { Color = new SKColor(255, 220, 0, 230) };
             canvas.DrawCircle(ox, oy, 2f, dotPaint);
         }
+    }
+
+    private static readonly SKColor HoverLabelBackground = new(80, 160, 255, 235);
+
+    /// <summary>
+    /// Draws the "Frame N" hover notch (#718) as a filled tag anchored at the top-left corner
+    /// of <paramref name="sr"/> (already screen-space), sized purely in fixed pixels so it never
+    /// scales with zoom the way the frame rect itself does.
+    /// </summary>
+    private static void DrawHoverLabel(SKCanvas canvas, SKRect sr, string label)
+    {
+        const float PadX = 5f;
+        const float PadY = 3f;
+
+        using var font = new SKFont { Size = 12f };
+        float textWidth = font.MeasureText(label);
+        float tagHeight = font.Size + PadY * 2f;
+        float tagWidth = textWidth + PadX * 2f;
+
+        // Anchored above the frame's top-left corner; clamp so it never draws off the top edge.
+        float tagLeft = sr.Left;
+        float tagTop = MathF.Max(0f, sr.Top - tagHeight);
+
+        var tagRect = new SKRect(tagLeft, tagTop, tagLeft + tagWidth, tagTop + tagHeight);
+        using var bgPaint = new SKPaint { Color = HoverLabelBackground, IsAntialias = true };
+        canvas.DrawRoundRect(tagRect, 3f, 3f, bgPaint);
+
+        using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+        canvas.DrawText(label, tagLeft + PadX, tagTop + tagHeight - PadY, font, textPaint);
     }
 
     private const float Hs = 5f;  // Handle half-size: handles are drawn this far outside the frame edge
@@ -242,6 +287,9 @@ public class WireframeControl : TextureViewport
             ? _frameRects.FirstOrDefault(fr => fr.Frame == f)
             : null;
     }
+
+    /// <summary>Frame currently under the mouse (#718), for the "Frame N" hover notch. Null when nothing is hovered.</summary>
+    private FrameRect? _hoverFrame;
 
     private FrameRect? _draggingRect;
     private HandleKind _draggingHandle;
@@ -342,6 +390,7 @@ public class WireframeControl : TextureViewport
     private IApplicationEvents? _events;
     private IProjectManager? _projectManager;
     private IUndoManager? _undoManager;
+    private IObjectFinder? _objectFinder;
     private Action<string>? _showError;
     private ThumbnailService? _thumbnailService;
 
@@ -365,6 +414,7 @@ public class WireframeControl : TextureViewport
         IProjectManager projectManager,
         IUndoManager undoManager,
         IPendingCutState pendingCutState,
+        IObjectFinder objectFinder,
         Action<string>? showError = null,
         ThumbnailService? thumbnailService = null)
     {
@@ -375,6 +425,7 @@ public class WireframeControl : TextureViewport
         _events          = events;
         _projectManager  = projectManager;
         _undoManager     = undoManager;
+        _objectFinder    = objectFinder;
         _showError       = showError;
         _thumbnailService = thumbnailService;
 
@@ -1086,6 +1137,12 @@ public class WireframeControl : TextureViewport
         foreach (var fr in _frameRects)
             snap.Frames.Add((fr.Bounds, fr.IsSelected));
 
+        if (_hoverFrame != null)
+        {
+            snap.HoverFrameBounds = _hoverFrame.Bounds;
+            snap.HoverLabel = ResolveHoverLabel(_hoverFrame);
+        }
+
         snap.PendingCutFrameBounds.AddRange(BuildPendingCutFrameBounds());
         snap.SelectionRevealProgress = _selectionRevealProgress;
         snap.HandleAlpha = RevealAnimation.HandleAlpha(_selectionRevealProgress);
@@ -1261,6 +1318,62 @@ public class WireframeControl : TextureViewport
 
         // Update hover preview for magic-wand / grid-snap
         UpdatePreview(pos);
+
+        UpdateHoverFrame(pos);
+    }
+
+    /// <summary>
+    /// Hit-tests <paramref name="pos"/> against <see cref="_frameRects"/> (#718) and updates
+    /// <see cref="_hoverFrame"/> for the "Frame N" hover notch. Only invalidates when the hovered
+    /// frame identity actually changes, mirroring the reveal's identity-diffing (see
+    /// <see cref="SelectedFramesIdentityChanged"/>) so a move within the same frame's bounds
+    /// doesn't repaint every tick.
+    /// </summary>
+    private void UpdateHoverFrame(Point pos)
+    {
+        if (_bitmap is null) { ClearHoverFrame(); return; }
+
+        var world = ScreenToTexture((float)pos.X, (float)pos.Y);
+        var hit = _frameRects.FirstOrDefault(fr => fr.Bounds.Contains(world));
+
+        if (!ReferenceEquals(hit, _hoverFrame))
+        {
+            _hoverFrame = hit;
+            InvalidateVisual();
+        }
+    }
+
+    private void ClearHoverFrame()
+    {
+        if (_hoverFrame != null)
+        {
+            _hoverFrame = null;
+            InvalidateVisual();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the "Frame N" label (<see cref="TreeBuilder.BuildFrameHeader"/>) for
+    /// <paramref name="fr"/> via its owning chain's frame index. Null if the frame's chain can't
+    /// be found (e.g. it was removed mid-hover).
+    /// </summary>
+    private string? ResolveHoverLabel(FrameRect fr)
+    {
+        var chain = _objectFinder?.GetAnimationChainContaining(fr.Frame);
+        if (chain is null) return null;
+        int index = chain.Frames.IndexOf(fr.Frame);
+        return TreeBuilder.BuildFrameHeader(fr.Frame, index);
+    }
+
+    /// <summary>
+    /// Test-only: runs the same hover hit-test as <see cref="OnEditPointerMoved"/> for a given
+    /// screen point and returns the resolved label (mirrors <see cref="GetPreviewStateForScreenPoint"/>'s
+    /// test-only pattern for the magic-wand/grid preview). Null when nothing is hovered.
+    /// </summary>
+    public string? GetHoverLabelForScreenPoint(float screenX, float screenY)
+    {
+        UpdateHoverFrame(new Point(screenX, screenY));
+        return _hoverFrame is null ? null : ResolveHoverLabel(_hoverFrame);
     }
 
     private void UpdateHoverCursor(Point pos, bool isCtrl = false)
@@ -1380,6 +1493,7 @@ public class WireframeControl : TextureViewport
         base.OnPointerExited(e);
         Cursor = Cursor.Default;
         if (_showPreview) { _showPreview = false; InvalidateVisual(); }
+        ClearHoverFrame();
     }
 
     // ── Mouse helpers ─────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -193,16 +193,25 @@ public class WireframeControl : TextureViewport
         float tagHeight = font.Size + PadY * 2f;
         float tagWidth = textWidth + PadX * 2f;
 
-        // Anchored above the frame's top-left corner; clamp so it never draws off the top edge.
-        float tagLeft = sr.Left;
-        float tagTop = MathF.Max(0f, sr.Top - tagHeight);
-
-        var tagRect = new SKRect(tagLeft, tagTop, tagLeft + tagWidth, tagTop + tagHeight);
+        var tagRect = ComputeHoverTagRect(sr, tagWidth, tagHeight);
         using var bgPaint = new SKPaint { Color = HoverLabelBackground, IsAntialias = true };
         canvas.DrawRoundRect(tagRect, 3f, 3f, bgPaint);
 
         using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true };
-        canvas.DrawText(label, tagLeft + PadX, tagTop + tagHeight - PadY, font, textPaint);
+        canvas.DrawText(label, tagRect.Left + PadX, tagRect.Top + tagHeight - PadY, font, textPaint);
+    }
+
+    /// <summary>
+    /// Positions the hover-label tag above the frame's top-left corner, clamped so it never
+    /// draws off the top or left edge of the canvas (it can still run off the right/bottom,
+    /// which is acceptable since frame boxes near those edges have room to spare on the side
+    /// the tag grows toward).
+    /// </summary>
+    internal static SKRect ComputeHoverTagRect(SKRect frameScreenBounds, float tagWidth, float tagHeight)
+    {
+        float tagLeft = MathF.Max(0f, frameScreenBounds.Left);
+        float tagTop = MathF.Max(0f, frameScreenBounds.Top - tagHeight);
+        return new SKRect(tagLeft, tagTop, tagLeft + tagWidth, tagTop + tagHeight);
     }
 
     private const float Hs = 5f;  // Handle half-size: handles are drawn this far outside the frame edge

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -58,7 +58,7 @@ internal sealed class TestServices
     public WireframeControl CreateWireframeControl(System.Action<string>? showError = null)
     {
         var ctrl = new WireframeControl();
-        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, PendingCutState, showError);
+        ctrl.InitializeServices(SelectedState, AppState, AppCommands, ApplicationEvents, ProjectManager, UndoManager, PendingCutState, ObjectFinder, showError);
         return ctrl;
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHoverLabelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHoverLabelTests.cs
@@ -1,0 +1,111 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #718: hovering a frame region on the wireframe shows a "Frame N" label, matching the
+/// tree view's 1-based naming (<see cref="AnimationEditor.Core.ViewModels.TreeBuilder.BuildFrameHeader"/>).
+/// </summary>
+public class WireframeHoverLabelTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier             = 1f;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, SKColor color, int size = 100, string name = "sprite.png")
+    {
+        var path = System.IO.Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        System.IO.File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// Two-frame chain: frame A (0,0,20,20) is at index 0, frame B (60,60,80,80) is at index 1 —
+    /// so hovering B must resolve to "Frame 2", not "Frame 1". Camera at (0,0,1) so texture
+    /// pixels == screen pixels.
+    /// </summary>
+    private static (WireframeControl ctrl, string dir) BuildCtrlWithTwoFrames(TestServices ctx)
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.DarkGray);
+
+        var frameA = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0.0f, TopCoordinate    = 0.0f,
+            RightCoordinate  = 0.2f, BottomCoordinate = 0.2f,
+            ShapesSave = new ShapesSave(),
+        };
+        var frameB = new AnimationFrameSave
+        {
+            TextureName      = "sprite.png",
+            FrameLength      = 0.1f,
+            LeftCoordinate   = 0.6f, TopCoordinate    = 0.6f,
+            RightCoordinate  = 0.8f, BottomCoordinate = 0.8f,
+            ShapesSave = new ShapesSave(),
+        };
+
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = System.IO.Path.Combine(dir, "test.achx");
+        ctx.SelectedState.SelectedChain = chain;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.RefreshFrames();
+
+        return (ctrl, dir);
+    }
+
+    [AvaloniaFact]
+    public void GetHoverLabelForScreenPoint_OverSecondFrame_ReturnsFrame2()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, dir) = BuildCtrlWithTwoFrames(ctx);
+        try
+        {
+            var label = ctrl.GetHoverLabelForScreenPoint(70f, 70f); // inside frame B (60,60,80,80)
+            Assert.Equal("Frame 2", label);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void GetHoverLabelForScreenPoint_OutsideAnyFrame_ReturnsNull()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, dir) = BuildCtrlWithTwoFrames(ctx);
+        try
+        {
+            var label = ctrl.GetHoverLabelForScreenPoint(40f, 40f); // gap between the two frames
+            Assert.Null(label);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHoverLabelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeHoverLabelTests.cs
@@ -108,4 +108,48 @@ public class WireframeHoverLabelTests
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
+
+    /// <summary>
+    /// Frame box sits with its left edge off-screen (negative X, e.g. panned so the box's
+    /// left edge is at -30) — the tag must clamp to the canvas's left edge (0), not draw
+    /// off-screen alongside it.
+    /// </summary>
+    [Fact]
+    public void ComputeHoverTagRect_FrameLeftEdgeOffScreen_ClampsTagToLeftEdge()
+    {
+        var frameBounds = new SKRect(-30f, 50f, 10f, 90f);
+
+        var tagRect = WireframeControl.ComputeHoverTagRect(frameBounds, tagWidth: 50f, tagHeight: 18f);
+
+        Assert.Equal(0f, tagRect.Left);
+    }
+
+    /// <summary>
+    /// Frame box sits with its top edge off-screen (negative Y) — same clamp, on the other axis,
+    /// already covered informally by manual testing; asserted here so both edges are locked in.
+    /// </summary>
+    [Fact]
+    public void ComputeHoverTagRect_FrameTopEdgeOffScreen_ClampsTagToTopEdge()
+    {
+        var frameBounds = new SKRect(50f, -30f, 90f, 10f);
+
+        var tagRect = WireframeControl.ComputeHoverTagRect(frameBounds, tagWidth: 50f, tagHeight: 18f);
+
+        Assert.Equal(0f, tagRect.Top);
+    }
+
+    /// <summary>
+    /// Frame box fully on-screen: the tag anchors at the frame's top-left corner, growing
+    /// upward, with no clamping applied.
+    /// </summary>
+    [Fact]
+    public void ComputeHoverTagRect_FrameFullyOnScreen_AnchorsAtFrameTopLeft()
+    {
+        var frameBounds = new SKRect(50f, 50f, 90f, 90f);
+
+        var tagRect = WireframeControl.ComputeHoverTagRect(frameBounds, tagWidth: 50f, tagHeight: 18f);
+
+        Assert.Equal(50f, tagRect.Left);
+        Assert.Equal(32f, tagRect.Top);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
@@ -559,7 +559,7 @@ public class WireframeTextureTests
         var ctrl = new AnimationEditor.App.Controls.WireframeControl();
         ctrl.InitializeServices(
             ctx.SelectedState, ctx.AppState, ctx.AppCommands, ctx.ApplicationEvents,
-            ctx.ProjectManager, ctx.UndoManager, ctx.PendingCutState,
+            ctx.ProjectManager, ctx.UndoManager, ctx.PendingCutState, ctx.ObjectFinder,
             thumbnailService: ctx.ThumbnailService);
 
         ctrl.RefreshAll();


### PR DESCRIPTION
Closes #718

Hovering a frame box in the wireframe panel now pops up a screen-space-sized "Frame N" notch anchored at its top-left corner, matching the tree view's naming.

## Test plan
- [x] New unit test: hovering frame index 1 resolves "Frame 2"; hovering the gap between frames resolves null
- [x] Confirmed test fails without the fix, passes with it
- [x] Full solution build + all test suites green (App.Tests 725/725, Core.Tests 1632/1632, Views.Tests 47/47)
- [ ] Manual: visual appearance of the notch (position/size/readability at different zoom levels) not yet eyeballed