### PR TITLE
Fix #567: Match Frame Size ignores rest of multi-selected rectangles

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -532,6 +532,29 @@ namespace AnimationEditor.Core.CommandsAndState
                 animationFrame.RelativeX, animationFrame.RelativeY, this, _events));
         }
 
+        /// <summary>
+        /// Batched "Match Frame Size" for a multi-selection of rectangles. Each rectangle is
+        /// matched to its own containing frame (via <see cref="ObjectFinder"/>), not a single
+        /// shared frame, so a selection spanning multiple frames still resizes correctly.
+        /// Records one undo entry for the whole batch.
+        /// </summary>
+        public void MatchRectanglesToFrames(List<AARectSave> rectangles)
+        {
+            var commands = new List<IUndoableCommand>();
+            foreach (var rect in rectangles.ToArray())
+            {
+                var ownerFrame = _objectFinder.GetAnimationFrameContaining(rect);
+                if (ownerFrame is null) continue;
+                commands.Add(new MoveShapeCommand(
+                    ownerFrame, rect, rect.X, rect.Y,
+                    ownerFrame.RelativeX, ownerFrame.RelativeY, this, _events));
+            }
+            if (commands.Count == 0) return;
+
+            string desc = commands.Count == 1 ? commands[0].Description : $"Match {commands.Count} Shapes to Frame";
+            _undoManager.Execute(new CompositeCommand(commands, desc));
+        }
+
         // Raw position assignment used by the internal shape-creation paths to set a
         // new shape's initial offset before it is handed to its Add command.
         private static void ApplyRectangleMatch(AARectSave rectangle, AnimationFrameSave animationFrame)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -129,6 +129,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void AddCircle(AnimationFrameSave frame);
         void MatchRectangleToFrame(AARectSave rectangle, AnimationFrameSave animationFrame);
         void MatchCircleToFrame(CircleSave circle, AnimationFrameSave animationFrame);
+        void MatchRectanglesToFrames(List<AARectSave> rectangles);
         void DeleteCircle(CircleSave circle, AnimationFrameSave owner);
         void DeleteAxisAlignedRectangle(AARectSave rectangle, AnimationFrameSave owner);
         void DeleteShapes(AnimationFrameSave frame, List<AARectSave> rectangles, List<CircleSave> circles);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuPlanBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuPlanBuilder.cs
@@ -107,10 +107,14 @@ public static class TreeMenuPlanBuilder
         return items;
     }
 
+    // Matches the whole multi-selection, not just the right-clicked rectangle (issue #567) —
+    // mirrors HandleDelete's fallback-to-single-item pattern. Each rectangle is matched to its
+    // own owning frame (see AppCommands.MatchRectanglesToFrames), so a selection spanning
+    // multiple frames still resizes correctly.
     private static void MatchFrameSize(AARectSave rect, IAppCommands appCommands, ISelectedState selectedState)
     {
-        if (selectedState.SelectedFrame is not { } frame) return;
-        appCommands.MatchRectangleToFrame(rect, frame);
+        var rects = selectedState.SelectedRectangles;
+        appCommands.MatchRectanglesToFrames(rects.Count > 0 ? rects : new List<AARectSave> { rect });
         appCommands.RefreshAnimationFrameDisplay();
         appCommands.SaveCurrentAnimationChainList();
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RightClickContextMenuMatchFrameSizeAppTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RightClickContextMenuMatchFrameSizeAppTests.cs
@@ -1,0 +1,192 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.Animation.Content;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #567: the tree context menu's "Match Frame Size" item
+/// only resized the single right-clicked rectangle, silently leaving the rest of a
+/// multi-selection unchanged — the same hardcoded-single-item bug already fixed for
+/// Delete in <see cref="RightClickContextMenuDeleteAppTests"/>.
+/// </summary>
+public class RightClickContextMenuMatchFrameSizeAppTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object[] { System.Array.Empty<string>() });
+        FlushUi();
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TreeNodeVm FirstChainNode(TreeView tree) =>
+        tree.ItemsSource is System.Collections.IEnumerable roots
+            ? roots.Cast<TreeNodeVm>().First()
+            : throw new Xunit.Sdk.XunitException("No tree roots");
+
+    // Right-clicks the realized TreeViewItem for `node` via a real pointer press, so the
+    // test exercises OnTreePointerPressed's selection-preserving logic, not just its effect.
+    private static void RightClick(MainWindow window, TreeView tree, TreeNodeVm node)
+    {
+        var tvi = tree.GetVisualDescendants().OfType<TreeViewItem>()
+            .First(t => ReferenceEquals(t.DataContext, node));
+        var centre = new Point(tvi.Bounds.Width / 2, tvi.Bounds.Height / 2);
+        var pointInWindow = tvi.TranslatePoint(centre, window)!.Value;
+        window.MouseDown(pointInWindow, MouseButton.Right);
+        FlushUi();
+    }
+
+    private static void OpenContextMenu(MainWindow window) =>
+        typeof(MainWindow)
+            .GetMethod("OnTreeContextMenuOpening", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object?[] { null, new CancelEventArgs() });
+
+    private static void ClickContextMenuItem(TreeView tree, string header)
+    {
+        var item = tree.ContextMenu!.Items
+            .OfType<MenuItem>()
+            .First(m => m.Header?.ToString() == header);
+        item.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+    }
+
+    [AvaloniaFact]
+    public void MatchFrameSize_ContextMenu_OnMultiSelection_MatchesAllSelectedRectangles()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave
+            {
+                TextureName = "a.png", ShapesSave = new ShapesSave(),
+                RelativeX = 40f, RelativeY = -20f
+            };
+            var r0 = new AARectSave { Name = "R0", X = 1f, Y = 1f };
+            var r1 = new AARectSave { Name = "R1", X = 2f, Y = 2f };
+            frame.ShapesSave.Shapes.Add(r0);
+            frame.ShapesSave.Shapes.Add(r1);
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+
+            var frameNode = chainNode.Children[0];
+            frameNode.IsExpanded = true;
+            FlushUi();
+
+            var rectNodes = frameNode.Children;
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rectNodes[0]);
+            tree.SelectedItems.Add(rectNodes[1]);
+            FlushUi();
+
+            // Right-click the first rect (not the whole selection) — selection must survive,
+            // and Match Frame Size must then act on both rectangles, not just this one.
+            RightClick(window, tree, rectNodes[0]);
+            Assert.Equal(2, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextMenuItem(tree, "Match Frame Size");
+
+            Assert.Equal(40f, r0.X);
+            Assert.Equal(-20f, r0.Y);
+            Assert.Equal(40f, r1.X);
+            Assert.Equal(-20f, r1.Y);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void MatchFrameSize_ContextMenu_OnMultiSelectionSpanningFrames_MatchesEachRectangleToItsOwnFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frameA = new AnimationFrameSave
+            {
+                TextureName = "a.png", ShapesSave = new ShapesSave(),
+                RelativeX = 5f, RelativeY = 6f
+            };
+            var frameB = new AnimationFrameSave
+            {
+                TextureName = "b.png", ShapesSave = new ShapesSave(),
+                RelativeX = 50f, RelativeY = 60f
+            };
+            var rectInA = new AARectSave { Name = "InA", X = 1f, Y = 1f };
+            var rectInB = new AARectSave { Name = "InB", X = 2f, Y = 2f };
+            frameA.ShapesSave.Shapes.Add(rectInA);
+            frameB.ShapesSave.Shapes.Add(rectInB);
+            chain.Frames.Add(frameA);
+            chain.Frames.Add(frameB);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+
+            var frameNodeA = chainNode.Children[0];
+            var frameNodeB = chainNode.Children[1];
+            frameNodeA.IsExpanded = true;
+            frameNodeB.IsExpanded = true;
+            FlushUi();
+
+            var rectNodeA = frameNodeA.Children[0];
+            var rectNodeB = frameNodeB.Children[0];
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rectNodeA);
+            tree.SelectedItems.Add(rectNodeB);
+            FlushUi();
+
+            RightClick(window, tree, rectNodeA);
+            Assert.Equal(2, tree.SelectedItems!.Count);
+
+            OpenContextMenu(window);
+            ClickContextMenuItem(tree, "Match Frame Size");
+
+            // Each rectangle matches its OWN frame, not frameA (the "current"/primary frame).
+            Assert.Equal(5f, rectInA.X);
+            Assert.Equal(6f, rectInA.Y);
+            Assert.Equal(50f, rectInB.X);
+            Assert.Equal(60f, rectInB.Y);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapeTests.cs
@@ -1,6 +1,7 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -333,6 +334,80 @@ public class AppCommandsShapeTests
         ctx.AppCommands.MatchRectangleToFrame(rect, frame);
 
         Assert.Equal(-9f, rect.Y);
+    }
+
+    // ── MatchRectanglesToFrames (issue #567: multi-selection) ────────────────
+
+    [Fact]
+    public void MatchRectanglesToFrames_MatchesEveryRectangleInTheBatch()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        frame.RelativeX = 12f;
+        frame.RelativeY = -4f;
+        var r0 = new AARectSave { Name = "R0" };
+        var r1 = new AARectSave { Name = "R1" };
+        frame.ShapesSave!.Shapes.Add(r0);
+        frame.ShapesSave!.Shapes.Add(r1);
+
+        ctx.AppCommands.MatchRectanglesToFrames(new List<AARectSave> { r0, r1 });
+
+        Assert.Equal(12f, r0.X);
+        Assert.Equal(-4f, r0.Y);
+        Assert.Equal(12f, r1.X);
+        Assert.Equal(-4f, r1.Y);
+    }
+
+    [Fact]
+    public void MatchRectanglesToFrames_UsesEachRectanglesOwnFrame_NotASharedFrame()
+    {
+        // Root cause from #567: a naive fix would resize every selected rectangle to the
+        // single "current" frame. A multi-selection spanning two frames must match each
+        // rectangle to its *own* containing frame instead.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        frameA.RelativeX = 5f;  frameA.RelativeY = 6f;
+        frameB.RelativeX = 50f; frameB.RelativeY = 60f;
+        var rectInA = new AARectSave { Name = "InA" };
+        var rectInB = new AARectSave { Name = "InB" };
+        frameA.ShapesSave!.Shapes.Add(rectInA);
+        frameB.ShapesSave!.Shapes.Add(rectInB);
+
+        ctx.AppCommands.MatchRectanglesToFrames(new List<AARectSave> { rectInA, rectInB });
+
+        Assert.Equal(5f, rectInA.X);
+        Assert.Equal(6f, rectInA.Y);
+        Assert.Equal(50f, rectInB.X);
+        Assert.Equal(60f, rectInB.Y);
+    }
+
+    [Fact]
+    public void MatchRectanglesToFrames_RecordsOneUndoStepForTheWholeBatch()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        frameA.RelativeX = 5f;  frameA.RelativeY = 6f;
+        frameB.RelativeX = 50f; frameB.RelativeY = 60f;
+        var rectInA = new AARectSave { Name = "InA", X = 1f, Y = 1f };
+        var rectInB = new AARectSave { Name = "InB", X = 2f, Y = 2f };
+        frameA.ShapesSave!.Shapes.Add(rectInA);
+        frameB.ShapesSave!.Shapes.Add(rectInB);
+
+        ctx.AppCommands.MatchRectanglesToFrames(new List<AARectSave> { rectInA, rectInB });
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(1f, rectInA.X);
+        Assert.Equal(1f, rectInA.Y);
+        Assert.Equal(2f, rectInB.X);
+        Assert.Equal(2f, rectInB.Y);
+        Assert.False(ctx.UndoManager.CanUndo);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeMenuPlanBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeMenuPlanBuilderTests.cs
@@ -180,4 +180,61 @@ public class TreeMenuPlanBuilderTests
         Assert.True(IndexOf(items, "Rename…") >= 0);
         Assert.True(IndexOf(items, "Delete Rectangle") >= 0);
     }
+
+    // ── Match Frame Size on a multi-selection (issue #567) ────────────────────
+
+    [Fact]
+    public void Build_RectNode_MatchFrameSizeClick_OnMultiSelection_MatchesEveryRectangle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.RelativeX = 40f;
+        frame.RelativeY = -20f;
+        chain.Frames.Add(frame);
+        var r0 = new AARectSave { Name = "R0", X = 1f, Y = 1f };
+        var r1 = new AARectSave { Name = "R1", X = 2f, Y = 2f };
+        frame.ShapesSave!.Shapes.Add(r0);
+        frame.ShapesSave.Shapes.Add(r1);
+        ctx.SelectedState.SelectedNodes = new List<object> { r0, r1 };
+
+        // Menu built for r0 (the right-clicked node) — Click must still act on the whole
+        // preserved multi-selection (r0 and r1), not just r0.
+        var items = TreeMenuPlanBuilder.Build(
+            r0, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+        items.Single(i => i.Header == "Match Frame Size").OnClick!();
+
+        Assert.Equal(40f, r0.X);
+        Assert.Equal(-20f, r0.Y);
+        Assert.Equal(40f, r1.X);
+        Assert.Equal(-20f, r1.Y);
+    }
+
+    [Fact]
+    public void Build_RectNode_MatchFrameSizeClick_OnMultiSelectionSpanningFrames_MatchesEachToItsOwnFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frameA = TestHelpers.MakeFrame("a.png");
+        var frameB = TestHelpers.MakeFrame("b.png");
+        frameA.RelativeX = 5f;  frameA.RelativeY = 6f;
+        frameB.RelativeX = 50f; frameB.RelativeY = 60f;
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        var rectInA = new AARectSave { Name = "InA", X = 1f, Y = 1f };
+        var rectInB = new AARectSave { Name = "InB", X = 2f, Y = 2f };
+        frameA.ShapesSave!.Shapes.Add(rectInA);
+        frameB.ShapesSave!.Shapes.Add(rectInB);
+        ctx.SelectedState.SelectedNodes = new List<object> { rectInA, rectInB };
+
+        var items = TreeMenuPlanBuilder.Build(
+            rectInA, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+        items.Single(i => i.Header == "Match Frame Size").OnClick!();
+
+        // Each rectangle matches its OWN frame, not frameA (the node the menu was built for).
+        Assert.Equal(5f, rectInA.X);
+        Assert.Equal(6f, rectInA.Y);
+        Assert.Equal(50f, rectInB.X);
+        Assert.Equal(60f, rectInB.Y);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -64,6 +64,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.AddCircle)]                    = Category.MutatingUndoable,
         [nameof(IAppCommands.MatchRectangleToFrame)]        = Category.MutatingUndoable,
         [nameof(IAppCommands.MatchCircleToFrame)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.MatchRectanglesToFrames)]      = Category.MutatingUndoable,
         [nameof(IAppCommands.DeleteCircle)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.DeleteAxisAlignedRectangle)]   = Category.MutatingUndoable,
         [nameof(IAppCommands.DeleteShapes)]                 = Category.MutatingUndoable,
@@ -210,6 +211,8 @@ public class UndoCoverageRosterTests
             ctx => Sync(() => ctx.AppCommands.MatchRectangleToFrame(Rect(ctx), Zebra(ctx).Frames[0])));
         yield return Row(nameof(IAppCommands.MatchCircleToFrame),
             ctx => Sync(() => ctx.AppCommands.MatchCircleToFrame(Circle(ctx), Zebra(ctx).Frames[0])));
+        yield return Row(nameof(IAppCommands.MatchRectanglesToFrames),
+            ctx => Sync(() => ctx.AppCommands.MatchRectanglesToFrames(new() { Rect(ctx) })));
         yield return Row(nameof(IAppCommands.DeleteCircle),
             ctx => Sync(() => ctx.AppCommands.DeleteCircle(Circle(ctx), Zebra(ctx).Frames[0])));
         yield return Row(nameof(IAppCommands.DeleteAxisAlignedRectangle),


### PR DESCRIPTION
## Summary
- The tree context menu's "Match Frame Size" action hardcoded the single right-clicked rectangle and `_selectedState.SelectedFrame`, so multi-selecting several rectangles and choosing "Match Frame Size" silently left everything but the right-clicked one unchanged.
- Adds `AppCommands.MatchRectanglesToFrames`, which resolves each rectangle's *own* containing frame via `ObjectFinder` (not a single shared frame) and batches the whole selection into one undo step — mirrors the existing `DeleteShapes` / `HandleDelete` pattern.
- `MainWindow`'s menu handler now reads `_selectedState.SelectedRectangles`, falling back to the single right-clicked rectangle when nothing else is selected (same fallback shape as `HandleDelete`).

Fixes #567.

## Test plan
- [x] New Core unit tests (`AppCommandsShapeTests`) covering: matches every rectangle in a batch, uses each rectangle's own frame (not a shared one) for a cross-frame selection, and records exactly one undo step for the batch.
- [x] New headless UI tests (`RightClickContextMenuMatchFrameSizeAppTests`) covering right-click-preserves-selection → Match Frame Size on: (1) a same-frame multi-selection, (2) a selection spanning two frames.
- [x] Added the required `UndoCoverageRosterTests` roster entry for the new `IAppCommands` method.
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1666/1667 passed (1 pre-existing flaky failure, `TabSwitchCacheTests.TryActivateTabFromCache_WhenDiskFileIsNewer_ReturnsFalseAndReloads`, confirmed to also fail on unmodified `main` — unrelated to this change).
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 746/746 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)