### PR TITLE
Dedup timeline chain/frame resolver into AnimationEditor.Core

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3544,7 +3544,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        var chain = GetTimelineChain();
+        var chain = TimelineChainResolver.GetChain(_selectedState, _objectFinder);
 
         // Show the active chain's total play time next to the ruler label so the duration is
         // visible without adding up per-frame times (#623).
@@ -3565,7 +3565,8 @@ public partial class MainWindow : Window
             _timelineSignature = signature;
         }
 
-        int preferred = GetPreferredTimelineFrameIndex(chain);
+        int preferred = TimelineChainResolver.GetPreferredFrameIndex(
+            _selectedState, _objectFinder, chain, PreviewCtrl.Playback.CurrentFrameIndex);
         UpdateTimelineScrubber(preferred);
         // Drive the playhead from the live playback position so a paused/scrubbed frame keeps its
         // sub-frame offset instead of snapping to the cell's left edge (#432).
@@ -3706,33 +3707,6 @@ public partial class MainWindow : Window
         var result = TimelineScrubMapper.Resolve(contentX, widths);
         // Fires GroupPlaybackTicked synchronously, which refreshes every track's playhead.
         PreviewCtrl.ScrubGroupTrack(track.Chain, result.FrameIndex, result.Fraction);
-    }
-
-    private AnimationChainSave? GetTimelineChain()
-    {
-        var chain = _selectedState.SelectedChain;
-        if (chain is null && _selectedState.SelectedFrame is { } selectedFrame)
-            chain = _objectFinder.GetAnimationChainContaining(selectedFrame);
-        return chain;
-    }
-
-    private int GetPreferredTimelineFrameIndex(AnimationChainSave? chain)
-    {
-        if (chain is null || chain.Frames.Count == 0)
-            return -1;
-
-        if (_selectedState.SelectedFrame is { } selectedFrame)
-        {
-            var selectedFrameChain = _objectFinder.GetAnimationChainContaining(selectedFrame);
-            if (ReferenceEquals(selectedFrameChain, chain))
-            {
-                var selectedFrameIndex = chain.Frames.IndexOf(selectedFrame);
-                if (selectedFrameIndex >= 0)
-                    return selectedFrameIndex;
-            }
-        }
-
-        return PreviewCtrl.Playback.CurrentFrameIndex;
     }
 
     private void UpdateTimelineScrubber(int frameIndex)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -1301,37 +1301,11 @@ public partial class App : Application
         DockPanel.SetDock(speedUpButton, Dock.Right);
         speedUpButton.BorderThickness = new Thickness(1, 0, 0, 0);
 
-        AnimationChainSave? GetTimelineChain()
-        {
-            var chain = selectedState.SelectedChain;
-            if (chain is null && selectedState.SelectedFrame is { } selectedFrame)
-                chain = objectFinder.GetAnimationChainContaining(selectedFrame);
-            return chain;
-        }
-
-        int GetPreferredTimelineFrameIndex(AnimationChainSave? chain)
-        {
-            if (chain is null || chain.Frames.Count == 0)
-                return -1;
-
-            if (selectedState.SelectedFrame is { } selectedFrame)
-            {
-                var selectedFrameChain = objectFinder.GetAnimationChainContaining(selectedFrame);
-                if (ReferenceEquals(selectedFrameChain, chain))
-                {
-                    int selectedFrameIndex = chain.Frames.IndexOf(selectedFrame);
-                    if (selectedFrameIndex >= 0)
-                        return selectedFrameIndex;
-                }
-            }
-
-            return preview.Playback.CurrentFrameIndex;
-        }
-
         void RefreshTimelineStrip()
         {
-            var chain = GetTimelineChain();
-            int preferred = GetPreferredTimelineFrameIndex(chain);
+            var chain = TimelineChainResolver.GetChain(selectedState, objectFinder);
+            int preferred = TimelineChainResolver.GetPreferredFrameIndex(
+                selectedState, objectFinder, chain, preview.Playback.CurrentFrameIndex);
             timelineStrip.SetChain(chain, preferred);
             if (preferred >= 0)
                 timelineStrip.ApplyPlaybackPosition(preferred, preview.Playback.FrameElapsed);
@@ -1347,7 +1321,7 @@ public partial class App : Application
         preview.Playback.FrameIndexChanged += index =>
         {
             if (selectedState.SelectedFrame is not null) return;
-            timelineStrip.SetChain(GetTimelineChain(), index);
+            timelineStrip.SetChain(TimelineChainResolver.GetChain(selectedState, objectFinder), index);
         };
         preview.Playback.PlaybackTicked += () =>
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TimelineChainResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TimelineChainResolver.cs
@@ -1,0 +1,47 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Resolves which chain and frame the timeline strip should display, given the app's
+/// selection state. Shared by desktop and browser hosts so the two don't drift.
+/// </summary>
+public static class TimelineChainResolver
+{
+    /// <summary>
+    /// Returns <see cref="ISelectedState.SelectedChain"/> if set, otherwise the chain
+    /// containing <see cref="ISelectedState.SelectedFrame"/> (or <c>null</c> if neither is set).
+    /// </summary>
+    public static AnimationChainSave? GetChain(ISelectedState selectedState, IObjectFinder objectFinder)
+    {
+        var chain = selectedState.SelectedChain;
+        if (chain is null && selectedState.SelectedFrame is { } selectedFrame)
+            chain = objectFinder.GetAnimationChainContaining(selectedFrame);
+        return chain;
+    }
+
+    /// <summary>
+    /// Returns the frame index the timeline scrubber should highlight for <paramref name="chain"/>:
+    /// the selected frame's index if it belongs to <paramref name="chain"/>, otherwise
+    /// <paramref name="playbackFrameIndex"/>. Returns -1 for a null or empty chain.
+    /// </summary>
+    public static int GetPreferredFrameIndex(
+        ISelectedState selectedState, IObjectFinder objectFinder, AnimationChainSave? chain, int playbackFrameIndex)
+    {
+        if (chain is null || chain.Frames.Count == 0)
+            return -1;
+
+        if (selectedState.SelectedFrame is { } selectedFrame)
+        {
+            var selectedFrameChain = objectFinder.GetAnimationChainContaining(selectedFrame);
+            if (ReferenceEquals(selectedFrameChain, chain))
+            {
+                var selectedFrameIndex = chain.Frames.IndexOf(selectedFrame);
+                if (selectedFrameIndex >= 0)
+                    return selectedFrameIndex;
+            }
+        }
+
+        return playbackFrameIndex;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineChainResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineChainResolverTests.cs
@@ -1,0 +1,99 @@
+using AnimationEditor.Core.CommandsAndState;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TimelineChainResolverTests
+{
+    [Fact]
+    public void GetChain_NoSelectedChain_FallsBackToChainContainingSelectedFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        ctx.SelectedState.SelectedChain = null;
+        ctx.SelectedState.SelectedFrame = chain.Frames[0];
+
+        var result = TimelineChainResolver.GetChain(ctx.SelectedState, ctx.ObjectFinder);
+
+        Assert.Same(chain, result);
+    }
+
+    [Fact]
+    public void GetChain_NothingSelected_ReturnsNull()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+
+        var result = TimelineChainResolver.GetChain(ctx.SelectedState, ctx.ObjectFinder);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetChain_SelectedChainSet_ReturnsIt()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        ctx.SelectedState.SelectedChain = chain;
+
+        var result = TimelineChainResolver.GetChain(ctx.SelectedState, ctx.ObjectFinder);
+
+        Assert.Same(chain, result);
+    }
+
+    [Fact]
+    public void GetPreferredFrameIndex_EmptyChain_ReturnsNegativeOne()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Empty", 0);
+
+        var result = TimelineChainResolver.GetPreferredFrameIndex(ctx.SelectedState, ctx.ObjectFinder, chain, playbackFrameIndex: 3);
+
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void GetPreferredFrameIndex_NoSelectedFrame_FallsBackToPlaybackIndex()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+
+        var result = TimelineChainResolver.GetPreferredFrameIndex(ctx.SelectedState, ctx.ObjectFinder, chain, playbackFrameIndex: 1);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void GetPreferredFrameIndex_NullChain_ReturnsNegativeOne()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+
+        var result = TimelineChainResolver.GetPreferredFrameIndex(ctx.SelectedState, ctx.ObjectFinder, null, playbackFrameIndex: 3);
+
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void GetPreferredFrameIndex_SelectedFrameBelongsToChain_ReturnsItsIndex()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        ctx.SelectedState.SelectedFrame = chain.Frames[2];
+
+        var result = TimelineChainResolver.GetPreferredFrameIndex(ctx.SelectedState, ctx.ObjectFinder, chain, playbackFrameIndex: 0);
+
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public void GetPreferredFrameIndex_SelectedFrameBelongsToDifferentChain_FallsBackToPlaybackIndex()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var otherChain = TestHelpers.MakeChain(ctx.Acls, "Jump", 2);
+        ctx.SelectedState.SelectedFrame = otherChain.Frames[0];
+
+        var result = TimelineChainResolver.GetPreferredFrameIndex(ctx.SelectedState, ctx.ObjectFinder, chain, playbackFrameIndex: 1);
+
+        Assert.Equal(1, result);
+    }
+}


### PR DESCRIPTION
Part of #748

Extracts the byte-identical `GetTimelineChain()`/`GetPreferredTimelineFrameIndex()` pair duplicated in the desktop (`MainWindow.axaml.cs`) and browser (`App.axaml.cs`) hosts into a single `TimelineChainResolver` static helper in `AnimationEditor.Core`. Both hosts now delegate to it; no behavior change.

Covered by new `TimelineChainResolverTests` in `AnimationEditor.Core.Tests`.