### PR TITLE
Ad-hoc sign the macOS Animation Editor .app bundle

### DIFF
--- a/.github/workflows/build-and-release-animation-editor.yml
+++ b/.github/workflows/build-and-release-animation-editor.yml
@@ -124,6 +124,15 @@ jobs:
           cp tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
           cp tools/AnimationEditorAvalonia/src/AnimationEditor.App/macos/Info.plist "$APP/Contents/Info.plist"
 
+      # Ad-hoc sign (no Apple Developer ID / notarization — none is configured for this repo).
+      # Without any signature, Gatekeeper rejects the bundle outright on first launch with
+      # "AnimationEditor.app is damaged and can't be opened", which is misleading — the bundle
+      # isn't corrupt, it's just unsigned. Ad-hoc signing replaces that hard rejection with the
+      # normal "unidentified developer" prompt users can approve once via Settings > Privacy.
+      - name: Ad-hoc sign macOS .app bundle
+        if: matrix.os == 'macos-latest'
+        run: codesign --force --deep --sign - dist/bundle/AnimationEditor.app
+
       - name: Package (zip, Windows)
         if: matrix.archive == 'zip' && matrix.os == 'windows-latest'
         shell: pwsh
@@ -136,10 +145,13 @@ jobs:
       # extracted binary loses its executable bit. Native `zip` preserves it.
       - name: Package (zip, macOS .app bundle)
         if: matrix.archive == 'zip' && matrix.os == 'macos-latest'
+        # `zip` doesn't preserve the extended-attribute/resource-fork data a code signature's
+        # seal depends on, so a plain-zipped signed bundle can still fail Gatekeeper validation
+        # after unzip. `ditto` is Apple's own tool for packaging signed .app bundles and
+        # preserves that metadata correctly.
         run: |
           mkdir -p dist/out
-          cd dist/bundle
-          zip -r "../out/${{ matrix.asset }}" AnimationEditor.app
+          ditto -c -k --sequesterRsrc --keepParent dist/bundle/AnimationEditor.app "dist/out/${{ matrix.asset }}"
 
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'


### PR DESCRIPTION
## Summary
Follow-up to #733. Manual test of that release surfaced "AnimationEditor.app is damaged and can't be opened" on launch — Gatekeeper's rejection message for a downloaded, unsigned bundle. Fixes:
- Ad-hoc sign the assembled `.app` in CI (no paid Apple Developer ID configured for this repo, so full notarization isn't available)
- Package with `ditto -c -k --sequesterRsrc --keepParent` instead of `zip`, since plain `zip` can strip the extended-attribute data a code signature's seal depends on

Users will still see one "unidentified developer" Gatekeeper prompt on first launch (expected for a non-notarized indie build), not the hard "damaged" rejection.

## Test plan
No automated test — CI-only workflow YAML. `codesign`/`ditto` are macOS-only with no cross-platform equivalent, so unlike the prior PR there's no local repro available at all.
- [ ] Trigger `workflow_dispatch` (`release_kind: test`), download the osx-x64 or osx-arm64 zip on a real Mac
- [ ] Unzip and launch `AnimationEditor.app` — confirm it opens (at most an "unidentified developer" prompt, no "damaged" error)
- [ ] `codesign -dv --verbose=4 AnimationEditor.app` shows a valid ad-hoc signature