### PR TITLE
Dedup toolbar numeric parse/clamp logic into AnimationEditor.Core

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -13,6 +13,7 @@ using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
 using AnimationEditor.Core.Update;
+using AnimationEditor.Core.Utilities;
 using AnimationEditor.Core.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -1026,10 +1027,7 @@ public partial class MainWindow : Window
         SaveCompanionFile();
     }
 
-    private int GetGridSizeFromInput()
-    {
-        return int.TryParse(GridSizeInput.Text, out int v) && v >= 1 ? Math.Min(v, 512) : 16;
-    }
+    private int GetGridSizeFromInput() => NumericToolbarInput.ParseGridSize(GridSizeInput.Text);
 
     private void OnGridSizeInputLostFocus(object? sender, RoutedEventArgs e) => ApplyGridSize();
 
@@ -4660,13 +4658,13 @@ public partial class MainWindow : Window
         SpeedUpBtn.Click   += (_, _) =>
         {
             double s = Math.Min(Math.Round(GetSpeedFromInput() + 0.1, 1), 10.0);
-            SpeedInput.Text = s.ToString("0.0#");
+            SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
             PreviewCtrl.SpeedMultiplier = s;
         };
         SpeedDownBtn.Click += (_, _) =>
         {
             double s = Math.Max(Math.Round(GetSpeedFromInput() - 0.1, 1), 0.1);
-            SpeedInput.Text = s.ToString("0.0#");
+            SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
             PreviewCtrl.SpeedMultiplier = s;
         };
     }
@@ -4749,16 +4747,12 @@ public partial class MainWindow : Window
         }
     }
 
-    private double GetSpeedFromInput() =>
-        double.TryParse(SpeedInput.Text, System.Globalization.NumberStyles.Any,
-            System.Globalization.CultureInfo.InvariantCulture, out double v)
-            ? Math.Clamp(v, 0.1, 10.0)
-            : 1.0;
+    private double GetSpeedFromInput() => NumericToolbarInput.ParseSpeed(SpeedInput.Text);
 
     private void ApplySpeedFromInput()
     {
         double s = GetSpeedFromInput();
-        SpeedInput.Text = s.ToString("0.0#");
+        SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
         PreviewCtrl.SpeedMultiplier = s;
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -906,8 +906,7 @@ public partial class App : Application
         };
         gridSizePlusBtn.Bind(Button.BorderBrushProperty, gridSizePlusBtn.GetResourceObservable("LineBrush"));
 
-        int GetGridSizeFromInput() =>
-            int.TryParse(gridSizeInput.Text, out var v) && v >= 1 ? Math.Min(v, 512) : 16;
+        int GetGridSizeFromInput() => NumericToolbarInput.ParseGridSize(gridSizeInput.Text);
 
         void ApplyGrid()
         {
@@ -1238,15 +1237,11 @@ public partial class App : Application
             Height = 26,
             VerticalAlignment = VerticalAlignment.Center,
         };
-        double GetSpeedFromInput() =>
-            double.TryParse(speedInput.Text, System.Globalization.NumberStyles.Any,
-                System.Globalization.CultureInfo.InvariantCulture, out double v)
-                ? Math.Clamp(v, 0.1, 10.0)
-                : 1.0;
+        double GetSpeedFromInput() => NumericToolbarInput.ParseSpeed(speedInput.Text);
         void ApplySpeedFromInput()
         {
             double s = GetSpeedFromInput();
-            speedInput.Text = s.ToString("0.0#");
+            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
             preview.SpeedMultiplier = s;
         }
         speedInput.LostFocus += (_, _) => ApplySpeedFromInput();
@@ -1260,7 +1255,7 @@ public partial class App : Application
         speedDownButton.Click += (_, _) =>
         {
             double s = Math.Max(Math.Round(GetSpeedFromInput() - 0.1, 1), 0.1);
-            speedInput.Text = s.ToString("0.0#");
+            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
             preview.SpeedMultiplier = s;
         };
         var speedUpButton = new Button
@@ -1273,7 +1268,7 @@ public partial class App : Application
         speedUpButton.Click += (_, _) =>
         {
             double s = Math.Min(Math.Round(GetSpeedFromInput() + 0.1, 1), 10.0);
-            speedInput.Text = s.ToString("0.0#");
+            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
             preview.SpeedMultiplier = s;
         };
         var speedPill = new Border

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/NumericToolbarInput.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/NumericToolbarInput.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+
+namespace AnimationEditor.Core.Utilities;
+
+/// <summary>
+/// Pure parse/clamp/format rules for the toolbar's numeric text inputs (grid size, playback
+/// speed). Shared by the desktop and browser hosts so the two can't drift out of sync.
+/// </summary>
+public static class NumericToolbarInput
+{
+    /// <summary>Formats a speed value for display, trimming trailing zeros beyond one decimal (e.g. 1.25 -> "1.25", 2.0 -> "2.0").</summary>
+    public static string FormatSpeed(double speed) => speed.ToString("0.0#");
+
+    /// <summary>Parses a grid-size input, clamping to [1, 512]. Falls back to 16 if the text doesn't parse or is below 1.</summary>
+    public static int ParseGridSize(string? text)
+        => int.TryParse(text, out int v) && v >= 1 ? Math.Min(v, 512) : 16;
+
+    /// <summary>Parses a playback-speed input (invariant culture), clamping to [0.1, 10.0]. Falls back to 1.0 if the text doesn't parse.</summary>
+    public static double ParseSpeed(string? text)
+        => double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double v)
+            ? Math.Clamp(v, 0.1, 10.0)
+            : 1.0;
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NumericToolbarInputTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NumericToolbarInputTests.cs
@@ -1,0 +1,63 @@
+using AnimationEditor.Core.Utilities;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class NumericToolbarInputTests
+{
+    [Fact]
+    public void FormatSpeed_FractionalValue_ReturnsTrimmedDecimal()
+    {
+        var result = NumericToolbarInput.FormatSpeed(1.25);
+
+        Assert.Equal("1.25", result);
+    }
+
+    [Fact]
+    public void ParseGridSize_AboveMax_ClampsTo512()
+    {
+        var result = NumericToolbarInput.ParseGridSize("9999");
+
+        Assert.Equal(512, result);
+    }
+
+    [Fact]
+    public void ParseGridSize_NonNumericText_FallsBackTo16()
+    {
+        var result = NumericToolbarInput.ParseGridSize("abc");
+
+        Assert.Equal(16, result);
+    }
+
+    [Fact]
+    public void ParseGridSize_ValidText_ReturnsParsedValue()
+    {
+        var result = NumericToolbarInput.ParseGridSize("32");
+
+        Assert.Equal(32, result);
+    }
+
+    [Fact]
+    public void ParseSpeed_BelowMin_ClampsToPoint1()
+    {
+        var result = NumericToolbarInput.ParseSpeed("0.01");
+
+        Assert.Equal(0.1, result, precision: 6);
+    }
+
+    [Fact]
+    public void ParseSpeed_NonNumericText_FallsBackTo1()
+    {
+        var result = NumericToolbarInput.ParseSpeed("nope");
+
+        Assert.Equal(1.0, result, precision: 6);
+    }
+
+    [Fact]
+    public void ParseSpeed_ValidText_ReturnsParsedValue()
+    {
+        var result = NumericToolbarInput.ParseSpeed("2.5");
+
+        Assert.Equal(2.5, result, precision: 6);
+    }
+}


### PR DESCRIPTION
Part of #748.

Extracts the grid-size and speed parse/clamp/format recipes (identical in both hosts) into a shared `NumericToolbarInput` static helper in `AnimationEditor.Core.Utilities`. Both `MainWindow.axaml.cs` (desktop) and `App.axaml.cs` (browser) now delegate instead of maintaining separate copies. No behavior change.

Diagnostics-toggle body was also checked (third item from the audit) but left in-host: the browser version also syncs the toolbar toggle's `IsChecked`, which desktop doesn't need, so it's not actually identical logic.

## Test plan
- [x] `NumericToolbarInputTests` added, TDD'd red→green
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 0 warnings/errors (incl. Browser/WASM)
- [x] `dotnet test` on Core.Tests (1686), Views.Tests (48), App.Tests (753) — all green