### PR TITLE
Animation Editor: restore crash-recovery file on launch

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -769,24 +769,72 @@ public partial class MainWindow : Window
 
     private void OnOpened(object? sender, EventArgs e)
     {
-        var args = Environment.GetCommandLineArgs();
-        if (args.Length >= 2 && File.Exists(args[1]))
+        _ = HandleStartupAsync();
+    }
+
+    private async Task HandleStartupAsync()
+    {
+        if (!await TryRestoreRecoveryFileAsync())
         {
-            _ = LoadAnimationFileAsync(args[1]);
-        }
-        else if (_appSettings.OpenTabPaths.Count > 0)
-        {
-            _ = RestoreTabsAsync();
-        }
-        else
-        {
-            _projectManager.AnimationChainListSave =
-                new AnimationChainListSave();
+            var args = Environment.GetCommandLineArgs();
+            if (args.Length >= 2 && File.Exists(args[1]))
+            {
+                _ = LoadAnimationFileAsync(args[1]);
+            }
+            else if (_appSettings.OpenTabPaths.Count > 0)
+            {
+                _ = RestoreTabsAsync();
+            }
+            else
+            {
+                _projectManager.AnimationChainListSave =
+                    new AnimationChainListSave();
+            }
         }
 
         RefreshFilesPanel();
         ShowDefaultHandlerBannerIfAppropriate();
         _ = RunStartupUpdateCheckAsync();
+    }
+
+    /// <summary>
+    /// Checks for a crash-recovery file left by <see cref="IIoManager.WriteRecoveryFile"/> after
+    /// an unclean shutdown of an unsaved document (see <see cref="AppCommands.SaveCurrentAnimationChainList"/>).
+    /// When found, asks the user via <see cref="IAppCommands.ConfirmAsync"/> whether to restore it.
+    /// Returns <c>true</c> when recovered content was loaded as the active document (still
+    /// unsaved — <see cref="ProjectManager.FileName"/> stays null, matching the pre-crash state),
+    /// so the caller should skip its normal open-file / restore-tabs / blank-document startup.
+    /// Returns <c>false</c> when there was nothing to restore, the user declined, or the file
+    /// could not be parsed — in the latter two cases the stale recovery file is deleted first.
+    /// </summary>
+    private async Task<bool> TryRestoreRecoveryFileAsync()
+    {
+        if (!_ioManager.RecoveryFileExists()) return false;
+
+        bool restore = await _appCommands.ConfirmAsync(
+            "A recovery file was found from an unexpected shutdown. Restore the unsaved animation?",
+            "Restore Recovery File");
+
+        if (!restore)
+        {
+            _ioManager.DeleteRecoveryFile();
+            return false;
+        }
+
+        var recovered = _ioManager.TryReadRecoveryFile();
+        if (recovered is null)
+        {
+            _ioManager.DeleteRecoveryFile();
+            return false;
+        }
+
+        _projectManager.AnimationChainListSave = recovered;
+        _projectManager.FileName = null;
+        _selectedState.Reset();
+        _selectedState.SelectedChain = recovered.AnimationChains.FirstOrDefault();
+        _undoManager.Clear();
+        RefreshTreeView();
+        return true;
     }
 
     // ── Default-handler prompt banner ─────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/BrowserIoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/BrowserIoManager.cs
@@ -45,6 +45,7 @@ public class BrowserIoManager : IIoManager
     public void WriteRecoveryFile(AnimationChainListSave? animationChainListSave) { }
     public void DeleteRecoveryFile() { }
     public bool RecoveryFileExists() => false;
+    public AnimationChainListSave? TryReadRecoveryFile() => null;
 
     /// <summary>
     /// Computes the companion file's bare name from an .achx file name, dropping any directory

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IIoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IIoManager.cs
@@ -25,5 +25,12 @@ namespace AnimationEditor.Core.IO
         void WriteRecoveryFile(AnimationChainListSave? animationChainListSave);
         void DeleteRecoveryFile();
         bool RecoveryFileExists();
+
+        /// <summary>
+        /// Reads back a recovery file written by <see cref="WriteRecoveryFile"/>. Returns null
+        /// when no recovery file exists or it fails to parse — callers should treat a null result
+        /// the same as "nothing to restore" and delete the stale file.
+        /// </summary>
+        AnimationChainListSave? TryReadRecoveryFile();
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IoManager.cs
@@ -102,6 +102,20 @@ namespace AnimationEditor.Core.IO
 
         public bool RecoveryFileExists() => File.Exists(RecoveryFilePath);
 
+        public AnimationChainListSave? TryReadRecoveryFile()
+        {
+            if (!RecoveryFileExists()) return null;
+
+            try
+            {
+                return AnimationChainListSave.FromFile(RecoveryFilePath);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         private void ApplySettings(AESettingsSave settings)
         {
             _appState.IsSnapToGridChecked = settings.SnapToGrid;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Covers the crash-recovery restore-on-launch path wired through <c>MainWindow.OnOpened</c>
+/// (issue #754 Phase 0): a recovery file written by <see cref="IIoManager.WriteRecoveryFile"/>
+/// after an unclean shutdown must be offered back to the user on the next launch.
+/// </summary>
+public class StartupRecoveryTests
+{
+    [AvaloniaFact]
+    public void NoRecoveryFile_StartsNormally_NeverPrompts()
+    {
+        var ctx = TestHelpers.BuildServices();
+        int confirmCalls = 0;
+        ctx.AppCommands.ConfirmAsync = (_, _) => { confirmCalls++; return Task.FromResult(true); };
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            Assert.Equal(0, confirmCalls);
+            Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_UserConfirms_RestoresContentAsUnsavedDocument()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var seed = new AnimationChainListSave();
+        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
+        ctx.IoManager.WriteRecoveryFile(seed);
+
+        var window = ctx.CreateMainWindow();
+        // Must be set AFTER CreateMainWindow: the constructor's WireAppCommands wires
+        // ConfirmAsync to the real dialog, so a mock set beforehand gets overwritten.
+        // Setting it here (before Show, which fires Opened) is what actually takes effect.
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            Assert.Contains(ctx.ProjectManager.AnimationChainListSave!.AnimationChains, c => c.Name == "Recovered");
+            Assert.Null(ctx.ProjectManager.FileName);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_UserDeclines_DeletesFileAndStartsNormally()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var seed = new AnimationChainListSave();
+        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
+        ctx.IoManager.WriteRecoveryFile(seed);
+
+        var window = ctx.CreateMainWindow();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(false);
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            Assert.False(ctx.IoManager.RecoveryFileExists());
+            Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -61,6 +61,11 @@ internal sealed class TestServices
         SelectedState     = new SelectedState(ProjectManager);
         AppState          = new AppState(ApplicationEvents, SelectedState);
         IoManager         = new IoManager(AppState);
+        // Each instance gets its own recovery path so concurrent test classes never race on
+        // the shared default temp file (see issue #703) — critical now that MainWindow's
+        // startup path (OnOpened) calls RecoveryFileExists() on every window it creates.
+        IoManager.RecoveryFilePath = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "AnimationEditorAppTests", $"recovery_{System.Guid.NewGuid():N}.achx");
         ObjectFinder      = new ObjectFinder(ProjectManager);
         UndoManager       = new UndoManager();
         PendingCutState   = new PendingCutState();


### PR DESCRIPTION
## Summary
- `IoManager.WriteRecoveryFile` was already called after every mutating command on an unsaved document, but nothing ever read the file back — `RecoveryFileExists()` was dead code with no restore prompt anywhere.
- Wires `MainWindow.OnOpened` to check for a recovery file, prompt the user via the existing `ConfirmAsync` pattern, and (on confirm) load the recovered `AnimationChainListSave` as the active document with `FileName` still `null` — matching the exact pre-crash state. On decline, deletes the stale file and proceeds to normal startup.
- Adds `IIoManager.TryReadRecoveryFile()` (deserializes via `AnimationChainListSave.FromFile`, same loader used elsewhere for `.achx` files; returns null on missing/corrupt file).
- Fixes a latent test-infra gap: `AnimationEditor.App.Tests`' `TestServices` never isolated `IoManager.RecoveryFilePath` per instance (unlike `Core.Tests`, which already had the #703 fix). Every one of the ~170 App.Tests files that construct a `MainWindow` now exercises `OnOpened`'s recovery check, so this isolation is required to avoid cross-test races on the shared default temp path.

This is desktop-only and unrelated to the browser/code-sharing work — a standalone bug fix that happens to be a prerequisite for the browser crash-recovery phases described in #754.

## Test plan
- Added `StartupRecoveryTests.cs`: no-recovery-file startup (no prompt), confirmed restore (recovered content becomes active unsaved doc), declined restore (file deleted, normal startup).
- Verified each new assertion actually fails without the fix (stashed the `MainWindow` change and reran — 2/3 failed as expected).
- Full solution build: 0 warnings/errors.
- Full test run: `AnimationEditor.Core.Tests` 1713/1713, `AnimationEditor.App.Tests` 756/756, `AnimationEditor.Views.Tests` 48/48, `AnimationEditor.DocScreenshots` 6/6 — all green.

Part of #754