### PR TITLE
Fix macOS/Linux release zips losing the executable bit

### DIFF
--- a/.github/workflows/build-and-release-animation-editor.yml
+++ b/.github/workflows/build-and-release-animation-editor.yml
@@ -108,12 +108,22 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: chmod +x dist/publish/AnimationEditor
 
-      - name: Package (zip)
-        if: matrix.archive == 'zip'
+      - name: Package (zip, Windows)
+        if: matrix.archive == 'zip' && matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist/out | Out-Null
           Compress-Archive -Path "dist/publish/*" -DestinationPath "dist/out/${{ matrix.asset }}"
+
+      # PowerShell's Compress-Archive doesn't store Unix permission bits in the zip's
+      # external attributes, so the chmod +x above gets silently dropped and the
+      # extracted binary loses its executable bit. Native `zip` preserves it.
+      - name: Package (zip, Unix)
+        if: matrix.archive == 'zip' && matrix.os != 'windows-latest'
+        run: |
+          mkdir -p dist/out
+          cd dist/publish
+          zip -r "../out/${{ matrix.asset }}" .
 
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'


### PR DESCRIPTION
## Summary
- `Compress-Archive` (used for the `zip`-packaged osx-x64/osx-arm64 assets) doesn't store Unix permission bits, so the `chmod +x` applied to the published binary was silently dropped in the archive — users unzipping on macOS got a non-executable file that Finder falls back to opening as text.
- Non-Windows `zip` assets now packaged with native `zip`, which preserves the executable bit through unzip/Archive Utility. Windows keeps `Compress-Archive` (no Unix bits to lose there). Linux's `tar.gz` path was already fine (tar preserves permissions natively) — no change needed.

## Test note
No automated test: this is CI-only workflow YAML with no local harness to run the actual GitHub Actions matrix build. I attempted a local zip/unzip repro of the exec-bit mechanism, but this dev machine's NTFS has no true POSIX executable bit, so `unzip` here ignores the archive's Unix permission attribute regardless of which tool wrote it — the round trip can't be faithfully verified off a macOS/Linux runner.

## Test plan
- [ ] Trigger `Build and Release Animation Editor` via `workflow_dispatch` with `release_kind: test` (draft release)
- [ ] Download the `osx-arm64` (or `osx-x64`) zip asset, unzip on a real Mac, confirm `AnimationEditor` is executable without a manual `chmod +x`
- [ ] Confirm `win-x64` zip and `linux-x64` tar.gz still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)