### PR TITLE
Support TilemapPolygonObject in TileMap.GetObjectLayerData

### DIFF
--- a/frb-skills/tmx/SKILL.md
+++ b/frb-skills/tmx/SKILL.md
@@ -155,7 +155,7 @@ Adjacent sub-cell rects participate in `SolidSides` seam suppression: if two sub
 
 ### Reading object-layer data directly (no entity, no collision)
 
-`TileMap.GetObjectLayerData(layerName)` returns each object's world-space rect, Class, tile GlobalId, and merged properties as an `ObjectLayerEntry` — for object layers used purely as data markers (a Water zone's bounds, Coast tile terrain/side properties) rather than `CreateEntities` spawns or collision generation. Polygon objects are skipped (rect-only); use `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` for polygon shapes.
+`TileMap.GetObjectLayerData(layerName)` returns each object's world-space rect (or, for polygons, `ObjectLayerEntry.Points`), Class, tile GlobalId, and merged properties — for object layers used purely as data markers (a Water zone's bounds, Coast tile terrain/side properties) rather than `CreateEntities` spawns or collision generation. Rotation is ignored for every shape here; use `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` if you need rotation-aware collision instead.
 
 ### Add an object layer for entity spawns
 

--- a/src/Tiled/ObjectLayerEntry.cs
+++ b/src/Tiled/ObjectLayerEntry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace FlatRedBall2.Tiled;
 
@@ -15,7 +16,7 @@ namespace FlatRedBall2.Tiled;
 /// objects anchor at their top-left in Tiled, tile-insert objects anchor at their bottom-left —
 /// both are normalized to a top-left world corner here.
 /// </param>
-/// <param name="Width">Width in world units. Zero for object types with no size (e.g. point objects).</param>
+/// <param name="Width">Width in world units. Zero for object types with no size (e.g. point or polygon objects).</param>
 /// <param name="Height">Height in world units. Zero for object types with no size.</param>
 /// <param name="Class">The object's Tiled "Class" value, or an empty string if unset.</param>
 /// <param name="GlobalId">
@@ -28,6 +29,12 @@ namespace FlatRedBall2.Tiled;
 /// properties, instance values winning on collision — the same merge
 /// <see cref="TileMap.CreateEntities{T}"/> performs. Empty if the object has no properties.
 /// </param>
+/// <param name="Points">
+/// The polygon's vertices in world space, non-null only for polygon objects (null for every
+/// other object type — <see cref="Width"/>/<see cref="Height"/> are 0 for these, not a bounding
+/// box). Like the rest of this entry, rotation is ignored — points reflect the object's
+/// unrotated local shape translated to <see cref="X"/>/<see cref="Y"/>'s coordinate space.
+/// </param>
 public readonly record struct ObjectLayerEntry(
     float X,
     float Y,
@@ -35,4 +42,5 @@ public readonly record struct ObjectLayerEntry(
     float Height,
     string Class,
     int GlobalId,
-    IReadOnlyDictionary<string, string> Properties);
+    IReadOnlyDictionary<string, string> Properties,
+    IReadOnlyList<Vector2>? Points = null);

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -328,11 +328,11 @@ public class TileMap
     /// (spawns entities) or <see cref="GenerateCollisionFromClass"/> (builds collision).
     /// </summary>
     /// <remarks>
-    /// Only rectangle objects, tile-insert objects, and other simple (unsized) object types are
-    /// included. Polygon objects are skipped — their shape can't be represented as a single
-    /// axis-aligned rect; use <see cref="GenerateCollisionFromClass"/> or
-    /// <see cref="GenerateCollisionFromProperty"/> for polygon collision. Object rotation is
-    /// ignored — <see cref="ObjectLayerEntry"/> always describes the object's unrotated placement.
+    /// Rectangle objects, tile-insert objects, polygon objects (as <see cref="ObjectLayerEntry.Points"/>),
+    /// and other simple (unsized) object types are all included. Object rotation is ignored —
+    /// <see cref="ObjectLayerEntry"/> always describes the object's unrotated placement; use
+    /// <see cref="GenerateCollisionFromClass"/> or <see cref="GenerateCollisionFromProperty"/>
+    /// instead if you need rotation-aware collision shapes.
     /// </remarks>
     /// <param name="layerName">The object layer's name (case-insensitive).</param>
     /// <returns>
@@ -355,8 +355,9 @@ public class TileMap
             {
                 switch (obj)
                 {
-                    case TilemapPolygonObject:
-                        continue;
+                    case TilemapPolygonObject polyObj:
+                        entries.Add(BuildPolygonObjectEntry(polyObj));
+                        break;
                     case TilemapTileObject tileObj:
                         entries.Add(BuildTileObjectEntry(tileObj));
                         break;
@@ -399,6 +400,28 @@ public class TileMap
         return new ObjectLayerEntry(
             worldX, worldY, rectObj.Size.X, rectObj.Size.Y,
             rectObj.Class ?? string.Empty, GlobalId: 0, StringifyProperties(merged));
+    }
+
+    private ObjectLayerEntry BuildPolygonObjectEntry(TilemapPolygonObject polyObj)
+    {
+        var merged = BuildMergedPropertySnapshot(classProps: null, polyObj.Properties);
+
+        Vector2[]? worldPoints = null;
+        if (polyObj.Points != null)
+        {
+            worldPoints = new Vector2[polyObj.Points.Length];
+            for (int i = 0; i < polyObj.Points.Length; i++)
+            {
+                var p = polyObj.Points[i];
+                worldPoints[i] = new Vector2(
+                    _x + polyObj.Position.X + p.X,
+                    _y - (polyObj.Position.Y + p.Y));
+            }
+        }
+
+        return new ObjectLayerEntry(
+            _x + polyObj.Position.X, _y - polyObj.Position.Y, 0f, 0f,
+            polyObj.Class ?? string.Empty, GlobalId: 0, StringifyProperties(merged), worldPoints);
     }
 
     private ObjectLayerEntry BuildPlainObjectEntry(TilemapObject obj)

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 using FlatRedBall2.Tiled;
 using MonoGame.Extended.Tilemaps;
 using Shouldly;
@@ -49,18 +50,44 @@ public class TileMapGetObjectLayerDataTests
     }
 
     [Fact]
-    public void GetObjectLayerData_PolygonObject_IsOmitted()
+    public void GetObjectLayerData_PolygonObject_ReturnsWorldSpacePoints()
     {
+        // Local triangle (0,0),(16,16),(0,16) at Tiled position (16,0), map at origin.
+        // World point = (mapX + Position.X + localX, mapY - (Position.Y + localY)) — no
+        // rotation applied, consistent with this method ignoring Rotation for every object type.
+        var polyObj = new TilemapPolygonObject(
+            id: 1, position: new XnaVec2(16, 0),
+            points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) }) { Class = "Zone" };
+        polyObj.Properties.SetString("Terrain", "reef");
         var layer = new TilemapObjectLayer("Water");
-        layer.AddObject(new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)));
-        layer.AddObject(new TilemapPolygonObject(
-            id: 2, position: new XnaVec2(32, 0), points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) }));
+        layer.AddObject(polyObj);
         var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
 
         var entries = tileMap.GetObjectLayerData("Water");
 
         entries.Count.ShouldBe(1);
-        entries[0].Width.ShouldBe(16f);
+        entries[0].Points.ShouldNotBeNull();
+        entries[0].Points!.Count.ShouldBe(3);
+        entries[0].Points![0].ShouldBe(new Vector2(16f, 0f));
+        entries[0].Points![1].ShouldBe(new Vector2(32f, -16f));
+        entries[0].Points![2].ShouldBe(new Vector2(16f, -16f));
+        entries[0].Width.ShouldBe(0f);
+        entries[0].Height.ShouldBe(0f);
+        entries[0].GlobalId.ShouldBe(0);
+        entries[0].Class.ShouldBe("Zone");
+        entries[0].Properties["Terrain"].ShouldBe("reef");
+    }
+
+    [Fact]
+    public void GetObjectLayerData_RectangleObject_PointsIsNull()
+    {
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)));
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].Points.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `ObjectLayerEntry.Points` (`IReadOnlyList<Vector2>?`, world-space, non-null only for polygon objects) rather than a separate polygon-only method — matches both Tiled's own object model (one shared object entity, optional points data) and this struct's existing precedent (`GlobalId`/`Width`/`Height` already default to 0 for object types that don't have them).
- Rotation stays ignored for polygon points, consistent with every other object type this method returns — `GenerateCollisionFromClass`/`GenerateCollisionFromProperty` remain the answer for rotation-aware collision shapes.
- Updated the `tmx` skill's now-stale "polygon objects are skipped" note.

Closes #737

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1180 passed (net +1: replaced the old "polygon omitted" test with two new ones covering polygon geometry/properties and confirming `Points` stays null for non-polygon objects)
- [x] `dotnet build src/FlatRedBall2.csproj` — 0 warnings, 0 errors