### PR TITLE
Animation Editor: browser keyboard shortcuts dispatch through shared HotkeyRegistry

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -11,6 +11,7 @@ using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.App.Theming;
 using AnimationEditor.Core.Export;
+using AnimationEditor.Core.Hotkeys;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Utilities;
@@ -121,6 +122,19 @@ public partial class App : Application
         };
         divider.Bind(Border.BackgroundProperty, divider.GetResourceObservable("LineBrush"));
         return divider;
+    }
+
+    // Translates Avalonia's native modifier flags into the UI-independent HotkeyModifiers used by
+    // AnimationEditor.Core.Hotkeys -- mirrors MainWindow.ToHotkeyModifiers (desktop host); kept in
+    // sync manually since the two hosts don't share an Avalonia-dependent project to host it in.
+    private static HotkeyModifiers ToHotkeyModifiers(KeyModifiers modifiers)
+    {
+        var result = HotkeyModifiers.None;
+        if (modifiers.HasFlag(KeyModifiers.Shift)) result |= HotkeyModifiers.Shift;
+        if (modifiers.HasFlag(KeyModifiers.Alt)) result |= HotkeyModifiers.Alt;
+        if (modifiers.HasFlag(KeyModifiers.Control) || modifiers.HasFlag(KeyModifiers.Meta))
+            result |= HotkeyModifiers.Command;
+        return result;
     }
 
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
@@ -1522,42 +1536,61 @@ public partial class App : Application
         // F3 is a best-effort accelerator only -- the diagnostics button above is the reliable
         // path, since browsers may intercept F3 themselves (e.g. "Find next") before the page
         // ever sees it.
+        //
+        // Dispatch goes through the same AnimationEditor.Core.Hotkeys.HotkeyRegistry.FindMatch
+        // the desktop host uses (MainWindow.WireKeyboard/BuildHotkeyDefinitions), instead of a
+        // hand-rolled if/else chain, so keypress-to-gesture matching exists in exactly one place
+        // (#748). Ids/gestures below mirror BuildHotkeyDefinitions's save/undo/redo/toggle-
+        // diagnostics entries -- keep them in sync if that table changes. Everything else in the
+        // desktop table is left out: New/Load/Duplicate/panel-zoom-in/panel-zoom-out are
+        // hard-reserved by the browser itself (BrowserHotkeys.ReservedIds -- Ctrl+N/L/D/+/- are
+        // intercepted before the page ever sees them), and Copy/Cut/Paste/Delete/Rename/Space/
+        // Move-up/Move-down have no action to wire in this build yet.
+        var browserHotkeys = BrowserHotkeys.Filter(new List<HotkeyDefinition>
+        {
+            new()
+            {
+                Id = "save", Description = "Save", Category = "File",
+                Gestures = new[] { new HotkeyGesture("S", HotkeyModifiers.Command) },
+                Action = () => saveButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)),
+            },
+            new()
+            {
+                Id = "undo", Description = "Undo", Category = "Edit",
+                Gestures = new[] { new HotkeyGesture("Z", HotkeyModifiers.Command, Forbidden: HotkeyModifiers.Shift) },
+                Action = () => historyUndoButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)),
+            },
+            new()
+            {
+                Id = "redo", Description = "Redo", Category = "Edit",
+                Gestures = new[]
+                {
+                    new HotkeyGesture("Y", HotkeyModifiers.Command),
+                    new HotkeyGesture("Z", HotkeyModifiers.Command | HotkeyModifiers.Shift, Forbidden: HotkeyModifiers.Alt),
+                },
+                Action = () => historyRedoButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)),
+            },
+            new()
+            {
+                Id = "toggle-diagnostics", Description = "Toggle Render Diagnostics", Category = "View",
+                Gestures = new[] { new HotkeyGesture("F3") },
+                Action = () => ApplyDiagnostics(diagnosticsButton.IsChecked != true),
+            },
+        });
+
         root.AttachedToVisualTree += (_, _) =>
         {
             var topLevelForKeys = TopLevel.GetTopLevel(root);
             if (topLevelForKeys is null) return;
             topLevelForKeys.KeyDown += (_, e) =>
             {
-                if (e.Key == Key.F3)
-                {
-                    e.Handled = true;
-                    ApplyDiagnostics(diagnosticsButton.IsChecked != true);
-                    return;
-                }
+                if (e.Handled) return;
 
-                // Phase 13 (#662): only the browser-safe subset from the roadmap's shortcut
-                // table -- Ctrl+S is interceptable via preventDefault; Ctrl+Z/Ctrl+Y aren't
-                // reserved. Ctrl+N/Ctrl+L/Ctrl+D/Ctrl+(+/-)/Ctrl+Shift+(+/-) are hard-reserved by
-                // Chrome (new window, address bar, bookmark, page zoom) and stay menu-only --
-                // no accelerator wired for those here, matching the roadmap's recommendation.
-                if (e.KeyModifiers == KeyModifiers.Control)
-                {
-                    if (e.Key == Key.S)
-                    {
-                        e.Handled = true;
-                        saveButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                    }
-                    else if (e.Key == Key.Z)
-                    {
-                        e.Handled = true;
-                        historyUndoButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                    }
-                    else if (e.Key == Key.Y)
-                    {
-                        e.Handled = true;
-                        historyRedoButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                    }
-                }
+                var match = HotkeyRegistry.FindMatch(browserHotkeys, e.Key.ToString(), ToHotkeyModifiers(e.KeyModifiers));
+                if (match is null) return;
+
+                e.Handled = true;
+                match.Action();
             };
         };
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/BrowserHotkeys.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Hotkeys/BrowserHotkeys.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.Hotkeys;
+
+/// <summary>
+/// Filters a hotkey table down to the subset safe to dispatch in a browser-hosted build.
+/// <see cref="ReservedIds"/> are ids the desktop table (<c>MainWindow.BuildHotkeyDefinitions</c>)
+/// defines whose gesture is hard-reserved by browsers before the page ever sees the keypress —
+/// Ctrl+N (new window), Ctrl+L (address bar), Ctrl+D (bookmark), Ctrl+Plus/Minus (page zoom).
+/// </summary>
+public static class BrowserHotkeys
+{
+    public static readonly IReadOnlyCollection<string> ReservedIds = new HashSet<string>
+    {
+        "new", "load", "duplicate", "panel-zoom-in", "panel-zoom-out",
+    };
+
+    /// <summary>Removes any definition whose <see cref="HotkeyDefinition.Id"/> is browser-reserved.</summary>
+    public static IReadOnlyList<HotkeyDefinition> Filter(IReadOnlyList<HotkeyDefinition> hotkeys) =>
+        hotkeys.Where(h => !ReservedIds.Contains(h.Id)).ToList();
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserHotkeysTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserHotkeysTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using AnimationEditor.Core.Hotkeys;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class BrowserHotkeysTests
+{
+    private static HotkeyDefinition MakeDefinition(string id) =>
+        new()
+        {
+            Id = id,
+            Description = id,
+            Category = "Edit",
+            Gestures = new[] { new HotkeyGesture(id) },
+            Action = () => { },
+        };
+
+    [Fact]
+    public void Filter_FullDesktopTable_ExcludesReservedIdsAndKeepsRest()
+    {
+        var hotkeys = new List<HotkeyDefinition>
+        {
+            MakeDefinition("save"),
+            MakeDefinition("undo"),
+            MakeDefinition("redo"),
+            MakeDefinition("toggle-diagnostics"),
+            MakeDefinition("new"),
+            MakeDefinition("load"),
+            MakeDefinition("duplicate"),
+            MakeDefinition("panel-zoom-in"),
+            MakeDefinition("panel-zoom-out"),
+        };
+
+        var filtered = BrowserHotkeys.Filter(hotkeys);
+
+        Assert.Equal(
+            new[] { "save", "undo", "redo", "toggle-diagnostics" },
+            filtered.Select(h => h.Id));
+    }
+}


### PR DESCRIPTION
Part of #748.

Browser hand-rolled its own `KeyDown` if/else chain for its Ctrl+S/Z/Y/F3 subset instead of reusing Core's `HotkeyRegistry.FindMatch` that desktop already uses. Now both hosts dispatch through the same matcher.

- New `AnimationEditor.Core.Hotkeys.BrowserHotkeys` — explicit, tested `ReservedIds` filter (excludes `new`/`load`/`duplicate`/`panel-zoom-in`/`panel-zoom-out` — hard browser-reserved gestures Ctrl+N/L/D/+/-).
- Browser now builds its filtered hotkey list and calls `HotkeyRegistry.FindMatch`, same as desktop.
- Desktop (`MainWindow.axaml.cs`) untouched.

**Behavior change:** Ctrl+Shift+Z now also triggers redo in the browser build (it fell out of reusing desktop's exact redo gesture list, which includes both Ctrl+Y and Ctrl+Shift+Z). Previously excluded by the old handler's narrower modifier check.

Manually verified in a running browser build: Ctrl+S/Z/Y/Shift+Z/F3 all work as expected; Ctrl+N/L/D/+/- are correctly not handled by the editor (browser-reserved, no double-fire).

Build: 0 warnings/errors including Browser/WASM. Tests: Core 1704, Views 48, App 753, all green.