### PR TITLE
Add TileMap.GetObjectLayerData for raw Tiled object-layer data

### DIFF
--- a/frb-skills/tmx/SKILL.md
+++ b/frb-skills/tmx/SKILL.md
@@ -153,6 +153,10 @@ Adjacent sub-cell rects participate in `SolidSides` seam suppression: if two sub
 - **Rectangles** support any position, size, and `rotation` that's an exact multiple of 90 — the rect stays axis-aligned (just reoriented/swapped) and is clipped against the grid, so it can span any number of cells and doesn't need to be grid-aligned at all. This is the recommended way to author a hand-drawn collision boundary that doesn't match the tile grid (a wall, a boss-arena floor, an irregular pit).
 - **Rotated rectangles at other angles, and all polygons,** are positioned relative to whichever grid cell contains their center (same convention as a tileset tile's sub-cell `<object>`s) and **must fit within roughly one cell** to be found by broad-phase collision queries — Tiled rotates around the object's own `(x,y)`, not its bounding-box center, so don't assume a rotated shape's world position matches a naive center-based mental model.
 
+### Reading object-layer data directly (no entity, no collision)
+
+`TileMap.GetObjectLayerData(layerName)` returns each object's world-space rect, Class, tile GlobalId, and merged properties as an `ObjectLayerEntry` — for object layers used purely as data markers (a Water zone's bounds, Coast tile terrain/side properties) rather than `CreateEntities` spawns or collision generation. Polygon objects are skipped (rect-only); use `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` for polygon shapes.
+
 ### Add an object layer for entity spawns
 
 Object layers hold tile objects that represent entity spawn positions. Each tile object references a tile from the tileset via its GID. The tile's Class determines the entity type. Add an `<objectgroup>` after the tile layers:

--- a/src/Tiled/ObjectLayerEntry.cs
+++ b/src/Tiled/ObjectLayerEntry.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace FlatRedBall2.Tiled;
+
+/// <summary>
+/// A read-only snapshot of one object on a Tiled object layer, returned by
+/// <see cref="TileMap.GetObjectLayerData"/> for game code that wants raw Tiled object data
+/// without spawning an entity (<see cref="TileMap.CreateEntities{T}"/>) or generating collision
+/// (<see cref="TileMap.GenerateCollisionFromClass"/>).
+/// </summary>
+/// <param name="X">Left edge, in world space (already includes the owning <see cref="TileMap"/>'s position).</param>
+/// <param name="Y">
+/// Top edge, in world space — matches <see cref="TileMap.Y"/>'s convention where a larger value
+/// is higher up. Note this holds regardless of the source object's Tiled anchor: rectangle
+/// objects anchor at their top-left in Tiled, tile-insert objects anchor at their bottom-left —
+/// both are normalized to a top-left world corner here.
+/// </param>
+/// <param name="Width">Width in world units. Zero for object types with no size (e.g. point objects).</param>
+/// <param name="Height">Height in world units. Zero for object types with no size.</param>
+/// <param name="Class">The object's Tiled "Class" value, or an empty string if unset.</param>
+/// <param name="GlobalId">
+/// The tile's global ID for tile-insert objects (placed with Tiled's "Insert Tile" tool);
+/// zero for objects not tied to a tile.
+/// </param>
+/// <param name="Properties">
+/// Custom properties as strings, keyed by name. For tile-insert objects this merges the tile's
+/// class-level properties (defined on the tile's type in the tileset) with instance-level
+/// properties, instance values winning on collision — the same merge
+/// <see cref="TileMap.CreateEntities{T}"/> performs. Empty if the object has no properties.
+/// </param>
+public readonly record struct ObjectLayerEntry(
+    float X,
+    float Y,
+    float Width,
+    float Height,
+    string Class,
+    int GlobalId,
+    IReadOnlyDictionary<string, string> Properties);

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -322,6 +322,109 @@ public class TileMap
         _layersByName.TryGetValue(name, out layer!);
 
     /// <summary>
+    /// Returns a snapshot of every object on the object layer named <paramref name="layerName"/>
+    /// (case-insensitive) — position, size, class, tile global ID, and properties — for reading
+    /// Tiled object data directly instead of going through <see cref="CreateEntities{T}"/>
+    /// (spawns entities) or <see cref="GenerateCollisionFromClass"/> (builds collision).
+    /// </summary>
+    /// <remarks>
+    /// Only rectangle objects, tile-insert objects, and other simple (unsized) object types are
+    /// included. Polygon objects are skipped — their shape can't be represented as a single
+    /// axis-aligned rect; use <see cref="GenerateCollisionFromClass"/> or
+    /// <see cref="GenerateCollisionFromProperty"/> for polygon collision. Object rotation is
+    /// ignored — <see cref="ObjectLayerEntry"/> always describes the object's unrotated placement.
+    /// </remarks>
+    /// <param name="layerName">The object layer's name (case-insensitive).</param>
+    /// <returns>
+    /// One entry per supported object, in the layer's authoring order. Empty if the layer
+    /// doesn't exist or has no supported objects.
+    /// </returns>
+    public IReadOnlyList<ObjectLayerEntry> GetObjectLayerData(string layerName)
+    {
+        var entries = new List<ObjectLayerEntry>();
+        if (_tilemap == null)
+            return entries;
+
+        foreach (var layer in _tilemap.Layers)
+        {
+            if (layer is not TilemapObjectLayer objectLayer ||
+                !string.Equals(objectLayer.Name, layerName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            foreach (var obj in objectLayer.Objects)
+            {
+                switch (obj)
+                {
+                    case TilemapPolygonObject:
+                        continue;
+                    case TilemapTileObject tileObj:
+                        entries.Add(BuildTileObjectEntry(tileObj));
+                        break;
+                    case TilemapRectangleObject rectObj:
+                        entries.Add(BuildRectangleObjectEntry(rectObj));
+                        break;
+                    default:
+                        entries.Add(BuildPlainObjectEntry(obj));
+                        break;
+                }
+            }
+            break; // layer names are unique in Tiled
+        }
+
+        return entries;
+    }
+
+    private ObjectLayerEntry BuildTileObjectEntry(TilemapTileObject tileObj)
+    {
+        // Tile-insert objects anchor at the bottom-left corner (Y-down) — flip to the
+        // top-left-anchored convention every other entry from this method uses.
+        float worldX = _x + tileObj.Position.X;
+        float worldY = _y - tileObj.Position.Y + tileObj.Size.Y;
+
+        var classProps = tileObj.Tile.GetTileData(_tilemap!.Tilesets)?.Properties;
+        var merged = BuildMergedPropertySnapshot(classProps, tileObj.Properties);
+
+        return new ObjectLayerEntry(
+            worldX, worldY, tileObj.Size.X, tileObj.Size.Y,
+            tileObj.Class ?? string.Empty, tileObj.Tile.GlobalId, StringifyProperties(merged));
+    }
+
+    private ObjectLayerEntry BuildRectangleObjectEntry(TilemapRectangleObject rectObj)
+    {
+        float worldX = _x + rectObj.Position.X;
+        float worldY = _y - rectObj.Position.Y;
+
+        var merged = BuildMergedPropertySnapshot(classProps: null, rectObj.Properties);
+
+        return new ObjectLayerEntry(
+            worldX, worldY, rectObj.Size.X, rectObj.Size.Y,
+            rectObj.Class ?? string.Empty, GlobalId: 0, StringifyProperties(merged));
+    }
+
+    private ObjectLayerEntry BuildPlainObjectEntry(TilemapObject obj)
+    {
+        float worldX = _x + obj.Position.X;
+        float worldY = _y - obj.Position.Y;
+
+        var merged = BuildMergedPropertySnapshot(classProps: null, obj.Properties);
+
+        return new ObjectLayerEntry(
+            worldX, worldY, 0f, 0f, obj.Class ?? string.Empty, GlobalId: 0, StringifyProperties(merged));
+    }
+
+    private static Dictionary<string, string> StringifyProperties(Dictionary<string, TilemapPropertyValue> merged)
+    {
+        var result = new Dictionary<string, string>(merged.Count);
+        foreach (var (key, value) in merged)
+        {
+            var s = value.AsString();
+            if (s != null)
+                result[key] = s;
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Generates a <see cref="TileShapes"/> from tiles whose
     /// <see cref="TilemapTileData.Class"/> matches <paramref name="className"/>. Also matches
     /// rectangle and polygon objects on any object layer whose own <see cref="TilemapObject.Class"/>

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using FlatRedBall2.Tiled;
+using MonoGame.Extended.Tilemaps;
+using Shouldly;
+using Xunit;
+using XnaVec2 = Microsoft.Xna.Framework.Vector2;
+
+namespace FlatRedBall2.Tests.Tiled;
+
+public class TileMapGetObjectLayerDataTests
+{
+    private static Tilemap BuildObjectOnlyTilemap(
+        int widthTiles, int heightTiles, int tileSize, TilemapObjectLayer objectLayer, TilemapTileset? tileset = null)
+    {
+        var tilemap = new Tilemap(
+            name: "test",
+            width: widthTiles,
+            height: heightTiles,
+            tileWidth: tileSize,
+            tileHeight: tileSize,
+            orientation: TilemapOrientation.Orthogonal);
+        if (tileset != null)
+            tilemap.Tilesets.Add(tileset);
+        tilemap.Layers.Add(objectLayer);
+        return tilemap;
+    }
+
+    [Fact]
+    public void GetObjectLayerData_LayerNameCaseInsensitive_FindsLayer()
+    {
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)));
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("WATER");
+
+        entries.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetObjectLayerData_NonExistentLayer_ReturnsEmptyList()
+    {
+        var layer = new TilemapObjectLayer("Water");
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("DoesNotExist");
+
+        entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetObjectLayerData_PolygonObject_IsOmitted()
+    {
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)));
+        layer.AddObject(new TilemapPolygonObject(
+            id: 2, position: new XnaVec2(32, 0), points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) }));
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.Count.ShouldBe(1);
+        entries[0].Width.ShouldBe(16f);
+    }
+
+    [Fact]
+    public void GetObjectLayerData_RectangleObject_ReturnsWorldSpaceTopLeftAndSize()
+    {
+        // TileMap positioned away from world origin to prove the map offset is folded in —
+        // raw Tiled-space coords would be wrong here.
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(10, 20), size: new XnaVec2(30, 40)) { Class = "Zone" });
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(4, 4, 16, layer), x: 100f, y: 200f);
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.Count.ShouldBe(1);
+        entries[0].X.ShouldBe(110f);
+        entries[0].Y.ShouldBe(180f);
+        entries[0].Width.ShouldBe(30f);
+        entries[0].Height.ShouldBe(40f);
+        entries[0].Class.ShouldBe("Zone");
+        entries[0].GlobalId.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetObjectLayerData_RectangleObject_UsesInstancePropertiesOnly()
+    {
+        var rectObj = new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16));
+        rectObj.Properties.SetString("Zone", "Water");
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(rectObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].Properties["Zone"].ShouldBe("Water");
+    }
+
+    [Fact]
+    public void GetObjectLayerData_TileObject_ConvertsBottomLeftAnchorToTopLeftAndSetsGlobalId()
+    {
+        // Tile object at Tiled position (16, 48), size 16x16 — same fixture geometry as
+        // TileMapCreateEntitiesTests' Origin.TopLeft case, which expects world (16, -32).
+        var tileData = new TilemapTileData(0) { Class = "Coast" };
+        var tileset = new TilemapTileset(name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(tileData);
+
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapTileObject(
+            id: 1, position: new XnaVec2(16, 48), tile: new TilemapTile(globalId: 1), size: new XnaVec2(16, 16)));
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(4, 4, 16, layer, tileset));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].X.ShouldBe(16f);
+        entries[0].Y.ShouldBe(-32f);
+        entries[0].Width.ShouldBe(16f);
+        entries[0].Height.ShouldBe(16f);
+        entries[0].GlobalId.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetObjectLayerData_TileObject_MergesClassAndInstanceProperties()
+    {
+        var tileData = new TilemapTileData(0) { Class = "Coast" };
+        tileData.Properties.SetString("Terrain", "grass");
+        tileData.Properties.SetString("Side", "top");
+        var tileset = new TilemapTileset(name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(tileData);
+
+        var tileObj = new TilemapTileObject(
+            id: 1, position: new XnaVec2(0, 16), tile: new TilemapTile(globalId: 1), size: new XnaVec2(16, 16));
+        tileObj.Properties.SetString("Terrain", "sand"); // instance overrides class
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(tileObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(4, 4, 16, layer, tileset));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].Properties["Terrain"].ShouldBe("sand");
+        entries[0].Properties["Side"].ShouldBe("top");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TileMap.GetObjectLayerData(layerName)` returning `IReadOnlyList<ObjectLayerEntry>` — position, size, Class, tile GlobalId, and merged properties for objects on an object layer, for data-marker use cases outside `CreateEntities`/collision generation (community suggestion, #735).
- Two corrections to the original proposal (posted to the issue before implementing): coordinates are world-space (fold in `TileMap.X`/`Y`), not raw Tiled-space — the original example was buggy for any non-origin-positioned map. Properties merge tileset-class + instance properties, matching `CreateEntities`.
- Polygon objects are intentionally skipped (documented) — no single rect can represent them; use `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` for those.
- Added a short pointer in the `tmx` skill.

Closes #735

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1179 passed (7 new)
- [x] `dotnet build src/FlatRedBall2.csproj` — 0 warnings, 0 errors