### PR TITLE
Animation Editor: BrowserIoManager for companion-file persistence (Phase A)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderCompanionFileStore.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderCompanionFileStore.cs
@@ -1,0 +1,48 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Text;
+using System.Threading.Tasks;
+using AnimationEditor.Core.IO;
+
+namespace AnimationEditor.Browser;
+
+/// <summary>
+/// <see cref="ICompanionFileStore"/> backed by the currently-held <c>FileSystemDirectoryHandle</c>
+/// (Open Folder / drag-drop), reusing the same <see cref="NativeFolderInterop"/> read/write calls
+/// <see cref="NativeReadWriteFile"/> and <see cref="NativeWriteStream"/> already use for the
+/// primary .achx save. Thin, untestable browser wiring (no dedicated test project for this
+/// assembly, by established precedent -- see docs/BROWSER_FOLDER_WATCH_DECISION.md); the actual
+/// persistence logic it's a conduit for lives in the portable, tested
+/// <see cref="AnimationEditor.Core.IO.BrowserIoManager"/>.
+/// <para>
+/// Not yet wired into <c>App.axaml.cs</c>'s service graph -- constructed against whichever
+/// directory handle is current requires the app layer to pass in the folder that was Opened
+/// (#754 Phase B).
+/// </para>
+/// </summary>
+internal sealed class NativeFolderCompanionFileStore : ICompanionFileStore
+{
+    private readonly JSObject _dirHandle;
+
+    public NativeFolderCompanionFileStore(JSObject dirHandle) => _dirHandle = dirHandle;
+
+    public Task WriteAsync(string fileName, string contents) =>
+        NativeFolderInterop.WriteFileBytesAsync(_dirHandle, fileName, Encoding.UTF8.GetBytes(contents));
+
+    public async Task<string?> TryReadAsync(string fileName)
+    {
+        var names = await NativeFolderInterop.ListFileNamesAsync(_dirHandle);
+        var found = false;
+        foreach (var name in names)
+        {
+            if (string.Equals(name, fileName, System.StringComparison.OrdinalIgnoreCase))
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return null;
+
+        var bytes = await NativeFolderInterop.ReadFileBytesAsync(_dirHandle, fileName);
+        return Encoding.UTF8.GetString(bytes);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/BrowserIoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/BrowserIoManager.cs
@@ -1,0 +1,131 @@
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using FlatRedBall2.Animation.Content;
+using System;
+using System.Threading.Tasks;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Browser-build counterpart to desktop's file-backed <see cref="IoManager"/> -- persists the
+/// same <c>.aeproperties</c> companion file (via <see cref="ICompanionFileStore"/>, backed by a
+/// <c>FileSystemDirectoryHandle</c> on the real browser build) instead of writing straight to
+/// disk. Portable and unit-tested with a fake store, same split as
+/// <see cref="BrowserSettingsStore"/>/<see cref="ILocalStorage"/>; the real
+/// <see cref="ICompanionFileStore"/> (JS interop) lives in <c>AnimationEditor.Browser</c>.
+/// <para>
+/// <see cref="ICompanionFileStore"/> is inherently async (no synchronous
+/// <c>FileSystemDirectoryHandle</c> API exists), but <see cref="IIoManager"/>'s save/load methods
+/// are synchronous (desktop's disk I/O is fast enough to block on) -- every method here fires the
+/// real work off as fire-and-forget and reports failures through <see cref="SaveFailed"/> /
+/// <see cref="SettingsLoaded"/> once it completes, rather than blocking the caller. This also
+/// means <see cref="TryLoadCompanionSettings"/> can never honor its synchronous contract on this
+/// implementation -- see its doc comment.
+/// </para>
+/// </summary>
+public class BrowserIoManager : IIoManager
+{
+    private readonly IAppState _appState;
+    private readonly ICompanionFileStore _store;
+
+    public BrowserIoManager(IAppState appState, ICompanionFileStore store)
+    {
+        _appState = appState;
+        _store = store;
+    }
+
+    public event Action<string, Exception>? SaveFailed;
+    public event Action<AESettingsSave>? SettingsLoaded;
+
+    // The browser has no local-temp-file crash-recovery story yet (no filesystem outside a
+    // user-granted directory handle) -- these members exist only to satisfy IIoManager and are
+    // no-ops. Revisit if/when browser recovery is designed.
+    public string RecoveryFilePath { get; set; } = string.Empty;
+    public void WriteRecoveryFile(AnimationChainListSave? animationChainListSave) { }
+    public void DeleteRecoveryFile() { }
+    public bool RecoveryFileExists() => false;
+
+    /// <summary>
+    /// Computes the companion file's bare name from an .achx file name, dropping any directory
+    /// component -- matches desktop's extension swap ("hero.achx" -&gt; "hero.aeproperties") but a
+    /// bare name rather than a full path, since a browser <c>FileSystemDirectoryHandle</c>
+    /// addresses files by name within one flat folder, never a path.
+    /// </summary>
+    internal static string GetCompanionFileName(FilePath achxFile)
+    {
+        var bareName = achxFile.NoPath;
+        var bareNameNoExtension = new FilePath(bareName).RemoveExtension().Original ?? bareName;
+        return bareNameNoExtension + ".aeproperties";
+    }
+
+    public void SaveCompanionFileFor(FilePath fileName, AESettingsSave settings)
+    {
+        var companionName = GetCompanionFileName(fileName);
+        _ = SaveAsync(companionName, settings);
+    }
+
+    private async Task SaveAsync(string companionName, AESettingsSave settings)
+    {
+        try
+        {
+            XmlFile.SerializeToString(settings, out var xml);
+            await _store.WriteAsync(companionName, xml);
+        }
+        catch (Exception e)
+        {
+            SaveFailed?.Invoke("Could not save companion file " + companionName + "\n\n" + e, e);
+        }
+    }
+
+    public void LoadAndApplyCompanionFileFor(string achxFile)
+    {
+        _ = LoadAndApplyAsync(achxFile);
+    }
+
+    private async Task LoadAndApplyAsync(string achxFile)
+    {
+        var settings = await TryLoadCompanionSettingsAsync(achxFile);
+        if (settings != null)
+        {
+            ApplySettings(settings);
+        }
+    }
+
+    /// <summary>
+    /// Always returns <c>null</c> -- reading a companion file requires an async round trip through
+    /// the browser's <c>FileSystemDirectoryHandle</c>, which this synchronous method has no way to
+    /// wait on without risking a deadlock (WASM is single-threaded; blocking here would starve the
+    /// same thread the read needs to complete on). Callers on the browser build that need this
+    /// data (e.g. to avoid a collapse-then-restore flicker) should call
+    /// <see cref="TryLoadCompanionSettingsAsync"/> directly instead of going through
+    /// <see cref="IIoManager"/>.
+    /// </summary>
+    public AESettingsSave? TryLoadCompanionSettings(string achxFile) => null;
+
+    /// <summary>Async counterpart to <see cref="TryLoadCompanionSettings"/> -- the real way to read
+    /// a companion file on the browser build. Returns <c>null</c> when no companion file exists or
+    /// it fails to deserialize.</summary>
+    public async Task<AESettingsSave?> TryLoadCompanionSettingsAsync(string achxFile)
+    {
+        var companionName = GetCompanionFileName(new FilePath(achxFile));
+        var xml = await _store.TryReadAsync(companionName);
+        if (xml is null) return null;
+
+        try
+        {
+            return XmlFile.DeserializeFromString<AESettingsSave>(xml);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void ApplySettings(AESettingsSave settings)
+    {
+        _appState.IsSnapToGridChecked = settings.SnapToGrid;
+        _appState.GridSize = settings.GridSize;
+        SettingsLoaded?.Invoke(settings);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ICompanionFileStore.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ICompanionFileStore.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// A minimal named-file read/write store, abstracting the browser's
+/// <c>FileSystemDirectoryHandle</c> (the only platform this is for -- desktop's
+/// <see cref="IoManager"/> writes straight to disk instead). Every real operation on a
+/// <c>FileSystemDirectoryHandle</c> is Promise-based, so unlike <see cref="ILocalStorage"/> this
+/// is async. Kept this narrow so the persistence logic in <see cref="BrowserIoManager"/> is
+/// testable with a fake, independent of the actual browser JS interop.
+/// </summary>
+public interface ICompanionFileStore
+{
+    /// <summary>Writes <paramref name="contents"/> to <paramref name="fileName"/>, overwriting any existing file.</summary>
+    Task WriteAsync(string fileName, string contents);
+
+    /// <summary>Returns the contents of <paramref name="fileName"/>, or <c>null</c> if it doesn't exist.</summary>
+    Task<string?> TryReadAsync(string fileName);
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserIoManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserIoManagerTests.cs
@@ -1,0 +1,185 @@
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.IO;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Core.Tests;
+
+// #754 Phase A: BrowserIoManager is the browser-build counterpart to IoManager (IoManagerTests.cs)
+// -- same .aeproperties companion-file contract, but backed by ICompanionFileStore (a
+// FileSystemDirectoryHandle on the real browser build) instead of disk. FakeCompanionFileStore
+// below stands in for that, same role FakeLocalStorage plays in BrowserSettingsStoreTests. The
+// real store (AnimationEditor.Browser/NativeFolderCompanionFileStore.cs) is untestable JS-interop
+// glue, same category as LocalStorageInterop.
+public class BrowserIoManagerTests
+{
+    private sealed class FakeCompanionFileStore : ICompanionFileStore
+    {
+        public readonly Dictionary<string, string> Written = new();
+        public Exception? ThrowOnWrite;
+
+        public Task WriteAsync(string fileName, string contents)
+        {
+            if (ThrowOnWrite != null) throw ThrowOnWrite;
+            Written[fileName] = contents;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> TryReadAsync(string fileName) =>
+            Task.FromResult(Written.TryGetValue(fileName, out var v) ? v : null);
+    }
+
+    private static (BrowserIoManager IoManager, FakeCompanionFileStore Store, IAppState AppState) Setup()
+    {
+        var applicationEvents = new ApplicationEvents();
+        var selectedState = new SelectedState(new ProjectManager());
+        var appState = new AppState(applicationEvents, selectedState);
+        var store = new FakeCompanionFileStore();
+        return (new BrowserIoManager(appState, store), store, appState);
+    }
+
+    // ── GetCompanionFileName ──────────────────────────────────────────────────
+
+    [Fact]
+    public void GetCompanionFileName_SwapsExtension_MatchingDesktopConvention()
+    {
+        var result = BrowserIoManager.GetCompanionFileName(new FilePath("hero.achx"));
+
+        Assert.Equal("hero.aeproperties", result);
+    }
+
+    [Fact]
+    public void GetCompanionFileName_GivenPathWithDirectory_DropsDirectory()
+    {
+        // Browser's FileSystemDirectoryHandle addresses files by bare name in one flat folder --
+        // unlike desktop, which keeps the full directory in the companion path.
+        var result = BrowserIoManager.GetCompanionFileName(new FilePath("sample/hero.achx"));
+
+        Assert.Equal("hero.aeproperties", result);
+    }
+
+    // ── SaveCompanionFileFor ──────────────────────────────────────────────────
+
+    [Fact]
+    public void SaveCompanionFileFor_WritesToStoreUnderCompanionName()
+    {
+        var (ioManager, store, _) = Setup();
+
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave());
+
+        Assert.True(store.Written.ContainsKey("hero.aeproperties"));
+    }
+
+    [Fact]
+    public void SaveCompanionFileFor_ContentRoundTripsThroughXmlFile()
+    {
+        var (ioManager, store, _) = Setup();
+        var settings = new AESettingsSave { GridSize = 32, SnapToGrid = true };
+
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), settings);
+
+        var xml = store.Written["hero.aeproperties"];
+        var deserialized = XmlFile.DeserializeFromString<AESettingsSave>(xml);
+        Assert.Equal(32, deserialized.GridSize);
+        Assert.True(deserialized.SnapToGrid);
+    }
+
+    [Fact]
+    public void SaveCompanionFileFor_WhenStoreThrows_FiresSaveFailed()
+    {
+        var (ioManager, store, _) = Setup();
+        store.ThrowOnWrite = new InvalidOperationException("permission denied");
+        Exception? caught = null;
+        ioManager.SaveFailed += (_, e) => caught = e;
+
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave());
+
+        Assert.Same(store.ThrowOnWrite, caught);
+    }
+
+    // ── LoadAndApplyCompanionFileFor ──────────────────────────────────────────
+
+    [Fact]
+    public void LoadAndApplyCompanionFileFor_WhenFileExists_SetsSnapToGridAndGridSize()
+    {
+        var (ioManager, _, appState) = Setup();
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave { SnapToGrid = true, GridSize = 48 });
+
+        ioManager.LoadAndApplyCompanionFileFor("hero.achx");
+
+        Assert.True(appState.IsSnapToGridChecked);
+        Assert.Equal(48, appState.GridSize);
+    }
+
+    [Fact]
+    public void LoadAndApplyCompanionFileFor_WhenFileExists_FiresSettingsLoaded()
+    {
+        var (ioManager, _, _) = Setup();
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave());
+        var fired = false;
+        ioManager.SettingsLoaded += _ => fired = true;
+
+        ioManager.LoadAndApplyCompanionFileFor("hero.achx");
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void LoadAndApplyCompanionFileFor_WhenFileDoesNotExist_DoesNothing()
+    {
+        var (ioManager, _, appState) = Setup();
+        appState.GridSize = 24; // baseline
+
+        ioManager.LoadAndApplyCompanionFileFor("missing.achx");
+
+        Assert.Equal(24, appState.GridSize);
+    }
+
+    [Fact]
+    public void LoadAndApplyCompanionFileFor_WhenXmlIsInvalid_DoesNotThrow()
+    {
+        var (ioManager, store, _) = Setup();
+        store.Written["bad.aeproperties"] = "<<NOT VALID XML>>";
+
+        var ex = Record.Exception(() => ioManager.LoadAndApplyCompanionFileFor("bad.achx"));
+
+        Assert.Null(ex);
+    }
+
+    // ── TryLoadCompanionSettings / TryLoadCompanionSettingsAsync ──────────────
+
+    [Fact]
+    public void TryLoadCompanionSettings_AlwaysReturnsNull_SynchronousReadNotSupported()
+    {
+        var (ioManager, _, _) = Setup();
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave());
+
+        // Unlike desktop's IoManager, the browser store is async-only -- documented limitation.
+        Assert.Null(ioManager.TryLoadCompanionSettings("hero.achx"));
+    }
+
+    [Fact]
+    public async Task TryLoadCompanionSettingsAsync_WhenFileExists_ReturnsSettings()
+    {
+        var (ioManager, _, _) = Setup();
+        ioManager.SaveCompanionFileFor(new FilePath("hero.achx"), new AESettingsSave { GridSize = 64 });
+
+        var result = await ioManager.TryLoadCompanionSettingsAsync("hero.achx");
+
+        Assert.Equal(64, result?.GridSize);
+    }
+
+    // ── Recovery file (no-op on the browser build) ────────────────────────────
+
+    [Fact]
+    public void RecoveryFileExists_AlwaysReturnsFalse()
+    {
+        var (ioManager, _, _) = Setup();
+
+        Assert.False(ioManager.RecoveryFileExists());
+    }
+}


### PR DESCRIPTION
Part of #754.

Phase A of browser settings persistence: a portable `IIoManager` implementation for the browser build that persists `.aeproperties` companion files (zoom/grid-snap/guides), matching desktop's `IoManager` naming convention and reusing Core's existing `XmlFile.SerializeToString`/`DeserializeFromString`. Not wired into `App.axaml.cs` yet -- that's Phase B.

## Design

Mirrors the established `ILocalStorage`/`BrowserSettingsStore` split (theme persistence, #610) rather than putting `BrowserIoManager` directly in `AnimationEditor.Browser` as originally scoped -- doing so lets the whole class be portable and unit-tested, not just an extracted helper:

- **`ICompanionFileStore`** (`AnimationEditor.Core/IO`) -- minimal async named-file read/write abstraction over a `FileSystemDirectoryHandle`. Async because unlike `localStorage`, there's no synchronous File System Access API.
- **`BrowserIoManager`** (`AnimationEditor.Core/IO`) -- the actual `IIoManager` implementation, portable and fully unit-tested against a fake store.
- **`NativeFolderCompanionFileStore`** (`AnimationEditor.Browser`) -- the real JS-interop-backed store, reusing the existing `NativeFolderInterop.WriteFileBytesAsync`/`ReadFileBytesAsync` calls Save already uses.

## API tension worth flagging

`IIoManager`'s save/load methods are synchronous (fine for desktop's blocking disk I/O), but every real browser directory-handle operation is Promise-based. `BrowserIoManager` fires writes/loads as fire-and-forget, reporting through the existing `SaveFailed`/`SettingsLoaded` events. `TryLoadCompanionSettings` (the one method with a synchronous *return value* contract) can't be honored at all on the browser -- it always returns `null`, with an async `TryLoadCompanionSettingsAsync` added alongside it for real callers. Phase B will need to decide how browser-side callers that need this (tab-switch expand-state) route around the synchronous interface method.

## Test coverage

12 new tests in `BrowserIoManagerTests.cs` (Core.Tests) cover: companion-file-name computation (extension swap, directory-stripping vs. desktop's full-path convention), save/load round-trip through `XmlFile`, `SaveFailed`/`SettingsLoaded` events, missing-file and corrupt-XML handling, and the `TryLoadCompanionSettings` vs. `TryLoadCompanionSettingsAsync` split.

**Untested**: `NativeFolderCompanionFileStore` (JS interop glue) -- same category as every other file in `AnimationEditor.Browser` (no dedicated test project, per established precedent in `docs/BROWSER_FOLDER_WATCH_DECISION.md`).

No user-visible behavior change -- nothing calls the new classes yet. Manual testing not needed for this PR.

Full solution build: 0 warnings/0 errors (including the Browser/WASM project). Full test suite: 1725 Core + 753 App + 48 Views + 6 DocScreenshots, all green.