### PR TITLE
Fix: multi-selected shape scale edits only applied to the last-selected shape

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4373,19 +4373,30 @@ public partial class MainWindow : Window
 
             if (rect is not null)
             {
-                PropRectName.Text    = rect.Name   ?? "";
-                PropRectX.Value      = (decimal)rect.X;
-                PropRectY.Value      = (decimal)rect.Y;
-                PropRectScaleX.Value = (decimal)rect.ScaleX;
-                PropRectScaleY.Value = (decimal)rect.ScaleY;
+                // Multi-selected rects can disagree on a property, same as multi-selected frames
+                // (#571) — show that field blank with a "(mixed)" placeholder instead of one rect's
+                // value; editing it then applies the new value to every selected rect. Name has no
+                // legitimate "mixed" display since it isn't numeric, so it's just disabled instead
+                // (see ApplyRectProps for why a shared literal name isn't applied across a batch).
+                var rects = _selectedState.SelectedRectangles;
+                bool rectsMulti = rects.Count > 1;
+                PropRectName.IsEnabled = !rectsMulti;
+                PropRectName.Text = rectsMulti ? "(multiple)" : (rect.Name ?? "");
+                SetValueOrMixed(PropRectX, rects.Select(r => (decimal)r.X).ToList());
+                SetValueOrMixed(PropRectY, rects.Select(r => (decimal)r.Y).ToList());
+                SetValueOrMixed(PropRectScaleX, rects.Select(r => (decimal)r.ScaleX).ToList());
+                SetValueOrMixed(PropRectScaleY, rects.Select(r => (decimal)r.ScaleY).ToList());
             }
 
             if (circ is not null)
             {
-                PropCircleName.Text    = circ.Name   ?? "";
-                PropCircleX.Value      = (decimal)circ.X;
-                PropCircleY.Value      = (decimal)circ.Y;
-                PropCircleRadius.Value = (decimal)circ.Radius;
+                var circles = _selectedState.SelectedCircles;
+                bool circlesMulti = circles.Count > 1;
+                PropCircleName.IsEnabled = !circlesMulti;
+                PropCircleName.Text = circlesMulti ? "(multiple)" : (circ.Name ?? "");
+                SetValueOrMixed(PropCircleX, circles.Select(c => (decimal)c.X).ToList());
+                SetValueOrMixed(PropCircleY, circles.Select(c => (decimal)c.Y).ToList());
+                SetValueOrMixed(PropCircleRadius, circles.Select(c => (decimal)c.Radius).ToList());
             }
         }
         finally
@@ -4496,27 +4507,35 @@ public partial class MainWindow : Window
     private void ApplyRectProps()
     {
         if (_suppressPropRefresh) return;
-        var rect = _selectedState.SelectedRectangle;
-        if (rect is null || !PropRectX.Value.HasValue || !PropRectY.Value.HasValue ||
-            !PropRectScaleX.Value.HasValue || !PropRectScaleY.Value.HasValue) return;
-        var frame = _selectedState.SelectedFrame;
-        _appCommands.SetRectProps(frame, rect,
-            PropRectName.Text ?? "",
-            (float)PropRectX.Value.Value, (float)PropRectY.Value.Value,
-            (float)PropRectScaleX.Value.Value, (float)PropRectScaleY.Value.Value);
+        var rects = _selectedState.SelectedRectangles;
+        if (rects.Count == 0) return;
+
+        // A null component here means "still showing (mixed), not edited" — leave that axis alone
+        // per-rect. Name is only applied for a single selected rect: propagating one literal name
+        // to every rect in a multi-selection would clobber their distinct names (PropRectName is
+        // disabled in RefreshPropertyPanel whenever more than one rect is selected).
+        float? x = PropRectX.Value.HasValue ? (float)PropRectX.Value.Value : null;
+        float? y = PropRectY.Value.HasValue ? (float)PropRectY.Value.Value : null;
+        float? scaleX = PropRectScaleX.Value.HasValue ? (float)PropRectScaleX.Value.Value : null;
+        float? scaleY = PropRectScaleY.Value.HasValue ? (float)PropRectScaleY.Value.Value : null;
+        string? name = rects.Count == 1 ? (PropRectName.Text ?? "") : null;
+
+        _appCommands.SetRectPropsBulk(rects, name, x, y, scaleX, scaleY);
     }
 
     private void ApplyCircleProps()
     {
         if (_suppressPropRefresh) return;
-        var circ = _selectedState.SelectedCircle;
-        if (circ is null || !PropCircleX.Value.HasValue || !PropCircleY.Value.HasValue ||
-            !PropCircleRadius.Value.HasValue) return;
-        var frame = _selectedState.SelectedFrame;
-        _appCommands.SetCircleProps(frame, circ,
-            PropCircleName.Text ?? "",
-            (float)PropCircleX.Value.Value, (float)PropCircleY.Value.Value,
-            (float)PropCircleRadius.Value.Value);
+        var circles = _selectedState.SelectedCircles;
+        if (circles.Count == 0) return;
+
+        // See ApplyRectProps for the null-means-"don't touch" / single-selection-only-name semantics.
+        float? x = PropCircleX.Value.HasValue ? (float)PropCircleX.Value.Value : null;
+        float? y = PropCircleY.Value.HasValue ? (float)PropCircleY.Value.Value : null;
+        float? radius = PropCircleRadius.Value.HasValue ? (float)PropCircleRadius.Value.Value : null;
+        string? name = circles.Count == 1 ? (PropCircleName.Text ?? "") : null;
+
+        _appCommands.SetCirclePropsBulk(circles, name, x, y, radius);
     }
 
     // ── Playback controls wiring ──────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1600,6 +1600,45 @@ namespace AnimationEditor.Core.CommandsAndState
             string name, float x, float y, float radius) =>
             _undoManager.Execute(SetShapePropsCommand.ForCircle(frame, circ, name, x, y, radius, this, _events));
 
+        public void SetRectPropsBulk(IReadOnlyList<AARectSave> rects,
+            string? name, float? x, float? y, float? scaleX, float? scaleY)
+        {
+            if (rects.Count == 0) return;
+            _undoManager.Execute(new BulkShapePropsCommand(
+                rects.Cast<object>().ToList(),
+                () =>
+                {
+                    foreach (var r in rects)
+                    {
+                        if (name != null) r.Name = name;
+                        if (x.HasValue) r.X = x.Value;
+                        if (y.HasValue) r.Y = y.Value;
+                        if (scaleX.HasValue) r.ScaleX = scaleX.Value;
+                        if (scaleY.HasValue) r.ScaleY = scaleY.Value;
+                    }
+                },
+                this, _events, _objectFinder, "Edit Rectangles"));
+        }
+
+        public void SetCirclePropsBulk(IReadOnlyList<CircleSave> circles,
+            string? name, float? x, float? y, float? radius)
+        {
+            if (circles.Count == 0) return;
+            _undoManager.Execute(new BulkShapePropsCommand(
+                circles.Cast<object>().ToList(),
+                () =>
+                {
+                    foreach (var c in circles)
+                    {
+                        if (name != null) c.Name = name;
+                        if (x.HasValue) c.X = x.Value;
+                        if (y.HasValue) c.Y = y.Value;
+                        if (radius.HasValue) c.Radius = radius.Value;
+                    }
+                },
+                this, _events, _objectFinder, "Edit Circles"));
+        }
+
         // ── Paste (clipboard → project) ───────────────────────────────────────
 
         /// <inheritdoc cref="IAppCommands.PasteChains"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkShapePropsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkShapePropsCommand.cs
@@ -1,0 +1,106 @@
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Captured Name/X/Y/P1/P2 of one shape (<see cref="AARectSave"/> or <see cref="CircleSave"/>),
+    /// where P1/P2 are ScaleX/ScaleY for a rectangle or Radius/(unused) for a circle. Used by
+    /// <see cref="BulkShapePropsCommand"/> to snapshot shapes before and after a batch edit.
+    /// </summary>
+    internal readonly record struct ShapeFieldSnapshot(object Shape, string Name, float X, float Y, float P1, float P2)
+    {
+        public static ShapeFieldSnapshot Capture(object shape) => shape switch
+        {
+            AARectSave r => new(shape, r.Name, r.X, r.Y, r.ScaleX, r.ScaleY),
+            CircleSave c => new(shape, c.Name, c.X, c.Y, c.Radius, 0f),
+            _ => throw new ArgumentException($"Unsupported shape type: {shape.GetType()}", nameof(shape)),
+        };
+
+        public void RestoreToShape()
+        {
+            switch (Shape)
+            {
+                case AARectSave r: r.Name = Name; r.X = X; r.Y = Y; r.ScaleX = P1; r.ScaleY = P2; break;
+                case CircleSave c: c.Name = Name; c.X = X; c.Y = Y; c.Radius = P1; break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Do/undo/redo record for an operation that edits Name/X/Y/ScaleOrRadius across many shapes
+    /// at once — the multi-select counterpart to <see cref="SetShapePropsCommand"/>. Shapes may
+    /// belong to different frames (a multi-select can span frames); each affected frame's tree
+    /// node is refreshed. <see cref="Do"/> snapshots the shapes, runs the supplied mutation, and
+    /// snapshots them again; undo and redo just replay whichever snapshot set. <see cref="Do"/>
+    /// returns <c>false</c> when the mutation changed nothing, so no empty undo entry is recorded.
+    /// </summary>
+    internal sealed class BulkShapePropsCommand : IUndoableCommand
+    {
+        private readonly IReadOnlyList<object> _shapes;
+        private readonly Action _mutate;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+        private readonly IObjectFinder _objectFinder;
+
+        private ShapeFieldSnapshot[] _before = [];
+        private ShapeFieldSnapshot[] _after = [];
+
+        public string Description { get; }
+
+        public BulkShapePropsCommand(
+            IReadOnlyList<object> shapes, Action mutate,
+            IAppCommands commands, IApplicationEvents events, IObjectFinder objectFinder,
+            string description)
+        {
+            _shapes = shapes;
+            _mutate = mutate;
+            _commands = commands;
+            _events = events;
+            _objectFinder = objectFinder;
+            Description = description;
+        }
+
+        public bool Do()
+        {
+            _before = _shapes.Select(ShapeFieldSnapshot.Capture).ToArray();
+            _mutate();
+            _after = _shapes.Select(ShapeFieldSnapshot.Capture).ToArray();
+
+            if (_before.SequenceEqual(_after)) return false;
+
+            RaiseSideEffects();
+            return true;
+        }
+
+        public void Undo() => Apply(_before);
+        public void Redo() => Apply(_after);
+
+        private void Apply(ShapeFieldSnapshot[] snapshots)
+        {
+            foreach (var snapshot in snapshots)
+                snapshot.RestoreToShape();
+            RaiseSideEffects();
+        }
+
+        private void RaiseSideEffects()
+        {
+            foreach (var shape in _shapes)
+            {
+                var frame = shape switch
+                {
+                    AARectSave r => _objectFinder.GetAnimationFrameContaining(r),
+                    CircleSave c => _objectFinder.GetAnimationFrameContaining(c),
+                    _ => null,
+                };
+                if (frame is not null) _commands.RefreshTreeNode(frame);
+            }
+            _commands.RefreshAnimationFrameDisplay();
+            _commands.RefreshWireframe();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -279,6 +279,24 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetRectProps(AnimationFrameSave? frame, AARectSave rect, string name, float x, float y, float scaleX, float scaleY);
         void SetCircleProps(AnimationFrameSave? frame, CircleSave circ, string name, float x, float y, float radius);
 
+        /// <summary>
+        /// Sets Name/X/Y/ScaleX/ScaleY on every rectangle in <paramref name="rects"/> as a single
+        /// undoable operation — the multi-select counterpart to <see cref="SetRectProps"/>. Rects may
+        /// belong to different frames. <paramref name="name"/> and each numeric parameter may be
+        /// <c>null</c> to leave that field untouched per-rect (its own existing value survives) —
+        /// used when the inspector field is showing "(mixed)", or (for name) when more than one
+        /// rect is selected and applying one literal name to every rect would clobber their
+        /// distinct names. See <see cref="SetFrameRelative"/> for why <c>null</c> is unambiguous here.
+        /// </summary>
+        void SetRectPropsBulk(IReadOnlyList<AARectSave> rects, string? name, float? x, float? y, float? scaleX, float? scaleY);
+
+        /// <summary>
+        /// Sets Name/X/Y/Radius on every circle in <paramref name="circles"/> as a single undoable
+        /// operation — the multi-select counterpart to <see cref="SetCircleProps"/>. See
+        /// <see cref="SetRectPropsBulk"/> for the null-means-"don't touch" semantics.
+        /// </summary>
+        void SetCirclePropsBulk(IReadOnlyList<CircleSave> circles, string? name, float? x, float? y, float? radius);
+
         // ── Hot Reload ────────────────────────────────────────────────────────────
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/SelectedState.cs
@@ -101,11 +101,27 @@ namespace AnimationEditor.Core
             }
         }
 
-        public List<AARectSave> SelectedRectangles =>
-            _selectedNodes.OfType<AARectSave>().ToList();
+        public List<AARectSave> SelectedRectangles
+        {
+            get
+            {
+                var rects = _selectedNodes.OfType<AARectSave>().ToList();
+                if (rects.Count == 0 && _selectedRectangle != null)
+                    rects.Add(_selectedRectangle);
+                return rects;
+            }
+        }
 
-        public List<CircleSave> SelectedCircles =>
-            _selectedNodes.OfType<CircleSave>().ToList();
+        public List<CircleSave> SelectedCircles
+        {
+            get
+            {
+                var circles = _selectedNodes.OfType<CircleSave>().ToList();
+                if (circles.Count == 0 && _selectedCircle != null)
+                    circles.Add(_selectedCircle);
+                return circles;
+            }
+        }
 
         /// <summary>
         /// Multi-selection bag. Can hold AnimationChainSave, AnimationFrameSave,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShapeMultiSelectPropertyPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShapeMultiSelectPropertyPanelTests.cs
@@ -1,0 +1,94 @@
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #724: Ctrl+click multi-select across frames highlighted every
+/// selected AARectSave/CircleSave, but editing ScaleX/ScaleY in the property panel only applied
+/// to the last-selected shape. Mirrors the existing frame multi-select property-panel behavior.
+/// </summary>
+public class ShapeMultiSelectPropertyPanelTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RebuildTreeView", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(window, new object[] { System.Array.Empty<string>() });
+        FlushUi();
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TreeNodeVm FirstChainNode(TreeView tree) =>
+        tree.ItemsSource is System.Collections.IEnumerable roots
+            ? roots.Cast<TreeNodeVm>().First()
+            : throw new Xunit.Sdk.XunitException("No tree roots");
+
+    [AvaloniaFact]
+    public void ApplyRectProps_TwoRectsMultiSelectedAcrossFrames_AppliesScaleXToBoth()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var rect0 = new AARectSave { Name = "Box0", ScaleX = 8f, ScaleY = 8f };
+            var rect1 = new AARectSave { Name = "Box1", ScaleX = 8f, ScaleY = 8f };
+            f0.ShapesSave!.Shapes.Add(rect0);
+            f1.ShapesSave!.Shapes.Add(rect1);
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+            var frame0Node = chainNode.Children[0];
+            var frame1Node = chainNode.Children[1];
+            frame0Node.IsExpanded = true;
+            frame1Node.IsExpanded = true;
+            FlushUi();
+            var rect0Node = frame0Node.Children.Single(n => ReferenceEquals(n.Data, rect0));
+            var rect1Node = frame1Node.Children.Single(n => ReferenceEquals(n.Data, rect1));
+
+            // Ctrl+click multi-select of both rect nodes, spanning two different frames.
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rect0Node);
+            tree.SelectedItems.Add(rect1Node);
+            FlushUi();
+
+            Assert.Equal(2, ctx.SelectedState.SelectedRectangles.Count);
+
+            var scaleXInput = window.FindControl<NumericUpDown>("PropRectScaleX")!;
+            scaleXInput.Value = 20m;
+            FlushUi();
+
+            Assert.Equal(20f, rect0.ScaleX);
+            Assert.Equal(20f, rect1.ScaleX);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
@@ -1,0 +1,81 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+[Collection("SequentialSingletons")]
+public class AppCommandsShapePropsBulkTests
+{
+    [Fact]
+    public void SetRectPropsBulk_MultipleRectangles_AppliesScaleToAll()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var rectA = new AARectSave { Name = "A", ScaleX = 8f, ScaleY = 8f };
+        var rectB = new AARectSave { Name = "B", ScaleX = 8f, ScaleY = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(rectB);
+
+        ctx.AppCommands.SetRectPropsBulk(
+            new List<AARectSave> { rectA, rectB }, null, null, null, 20f, 20f);
+
+        Assert.Equal(20f, rectA.ScaleX);
+        Assert.Equal(20f, rectA.ScaleY);
+        Assert.Equal(20f, rectB.ScaleX);
+        Assert.Equal(20f, rectB.ScaleY);
+    }
+
+    [Fact]
+    public void SetRectPropsBulk_NullXY_LeavesXYUnchangedPerRect()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var rectA = new AARectSave { Name = "A", X = 1f, Y = 2f, ScaleX = 8f, ScaleY = 8f };
+        var rectB = new AARectSave { Name = "B", X = 3f, Y = 4f, ScaleX = 8f, ScaleY = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(rectB);
+
+        ctx.AppCommands.SetRectPropsBulk(
+            new List<AARectSave> { rectA, rectB }, null, null, null, 20f, 20f);
+
+        Assert.Equal(1f, rectA.X);
+        Assert.Equal(2f, rectA.Y);
+        Assert.Equal(3f, rectB.X);
+        Assert.Equal(4f, rectB.Y);
+    }
+
+    [Fact]
+    public void SetRectPropsBulk_Undo_RestoresOriginalScale()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var rect = new AARectSave { Name = "A", ScaleX = 8f, ScaleY = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rect);
+
+        ctx.AppCommands.SetRectPropsBulk(new List<AARectSave> { rect }, null, null, null, 20f, 20f);
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(8f, rect.ScaleX);
+        Assert.Equal(8f, rect.ScaleY);
+    }
+
+    [Fact]
+    public void SetCirclePropsBulk_MultipleCircles_AppliesRadiusToAll()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Jump", 2);
+        var circleA = new CircleSave { Name = "A", Radius = 8f };
+        var circleB = new CircleSave { Name = "B", Radius = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(circleA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(circleB);
+
+        ctx.AppCommands.SetCirclePropsBulk(
+            new List<CircleSave> { circleA, circleB }, null, null, null, 15f);
+
+        Assert.Equal(15f, circleA.Radius);
+        Assert.Equal(15f, circleB.Radius);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SelectedStateTests.cs
@@ -25,4 +25,49 @@ public class SelectedStateTests
         ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
         Assert.Equal(1, changes);
     }
+
+    [Fact]
+    public void SelectedRectangles_MultipleRectsInSelectedNodes_ReturnsAll()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        ctx.SelectedState.SelectedNodes = new List<object> { rectA, rectB };
+
+        var result = ctx.SelectedState.SelectedRectangles;
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(rectA, result);
+        Assert.Contains(rectB, result);
+    }
+
+    [Fact]
+    public void SelectedRectangles_SelectedNodesEmpty_FallsBackToSelectedRectangle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var rect = new AARectSave { Name = "A" };
+
+        // Simulates selecting a shape via a drag in the preview panel, which sets
+        // SelectedRectangle directly without touching the tree's multi-select bag.
+        ctx.SelectedState.SelectedRectangle = rect;
+
+        var result = ctx.SelectedState.SelectedRectangles;
+
+        Assert.Single(result);
+        Assert.Same(rect, result[0]);
+    }
+
+    [Fact]
+    public void SelectedCircles_SelectedNodesEmpty_FallsBackToSelectedCircle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var circle = new CircleSave { Name = "A" };
+
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var result = ctx.SelectedState.SelectedCircles;
+
+        Assert.Single(result);
+        Assert.Same(circle, result[0]);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -114,6 +114,8 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetFramePixelRegion)]          = Category.MutatingUndoable,
         [nameof(IAppCommands.SetRectProps)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetRectPropsBulk)]             = Category.MutatingUndoable,
+        [nameof(IAppCommands.SetCirclePropsBulk)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteRectangle)]               = Category.MutatingUndoable,
@@ -319,6 +321,10 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.SetRectProps(Zebra(ctx).Frames[0], Rect(ctx), "Renamed", 5f, 6f, 7f, 8f)));
         yield return Row(nameof(IAppCommands.SetCircleProps),
             ctx => Sync(() => ctx.AppCommands.SetCircleProps(Zebra(ctx).Frames[0], Circle(ctx), "Renamed", 5f, 6f, 9f)));
+        yield return Row(nameof(IAppCommands.SetRectPropsBulk),
+            ctx => Sync(() => ctx.AppCommands.SetRectPropsBulk(new[] { Rect(ctx), SecondRect(ctx) }, null, null, null, 20f, 20f)));
+        yield return Row(nameof(IAppCommands.SetCirclePropsBulk),
+            ctx => Sync(() => ctx.AppCommands.SetCirclePropsBulk(new[] { Circle(ctx), SecondCircle(ctx) }, null, null, null, 20f)));
         yield return Row(nameof(IAppCommands.PasteChains),
             ctx => Sync(() => ctx.AppCommands.PasteChains(
                 new List<AnimationChainSave> { new() { Name = "Pasted" } })));
@@ -431,6 +437,7 @@ public class UndoCoverageRosterTests
     private static AnimationChainSave Zebra(TestServices ctx) => ctx.Acls.AnimationChains[0];
     private static AnimationChainSave Alpha(TestServices ctx) => ctx.Acls.AnimationChains[1];
     private static AARectSave Rect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves.First();
+    private static AARectSave SecondRect(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.AARectSaves.ElementAt(1);
     private static CircleSave Circle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves.First();
     private static CircleSave SecondCircle(TestServices ctx) => Zebra(ctx).Frames[0].ShapesSave!.CircleSaves.ElementAt(1);
 


### PR DESCRIPTION
## Summary
- Ctrl+click multi-select across frames highlighted every selected AARect/Circle, but editing ScaleX/ScaleY only applied to the last-selected shape — `SelectedRectangles`/`SelectedCircles` lacked the single-selection fallback `SelectedFrames` already had, and the property panel read the singular `SelectedRectangle`/`SelectedCircle` instead of the multi-select list.
- Adds `SetRectPropsBulk`/`SetCirclePropsBulk` (mirroring the existing frame bulk-edit commands, one undo entry per batch) and wires the desktop property panel to use them, with per-field null-means-"(mixed)"/don't-touch semantics matching frame multi-edit. Name is excluded from batch apply (disabled in the panel when >1 shape selected) since applying one literal name to a batch would clobber their distinct names.
- Scoped to the desktop app (`MainWindow.axaml.cs`) — the Browser/WASM head's `InspectorControl` has no shape multi-select to begin with, so it's untouched.

The regex-based cross-file batch rename/scope tool proposed in #724 is deferred; this PR only fixes the multi-edit bug.

## Test plan
- [x] `AppCommandsShapePropsBulkTests` — bulk apply, mixed-null passthrough, undo
- [x] `SelectedStateTests` — rectangles/circles fallback to single selection
- [x] `ShapeMultiSelectPropertyPanelTests` — end-to-end headless repro: Ctrl+click two rects across two frames in the real tree, edit ScaleX in the property panel, confirm both update (confirmed this test fails on pre-fix code, reproducing the exact reported bug)
- [x] `UndoCoverageRosterTests` updated for the two new `IAppCommands` methods
- [x] Full `AnimationEditor.Core.Tests` (1648), `AnimationEditor.App.Tests` (737), `AnimationEditor.Views.Tests` (47) all green

Closes #724