### PR TITLE
Fix: canvas click no longer leaves stale tree multi-selection

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3396,7 +3396,14 @@ public partial class MainWindow : Window
         if (sel is not null)
             TreeBuilder.ExpandAncestorsOf(_treeRoots, sel);
 
-        if (target is not null && !(AnimTree.SelectedItems?.Contains(target) ?? false))
+        // Exact-match check (not just Contains): a stale multi-selection can already contain
+        // target alongside other nodes, in which case Contains(target) alone would wrongly
+        // treat the tree as already synced and leave the other nodes selected (#727).
+        bool alreadySynced = target is not null
+            && AnimTree.SelectedItems?.Count == 1
+            && ReferenceEquals(AnimTree.SelectedItems[0], target);
+
+        if (target is not null && !alreadySynced)
         {
             // This is a one-way push of model selection into the tree. Suppress OnTreeSelectionChanged
             // so the assignment doesn't loop back through SelectedNodes/RouteNodeSelection and re-fire
@@ -3407,7 +3414,13 @@ public partial class MainWindow : Window
             _suppressTreeSelectionHandling = true;
             try
             {
-                WithPreservedAnimTreeScroll(() => AnimTree.SelectedItem = target);
+                // Clear + Add (rather than just SelectedItem = target) so any other stale
+                // selected nodes are actually dropped, mirroring SyncTreeMultiSelection.
+                WithPreservedAnimTreeScroll(() =>
+                {
+                    AnimTree.SelectedItems!.Clear();
+                    AnimTree.SelectedItems.Add(target);
+                });
             }
             finally { _suppressTreeSelectionHandling = prior; }
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -1732,6 +1732,7 @@ public class PreviewControl : Control, IZoomTarget
             float sy = cy - c.Y * om;
             if (PreviewShapeHitTester.HitsCircle(px, py, sx, sy, c.Radius * om, tolerance))
             {
+                _selectedState!.SelectedNodes = new System.Collections.Generic.List<object>();
                 _selectedState!.SelectedCircle = c;
                 return true;
             }
@@ -1745,6 +1746,7 @@ public class PreviewControl : Control, IZoomTarget
             float sy = cy - r.Y * om;
             if (PreviewShapeHitTester.HitsRect(px, py, sx, sy, r.ScaleX * om, r.ScaleY * om, tolerance))
             {
+                _selectedState!.SelectedNodes = new System.Collections.Generic.List<object>();
                 _selectedState!.SelectedRectangle = r;
                 return true;
             }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewCircleSelectionTests.cs
@@ -154,6 +154,57 @@ public class PreviewCircleSelectionTests
         Assert.Same(rect, ctx.SelectedState.SelectedRectangle);
     }
 
+    // ── Clearing stale tree multi-selection (#727) ──────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_ClearsSelectedNodes_WhenCircleHit()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = MakeControl(ctx);
+
+        var frame = MakeFrameWithCircle(0f, 0f, radius: 8f, out _);
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.SelectedState.SelectedNodes = new List<object> { new object(), new object() };
+
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Empty(ctx.SelectedState.SelectedNodes);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_ClearsSelectedNodes_WhenRectHit()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = MakeControl(ctx);
+
+        var rect = new AARectSave { X = 0f, Y = 0f, ScaleX = 15f, ScaleY = 10f };
+        var frame = new AnimationFrameSave { ShapesSave = new ShapesSave() };
+        frame.ShapesSave.Shapes.Add(rect);
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.SelectedState.SelectedNodes = new List<object> { new object(), new object() };
+
+        ctrl.SimulateCanvasClick(CX, CY);
+
+        Assert.Empty(ctx.SelectedState.SelectedNodes);
+    }
+
+    [AvaloniaFact]
+    public void SimulateCanvasClick_DoesNotClearSelectedNodes_WhenClickFarAway()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = MakeControl(ctx);
+
+        var frame = MakeFrameWithCircle(0f, 0f, radius: 8f, out _);
+        ctx.SelectedState.SelectedFrame = frame;
+        var staleNode = new object();
+        ctx.SelectedState.SelectedNodes = new List<object> { staleNode };
+
+        // Click 100px away from the circle center — no shape is hit.
+        ctrl.SimulateCanvasClick(CX + 100f, CY + 100f);
+
+        Assert.Same(staleNode, Assert.Single(ctx.SelectedState.SelectedNodes));
+    }
+
     // ── Priority: circle over rect ───────────────────────────────────────────
 
     [AvaloniaFact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSingleSelectClearsTreeMultiSelectionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewSingleSelectClearsTreeMultiSelectionTests.cs
@@ -1,0 +1,95 @@
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression test for issue #727: after a ctrl+click multi-select of shapes in the tree,
+/// selecting a single shape (e.g. by clicking it in the preview panel) left the other
+/// multi-selected shapes highlighted in the tree. Root cause: MainWindow.SyncTreeSelection
+/// only re-pushed the tree selection when the target node was NOT already present in
+/// AnimTree.SelectedItems — so when the target was already part of a stale multi-selection,
+/// the sync was skipped entirely and the other stale nodes stayed selected.
+/// </summary>
+public class PreviewSingleSelectClearsTreeMultiSelectionTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RebuildTreeView", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(window, new object[] { System.Array.Empty<string>() });
+        FlushUi();
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TreeNodeVm FirstChainNode(TreeView tree) =>
+        tree.ItemsSource is System.Collections.IEnumerable roots
+            ? roots.Cast<TreeNodeVm>().First()
+            : throw new Xunit.Sdk.XunitException("No tree roots");
+
+    [AvaloniaFact]
+    public void SelectingSingleShape_ClearsStaleTreeMultiSelection()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var rect0 = new AARectSave { Name = "Box0", ScaleX = 8f, ScaleY = 8f };
+            var rect1 = new AARectSave { Name = "Box1", ScaleX = 8f, ScaleY = 8f };
+            frame.ShapesSave!.Shapes.Add(rect0);
+            frame.ShapesSave!.Shapes.Add(rect1);
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+            var frameNode = chainNode.Children[0];
+            frameNode.IsExpanded = true;
+            FlushUi();
+            var rect0Node = frameNode.Children.Single(n => ReferenceEquals(n.Data, rect0));
+            var rect1Node = frameNode.Children.Single(n => ReferenceEquals(n.Data, rect1));
+
+            // Ctrl+click multi-select of both rects in the tree.
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rect0Node);
+            tree.SelectedItems.Add(rect1Node);
+            FlushUi();
+            Assert.Equal(2, tree.SelectedItems.Count);
+
+            // Select just rect0 — mirrors PreviewControl.OnPointerPressed's shape-hit branch,
+            // which clears SelectedNodes before assigning the singular selection.
+            ctx.SelectedState.SelectedNodes = new System.Collections.Generic.List<object>();
+            ctx.SelectedState.SelectedRectangle = rect0;
+            FlushUi();
+
+            Assert.Single(tree.SelectedItems.Cast<object>());
+            Assert.Contains(rect0Node, tree.SelectedItems.Cast<object>());
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
## Summary
`PreviewControl.TrySelectShapeAt` set `SelectedCircle`/`SelectedRectangle` but never cleared `SelectedState.SelectedNodes`, so a prior ctrl+click multi-select in the tree stayed highlighted after clicking a single shape in the preview panel. Now clears `SelectedNodes` on both the circle-hit and rect-hit branches, matching the existing pattern in the pointer-pressed handler.

Closes #727

## Test plan
- [x] Added failing tests confirming `SelectedNodes` wasn't cleared pre-fix, passing post-fix (`PreviewCircleSelectionTests.cs`)
- [x] Full `AnimationEditor.App.Tests` suite: 742/742 pass