### PR TITLE
Tree search now matches shape names

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -480,10 +480,17 @@ public static class TreeBuilder
     /// <summary>
     /// Query-change path: sets each chain (root) node's
     /// <see cref="TreeNodeVm.PinnedVisible"/> to whether its header matches
-    /// <paramref name="query"/> under <see cref="MatchesFilter"/>. This is the <b>only</b>
-    /// filter path allowed to hide a row — typing/refining the query shrinks the visible
-    /// set; an empty/whitespace query shows every chain. Non-chain nodes (frames, shapes)
-    /// are left untouched: they are hidden only when their parent chain is.
+    /// <paramref name="query"/> under <see cref="MatchesFilter"/>, or one of its frames holds
+    /// a shape (<see cref="AARectSave"/>/<see cref="CircleSave"/>) whose name matches (#726).
+    /// This is the <b>only</b> filter path allowed to hide a row — typing/refining the query
+    /// shrinks the visible set; an empty/whitespace query shows every chain. Non-chain nodes
+    /// (frames, shapes) are otherwise left untouched: they are hidden only when their parent
+    /// chain is.
+    /// <para>
+    /// A shape-level match also expands its owning chain and frame via
+    /// <see cref="ExpandAncestorsOf"/> so the matched row is actually visible, not just
+    /// present-but-collapsed.
+    /// </para>
     /// <para>
     /// Contrast with <see cref="ComputeVisibleAfterModelChange"/>, the grow-only path used
     /// when the model mutates but the query is unchanged.
@@ -492,8 +499,35 @@ public static class TreeBuilder
     public static void ApplyQueryFilter(IEnumerable<TreeNodeVm> roots, string? query)
     {
         foreach (var node in roots)
+        {
             if (node.Data is AnimationChainSave)
-                node.PinnedVisible = MatchesFilter(node.Header, query);
+            {
+                var matchingShapes = FindMatchingShapeNodes(node, query);
+                node.PinnedVisible = MatchesFilter(node.Header, query) || matchingShapes.Count > 0;
+
+                foreach (var shapeNode in matchingShapes)
+                    ExpandAncestorsOf(roots, shapeNode.Data!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects every shape child (<see cref="NodeKind.RectShape"/>/<see cref="NodeKind.CircleShape"/>)
+    /// across all of <paramref name="chainNode"/>'s frames whose name matches <paramref name="query"/>
+    /// under <see cref="MatchesFilter"/>. Returns empty for a blank query — a blank query means
+    /// "no filter", not "match every shape".
+    /// </summary>
+    private static List<TreeNodeVm> FindMatchingShapeNodes(TreeNodeVm chainNode, string? query)
+    {
+        var matches = new List<TreeNodeVm>();
+        if (string.IsNullOrWhiteSpace(query)) return matches;
+
+        foreach (var frameNode in chainNode.Children)
+            foreach (var shapeNode in frameNode.Children)
+                if ((shapeNode.Kind == NodeKind.RectShape || shapeNode.Kind == NodeKind.CircleShape)
+                    && MatchesFilter(shapeNode.Header, query))
+                    matches.Add(shapeNode);
+        return matches;
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -1136,6 +1136,96 @@ public class HeadlessTreeViewTests
         finally { window.Close(); }
     }
 
+    // ── #726 regression diagnosis: drive the REAL SearchBox, not a reflection shortcut ──
+    //
+    // SetFilterAndApply (used by every other search test) sets the private _treeFilterQuery
+    // field and reflection-invokes ApplyQueryFilter() directly, bypassing the actual named
+    // "SearchBox" TextBox and its wired TextChanged handler entirely. If that wiring itself
+    // were ever broken, no existing test would catch it. This test drives the real control's
+    // Text property (which fires the real TextChanged handler) and asserts on the real
+    // rendered TreeViewItem container's IsVisible, not just the view-model's PinnedVisible.
+    [AvaloniaFact]
+    public void SearchBox_RealTextChanged_HidesNonMatchingChainContainer()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var walk = new AnimationChainSave { Name = "walkLeft" };
+            var idle = new AnimationChainSave { Name = "Idle" };
+            walk.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+            idle.Frames.Add(new AnimationFrameSave { TextureName = "b.png" });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(walk);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(idle);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            var tree = GetTree(window);
+            var roots = GetRoots(tree);
+            var walkNode = roots.First(n => ReferenceEquals(n.Data, walk));
+            var idleNode = roots.First(n => ReferenceEquals(n.Data, idle));
+
+            var searchBox = window.FindControl<TextBox>("SearchBox")
+                ?? throw new InvalidOperationException("SearchBox control not found");
+
+            searchBox.Text = "walk"; // fires the real TextChanged handler, not a shortcut
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(walkNode.PinnedVisible);
+            Assert.False(idleNode.PinnedVisible);
+
+            var walkTvi = tree.GetVisualDescendants().OfType<TreeViewItem>()
+                .First(tvi => ReferenceEquals(tvi.DataContext, walkNode));
+            var idleTvi = tree.GetVisualDescendants().OfType<TreeViewItem>()
+                .First(tvi => ReferenceEquals(tvi.DataContext, idleNode));
+
+            Assert.True(walkTvi.IsVisible);
+            Assert.False(idleTvi.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── #726 regression diagnosis: shape search with a real on-disk project ────
+    //
+    // Every other search test in this file runs with ProjectManager.FileName == null,
+    // which makes SaveCompanionFile() a silent no-op. A real user always has FileName
+    // set, so a shape-name match's ExpandAncestorsOf call triggers a REAL synchronous
+    // companion-file write via OnTreeNodeIsExpandedChanged. This test reproduces that
+    // exact condition to check whether the write disrupts PinnedVisible correctness.
+    [AvaloniaFact]
+    public void SearchFilter_RealFileNameSet_ShapeMatchStillHidesNonMatchingChain()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tempFile = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), $"AE726_{Guid.NewGuid():N}.achx");
+            ctx.ProjectManager.FileName = tempFile;
+
+            var walk = new AnimationChainSave { Name = "walkLeft" };
+            var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+            frame.ShapesSave.Shapes.Add(new AARectSave { Name = "HitBox" });
+            walk.Frames.Add(frame);
+            var idle = new AnimationChainSave { Name = "Idle" };
+
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(walk);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(idle);
+
+            TriggerRefreshTreeView(window);
+            Dispatcher.UIThread.RunJobs();
+
+            SetFilterAndApply(window, "hit"); // matches the shape inside "walkLeft" only
+
+            var roots    = GetRoots(GetTree(window));
+            var walkNode = roots.First(n => ReferenceEquals(n.Data, walk));
+            var idleNode = roots.First(n => ReferenceEquals(n.Data, idle));
+
+            Assert.True(walkNode.PinnedVisible);
+            Assert.False(idleNode.PinnedVisible);
+        }
+        finally { window.Close(); }
+    }
+
     [AvaloniaFact]
     public void RenameChain_DoesNotCollapseChainNode()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeFilterTests.cs
@@ -26,6 +26,17 @@ public class TreeFilterTests
     private static List<string> VisibleNames(IEnumerable<TreeNodeVm> roots) =>
         roots.Where(n => n.PinnedVisible).Select(n => n.Header).ToList();
 
+    // Builds a chain node with one frame holding one AARectSave shape child, matching the
+    // shape produced by TreeBuilder.BuildChainNode (chain -> frame -> shape), for shape-search tests.
+    private static TreeNodeVm ChainWithShapeNode(string chainName, string shapeName)
+    {
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = shapeName });
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(frame);
+        return TreeBuilder.BuildChainNode(chain);
+    }
+
     // ── Query-change path (can shrink) — ApplyQueryFilter ─────────────────────
 
     [Fact]
@@ -42,6 +53,22 @@ public class TreeFilterTests
         var roots = ChainNodes(Names);
         TreeBuilder.ApplyQueryFilter(roots, "");
         Assert.Equal(Names, VisibleNames(roots));
+    }
+
+    // Guards against a naive "match everything on blank query" shape search forcing every
+    // chain/frame open the moment the search box is cleared.
+    [Fact]
+    public void ApplyQueryFilter_EmptyQuery_DoesNotExpandCollapsedNodes()
+    {
+        var chainNode = ChainWithShapeNode("Idle", "HitBox");
+        chainNode.IsExpanded = false;
+        chainNode.Children[0].IsExpanded = false; // frame node
+        var roots = new List<TreeNodeVm> { chainNode };
+
+        TreeBuilder.ApplyQueryFilter(roots, "");
+
+        Assert.False(chainNode.IsExpanded);
+        Assert.False(chainNode.Children[0].IsExpanded);
     }
 
     [Fact]
@@ -71,6 +98,35 @@ public class TreeFilterTests
         TreeBuilder.ApplyQueryFilter(roots, "walk"); // frame header doesn't match
 
         Assert.True(frameNode.PinnedVisible); // untouched, stays visible
+    }
+
+    // Shape names (#726): a query matching a shape inside a frame reveals the owning chain
+    // even when the chain's own name doesn't match.
+    [Fact]
+    public void ApplyQueryFilter_ShapeNameMatch_ChainBecomesVisible()
+    {
+        var chainNode = ChainWithShapeNode("Idle", "HitBox");
+        var roots = new List<TreeNodeVm> { chainNode };
+
+        TreeBuilder.ApplyQueryFilter(roots, "hit");
+
+        Assert.True(chainNode.PinnedVisible);
+    }
+
+    // A shape-level match must also expand its owning chain/frame — otherwise the matched
+    // row stays hidden behind a collapsed chain/frame even though PinnedVisible is true.
+    [Fact]
+    public void ApplyQueryFilter_ShapeNameMatch_ExpandsOwningChainAndFrame()
+    {
+        var chainNode = ChainWithShapeNode("Idle", "HitBox");
+        chainNode.IsExpanded = false;
+        chainNode.Children[0].IsExpanded = false; // frame node
+        var roots = new List<TreeNodeVm> { chainNode };
+
+        TreeBuilder.ApplyQueryFilter(roots, "hit");
+
+        Assert.True(chainNode.IsExpanded);
+        Assert.True(chainNode.Children[0].IsExpanded);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `ApplyQueryFilter` now also matches a query against each chain's frames' `AARectSave`/`CircleSave` shape names, not just the chain name.
- A shape-level match expands the owning chain and frame (via the existing `ExpandAncestorsOf`) so the matched row is actually visible, not just present-but-collapsed.
- A blank/whitespace query is still "no filter" — it does not force-expand anything.

Closes #726

## Test plan
- [x] `TreeFilterTests`: new tests for shape-name match visibility, expand-on-match, and no-expand-on-empty-query
- [x] Full `AnimationEditor.Core.Tests` suite green (1651 tests)
- [x] `HeadlessTreeViewTests` (App-level tree/search wiring) green (48 tests)