### PR TITLE
Dedup new-animation-name uniqueness recipe into AppCommands

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -36,7 +36,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
-using StringFunctions = AnimationEditor.Core.Utilities.StringFunctions;
 
 namespace AnimationEditor.App;
 
@@ -2515,11 +2514,7 @@ public partial class MainWindow : Window
         if (_projectManager.AnimationChainListSave is null)
             _projectManager.AnimationChainListSave = new AnimationChainListSave();
 
-        var existingNames = _projectManager.AnimationChainListSave.AnimationChains
-            .Select(c => c.Name)
-            .ToList();
-        var defaultName = StringFunctions.MakeStringUnique("NewAnimation", existingNames);
-        var chain = _appCommands.AddAnimationChainWithName(defaultName);
+        var chain = _appCommands.AddNewAnimationChain();
         if (chain is null) return;
 
         Dispatcher.UIThread.Post(() =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -673,14 +673,7 @@ public partial class App : Application
         // tab switch (e.g. Add Frame on a chain that borrows a different texture).
         applicationEvents.AnimationChainsChanged += () => textureListPanel.SetAnimationChainList(projectManager.AnimationChainListSave);
 
-        addAnimationButton.Click += (_, _) =>
-        {
-            var currentAcls = projectManager.AnimationChainListSave;
-            if (currentAcls is null) return;
-            var existingNames = currentAcls.AnimationChains.Select(c => c.Name).ToList();
-            var name = StringFunctions.MakeStringUnique("NewAnimation", existingNames);
-            appCommands.AddAnimationChainWithName(name);
-        };
+        addAnimationButton.Click += (_, _) => appCommands.AddNewAnimationChain();
 
         addFrameButton.Click += (_, _) =>
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -621,6 +621,21 @@ namespace AnimationEditor.Core.CommandsAndState
             AddAnimationChainWithName(name);
         }
 
+        /// <summary>
+        /// Adds a new chain named "NewAnimation" (or a de-duped variant, e.g. "NewAnimation2")
+        /// without prompting — the toolbar/menu "Add Animation" entry point shared by both hosts.
+        /// Returns <c>null</c> when no project is loaded.
+        /// </summary>
+        public AnimationChainSave? AddNewAnimationChain()
+        {
+            var acls = _pm.AnimationChainListSave;
+            if (acls is null) return null;
+
+            var existingNames = acls.AnimationChains.Select(c => c.Name).ToList();
+            var defaultName = StringFunctions.MakeStringUnique("NewAnimation", existingNames);
+            return AddAnimationChainWithName(defaultName);
+        }
+
         public AnimationChainSave? AddAnimationChainWithName(string name)
         {
             var acls = _pm.AnimationChainListSave;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -135,6 +135,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void DeleteFrames(List<AnimationFrameSave> frames);
         Task AddAnimationChain();
         AnimationChainSave? AddAnimationChainWithName(string name);
+        AnimationChainSave? AddNewAnimationChain();
         bool RenameChain(AnimationChainSave chain, string newName);
         void AddFrame(AnimationChainSave chain, string? textureName = null);
         void MoveChain(AnimationChainSave chain, int delta);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -114,6 +114,46 @@ public class AppCommandsChainTests
         Assert.Same(chain, ctx.SelectedState.SelectedChain);
     }
 
+    // ── AddNewAnimationChain (shared "NewAnimation" recipe used by both hosts) ──
+
+    [Fact]
+    public void AddNewAnimationChain_AddsChainNamedNewAnimation()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+
+        var chain = ctx.AppCommands.AddNewAnimationChain();
+
+        Assert.NotNull(chain);
+        Assert.Equal("NewAnimation", chain!.Name);
+        Assert.Single(acls.AnimationChains);
+    }
+
+    [Fact]
+    public void AddNewAnimationChain_UsesUniqueNamesWhenCalledMultipleTimes()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+
+        ctx.AppCommands.AddNewAnimationChain();
+        ctx.AppCommands.AddNewAnimationChain();
+        ctx.AppCommands.AddNewAnimationChain();
+
+        var names = acls.AnimationChains.Select(c => c.Name).ToList();
+        Assert.Equal(3, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void AddNewAnimationChain_WhenAclsIsNull_ReturnsNull()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.ProjectManager.AnimationChainListSave = null;
+
+        var chain = ctx.AppCommands.AddNewAnimationChain();
+
+        Assert.Null(chain);
+    }
+
     // ── MoveChain ────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -70,6 +70,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.DeleteFrames)]                 = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChain)]            = Category.MutatingUndoable,
         [nameof(IAppCommands.AddAnimationChainWithName)]    = Category.MutatingUndoable,
+        [nameof(IAppCommands.AddNewAnimationChain)]         = Category.MutatingUndoable,
         [nameof(IAppCommands.RenameChain)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.AddFrame)]                     = Category.MutatingUndoable,
         [nameof(IAppCommands.MoveChain)]                    = Category.MutatingUndoable,
@@ -221,6 +222,8 @@ public class UndoCoverageRosterTests
             ctx => ctx.AppCommands.AddAnimationChain());
         yield return Row(nameof(IAppCommands.AddAnimationChainWithName),
             ctx => Sync(() => ctx.AppCommands.AddAnimationChainWithName("Brand New")));
+        yield return Row(nameof(IAppCommands.AddNewAnimationChain),
+            ctx => Sync(() => ctx.AppCommands.AddNewAnimationChain()));
         yield return Row(nameof(IAppCommands.RenameChain),
             ctx => Sync(() => ctx.AppCommands.RenameChain(Zebra(ctx), "Renamed")));
         yield return Row(nameof(IAppCommands.AddFrame),


### PR DESCRIPTION
Part of #748

Extracts the duplicated "compute a unique NewAnimation name, add the chain" recipe from both Animation Editor hosts into a new `AppCommands.AddNewAnimationChain()` method in Core.

- Desktop's `AddAnimationChainAndBeginInlineRename` and Browser's `addAnimationButton.Click` handler both independently computed `MakeStringUnique("NewAnimation", existingNames)` before calling `AddAnimationChainWithName`. Both now call `AddNewAnimationChain()`.
- Desktop keeps its host-specific ACLS-create-if-null guard and inline-rename follow-up.
- No behavior change. Covered by new tests in `AppCommandsChainTests` plus roster/round-trip entries in `UndoCoverageRosterTests`.