### PR TITLE
Animation Editor: check for updates, notify, and auto-update on Windows

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Update;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -190,6 +191,9 @@ public partial class App : Application
         else
             sc.AddSingleton<IFileAssociationService, NullFileAssociationService>();
 
+        sc.AddSingleton<IGitHubReleaseClient, HttpGitHubReleaseClient>();
+        sc.AddSingleton<IUpdateChecker, UpdateChecker>();
+
         sc.AddTransient<MainWindow>(sp => new MainWindow(
             sp.GetRequiredService<IProjectManager>(),
             sp.GetRequiredService<ISelectedState>(),
@@ -202,6 +206,7 @@ public partial class App : Application
             sp.GetRequiredService<IPendingCutState>(),
             sp.GetRequiredService<ThumbnailService>(),
             sp.GetRequiredService<IFileAssociationService>(),
+            sp.GetRequiredService<IUpdateChecker>(),
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)));
 
         return sc.BuildServiceProvider();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -281,7 +281,7 @@
                                 Spacing="8"
                                 VerticalAlignment="Center">
                         <Button x:Name="DownloadUpdateBtn"
-                                Content="Download Update"
+                                Content="Get Update"
                                 Padding="10,3"
                                 FontSize="12" />
                         <Button x:Name="DismissUpdateBannerBtn"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -262,6 +262,54 @@
             </DockPanel>
         </Border>
 
+        <!-- ── Update-available banner (issue #681) ── same "actionable info" tier as
+             DefaultHandlerBanner above; stays until dismissed or the app is updated,
+             so it doesn't get missed the way an auto-dismissing toast would. ── -->
+        <Border x:Name="UpdateAvailableBanner"
+                DockPanel.Dock="Top"
+                IsVisible="False"
+                Background="{DynamicResource InfoBannerBg}"
+                BorderBrush="{DynamicResource LineBrush}"
+                BorderThickness="0,0,0,1">
+            <DockPanel>
+                <Border DockPanel.Dock="Left"
+                        Width="3"
+                        Background="{DynamicResource AccentCool}" />
+                <DockPanel Margin="12,6">
+                    <StackPanel DockPanel.Dock="Right"
+                                Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                        <Button x:Name="DownloadUpdateBtn"
+                                Content="Download Update"
+                                Padding="10,3"
+                                FontSize="12" />
+                        <Button x:Name="DismissUpdateBannerBtn"
+                                Content="Dismiss"
+                                Padding="10,3"
+                                FontSize="12"
+                                Background="Transparent"
+                                Foreground="{DynamicResource InkMid}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                        <Path Width="16"
+                              Height="16"
+                              VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource AccentCool}"
+                              Data="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+                        <TextBlock x:Name="UpdateAvailableBannerText"
+                                   Text="A new version of the Animation Editor is available."
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource Ink}" />
+                    </StackPanel>
+                </DockPanel>
+            </DockPanel>
+        </Border>
+
         <Border DockPanel.Dock="Bottom"
                 Background="{DynamicResource BgRail}"
                 BorderBrush="{DynamicResource LineBrush}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2119,7 +2119,7 @@ public partial class MainWindow : Window
             ? $"Update available: v{updateCheck.LatestVersion}"
             : "Check here for updates:";
         var releaseUrl = updateCheck?.ReleaseUrl ?? ReleasesUrl;
-        var buttonLabel = updateCheck?.IsUpdateAvailable == true ? "Download Update" : "View Releases on GitHub";
+        var buttonLabel = updateCheck?.IsUpdateAvailable == true ? "Get Update" : "View Releases on GitHub";
 
         return new StackPanel
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -226,6 +226,7 @@ public partial class MainWindow : Window
         WireKeyboard();
         WireTabBar();
         WireDefaultHandlerBanner();
+        WireUpdateAvailableBanner();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState, _objectFinder, msg => ShowStatusMessage(msg, isError: true));
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
@@ -818,6 +819,33 @@ public partial class MainWindow : Window
         {
             DefaultHandlerBanner.IsVisible = true;
         }
+    }
+
+    // ── Update-available banner (issue #681) ──────────────────────────────────
+
+    // Session-only (not persisted): dismissing just quiets the current run. The check
+    // re-runs (and can re-show the banner) on the next launch until the user actually updates.
+    private bool _updateBannerDismissed;
+
+    private void WireUpdateAvailableBanner()
+    {
+        DownloadUpdateBtn.Click += (_, _) => OpenUrl((string)DownloadUpdateBtn.Tag!);
+
+        DismissUpdateBannerBtn.Click += (_, _) =>
+        {
+            _updateBannerDismissed = true;
+            UpdateAvailableBanner.IsVisible = false;
+        };
+    }
+
+    private void ShowUpdateAvailableBannerIfAppropriate(UpdateCheckResult result)
+    {
+        if (!result.IsUpdateAvailable || _updateBannerDismissed)
+            return;
+
+        UpdateAvailableBannerText.Text = $"Animation Editor v{result.LatestVersion} is available — you're on v{typeof(MainWindow).Assembly.GetName().Version}.";
+        DownloadUpdateBtn.Tag = result.ReleaseUrl ?? ReleasesUrl;
+        UpdateAvailableBanner.IsVisible = true;
     }
 
     // ── AppCommands wiring ────────────────────────────────────────────────────
@@ -1964,17 +1992,14 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Silent startup check (issue #681) — respects <see cref="UpdateCheckPolicy"/>'s cache
-    /// window so re-launching the same day doesn't re-hit the GitHub API. Shows a toast only
-    /// when an update is actually available; never blocks or errors visibly on failure.
+    /// window so re-launching the same day doesn't re-hit the GitHub API. Shows the persistent
+    /// <see cref="UpdateAvailableBanner"/> only when an update is actually available; never
+    /// blocks or errors visibly on failure.
     /// </summary>
     private async Task RunStartupUpdateCheckAsync()
     {
         var result = await GetUpdateCheckResultAsync(forceRefresh: false);
-        if (result.IsUpdateAvailable)
-        {
-            var url = result.ReleaseUrl ?? ReleasesUrl;
-            ShowToast($"Update available: v{result.LatestVersion}", retryAction: () => OpenUrl(url), actionLabel: "View");
-        }
+        ShowUpdateAvailableBannerIfAppropriate(result);
     }
 
     /// <summary>
@@ -5303,11 +5328,10 @@ public partial class MainWindow : Window
         };
     }
 
-    private void ShowToast(string message, Action? retryAction = null, string actionLabel = "Retry")
+    private void ShowToast(string message, Action? retryAction = null)
     {
         _toastRetryAction = retryAction;
         ToastMessage.Text = message;
-        ToastRetryBtn.Content = actionLabel;
         ToastRetryBtn.IsVisible = retryAction is not null;
         ToastPanel.IsVisible = true;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -12,6 +12,7 @@ using AnimationEditor.Core.Hotkeys;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
+using AnimationEditor.Core.Update;
 using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -52,6 +53,7 @@ public partial class MainWindow : Window
     private readonly IPendingCutState _pendingCutState;
     private readonly Services.ThumbnailService _thumbnailService;
     private readonly IFileAssociationService _fileAssociation;
+    private readonly IUpdateChecker _updateChecker;
     private readonly PngFolderWatcher _pngFolderWatcher = new();
 
     private AppSettingsModel _appSettings = new();
@@ -175,6 +177,7 @@ public partial class MainWindow : Window
         IPendingCutState pendingCutState,
         Services.ThumbnailService thumbnailService,
         IFileAssociationService fileAssociation,
+        IUpdateChecker updateChecker,
         string applicationDataRoot)
     {
         _applicationDataRoot = applicationDataRoot;
@@ -190,6 +193,7 @@ public partial class MainWindow : Window
         _pendingCutState = pendingCutState;
         _thumbnailService = thumbnailService;
         _fileAssociation = fileAssociation;
+        _updateChecker = updateChecker;
         // Desktop renders the tree with its own _treeRoots collection, so the controller
         // reads expand state from there (browser reads its AnimationTreeControl instead).
         _tabController = new TabController(_undoManager, _appCommands,
@@ -781,6 +785,7 @@ public partial class MainWindow : Window
 
         RefreshFilesPanel();
         ShowDefaultHandlerBannerIfAppropriate();
+        _ = RunStartupUpdateCheckAsync();
     }
 
     // ── Default-handler prompt banner ─────────────────────────────────────────
@@ -1866,7 +1871,7 @@ public partial class MainWindow : Window
         ResizeTexture:   () => _ = DoResizeTextureAsync(),
         ShowHistory:     () => SelectHistoryTab(),
         ViewLog:         () => OnViewLogClick(null, null!),
-        About:           () => _ = BuildAboutWindow().ShowDialog(this));
+        About:           () => _ = ShowAboutDialogAsync());
 
     private void RefreshRecentFiles()
     {
@@ -1944,7 +1949,57 @@ public partial class MainWindow : Window
     internal const string ReleasesUrl = "https://github.com/vchelaru/FlatRedBall2/releases";
 
     private void OnAboutClick(object? sender, RoutedEventArgs e)
-        => _ = BuildAboutWindow().ShowDialog(this);
+        => _ = ShowAboutDialogAsync();
+
+    /// <summary>
+    /// Opening the About dialog is the manual "check for updates" action — it always forces a
+    /// fresh check (bypassing <see cref="UpdateCheckPolicy"/>'s cache) rather than adding a
+    /// separate button, since opening this dialog is already an infrequent, explicit user action.
+    /// </summary>
+    private async Task ShowAboutDialogAsync()
+    {
+        var result = await GetUpdateCheckResultAsync(forceRefresh: true);
+        await BuildAboutWindow(result).ShowDialog(this);
+    }
+
+    /// <summary>
+    /// Silent startup check (issue #681) — respects <see cref="UpdateCheckPolicy"/>'s cache
+    /// window so re-launching the same day doesn't re-hit the GitHub API. Shows a toast only
+    /// when an update is actually available; never blocks or errors visibly on failure.
+    /// </summary>
+    private async Task RunStartupUpdateCheckAsync()
+    {
+        var result = await GetUpdateCheckResultAsync(forceRefresh: false);
+        if (result.IsUpdateAvailable)
+        {
+            var url = result.ReleaseUrl ?? ReleasesUrl;
+            ShowToast($"Update available: v{result.LatestVersion}", retryAction: () => OpenUrl(url), actionLabel: "View");
+        }
+    }
+
+    /// <summary>
+    /// Runs the update check (or reuses the cached result if <see cref="UpdateCheckPolicy"/>
+    /// says it's still fresh and <paramref name="forceRefresh"/> is false), persisting the
+    /// outcome to <see cref="AppSettingsModel"/> so it survives restarts.
+    /// </summary>
+    private async Task<UpdateCheckResult> GetUpdateCheckResultAsync(bool forceRefresh)
+    {
+        var currentVersion = typeof(MainWindow).Assembly.GetName().Version ?? new Version(1, 0, 0, 0);
+        var now = DateTime.UtcNow;
+
+        if (!forceRefresh && !UpdateCheckPolicy.ShouldCheck(_appSettings.LastUpdateCheckUtc, now))
+        {
+            return UpdateCheckResult.FromCached(
+                _appSettings.LatestKnownUpdateVersion, _appSettings.LatestKnownUpdateUrl, currentVersion);
+        }
+
+        var result = await _updateChecker.CheckAsync(currentVersion);
+        _appSettings.LastUpdateCheckUtc = now;
+        _appSettings.LatestKnownUpdateVersion = result.LatestVersion?.ToString();
+        _appSettings.LatestKnownUpdateUrl = result.ReleaseUrl;
+        SaveSettingsFile();
+        return result;
+    }
 
     private void OnSettingsClick(object? sender, RoutedEventArgs e)
     {
@@ -2011,10 +2066,11 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Returns a fully-configured About window centered on its owner.
+    /// Returns a fully-configured About window centered on its owner. <paramref name="updateCheck"/>
+    /// is <c>null</c> when no check has run yet (default text: "Check here for updates").
     /// Extracted for testability.
     /// </summary>
-    internal static Window BuildAboutWindow() =>
+    internal static Window BuildAboutWindow(UpdateCheckResult? updateCheck = null) =>
         new Window
         {
             Title = "About AnimationEditor",
@@ -2022,17 +2078,23 @@ public partial class MainWindow : Window
             Height = 240,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = false,
-            Content = BuildAboutContent(),
+            Content = BuildAboutContent(updateCheck),
         };
 
     /// <summary>
     /// Builds the content panel for the About dialog.
     /// Extracted for testability.
     /// </summary>
-    internal static Control BuildAboutContent()
+    internal static Control BuildAboutContent(UpdateCheckResult? updateCheck = null)
     {
         var ver = typeof(MainWindow).Assembly.GetName().Version;
         var versionText = ver is null ? "unknown" : $"{ver.Major}.{ver.Minor}.{ver.Build}";
+
+        var updatePromptText = updateCheck?.IsUpdateAvailable == true
+            ? $"Update available: v{updateCheck.LatestVersion}"
+            : "Check here for updates:";
+        var releaseUrl = updateCheck?.ReleaseUrl ?? ReleasesUrl;
+        var buttonLabel = updateCheck?.IsUpdateAvailable == true ? "Download Update" : "View Releases on GitHub";
 
         return new StackPanel
         {
@@ -2043,10 +2105,23 @@ public partial class MainWindow : Window
                 new TextBlock { Text = "AnimationEditor", FontSize = 16 },
                 new TextBlock { Text = $"Version {versionText}" },
                 new TextBlock { Text = "© FlatRedBall Contributors" },
-                new TextBlock { Text = "Check here for updates:", Margin = new Avalonia.Thickness(0, 12, 0, 0) },
-                BuildOpenUrlButton(ReleasesUrl, "View Releases on GitHub"),
+                new TextBlock { Text = updatePromptText, Margin = new Avalonia.Thickness(0, 12, 0, 0) },
+                BuildOpenUrlButton(releaseUrl, buttonLabel),
             }
         };
+    }
+
+    /// <summary>
+    /// Opens a URL in the user's default browser. Network/shell failures are swallowed —
+    /// there's no useful recovery action for the user beyond trying the link themselves.
+    /// </summary>
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch { }
     }
 
     /// <summary>
@@ -2056,14 +2131,7 @@ public partial class MainWindow : Window
     private static Button BuildOpenUrlButton(string url, string label)
     {
         var button = new Button { Content = label, Tag = url };
-        button.Click += (_, _) =>
-        {
-            try
-            {
-                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
-            }
-            catch { }
-        };
+        button.Click += (_, _) => OpenUrl(url);
         return button;
     }
 
@@ -5235,10 +5303,11 @@ public partial class MainWindow : Window
         };
     }
 
-    private void ShowToast(string message, Action? retryAction = null)
+    private void ShowToast(string message, Action? retryAction = null, string actionLabel = "Retry")
     {
         _toastRetryAction = retryAction;
         ToastMessage.Text = message;
+        ToastRetryBtn.Content = actionLabel;
         ToastRetryBtn.IsVisible = retryAction is not null;
         ToastPanel.IsVisible = true;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -48,6 +48,22 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public bool SuppressDefaultHandlerPrompt { get; set; }
 
+        /// <summary>
+        /// UTC time of the last update check (startup or forced). <c>null</c> means never
+        /// checked. See <see cref="Update.UpdateCheckPolicy"/> for the cache window this backs.
+        /// </summary>
+        public System.DateTime? LastUpdateCheckUtc { get; set; }
+
+        /// <summary>
+        /// The latest released version as of <see cref="LastUpdateCheckUtc"/>, or <c>null</c>
+        /// if no update was known at that time. Lets a cache-hit path (within the check window)
+        /// report the same result without re-hitting the GitHub API.
+        /// </summary>
+        public string? LatestKnownUpdateVersion { get; set; }
+
+        /// <summary>Release page URL paired with <see cref="LatestKnownUpdateVersion"/>.</summary>
+        public string? LatestKnownUpdateUrl { get; set; }
+
         public void AddFile(FilePath filePath)
         {
             RecentFiles.RemoveAll(item => new FilePath(item) == filePath);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/GitHubReleaseInfo.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/GitHubReleaseInfo.cs
@@ -1,0 +1,10 @@
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// The subset of a GitHub "latest release" API response the update checker needs.
+/// </summary>
+public sealed class GitHubReleaseInfo
+{
+    public required DateTimeOffset PublishedAt { get; init; }
+    public required string HtmlUrl { get; init; }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/HttpGitHubReleaseClient.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/HttpGitHubReleaseClient.cs
@@ -1,0 +1,47 @@
+using System.Net.Http;
+using System.Text.Json.Serialization;
+
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// Hits the GitHub Releases API for this repo. Anonymous requests get a 60/hr-per-IP
+/// rate limit — <see cref="UpdateCheckPolicy"/> keeps callers well under that by caching
+/// the result for 24h — and GitHub rejects requests with no User-Agent header, so one is
+/// always set.
+/// </summary>
+public sealed class HttpGitHubReleaseClient : IGitHubReleaseClient
+{
+    private const string LatestReleaseUrl =
+        "https://api.github.com/repos/vchelaru/FlatRedBall2/releases/latest";
+
+    private readonly HttpClient _httpClient;
+
+    public HttpGitHubReleaseClient(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+        if (_httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("FlatRedBall2-AnimationEditor");
+        }
+    }
+
+    public async Task<GitHubReleaseInfo?> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
+    {
+        var json = await _httpClient.GetStringAsync(LatestReleaseUrl, cancellationToken).ConfigureAwait(false);
+        var response = System.Text.Json.JsonSerializer.Deserialize<ReleaseResponse>(json);
+
+        if (response?.HtmlUrl is null)
+            return null;
+
+        return new GitHubReleaseInfo { PublishedAt = response.PublishedAt, HtmlUrl = response.HtmlUrl };
+    }
+
+    private sealed class ReleaseResponse
+    {
+        [JsonPropertyName("published_at")]
+        public DateTimeOffset PublishedAt { get; set; }
+
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/IGitHubReleaseClient.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/IGitHubReleaseClient.cs
@@ -1,0 +1,10 @@
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// Fetches the latest non-draft, non-prerelease GitHub release. Abstracted from
+/// <see cref="UpdateChecker"/> so tests can fake it without any real network traffic.
+/// </summary>
+public interface IGitHubReleaseClient
+{
+    Task<GitHubReleaseInfo?> GetLatestReleaseAsync(CancellationToken cancellationToken = default);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/IUpdateChecker.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/IUpdateChecker.cs
@@ -1,0 +1,6 @@
+namespace AnimationEditor.Core.Update;
+
+public interface IUpdateChecker
+{
+    Task<UpdateCheckResult> CheckAsync(Version currentVersion, CancellationToken cancellationToken = default);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateCheckPolicy.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateCheckPolicy.cs
@@ -1,0 +1,15 @@
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// Rate-limits how often the startup check hits the GitHub API — an unauthenticated caller
+/// gets 60 requests/hour per IP, and re-checking on every launch could burn through that
+/// across many users sharing an egress IP (office/CI network). A forced/manual recheck
+/// (e.g. opening the About dialog) bypasses this by simply not consulting it.
+/// </summary>
+public static class UpdateCheckPolicy
+{
+    public static readonly TimeSpan CacheWindow = TimeSpan.FromHours(24);
+
+    public static bool ShouldCheck(DateTime? lastCheckUtc, DateTime nowUtc) =>
+        lastCheckUtc is null || nowUtc - lastCheckUtc.Value >= CacheWindow;
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateCheckResult.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateCheckResult.cs
@@ -1,0 +1,21 @@
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// Result of comparing the running assembly version against the latest published release.
+/// </summary>
+public sealed record UpdateCheckResult(bool IsUpdateAvailable, Version? LatestVersion, string? ReleaseUrl)
+{
+    public static readonly UpdateCheckResult NoUpdate = new(false, null, null);
+
+    /// <summary>
+    /// Rebuilds a result from the <c>AppSettingsModel</c> cache fields without a network call —
+    /// used when <see cref="UpdateCheckPolicy.ShouldCheck"/> says the cache is still fresh.
+    /// </summary>
+    public static UpdateCheckResult FromCached(string? latestVersionText, string? releaseUrl, Version currentVersion)
+    {
+        if (string.IsNullOrEmpty(latestVersionText) || !Version.TryParse(latestVersionText, out var latestVersion))
+            return NoUpdate;
+
+        return new UpdateCheckResult(latestVersion > currentVersion, latestVersion, releaseUrl);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateChecker.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateChecker.cs
@@ -1,0 +1,41 @@
+namespace AnimationEditor.Core.Update;
+
+/// <summary>
+/// Compares the running assembly version against the latest published GitHub release.
+/// Release CI stamps the assembly version as <c>yyyy.M.d</c> (see
+/// build-and-release-animation-editor.yml's <c>-p:Version</c>), so a plain <see cref="Version"/>
+/// comparison against the release's publish date is the whole algorithm — no tag-name parsing
+/// needed. A local <c>dotnet build</c> without that MSBuild property defaults to 1.0.0.0, which
+/// is not comparable, so those builds skip the check entirely rather than risk a false positive.
+/// </summary>
+public sealed class UpdateChecker : IUpdateChecker
+{
+    private const int MinReleaseYear = 2000;
+
+    private readonly IGitHubReleaseClient _client;
+
+    public UpdateChecker(IGitHubReleaseClient client) => _client = client;
+
+    public async Task<UpdateCheckResult> CheckAsync(Version currentVersion, CancellationToken cancellationToken = default)
+    {
+        if (currentVersion.Major < MinReleaseYear)
+            return UpdateCheckResult.NoUpdate;
+
+        GitHubReleaseInfo? release;
+        try
+        {
+            release = await _client.GetLatestReleaseAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Offline / rate-limited / GitHub hiccup — fail silently, never block startup.
+            return UpdateCheckResult.NoUpdate;
+        }
+
+        if (release is null)
+            return UpdateCheckResult.NoUpdate;
+
+        var latestVersion = new Version(release.PublishedAt.Year, release.PublishedAt.Month, release.PublishedAt.Day);
+        return new UpdateCheckResult(latestVersion > currentVersion, latestVersion, release.HtmlUrl);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AboutDialogTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AboutDialogTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.RegularExpressions;
+using AnimationEditor.Core.Update;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Xunit;
@@ -83,5 +84,45 @@ public class AboutDialogTests
         var window = MainWindow.BuildAboutWindow();
 
         Assert.Equal("About AnimationEditor", window.Title);
+    }
+
+    // ── Update-check surface (issue #681) ─────────────────────────────────────
+
+    [AvaloniaFact]
+    public void BuildAboutContent_NoUpdateAvailable_KeepsDefaultReleasesPromptAndButton()
+    {
+        var panel = (StackPanel)MainWindow.BuildAboutContent(UpdateCheckResult.NoUpdate);
+
+        var promptBlock = panel.Children.OfType<TextBlock>()
+            .FirstOrDefault(tb => tb.Text?.Contains("updates", System.StringComparison.OrdinalIgnoreCase) == true);
+        var releasesBtn = panel.Children.OfType<Button>()
+            .FirstOrDefault(b => b.Tag?.ToString() == "https://github.com/vchelaru/FlatRedBall2/releases");
+
+        Assert.NotNull(promptBlock);
+        Assert.NotNull(releasesBtn);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutContent_UpdateAvailable_ShowsLatestVersionText()
+    {
+        var result = new UpdateCheckResult(true, new System.Version(2026, 7, 17), "https://example.com/latest");
+        var panel = (StackPanel)MainWindow.BuildAboutContent(result);
+
+        var updateBlock = panel.Children.OfType<TextBlock>()
+            .FirstOrDefault(tb => tb.Text?.Contains("2026.7.17") == true);
+
+        Assert.NotNull(updateBlock);
+    }
+
+    [AvaloniaFact]
+    public void BuildAboutContent_UpdateAvailable_ButtonPointsAtReleaseUrl()
+    {
+        var result = new UpdateCheckResult(true, new System.Version(2026, 7, 17), "https://example.com/latest");
+        var panel = (StackPanel)MainWindow.BuildAboutContent(result);
+
+        var downloadBtn = panel.Children.OfType<Button>()
+            .FirstOrDefault(b => b.Tag?.ToString() == "https://example.com/latest");
+
+        Assert.NotNull(downloadBtn);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -4,8 +4,27 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Update;
 
 namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// No-op <see cref="IUpdateChecker"/> for tests that don't care about the update check — never
+/// hits the network. Tests exercising the update-check wiring itself set
+/// <see cref="TestServices.UpdateChecker"/> to a fake with a canned <see cref="UpdateCheckResult"/>
+/// before calling <see cref="TestServices.CreateMainWindow"/>.
+/// </summary>
+internal sealed class FakeUpdateChecker : IUpdateChecker
+{
+    public UpdateCheckResult Result { get; set; } = UpdateCheckResult.NoUpdate;
+    public int CallCount { get; private set; }
+
+    public Task<UpdateCheckResult> CheckAsync(Version currentVersion, CancellationToken cancellationToken = default)
+    {
+        CallCount++;
+        return Task.FromResult(Result);
+    }
+}
 
 /// <summary>
 /// Per-test service graph for headless App tests. Each call builds a brand-new
@@ -25,6 +44,7 @@ internal sealed class TestServices
     public PendingCutState PendingCutState { get; }
     public ThumbnailService ThumbnailService { get; }
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
+    public IUpdateChecker UpdateChecker { get; set; } = new FakeUpdateChecker();
 
     /// <summary>
     /// Unique-per-instance temp application-data root. Injected into the <see cref="MainWindow"/>
@@ -53,7 +73,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
-            ThumbnailService, FileAssociationService, SettingsRoot);
+            ThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
 
     public WireframeControl CreateWireframeControl(System.Action<string>? showError = null)
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
@@ -11,11 +11,12 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests for the update-check wiring (issue #681): the silent startup check drives the shared
-/// toast, and <c>GetUpdateCheckResultAsync</c> (reached via reflection — there's no non-modal
-/// public trigger; the About dialog's forced recheck goes through <c>Window.ShowDialog</c>,
-/// which deadlocks headless per the AvaloniaFact landmine) respects the 24h cache window and
-/// persists results to <c>AppSettingsModel</c>.
+/// Tests for the update-check wiring (issue #681): the silent startup check drives the
+/// persistent <c>UpdateAvailableBanner</c> (a toast was tried first but auto-dismisses too
+/// fast for something worth acting on), and <c>GetUpdateCheckResultAsync</c> (reached via
+/// reflection — there's no non-modal public trigger; the About dialog's forced recheck goes
+/// through <c>Window.ShowDialog</c>, which deadlocks headless per the AvaloniaFact landmine)
+/// respects the 24h cache window and persists results to <c>AppSettingsModel</c>.
 /// </summary>
 public class UpdateCheckStartupTests
 {
@@ -31,7 +32,7 @@ public class UpdateCheckStartupTests
             .GetValue(window)!;
 
     [AvaloniaFact]
-    public void Startup_UpdateAvailable_ShowsToast()
+    public void Startup_UpdateAvailable_ShowsBanner()
     {
         var ctx = TestHelpers.BuildServices();
         var fake = new FakeUpdateChecker
@@ -44,12 +45,12 @@ public class UpdateCheckStartupTests
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
-        var toastPanel = window.FindControl<Border>("ToastPanel");
-        Assert.True(toastPanel!.IsVisible);
+        var banner = window.FindControl<Border>("UpdateAvailableBanner");
+        Assert.True(banner!.IsVisible);
     }
 
     [AvaloniaFact]
-    public void Startup_NoUpdate_ToastStaysHidden()
+    public void Startup_NoUpdate_BannerStaysHidden()
     {
         var ctx = TestHelpers.BuildServices();
         ctx.UpdateChecker = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
@@ -58,8 +59,28 @@ public class UpdateCheckStartupTests
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
-        var toastPanel = window.FindControl<Border>("ToastPanel");
-        Assert.False(toastPanel!.IsVisible);
+        var banner = window.FindControl<Border>("UpdateAvailableBanner");
+        Assert.False(banner!.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void DismissUpdateBanner_HidesIt()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.UpdateChecker = new FakeUpdateChecker
+        {
+            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
+        };
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var banner = window.FindControl<Border>("UpdateAvailableBanner");
+        Assert.True(banner!.IsVisible);
+
+        var dismissBtn = window.FindControl<Button>("DismissUpdateBannerBtn");
+        dismissBtn!.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+
+        Assert.False(banner.IsVisible);
     }
 
     [AvaloniaFact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Update;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for the update-check wiring (issue #681): the silent startup check drives the shared
+/// toast, and <c>GetUpdateCheckResultAsync</c> (reached via reflection — there's no non-modal
+/// public trigger; the About dialog's forced recheck goes through <c>Window.ShowDialog</c>,
+/// which deadlocks headless per the AvaloniaFact landmine) respects the 24h cache window and
+/// persists results to <c>AppSettingsModel</c>.
+/// </summary>
+public class UpdateCheckStartupTests
+{
+    private static Task<UpdateCheckResult> InvokeGetUpdateCheckResultAsync(MainWindow window, bool forceRefresh)
+    {
+        var method = typeof(MainWindow).GetMethod("GetUpdateCheckResultAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Task<UpdateCheckResult>)method.Invoke(window, new object[] { forceRefresh })!;
+    }
+
+    private static AppSettingsModel GetAppSettings(MainWindow window) =>
+        (AppSettingsModel)typeof(MainWindow)
+            .GetField("_appSettings", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    [AvaloniaFact]
+    public void Startup_UpdateAvailable_ShowsToast()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var fake = new FakeUpdateChecker
+        {
+            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
+        };
+        ctx.UpdateChecker = fake;
+        var window = ctx.CreateMainWindow();
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var toastPanel = window.FindControl<Border>("ToastPanel");
+        Assert.True(toastPanel!.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void Startup_NoUpdate_ToastStaysHidden()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.UpdateChecker = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
+        var window = ctx.CreateMainWindow();
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var toastPanel = window.FindControl<Border>("ToastPanel");
+        Assert.False(toastPanel!.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public async Task GetUpdateCheckResultAsync_WithinCacheWindow_DoesNotRecheck()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var fake = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
+        ctx.UpdateChecker = fake;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var baseline = fake.CallCount; // OnOpened already ran the silent startup check once.
+
+        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: false);
+        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: false);
+
+        Assert.Equal(baseline, fake.CallCount);
+    }
+
+    [AvaloniaFact]
+    public async Task GetUpdateCheckResultAsync_ForceRefresh_AlwaysRechecks()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var fake = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
+        ctx.UpdateChecker = fake;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var baseline = fake.CallCount;
+
+        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
+        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
+
+        Assert.Equal(baseline + 2, fake.CallCount);
+    }
+
+    [AvaloniaFact]
+    public async Task GetUpdateCheckResultAsync_PersistsResultToAppSettings()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var fake = new FakeUpdateChecker
+        {
+            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
+        };
+        ctx.UpdateChecker = fake;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
+
+        var settings = GetAppSettings(window);
+        Assert.NotNull(settings.LastUpdateCheckUtc);
+        Assert.Equal("2026.7.17", settings.LatestKnownUpdateVersion);
+        Assert.Equal("https://example.com/latest", settings.LatestKnownUpdateUrl);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -186,4 +186,30 @@ public class AppSettingsModelTests
 
         Assert.True(restored!.SuppressDefaultHandlerPrompt);
     }
+
+    [Fact]
+    public void LastUpdateCheckUtc_DefaultsToNull()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.Null(model.LastUpdateCheckUtc);
+    }
+
+    [Fact]
+    public void UpdateCheckCacheFields_SurviveJsonRoundTrip()
+    {
+        var model = new AppSettingsModel
+        {
+            LastUpdateCheckUtc = new System.DateTime(2026, 7, 17, 8, 0, 0, System.DateTimeKind.Utc),
+            LatestKnownUpdateVersion = "2026.7.17",
+            LatestKnownUpdateUrl = "https://github.com/vchelaru/FlatRedBall2/releases/tag/ae-Release_July_17_2026",
+        };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.Equal(model.LastUpdateCheckUtc, restored!.LastUpdateCheckUtc);
+        Assert.Equal(model.LatestKnownUpdateVersion, restored.LatestKnownUpdateVersion);
+        Assert.Equal(model.LatestKnownUpdateUrl, restored.LatestKnownUpdateUrl);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckPolicyTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckPolicyTests.cs
@@ -1,0 +1,44 @@
+using AnimationEditor.Core.Update;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="UpdateCheckPolicy"/> — the 24h cache window that keeps the
+/// startup update check from hitting GitHub's anonymous rate limit on every launch.
+/// </summary>
+public class UpdateCheckPolicyTests
+{
+    [Fact]
+    public void ShouldCheck_NoPriorCheck_ReturnsTrue()
+    {
+        Assert.True(UpdateCheckPolicy.ShouldCheck(null, new DateTime(2026, 7, 17, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Fact]
+    public void ShouldCheck_WithinCacheWindow_ReturnsFalse()
+    {
+        var lastCheck = new DateTime(2026, 7, 17, 8, 0, 0, DateTimeKind.Utc);
+        var now = lastCheck.AddHours(1);
+
+        Assert.False(UpdateCheckPolicy.ShouldCheck(lastCheck, now));
+    }
+
+    [Fact]
+    public void ShouldCheck_ExactlyAtCacheWindow_ReturnsTrue()
+    {
+        var lastCheck = new DateTime(2026, 7, 17, 8, 0, 0, DateTimeKind.Utc);
+        var now = lastCheck + UpdateCheckPolicy.CacheWindow;
+
+        Assert.True(UpdateCheckPolicy.ShouldCheck(lastCheck, now));
+    }
+
+    [Fact]
+    public void ShouldCheck_PastCacheWindow_ReturnsTrue()
+    {
+        var lastCheck = new DateTime(2026, 7, 17, 8, 0, 0, DateTimeKind.Utc);
+        var now = lastCheck.AddHours(25);
+
+        Assert.True(UpdateCheckPolicy.ShouldCheck(lastCheck, now));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckResultTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckResultTests.cs
@@ -1,0 +1,47 @@
+using AnimationEditor.Core.Update;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="UpdateCheckResult.FromCached"/> — rebuilds a result from the
+/// persisted <c>AppSettingsModel</c> fields without a network call, so a cache-hit path
+/// (within <see cref="UpdateCheckPolicy.CacheWindow"/>) still reports accurately.
+/// </summary>
+public class UpdateCheckResultTests
+{
+    [Fact]
+    public void FromCached_NoCachedVersion_ReturnsNoUpdate()
+    {
+        var result = UpdateCheckResult.FromCached(null, null, new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+        Assert.Null(result.LatestVersion);
+    }
+
+    [Fact]
+    public void FromCached_UnparsableCachedVersion_ReturnsNoUpdate()
+    {
+        var result = UpdateCheckResult.FromCached("not-a-version", "https://example.com", new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public void FromCached_CachedVersionNewerThanCurrent_ReturnsUpdateAvailable()
+    {
+        var result = UpdateCheckResult.FromCached("2026.7.17", "https://example.com/latest", new Version(2026, 7, 16));
+
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal(new Version(2026, 7, 17), result.LatestVersion);
+        Assert.Equal("https://example.com/latest", result.ReleaseUrl);
+    }
+
+    [Fact]
+    public void FromCached_CachedVersionSameAsCurrent_ReturnsNoUpdate()
+    {
+        var result = UpdateCheckResult.FromCached("2026.7.16", "https://example.com/latest", new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,126 @@
+using AnimationEditor.Core.Update;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="UpdateChecker"/> against a fake <see cref="IGitHubReleaseClient"/> —
+/// no real network traffic. Release CI stamps the assembly version as yyyy.M.d (see
+/// build-and-release-animation-editor.yml), so a plain <see cref="Version"/> comparison against
+/// the release's publish date is the whole algorithm.
+/// </summary>
+public class UpdateCheckerTests
+{
+    private sealed class FakeGitHubReleaseClient : IGitHubReleaseClient
+    {
+        public GitHubReleaseInfo? Response;
+        public Exception? ThrowOnGet;
+
+        public Task<GitHubReleaseInfo?> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnGet is not null)
+                throw ThrowOnGet;
+            return Task.FromResult(Response);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LatestReleaseNewerThanCurrent_ReturnsUpdateAvailable()
+    {
+        var client = new FakeGitHubReleaseClient
+        {
+            Response = new GitHubReleaseInfo
+            {
+                PublishedAt = new DateTimeOffset(2026, 7, 17, 0, 0, 0, TimeSpan.Zero),
+                HtmlUrl = "https://github.com/vchelaru/FlatRedBall2/releases/tag/ae-Release_July_17_2026",
+            }
+        };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(2026, 7, 16));
+
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal(new Version(2026, 7, 17), result.LatestVersion);
+        Assert.Equal("https://github.com/vchelaru/FlatRedBall2/releases/tag/ae-Release_July_17_2026", result.ReleaseUrl);
+    }
+
+    [Fact]
+    public async Task CheckAsync_LatestReleaseSameAsCurrent_ReturnsNoUpdate()
+    {
+        var client = new FakeGitHubReleaseClient
+        {
+            Response = new GitHubReleaseInfo
+            {
+                PublishedAt = new DateTimeOffset(2026, 7, 16, 0, 0, 0, TimeSpan.Zero),
+                HtmlUrl = "https://github.com/vchelaru/FlatRedBall2/releases/tag/ae-Release_July_16_2026",
+            }
+        };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_LatestReleaseOlderThanCurrent_ReturnsNoUpdate()
+    {
+        // A locally-built pre-release binary can be newer than the last published release.
+        var client = new FakeGitHubReleaseClient
+        {
+            Response = new GitHubReleaseInfo
+            {
+                PublishedAt = new DateTimeOffset(2026, 7, 10, 0, 0, 0, TimeSpan.Zero),
+                HtmlUrl = "https://github.com/vchelaru/FlatRedBall2/releases/tag/ae-Release_July_10_2026",
+            }
+        };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_DevBuildVersion_SkipsCheckEntirely()
+    {
+        // Local `dotnet build` without -p:Version defaults to 1.0.0.0 — not date-comparable,
+        // so the check must not run at all (never claim a dev build is "out of date").
+        var client = new FakeGitHubReleaseClient
+        {
+            Response = new GitHubReleaseInfo
+            {
+                PublishedAt = new DateTimeOffset(2026, 7, 17, 0, 0, 0, TimeSpan.Zero),
+                HtmlUrl = "https://github.com/vchelaru/FlatRedBall2/releases",
+            }
+        };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(1, 0, 0, 0));
+
+        Assert.False(result.IsUpdateAvailable);
+        Assert.Null(result.LatestVersion);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ClientThrows_ReturnsNoUpdateSilently()
+    {
+        var client = new FakeGitHubReleaseClient { ThrowOnGet = new HttpRequestException("offline") };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ClientReturnsNull_ReturnsNoUpdate()
+    {
+        var client = new FakeGitHubReleaseClient { Response = null };
+        var checker = new UpdateChecker(client);
+
+        var result = await checker.CheckAsync(new Version(2026, 7, 16));
+
+        Assert.False(result.IsUpdateAvailable);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/TestHelpers.cs
@@ -4,8 +4,16 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Update;
 
 namespace AnimationEditor.DocScreenshots;
+
+/// <summary>No-op <see cref="IUpdateChecker"/> — screenshot generation never needs a real check.</summary>
+internal sealed class FakeUpdateChecker : IUpdateChecker
+{
+    public Task<UpdateCheckResult> CheckAsync(Version currentVersion, CancellationToken cancellationToken = default) =>
+        Task.FromResult(UpdateCheckResult.NoUpdate);
+}
 
 /// <summary>
 /// Per-test service graph for headless doc-screenshot generation. Mirrors
@@ -26,6 +34,7 @@ internal sealed class TestServices
     public PendingCutState PendingCutState { get; }
     public ThumbnailService ThumbnailService { get; }
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
+    public IUpdateChecker UpdateChecker { get; } = new FakeUpdateChecker();
 
     public string SettingsRoot { get; } =
         System.IO.Path.Combine(System.IO.Path.GetTempPath(), "AnimationEditorDocScreenshots", System.Guid.NewGuid().ToString("N"));
@@ -49,7 +58,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
-            ThumbnailService, FileAssociationService, SettingsRoot);
+            ThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
 }
 
 internal static class TestHelpers


### PR DESCRIPTION
## Summary
- Silent startup check against the GitHub Releases API, cached 24h, surfaces a persistent dismissible banner (not a toast — auto-dismiss was a bad fit) when out of date. Opening About forces a fresh check and shows the same info.
- Version compare piggybacks on the `yyyy.M.d` version release CI already stamps on the assembly — no tag parsing. Local dev builds (1.0.0.0) skip the check entirely.
- **Windows auto-update (phase 1):** clicking "Get Update" downloads the win-x64 release zip, shows an indeterminate progress bar while it works, then hands off to a small PowerShell-driven relauncher — a WinForms status window ("Waiting for Animation Editor to close…" → "Installing update…" → "Launching Animation Editor…") that waits for this process to exit, copies files into the install dir, and relaunches, since a running exe can't overwrite itself. No separate compiled updater app. Other platforms fall back to opening the release page.
- Network/API failures fail silently; auto-update failures show the error banner and restore the button, since it's an explicit user action.

## Test plan
- [x] `AnimationEditor.Core.Tests` (1693 passed): update-check logic, cache policy, Windows-asset selection, `SelfUpdateScriptBuilder`'s generated script content — all against fakes
- [x] `AnimationEditor.App.Tests` (765 passed): banner/About dialog wiring, dismiss behavior, progress-bar/button state, auto-update invocation/fallback/error-handling via `FakeAppUpdateInstaller` (the real installer's success path calls `Environment.Exit`, which would kill the test runner)
- [x] Real, out-of-band verification of everything unit tests can't reach: downloaded and extracted the actual win-x64 release zip via `HttpClient`/`ZipFile`; confirmed the generated relauncher script parses with zero syntax errors via the PowerShell language parser; ran the actual generated script end-to-end against real files (fake PID so the wait loop exits immediately, a renamed real exe standing in for the app) and confirmed the copy and relaunch both worked
- [x] Manual: published a real self-contained win-x64 build stamped with an old version and clicked "Get Update" for real — confirmed the app closes and relaunches as the current version. One thing manual testing caught that units couldn't: two tests were exercising the real `Process.Start` fallback path and popping actual browser tabs during test runs — fixed by extracting the gating decision (`CanAutoUpdate`) so tests never touch that code path
- [x] Full solution build (App, Core, Views, Browser/WASM, DocScreenshots) — 0 errors, 0 warnings

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)