### PR TITLE
Extract history-panel row ordering into Core.HistoryRowBuilder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1578,7 +1578,6 @@ public partial class MainWindow : Window
     {
         var undoHistory = _undoManager.UndoHistory;
         var redoHistory = _undoManager.RedoHistory;
-        var items = new List<Models.HistoryEntryVm>();
         // Applied (undo) rows use full-strength ink; redo rows are muted. All brushes come from
         // theme tokens so the panel stays legible in both light and dark (this method re-runs on
         // ActualThemeVariantChanged). The current entry gets an accent fill with on-accent text —
@@ -1588,15 +1587,14 @@ public partial class MainWindow : Window
         IBrush redoInk    = new SolidColorBrush(Color.Parse(dark ? "#6a6e76" : "#9aa1ad"));
         IBrush accentFill = ThemedBrush("Accent");
         IBrush onAccent   = ThemedBrush("OnAccent");
-        // Photoshop order: oldest applied at top, newest applied at bottom, redo items below.
-        foreach (var cmd in undoHistory)
-            items.Add(new Models.HistoryEntryVm(cmd.Description, appliedInk, Brushes.Transparent));
-        // Mark the most recently applied command as "you are here".
-        if (items.Count > 0)
-            items[^1] = items[^1] with { IsCurrent = true, Foreground = onAccent, Background = accentFill };
-        // Redo items follow: next-to-redo first, furthest future last.
-        foreach (var cmd in redoHistory)
-            items.Add(new Models.HistoryEntryVm(cmd.Description, redoInk, Brushes.Transparent));
+        // Ordering/marking (oldest-applied first, current entry, then redo entries) lives in
+        // Core's HistoryRowBuilder so desktop and browser stay in lockstep (#748); only the
+        // brush mapping below is host-specific.
+        var items = HistoryRowBuilder.BuildRows(undoHistory, redoHistory)
+            .Select(row => row.IsCurrent
+                ? new Models.HistoryEntryVm(row.Description, onAccent, accentFill, IsCurrent: true)
+                : new Models.HistoryEntryVm(row.Description, row.IsRedo ? redoInk : appliedInk, Brushes.Transparent))
+            .ToList();
         HistoryList.ItemsSource = items;
         int currentIndex = undoHistory.Count - 1;
         ScrollHistoryToCurrent(currentIndex, items.Count);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -458,15 +458,11 @@ public partial class App : Application
 
         void RefreshHistoryList()
         {
-            var undoHistory = undoManager.UndoHistory;
-            var redoHistory = undoManager.RedoHistory;
             historyRows.Clear();
-            // Photoshop order: oldest applied at top, newest applied (current) at bottom, then
-            // redo entries (next-to-redo first).
-            for (int i = 0; i < undoHistory.Count; i++)
-                historyRows.Add(new HistoryRowVm(undoHistory[i].Description, IsCurrent: i == undoHistory.Count - 1, IsRedo: false));
-            foreach (var cmd in redoHistory)
-                historyRows.Add(new HistoryRowVm(cmd.Description, IsCurrent: false, IsRedo: true));
+            // Ordering/marking (oldest-applied first, current entry, then redo entries) lives in
+            // Core's HistoryRowBuilder so desktop and browser stay in lockstep (#748).
+            foreach (var row in HistoryRowBuilder.BuildRows(undoManager.UndoHistory, undoManager.RedoHistory))
+                historyRows.Add(new HistoryRowVm(row.Description, row.IsCurrent, row.IsRedo));
             // New list instance so ItemsControl always sees a source change, even if it was
             // detached from the visual tree while History was not the selected sidebar tab.
             historyList.ItemsSource = historyRows.ToList();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/HistoryRowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/HistoryRowBuilder.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// One row's worth of History-panel ordering/marking metadata. Hosts map this into their
+    /// own themed row view model (desktop uses brushes, browser uses opacity/font weight).
+    /// </summary>
+    /// <param name="IsCurrent">True for the most-recently-applied undo entry ("you are here").</param>
+    /// <param name="IsRedo">True for entries that have been undone and are pending redo.</param>
+    public readonly record struct HistoryRow(string Description, bool IsCurrent, bool IsRedo);
+
+    /// <summary>
+    /// Builds the ordered, marked History-panel row sequence shared by every editor host.
+    /// </summary>
+    public static class HistoryRowBuilder
+    {
+        /// <summary>
+        /// Orders <paramref name="undoHistory"/> oldest-first (its last entry marked
+        /// <see cref="HistoryRow.IsCurrent"/>), then appends <paramref name="redoHistory"/>
+        /// in next-to-redo-first order, marked <see cref="HistoryRow.IsRedo"/>.
+        /// </summary>
+        public static IEnumerable<HistoryRow> BuildRows(
+            IReadOnlyList<IUndoableCommand> undoHistory,
+            IReadOnlyList<IUndoableCommand> redoHistory)
+        {
+            for (int i = 0; i < undoHistory.Count; i++)
+                yield return new HistoryRow(undoHistory[i].Description, IsCurrent: i == undoHistory.Count - 1, IsRedo: false);
+
+            foreach (var cmd in redoHistory)
+                yield return new HistoryRow(cmd.Description, IsCurrent: false, IsRedo: true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HistoryRowBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/HistoryRowBuilderTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class HistoryRowBuilderTests
+{
+    [Fact]
+    public void BuildRows_EmptyUndoAndRedo_YieldsNoRows()
+    {
+        var rows = HistoryRowBuilder.BuildRows(new StubCommand[0], new StubCommand[0]);
+
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void BuildRows_OnlyUndo_MarksLastEntryAsCurrent()
+    {
+        var undo = new[] { new StubCommand("A"), new StubCommand("B"), new StubCommand("C") };
+
+        var rows = HistoryRowBuilder.BuildRows(undo, new StubCommand[0]).ToList();
+
+        Assert.Equal(new[] { "A", "B", "C" }, rows.Select(r => r.Description));
+        Assert.Equal(new[] { false, false, true }, rows.Select(r => r.IsCurrent));
+        Assert.All(rows, r => Assert.False(r.IsRedo));
+    }
+
+    [Fact]
+    public void BuildRows_SingleUndoEntry_IsCurrent()
+    {
+        var rows = HistoryRowBuilder.BuildRows(new[] { new StubCommand("Only") }, new StubCommand[0]).ToList();
+
+        var row = Assert.Single(rows);
+        Assert.True(row.IsCurrent);
+        Assert.False(row.IsRedo);
+    }
+
+    [Fact]
+    public void BuildRows_OnlyRedo_NoneAreCurrentAndAllAreRedo()
+    {
+        var redo = new[] { new StubCommand("NextRedo"), new StubCommand("FutureRedo") };
+
+        var rows = HistoryRowBuilder.BuildRows(new StubCommand[0], redo).ToList();
+
+        Assert.Equal(new[] { "NextRedo", "FutureRedo" }, rows.Select(r => r.Description));
+        Assert.All(rows, r => Assert.False(r.IsCurrent));
+        Assert.All(rows, r => Assert.True(r.IsRedo));
+    }
+
+    [Fact]
+    public void BuildRows_UndoAndRedoBothPopulated_OrdersUndoThenRedo()
+    {
+        var undo = new[] { new StubCommand("A"), new StubCommand("B") };
+        var redo = new[] { new StubCommand("C"), new StubCommand("D") };
+
+        var rows = HistoryRowBuilder.BuildRows(undo, redo).ToList();
+
+        Assert.Equal(new[] { "A", "B", "C", "D" }, rows.Select(r => r.Description));
+        Assert.Equal(new[] { false, true, false, false }, rows.Select(r => r.IsCurrent));
+        Assert.Equal(new[] { false, false, true, true }, rows.Select(r => r.IsRedo));
+    }
+
+    private sealed class StubCommand : IUndoableCommand
+    {
+        public StubCommand(string description = "Stub") => Description = description;
+        public string Description { get; }
+        public bool Do() => true;
+        public void Undo() { }
+    }
+}


### PR DESCRIPTION
## Summary
- Desktop's `MainWindow.RefreshHistoryPanel` and browser's `App.axaml.cs RefreshHistoryList` duplicated the same undo/redo ordering algorithm (oldest-applied first, current marker, then muted redo entries).
- Extracted the pure ordering/marking logic into `AnimationEditor.Core.CommandsAndState.Commands.HistoryRowBuilder.BuildRows`, returning `HistoryRow` (Description/IsCurrent/IsRedo) tuples.
- Each host still maps rows into its own themed VM (`HistoryEntryVm` with brushes, `HistoryRowVm` with opacity/FontWeight) unchanged — no view-model unification, no styling change.

No behavior change.

Part of #748

## Test plan
- [x] New `HistoryRowBuilderTests` (empty undo/redo, only undo, only redo, single entry, both populated) — all pass
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 0 warnings/errors
- [x] `dotnet test` on Core/Views/App test projects — all green (1699 / 48 / 753 passed)