### PR TITLE
Fully cover TileMap.GetObjectLayerData branches and edge cases

### DIFF
--- a/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
@@ -39,6 +39,31 @@ public class TileMapGetObjectLayerDataTests
     }
 
     [Fact]
+    public void GetObjectLayerData_MixedObjectTypes_ReturnsOneEntryPerObjectInAuthoringOrder()
+    {
+        var tileset = new TilemapTileset(name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(new TilemapTileData(0));
+
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16)) { Class = "Rect" });
+        layer.AddObject(new TilemapPointObject(id: 2, position: new XnaVec2(0, 0)) { Class = "Point" });
+        layer.AddObject(new TilemapPolygonObject(
+            id: 3, position: new XnaVec2(0, 0), points: new[] { new XnaVec2(0, 0), new XnaVec2(1, 1), new XnaVec2(0, 1) }) { Class = "Poly" });
+        layer.AddObject(new TilemapTileObject(
+            id: 4, position: new XnaVec2(0, 16), tile: new TilemapTile(globalId: 1), size: new XnaVec2(16, 16)) { Class = "TileObj" });
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer, tileset));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.Count.ShouldBe(4);
+        entries[0].Class.ShouldBe("Rect");
+        entries[1].Class.ShouldBe("Point");
+        entries[2].Class.ShouldBe("Poly");
+        entries[3].Class.ShouldBe("TileObj");
+    }
+
+    [Fact]
     public void GetObjectLayerData_NonExistentLayer_ReturnsEmptyList()
     {
         var layer = new TilemapObjectLayer("Water");
@@ -50,15 +75,46 @@ public class TileMapGetObjectLayerDataTests
     }
 
     [Fact]
-    public void GetObjectLayerData_PolygonObject_ReturnsWorldSpacePoints()
+    public void GetObjectLayerData_NoTilemapLoaded_ReturnsEmptyList()
     {
-        // Local triangle (0,0),(16,16),(0,16) at Tiled position (16,0), map at origin.
-        // World point = (mapX + Position.X + localX, mapY - (Position.Y + localY)) — no
-        // rotation applied, consistent with this method ignoring Rotation for every object type.
+        var tileMap = new TileMap(width: 64f, height: 64f, tileWidth: 16, tileHeight: 16, layers: new List<TileMapLayer>());
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetObjectLayerData_PlainObject_ReturnsAnchorPositionWithZeroSize()
+    {
+        var pointObj = new TilemapPointObject(id: 1, position: new XnaVec2(24, 8)) { Class = "Spawn" };
+        pointObj.Properties.SetString("Kind", "Player");
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(pointObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer), x: 50f, y: 60f);
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.Count.ShouldBe(1);
+        entries[0].X.ShouldBe(74f);
+        entries[0].Y.ShouldBe(52f);
+        entries[0].Width.ShouldBe(0f);
+        entries[0].Height.ShouldBe(0f);
+        entries[0].GlobalId.ShouldBe(0);
+        entries[0].Class.ShouldBe("Spawn");
+        entries[0].Points.ShouldBeNull();
+        entries[0].Properties["Kind"].ShouldBe("Player");
+    }
+
+    [Fact]
+    public void GetObjectLayerData_PolygonObject_NullPointsReturnsNullPointsEntry()
+    {
+        // TilemapPolygonObject.Points has a public setter and TileMapCollisions already guards
+        // against it being null (AddPolygonObject) — a reachable state, not a hypothetical one.
         var polyObj = new TilemapPolygonObject(
-            id: 1, position: new XnaVec2(16, 0),
-            points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) }) { Class = "Zone" };
-        polyObj.Properties.SetString("Terrain", "reef");
+            id: 1, position: new XnaVec2(0, 0),
+            points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) });
+        polyObj.Points = null!;
         var layer = new TilemapObjectLayer("Water");
         layer.AddObject(polyObj);
         var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
@@ -66,11 +122,36 @@ public class TileMapGetObjectLayerDataTests
         var entries = tileMap.GetObjectLayerData("Water");
 
         entries.Count.ShouldBe(1);
+        entries[0].Points.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetObjectLayerData_PolygonObject_ReturnsWorldSpacePoints()
+    {
+        // Local triangle (0,0),(16,16),(0,16) at Tiled position (16,40), map at (200,300) — both
+        // the object's own anchor position and the map offset are nonzero so this also proves the
+        // entry's own X/Y reflect the world-space anchor (not just Points), and that the map
+        // offset is folded into polygon conversion the same as it is for rects/tile-objects.
+        // World point = (mapX + Position.X + localX, mapY - (Position.Y + localY)) — no
+        // rotation applied, consistent with this method ignoring Rotation for every object type.
+        var polyObj = new TilemapPolygonObject(
+            id: 1, position: new XnaVec2(16, 40),
+            points: new[] { new XnaVec2(0, 0), new XnaVec2(16, 16), new XnaVec2(0, 16) }) { Class = "Zone" };
+        polyObj.Properties.SetString("Terrain", "reef");
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(polyObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer), x: 200f, y: 300f);
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries.Count.ShouldBe(1);
+        entries[0].X.ShouldBe(216f);
+        entries[0].Y.ShouldBe(260f);
         entries[0].Points.ShouldNotBeNull();
         entries[0].Points!.Count.ShouldBe(3);
-        entries[0].Points![0].ShouldBe(new Vector2(16f, 0f));
-        entries[0].Points![1].ShouldBe(new Vector2(32f, -16f));
-        entries[0].Points![2].ShouldBe(new Vector2(16f, -16f));
+        entries[0].Points![0].ShouldBe(new Vector2(216f, 260f));
+        entries[0].Points![1].ShouldBe(new Vector2(232f, 244f));
+        entries[0].Points![2].ShouldBe(new Vector2(216f, 244f));
         entries[0].Width.ShouldBe(0f);
         entries[0].Height.ShouldBe(0f);
         entries[0].GlobalId.ShouldBe(0);
@@ -147,6 +228,29 @@ public class TileMapGetObjectLayerDataTests
         entries[0].Width.ShouldBe(16f);
         entries[0].Height.ShouldBe(16f);
         entries[0].GlobalId.ShouldBe(1);
+        entries[0].Points.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetObjectLayerData_TileObject_FoldsInMapOffset()
+    {
+        // Same object geometry as the ConvertsBottomLeftAnchor test, but with the map itself
+        // moved off the origin — proves the map offset combines correctly with the
+        // bottom-left-to-top-left flip, not just with the simpler top-left-anchored formula
+        // rectangle/plain/polygon objects use.
+        var tileset = new TilemapTileset(name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(new TilemapTileData(0));
+
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(new TilemapTileObject(
+            id: 1, position: new XnaVec2(16, 48), tile: new TilemapTile(globalId: 1), size: new XnaVec2(16, 16)));
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(4, 4, 16, layer, tileset), x: 100f, y: 50f);
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].X.ShouldBe(116f);
+        entries[0].Y.ShouldBe(18f);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Follow-up to #736 / #738 (`TileMap.GetObjectLayerData` / `ObjectLayerEntry.Points`). While answering a question about Y-axis test coverage after #738 merged, found the polygon entry's own `X`/`Y` anchor was never asserted (only `Points` was) — closing that gap surfaced several other untested branches:

- Polygon `X`/`Y` anchor + map-offset folding for polygons specifically (previously only proven for rects/tile-objects)
- `TilemapPolygonObject.Points == null` (a state `TileMapCollisions` already guards against elsewhere)
- The plain-object fallback branch (`TilemapPointObject`) — had zero coverage
- Map offset combined with the tile-object bottom-left→top-left flip specifically (only the simpler top-left-anchored rect formula had an offset test)
- Mixed object types on one layer / authoring order
- The `_tilemap == null` guard (test-only constructor path)

No production code changed — every new/modified assertion passed against the existing implementation as-is.

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1185 passed (net +5)
- [x] `dotnet build src/FlatRedBall2.csproj` — 0 new warnings (2 pre-existing, unrelated `CS1574` warnings on `Line.cs`)