### PR TITLE
Fix crash when two single-cell polygon objects share a grid cell

### DIFF
--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -473,8 +473,18 @@ public static class TileMapCollisions
         var centroid = new Vector2(sumX / worldPoints.Length, sumY / worldPoints.Length);
 
         var (col, row) = collection.GetCellAt(centroid);
-        var cellCenter = collection.GetCellWorldPosition(col, row);
 
+        // AddPolygonTileAtCell supports only one polygon per cell. Object-layer authoring has no
+        // such restriction — a rotated rect (converted to a polygon above) and a separate polygon
+        // object can legitimately centroid into the same cell. Fall back to the same
+        // AddSpanningPolygon mechanism used for multi-cell shapes rather than throwing.
+        if (collection.GetPolygonTileAtCell(col, row) != null)
+        {
+            collection.AddSpanningPolygon(worldPoints);
+            return;
+        }
+
+        var cellCenter = collection.GetCellWorldPosition(col, row);
         var localPoints = new List<Vector2>(worldPoints.Length);
         foreach (var p in worldPoints)
             localPoints.Add(p - cellCenter);

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCollisionsTests.cs
@@ -730,4 +730,30 @@ public class TileMapCollisionsTests
         rect.SolidSides.ShouldBe(
             SolidSides.Up | SolidSides.Down | SolidSides.Right);
     }
+
+    [Fact]
+    public void GenerateFromClass_ObjectLayerRotatedRectAndPolygonSameCellSameClass_BothEmitted()
+    {
+        // Issue #741 repro: a rectangle object rotated to a non-90-degree angle (so it converts
+        // to a polygon per AddRectangleObject) and a genuine polygon object, both matching class
+        // "Solid" on the same object layer, with bounding boxes landing in the SAME single cell
+        // (0,0). AddPolygonFromWorldPoints routes both through AddPolygonTileAtCell(0,0,...) —
+        // the second call throws InvalidOperationException ("A polygon tile already exists at
+        // cell...") because multi-polygon-per-cell is not supported, even though the two source
+        // objects are unrelated shapes that merely happen to share a cell.
+        var layer = new TilemapObjectLayer("Objects");
+        layer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(8, 4), size: new XnaVec2(6, 6))
+        { Class = "Solid", Rotation = MathF.PI / 4f });
+
+        var tri = new XnaVec2[] { new(12, 12), new(15, 12), new(12, 15) };
+        layer.AddObject(new TilemapPolygonObject(
+            id: 2, position: new XnaVec2(0, 0), points: tri) { Class = "Solid" });
+
+        var tilemap = BuildObjectOnlyTilemap(1, 1, 16, layer);
+
+        var coll = TileMapCollisions.GenerateFromClass(tilemap, "Solid");
+
+        coll.AllTiles.OfType<Polygon>().Count().ShouldBe(2);
+    }
 }


### PR DESCRIPTION
## Summary
- `AddPolygonTileAtCell` allows only one polygon per grid cell. A rotated rectangle object (converted to a polygon) and a genuine polygon object with the same class, on the same object layer, whose centroids land in the same cell, hit this limit and threw `InvalidOperationException` during `GenerateCollisionFromClass`.
- Fix: when a second single-cell polygon targets an already-occupied cell, route it through `AddSpanningPolygon` (the existing mechanism for polygons that cross cell boundaries) instead of throwing.
- The issue's suspected root causes (SAT/decomposition, aggregation, GC) were speculative and not the actual cause — the real bug is the same-cell collision in `TileShapes`'s single-polygon-per-cell bookkeeping, reproduced with a minimal unit test before any fix was written.

Closes #741

## Test plan
- [x] New test `GenerateFromClass_ObjectLayerRotatedRectAndPolygonSameCellSameClass_BothEmitted` reproduces the crash pre-fix (`InvalidOperationException`) and passes post-fix.
- [x] Full suite: `dotnet test tests/FlatRedBall2.Tests/` — 1189 passed, 0 failed.