### PR TITLE
Extract tree context-menu plan into Core.TreeMenuPlanBuilder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3872,135 +3872,72 @@ public partial class MainWindow : Window
         AnimTree.ContextMenu.Items.Clear();
 
         var vm = AnimTree.SelectedItem as TreeNodeVm;
+        var data = vm?.Data;
 
-        if (vm?.Data is AARectSave rect)
+        // Rename and the chain-duplicate flip variants need the tree's visual nodes / a
+        // captured node reference, so they stay host callbacks rather than moving into the
+        // shared plan.
+        Action? rename = data switch
         {
-            AddShapeReorderItems(rect, _objectFinder.GetAnimationFrameContaining(rect));
-            AddMenuItem("Match Frame Size", () =>
-            {
-                var frame = _selectedState.SelectedFrame;
-                if (frame is not null)
-                {
-                    _appCommands.MatchRectangleToFrame(rect, frame);
-                    _appCommands.RefreshAnimationFrameDisplay();
-                    _appCommands.SaveCurrentAnimationChainList();
-                }
-            });
-            AddSeparator();
-            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
-            AddMenuItem("Cut",   () => _ = HandleCutAsync());
-            AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            AddMenuItem("Duplicate", HandleDuplicate);
-            AddSeparator();
-            AddMenuItem("Rename…", () => BeginInlineRename(vm!, rect.Name));
-            AddSeparator();
-            AddMenuItem("Delete Rectangle", HandleDelete);
-        }
-        else if (vm?.Data is CircleSave circle)
-        {
-            AddShapeReorderItems(circle, _objectFinder.GetAnimationFrameContaining(circle));
-            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
-            AddMenuItem("Cut",   () => _ = HandleCutAsync());
-            AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            AddMenuItem("Duplicate", HandleDuplicate);
-            AddSeparator();
-            AddMenuItem("Rename…", () => BeginInlineRename(vm!, circle.Name));
-            AddSeparator();
-            AddMenuItem("Delete Circle", HandleDelete);
-        }
-        else if (vm?.Data is AnimationFrameSave frame2)
-        {
-            var chain2 = _objectFinder.GetAnimationChainContaining(frame2);
-            if (chain2 is not null && chain2.Frames.Count > 1)
-            {
-                var frameIndex = chain2.Frames.IndexOf(frame2);
-                var isFirst    = frameIndex == 0;
-                var isLast     = frameIndex == chain2.Frames.Count - 1;
-                if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveFrameToTop(frame2, chain2));
-                if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveFrame(frame2, chain2, -1));
-                if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveFrame(frame2, chain2, +1));
-                if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveFrameToBottom(frame2, chain2));
-                AddSeparator();
-            }
-            AddMenuItem("Add AxisAlignedRectangle", () => _appCommands.AddAxisAlignedRectangle(frame2));
-            AddMenuItem("Add Circle",               () => _appCommands.AddCircle(frame2));
-            AddSeparator();
-            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
-            AddMenuItem("Cut",   () => _ = HandleCutAsync());
-            AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            if (chain2 is not null)
-                AddMenuItem("Duplicate", HandleDuplicate);
-            AddSeparator();
-            AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame2));
-            AddSeparator();
-            AddMenuItem("Delete Frame", HandleDelete);
-        }
-        else if (vm?.Data is AnimationChainSave chain)
-        {
-            var chains = _projectManager.AnimationChainListSave?.AnimationChains;
-            if (chains is not null && chains.Count > 1)
-            {
-                var chainIndex = chains.IndexOf(chain);
-                var isFirst    = chainIndex == 0;
-                var isLast     = chainIndex == chains.Count - 1;
-                if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveChainToTop(chain));
-                if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveChain(chain, -1));
-                if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveChain(chain, +1));
-                if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveChainToBottom(chain));
-                AddSeparator();
-            }
-            AddMenuItem("Adjust Frame Time…", () => AskAdjustFrameTime(chain));
-            AddMenuItem("Flip Horizontally",  () => _appCommands.FlipChainHorizontally(chain));
-            AddMenuItem("Flip Vertically",    () => _appCommands.FlipChainVertically(chain));
-            AddMenuItem("Invert Frame Order", () => _appCommands.InvertFrameOrder(chain));
-            AddSeparator();
-            AddMenuItem("Add Animation", AddAnimationChainAndBeginInlineRename);
-            AddMenuItem("Add Frame",          () => _appCommands.AddFrame(chain));
-            AddMenuItem("Add Multiple Frames…", () => _ = AskAddMultipleFramesAsync(chain));
-            AddSeparator();
-            AddMenuItem("Copy",  () => _ = HandleCopyAsync());
-            AddMenuItem("Cut",   () => _ = HandleCutAsync());
-            AddMenuItem("Paste", () => _ = HandlePasteAsync());
-            AddSubMenu("Duplicate",
-                ("Original",        HandleDuplicate),
-                ("Flip Horizontal", () => HandleDuplicateChainsFlip(chain, flipH: true, flipV: false)),
-                ("Flip Vertical",   () => HandleDuplicateChainsFlip(chain, flipH: false, flipV: true)));
-            AddSeparator();
-            AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
-            AddMenuItem("Rename…",          () => BeginInlineRenameSelected(chain));
-            AddSeparator();
-            AddMenuItem("Delete Animation", HandleDelete);
-        }
-        else
-        {
-            AddMenuItem("Add Animation", () =>
-            {
-                if (_projectManager.AnimationChainListSave is null)
-                    _projectManager.AnimationChainListSave = new AnimationChainListSave();
-                AddAnimationChainAndBeginInlineRename();
-            });
-        }
+            AARectSave rect          => () => BeginInlineRename(vm!, rect.Name),
+            CircleSave circle        => () => BeginInlineRename(vm!, circle.Name),
+            AnimationChainSave chain => () => BeginInlineRenameSelected(chain),
+            _                        => null
+        };
+        Action<bool, bool>? duplicateChainFlip = data is AnimationChainSave flipChain
+            ? (flipH, flipV) => HandleDuplicateChainsFlip(flipChain, flipH, flipV)
+            : null;
 
-        AddSeparator();
-        AddMenuItem("Sort Animations Alphabetically",
-            () => _appCommands.SortAnimationsAlphabetically());
+        var actions = new TreeMenuActions(
+            Copy: () => _ = HandleCopyAsync(),
+            Cut: () => _ = HandleCutAsync(),
+            Paste: () => _ = HandlePasteAsync(),
+            Duplicate: HandleDuplicate,
+            Delete: HandleDelete,
+            Rename: rename,
+            AddAnimation: AddAnimationChainAndBeginInlineRename,
+            DuplicateChainFlip: duplicateChainFlip);
+
+        var plan = TreeMenuPlanBuilder.Build(data, _appCommands, _selectedState, _objectFinder, _projectManager, actions);
+        RenderMenuPlan(plan, data);
     }
 
-    // Adds the four reorder items (To Top / Up / Down / To Bottom) for a shape,
-    // guarded by the shape's position within its frame's combined shape list — the
-    // same convention the frame menu uses. No-op when the frame has one shape or less.
-    private void AddShapeReorderItems(object shape, AnimationFrameSave? frame)
+    // Thin walk over the shared plan built by TreeMenuPlanBuilder: adds each entry via the
+    // existing Avalonia-building helpers below, substituting the real dialog/filesystem menu
+    // item at each host-slot placeholder (see TreeMenuHostSlot — these four stay desktop-only
+    // until issue #756).
+    private void RenderMenuPlan(IReadOnlyList<TreeMenuItem> plan, object? nodeData)
     {
-        var shapes = frame?.ShapesSave?.Shapes;
-        if (shapes is null || shapes.Count <= 1) return;
-        int  index   = shapes.IndexOf(shape);
-        bool isFirst = index == 0;
-        bool isLast  = index == shapes.Count - 1;
-        if (!isFirst) AddMenuItem("^^ Move To Top",   () => _appCommands.MoveShapeToTop(shape, frame!));
-        if (!isFirst) AddMenuItem("^  Move Up",        () => _appCommands.MoveShape(shape, frame!, -1));
-        if (!isLast)  AddMenuItem("v  Move Down",      () => _appCommands.MoveShape(shape, frame!, +1));
-        if (!isLast)  AddMenuItem("vv Move To Bottom", () => _appCommands.MoveShapeToBottom(shape, frame!));
-        AddSeparator();
+        foreach (var entry in plan)
+        {
+            if (entry.IsSeparator)
+                AddSeparator();
+            else if (entry.HostSlot is { } slot)
+                AddHostSlotItem(slot, nodeData);
+            else if (entry.Children is { } children)
+                AddSubMenu(entry.Header!, children.Select(c => (c.Header!, c.OnClick!)).ToArray());
+            else
+                AddMenuItem(entry.Header!, entry.OnClick!);
+        }
+    }
+
+    private void AddHostSlotItem(TreeMenuHostSlot slot, object? nodeData)
+    {
+        switch (slot)
+        {
+            case TreeMenuHostSlot.AdjustFrameTime when nodeData is AnimationChainSave chain:
+                AddMenuItem("Adjust Frame Time…", () => AskAdjustFrameTime(chain));
+                break;
+            case TreeMenuHostSlot.AddMultipleFrames when nodeData is AnimationChainSave chain:
+                AddMenuItem("Add Multiple Frames…", () => _ = AskAddMultipleFramesAsync(chain));
+                break;
+            case TreeMenuHostSlot.AdjustOffsets when nodeData is AnimationChainSave chain:
+                AddMenuItem("Adjust Offsets…", () => _ = AskAdjustOffsetsAsync(chain));
+                break;
+            case TreeMenuHostSlot.ViewTextureInExplorer when nodeData is AnimationFrameSave frame:
+                AddMenuItem("View Texture in Explorer", () => ViewTextureInExplorer(frame));
+                break;
+        }
     }
 
     private void AddMenuItem(string header, Action onClick)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuActions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuActions.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Host-supplied callbacks for tree context-menu actions <see cref="TreeMenuPlanBuilder"/> can't
+/// express purely through <see cref="IAppCommands"/>/<see cref="ISelectedState"/>/
+/// <see cref="IObjectFinder"/> — either because they touch UI-framework state (inline tree
+/// rename needs the tree's visual nodes) or because the existing host implementation is already
+/// working, framework-free logic the host owns (copy/cut/paste/duplicate/delete).
+/// </summary>
+/// <param name="Rename">Only invoked for rectangle/circle/chain nodes.</param>
+/// <param name="AddAnimation">Only invoked for the chain and empty-selection nodes.</param>
+/// <param name="DuplicateChainFlip">Only invoked from the chain node's Duplicate submenu (flipH, flipV).</param>
+public sealed record TreeMenuActions(
+    Action Copy,
+    Action Cut,
+    Action Paste,
+    Action Duplicate,
+    Action Delete,
+    Action? Rename = null,
+    Action? AddAnimation = null,
+    Action<bool, bool>? DuplicateChainFlip = null);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuItem.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuItem.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// One entry in a tree context-menu plan built by <see cref="TreeMenuPlanBuilder"/>. Hosts
+/// (desktop Avalonia, browser) walk the ordered list and materialize their own menu-item type
+/// from each entry — this type carries no UI-framework dependency.
+/// </summary>
+public sealed class TreeMenuItem
+{
+    public string? Header { get; }
+    public Action? OnClick { get; }
+    public IReadOnlyList<TreeMenuItem>? Children { get; }
+    public TreeMenuHostSlot? HostSlot { get; }
+    public bool IsSeparator { get; }
+
+    private TreeMenuItem(string? header, Action? onClick, IReadOnlyList<TreeMenuItem>? children,
+        TreeMenuHostSlot? hostSlot, bool isSeparator)
+    {
+        Header = header;
+        OnClick = onClick;
+        Children = children;
+        HostSlot = hostSlot;
+        IsSeparator = isSeparator;
+    }
+
+    public static TreeMenuItem Item(string header, Action onClick) => new(header, onClick, null, null, false);
+
+    public static TreeMenuItem Separator() => new(null, null, null, null, true);
+
+    public static TreeMenuItem SubMenu(string header, params TreeMenuItem[] children) =>
+        new(header, null, children, null, false);
+
+    /// <summary>
+    /// A placeholder for a menu item the host builds itself — a dialog or filesystem action
+    /// that needs UI-framework types <see cref="TreeMenuPlanBuilder"/> can't depend on (see
+    /// <see cref="TreeMenuHostSlot"/>). The host substitutes its own menu item at this position
+    /// when walking the plan.
+    /// </summary>
+    public static TreeMenuItem HostSlotItem(TreeMenuHostSlot slot) => new(null, null, null, slot, false);
+}
+
+/// <summary>
+/// Identifies which host-built item belongs at a <see cref="TreeMenuItem.HostSlot"/> position.
+/// These four are excluded from the shared plan (tracked separately, issue #756) because each
+/// needs UI-framework or filesystem access <see cref="TreeMenuPlanBuilder"/> can't depend on:
+/// a dialog window (<see cref="AdjustFrameTime"/>, <see cref="AddMultipleFrames"/>,
+/// <see cref="AdjustOffsets"/>) or shelling out to the OS file explorer
+/// (<see cref="ViewTextureInExplorer"/>).
+/// </summary>
+public enum TreeMenuHostSlot
+{
+    AdjustFrameTime,
+    AddMultipleFrames,
+    AdjustOffsets,
+    ViewTextureInExplorer,
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuPlanBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/TreeMenuPlanBuilder.cs
@@ -1,0 +1,167 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState;
+
+/// <summary>
+/// Builds the ordered tree right-click menu plan shared by every editor host, branching on the
+/// selected tree node's data type (rectangle, circle, frame, chain, or nothing selected).
+/// </summary>
+public static class TreeMenuPlanBuilder
+{
+    public static IReadOnlyList<TreeMenuItem> Build(
+        object? nodeData,
+        IAppCommands appCommands,
+        ISelectedState selectedState,
+        IObjectFinder objectFinder,
+        IProjectManager projectManager,
+        TreeMenuActions actions)
+    {
+        var items = new List<TreeMenuItem>();
+
+        switch (nodeData)
+        {
+            case AARectSave rect:
+                AddShapeReorderItems(items, rect, objectFinder.GetAnimationFrameContaining(rect), appCommands);
+                items.Add(TreeMenuItem.Item("Match Frame Size", () => MatchFrameSize(rect, appCommands, selectedState)));
+                items.Add(TreeMenuItem.Separator());
+                AddCopyCutPasteDuplicate(items, actions);
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Rename…", actions.Rename!));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Delete Rectangle", actions.Delete));
+                break;
+
+            case CircleSave circle:
+                AddShapeReorderItems(items, circle, objectFinder.GetAnimationFrameContaining(circle), appCommands);
+                AddCopyCutPasteDuplicate(items, actions);
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Rename…", actions.Rename!));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Delete Circle", actions.Delete));
+                break;
+
+            case AnimationFrameSave frame:
+            {
+                var chain = objectFinder.GetAnimationChainContaining(frame);
+                if (chain is not null && chain.Frames.Count > 1)
+                {
+                    AddFrameReorderItems(items, frame, chain, appCommands);
+                    items.Add(TreeMenuItem.Separator());
+                }
+                items.Add(TreeMenuItem.Item("Add AxisAlignedRectangle", () => appCommands.AddAxisAlignedRectangle(frame)));
+                items.Add(TreeMenuItem.Item("Add Circle", () => appCommands.AddCircle(frame)));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Copy", actions.Copy));
+                items.Add(TreeMenuItem.Item("Cut", actions.Cut));
+                items.Add(TreeMenuItem.Item("Paste", actions.Paste));
+                if (chain is not null)
+                    items.Add(TreeMenuItem.Item("Duplicate", actions.Duplicate));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.HostSlotItem(TreeMenuHostSlot.ViewTextureInExplorer));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Delete Frame", actions.Delete));
+                break;
+            }
+
+            case AnimationChainSave chain2:
+            {
+                var chains = projectManager.AnimationChainListSave?.AnimationChains;
+                if (chains is not null && chains.Count > 1)
+                {
+                    AddChainReorderItems(items, chain2, chains, appCommands);
+                    items.Add(TreeMenuItem.Separator());
+                }
+                items.Add(TreeMenuItem.HostSlotItem(TreeMenuHostSlot.AdjustFrameTime));
+                items.Add(TreeMenuItem.Item("Flip Horizontally", () => appCommands.FlipChainHorizontally(chain2)));
+                items.Add(TreeMenuItem.Item("Flip Vertically", () => appCommands.FlipChainVertically(chain2)));
+                items.Add(TreeMenuItem.Item("Invert Frame Order", () => appCommands.InvertFrameOrder(chain2)));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Add Animation", actions.AddAnimation!));
+                items.Add(TreeMenuItem.Item("Add Frame", () => appCommands.AddFrame(chain2)));
+                items.Add(TreeMenuItem.HostSlotItem(TreeMenuHostSlot.AddMultipleFrames));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Copy", actions.Copy));
+                items.Add(TreeMenuItem.Item("Cut", actions.Cut));
+                items.Add(TreeMenuItem.Item("Paste", actions.Paste));
+                items.Add(TreeMenuItem.SubMenu("Duplicate",
+                    TreeMenuItem.Item("Original", actions.Duplicate),
+                    TreeMenuItem.Item("Flip Horizontal", () => actions.DuplicateChainFlip!(true, false)),
+                    TreeMenuItem.Item("Flip Vertical", () => actions.DuplicateChainFlip!(false, true))));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.HostSlotItem(TreeMenuHostSlot.AdjustOffsets));
+                items.Add(TreeMenuItem.Item("Rename…", actions.Rename!));
+                items.Add(TreeMenuItem.Separator());
+                items.Add(TreeMenuItem.Item("Delete Animation", actions.Delete));
+                break;
+            }
+
+            default:
+                items.Add(TreeMenuItem.Item("Add Animation", actions.AddAnimation!));
+                break;
+        }
+
+        items.Add(TreeMenuItem.Separator());
+        items.Add(TreeMenuItem.Item("Sort Animations Alphabetically", appCommands.SortAnimationsAlphabetically));
+
+        return items;
+    }
+
+    private static void MatchFrameSize(AARectSave rect, IAppCommands appCommands, ISelectedState selectedState)
+    {
+        if (selectedState.SelectedFrame is not { } frame) return;
+        appCommands.MatchRectangleToFrame(rect, frame);
+        appCommands.RefreshAnimationFrameDisplay();
+        appCommands.SaveCurrentAnimationChainList();
+    }
+
+    private static void AddCopyCutPasteDuplicate(List<TreeMenuItem> items, TreeMenuActions actions)
+    {
+        items.Add(TreeMenuItem.Item("Copy", actions.Copy));
+        items.Add(TreeMenuItem.Item("Cut", actions.Cut));
+        items.Add(TreeMenuItem.Item("Paste", actions.Paste));
+        items.Add(TreeMenuItem.Item("Duplicate", actions.Duplicate));
+    }
+
+    // Mirrors the shape/frame/chain reorder convention: four items (Move to Top/Up/Down/Bottom)
+    // guarded by the node's position within its containing list. No-op (and no separator) when
+    // that list has one entry or less.
+    private static void AddShapeReorderItems(
+        List<TreeMenuItem> items, object shape, AnimationFrameSave? frame, IAppCommands appCommands)
+    {
+        var shapes = frame?.ShapesSave?.Shapes;
+        if (shapes is null || shapes.Count <= 1) return;
+        int index = shapes.IndexOf(shape);
+        bool isFirst = index == 0;
+        bool isLast = index == shapes.Count - 1;
+        if (!isFirst) items.Add(TreeMenuItem.Item("^^ Move To Top", () => appCommands.MoveShapeToTop(shape, frame!)));
+        if (!isFirst) items.Add(TreeMenuItem.Item("^  Move Up", () => appCommands.MoveShape(shape, frame!, -1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("v  Move Down", () => appCommands.MoveShape(shape, frame!, +1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("vv Move To Bottom", () => appCommands.MoveShapeToBottom(shape, frame!)));
+        items.Add(TreeMenuItem.Separator());
+    }
+
+    private static void AddFrameReorderItems(
+        List<TreeMenuItem> items, AnimationFrameSave frame, AnimationChainSave chain, IAppCommands appCommands)
+    {
+        int index = chain.Frames.IndexOf(frame);
+        bool isFirst = index == 0;
+        bool isLast = index == chain.Frames.Count - 1;
+        if (!isFirst) items.Add(TreeMenuItem.Item("^^ Move To Top", () => appCommands.MoveFrameToTop(frame, chain)));
+        if (!isFirst) items.Add(TreeMenuItem.Item("^  Move Up", () => appCommands.MoveFrame(frame, chain, -1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("v  Move Down", () => appCommands.MoveFrame(frame, chain, +1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("vv Move To Bottom", () => appCommands.MoveFrameToBottom(frame, chain)));
+    }
+
+    private static void AddChainReorderItems(
+        List<TreeMenuItem> items, AnimationChainSave chain, List<AnimationChainSave> chains, IAppCommands appCommands)
+    {
+        int index = chains.IndexOf(chain);
+        bool isFirst = index == 0;
+        bool isLast = index == chains.Count - 1;
+        if (!isFirst) items.Add(TreeMenuItem.Item("^^ Move To Top", () => appCommands.MoveChainToTop(chain)));
+        if (!isFirst) items.Add(TreeMenuItem.Item("^  Move Up", () => appCommands.MoveChain(chain, -1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("v  Move Down", () => appCommands.MoveChain(chain, +1)));
+        if (!isLast) items.Add(TreeMenuItem.Item("vv Move To Bottom", () => appCommands.MoveChainToBottom(chain)));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeMenuPlanBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeMenuPlanBuilderTests.cs
@@ -1,0 +1,183 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class TreeMenuPlanBuilderTests
+{
+    private static TreeMenuActions NoOpActions() => new(
+        Copy: () => { }, Cut: () => { }, Paste: () => { }, Duplicate: () => { }, Delete: () => { },
+        Rename: () => { }, AddAnimation: () => { }, DuplicateChainFlip: (_, _) => { });
+
+    private static int IndexOf(IReadOnlyList<TreeMenuItem> items, string header) =>
+        items.ToList().FindIndex(i => i.Header == header);
+
+    [Fact]
+    public void Build_ChainNode_DuplicateIsSubmenuWithThreeChildren()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run");
+
+        var items = TreeMenuPlanBuilder.Build(
+            chain, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        var duplicate = items.Single(i => i.Header == "Duplicate");
+        Assert.Equal(new[] { "Original", "Flip Horizontal", "Flip Vertical" }, duplicate.Children!.Select(c => c.Header));
+    }
+
+    [Fact]
+    public void Build_ChainNode_MultipleChains_FirstChain_HasMoveDownButNotMoveUp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        TestHelpers.MakeChain(ctx.Acls, "Run");
+
+        var items = TreeMenuPlanBuilder.Build(
+            chain, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.True(IndexOf(items, "v  Move Down") >= 0);
+        Assert.True(IndexOf(items, "vv Move To Bottom") >= 0);
+        Assert.Equal(-1, IndexOf(items, "^  Move Up"));
+        Assert.Equal(-1, IndexOf(items, "^^ Move To Top"));
+    }
+
+    [Fact]
+    public void Build_ChainNode_SingleChain_HasHostSlotsAndCopyPasteRenameDeleteInOrder()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+
+        var items = TreeMenuPlanBuilder.Build(
+            chain, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.Equal(-1, IndexOf(items, "^  Move Up")); // single chain: no reorder items
+        Assert.Equal(TreeMenuHostSlot.AdjustFrameTime, items[0].HostSlot);
+        int copy = IndexOf(items, "Copy");
+        Assert.True(copy >= 0);
+        Assert.Equal(copy + 1, IndexOf(items, "Cut"));
+        Assert.Equal(copy + 2, IndexOf(items, "Paste"));
+        Assert.Contains(items, i => i.HostSlot == TreeMenuHostSlot.AddMultipleFrames);
+        Assert.Contains(items, i => i.HostSlot == TreeMenuHostSlot.AdjustOffsets);
+        Assert.True(IndexOf(items, "Rename…") >= 0);
+        Assert.True(IndexOf(items, "Delete Animation") >= 0);
+        Assert.Equal("Sort Animations Alphabetically", items[^1].Header);
+    }
+
+    [Fact]
+    public void Build_CircleNode_HasCopyPasteDuplicateRename_AndNoMatchFrameSize()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        var circle = new CircleSave { Name = "Circle" };
+        frame.ShapesSave!.Shapes.Add(circle);
+
+        var items = TreeMenuPlanBuilder.Build(
+            circle, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        int copy = IndexOf(items, "Copy");
+        Assert.True(copy >= 0);
+        Assert.Equal(copy + 1, IndexOf(items, "Cut"));
+        Assert.Equal(copy + 2, IndexOf(items, "Paste"));
+        Assert.Equal(copy + 3, IndexOf(items, "Duplicate"));
+        Assert.True(IndexOf(items, "Rename…") >= 0);
+        Assert.True(IndexOf(items, "Delete Circle") >= 0);
+        Assert.Equal(-1, IndexOf(items, "Match Frame Size"));
+    }
+
+    [Fact]
+    public void Build_EmptySelection_OnlyAddAnimationThenSort()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+
+        var items = TreeMenuPlanBuilder.Build(
+            null, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.Equal(3, items.Count);
+        Assert.Equal("Add Animation", items[0].Header);
+        Assert.True(items[1].IsSeparator);
+        Assert.Equal("Sort Animations Alphabetically", items[2].Header);
+    }
+
+    [Fact]
+    public void Build_FrameNode_HasAddShapeItemsAndViewTextureHostSlotAndDeleteFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame("run.png");
+        chain.Frames.Add(frame);
+
+        var items = TreeMenuPlanBuilder.Build(
+            frame, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.True(IndexOf(items, "Add AxisAlignedRectangle") >= 0);
+        Assert.True(IndexOf(items, "Add Circle") >= 0);
+        Assert.Contains(items, i => i.HostSlot == TreeMenuHostSlot.ViewTextureInExplorer);
+        Assert.True(IndexOf(items, "Delete Frame") >= 0);
+    }
+
+    [Fact]
+    public void Build_FrameNode_SingleFrameInChain_NoReorderItems()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame("run.png");
+        chain.Frames.Add(frame);
+
+        var items = TreeMenuPlanBuilder.Build(
+            frame, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.Equal(-1, IndexOf(items, "^  Move Up"));
+        Assert.Equal(-1, IndexOf(items, "v  Move Down"));
+    }
+
+    [Fact]
+    public void Build_RectNode_FirstOfTwoShapes_ShowsMoveDownButNotMoveUp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        var rect = new AARectSave { Name = "Rect" };
+        var circle = new CircleSave { Name = "Circle" };
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave.Shapes.Add(circle);
+
+        var items = TreeMenuPlanBuilder.Build(
+            rect, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        Assert.True(IndexOf(items, "v  Move Down") >= 0);
+        Assert.True(IndexOf(items, "vv Move To Bottom") >= 0);
+        Assert.Equal(-1, IndexOf(items, "^  Move Up"));
+        Assert.Equal(-1, IndexOf(items, "^^ Move To Top"));
+    }
+
+    [Fact]
+    public void Build_RectNode_HasMatchFrameSizeCopyPasteDuplicateRenameAndDelete()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+        var rect = new AARectSave { Name = "Rect" };
+        var circle = new CircleSave { Name = "Circle" };
+        frame.ShapesSave!.Shapes.Add(rect);
+        frame.ShapesSave.Shapes.Add(circle);
+
+        var items = TreeMenuPlanBuilder.Build(
+            rect, ctx.AppCommands, ctx.SelectedState, ctx.ObjectFinder, ctx.ProjectManager, NoOpActions());
+
+        int copy = IndexOf(items, "Copy");
+        Assert.True(copy >= 0);
+        Assert.Equal(copy + 1, IndexOf(items, "Cut"));
+        Assert.Equal(copy + 2, IndexOf(items, "Paste"));
+        Assert.Equal(copy + 3, IndexOf(items, "Duplicate"));
+        Assert.True(IndexOf(items, "Match Frame Size") >= 0);
+        Assert.True(IndexOf(items, "Rename…") >= 0);
+        Assert.True(IndexOf(items, "Delete Rectangle") >= 0);
+    }
+}


### PR DESCRIPTION
Part of #754 — Phase 1 of 3 for tree context-menu + drag-reorder parity between desktop and browser.

## Summary
Pure refactor, desktop-only, zero behavior change. Pulls the "which menu items apply to this node, in what order" branching out of `MainWindow.OnTreeContextMenuOpening` into a framework-free `TreeMenuPlanBuilder` in `AnimationEditor.Core`. Desktop's method is now a thin loop that walks the returned plan and materializes Avalonia `MenuItem`s via the existing `AddMenuItem`/`AddSeparator`/`AddSubMenu` helpers.

Four dialog/filesystem items — Adjust Frame Time…, Add Multiple Frames…, Adjust Offsets…, View Texture in Explorer — stay wired directly on desktop via `TreeMenuHostSlot` placeholders in the plan (tracked separately in #756, since they need a dialog window or `Process.Start`).

New types (`AnimationEditor.Core.CommandsAndState`):
- `TreeMenuItem` — ordered entry (item / separator / submenu / host-slot placeholder), no UI-framework dependency
- `TreeMenuActions` — host-supplied delegates for actions that can't be expressed through `IAppCommands`/`ISelectedState`/`IObjectFinder` (inline rename, copy/cut/paste/duplicate/delete, chain-duplicate-flip)
- `TreeMenuPlanBuilder.Build(...)` — the extracted branching logic

Sets up Phase 2 (a separate future PR) to build the browser's context menu from the same plan.

## Test plan
- [x] New `TreeMenuPlanBuilderTests` in `AnimationEditor.Core.Tests` cover rect/circle/frame/chain/empty-selection menus per the node-type table, including reorder-guard edge cases and the host-slot placeholders
- [x] Existing `TreeContextMenuTests` (desktop, Avalonia headless) pass unmodified — proves the real menu is unchanged
- [x] Full solution build: 0 warnings/errors (including Browser/WASM project)
- [x] Full test run: 2520 tests passed across Core.Tests, Views.Tests, App.Tests, DocScreenshots