### PR TITLE
Animation Editor browser: fallback file-picker when Load Folder enumeration fails

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -1643,20 +1643,65 @@ public partial class App : Application
         void LogOpenFolderStep(string step) =>
             Console.WriteLine($"[OpenFolder] {openFolderStopwatch.ElapsedMilliseconds}ms: {step}");
 
+        // #763 fallback: directory enumeration (dirHandle.entries(), used by
+        // folder.GetItemsAsync() below) can throw NotFoundError on some environments even though
+        // named lookups (getFileHandle) on the identical handle keep working -- confirmed live on
+        // a real project folder, deterministic (retrying does not help). Recover by asking the
+        // user to pick the .achx directly (seeded already inside the granted folder), then
+        // resolve it and its textures by name instead of by enumerating. If this fallback itself
+        // fails or is cancelled, it propagates/returns null and the caller's existing
+        // catch (JSException) around LoadFromNativeDirectoryAsync still shows the error toast.
+        async Task<IEditorFile?> LoadViaNamedAchxFallbackAsync(JSObject nativeDir)
+        {
+            var achxName = await NativeFolderInterop.PickAchxFileNameAsync(nativeDir);
+            if (achxName is null) return null; // user cancelled the fallback picker
+
+            var achxFile = new NativeReadWriteFile(nativeDir, achxName);
+
+            async Task<IEditorFile?> ResolveTextureAsync(string textureName)
+            {
+                try
+                {
+                    var file = new NativeReadWriteFile(nativeDir, textureName);
+                    await file.GetBasicPropertiesAsync(); // getFileHandle(name) -- proven-working named lookup
+                    return file;
+                }
+                catch (JSException)
+                {
+                    // Separate, out-of-scope problem (#763): a texture living outside the
+                    // granted folder, or genuinely missing -- skip it instead of failing the load.
+                    return null;
+                }
+            }
+
+            return await BrowserProjectLoader.TryLoadFromNamedAchxAsync(
+                achxFile, ResolveTextureAsync, projectManager, thumbnailService, selectedState);
+        }
+
         // File → Load Folder uses Avalonia's picker (only path that opens from WASM menus).
         // Write grant is requested immediately after pick via EnsureReadWriteAsync.
         async Task LoadFromNativeDirectoryAsync(JSObject nativeDir, string writeState)
         {
             LogOpenFolderStep($"LoadFromNativeDirectoryAsync start (writeState={writeState})");
             var folder = new NativeReadWriteFolder(nativeDir);
-            var files = new List<IEditorFile>();
-            await foreach (var item in folder.GetItemsAsync())
-                files.Add(item);
-            LogOpenFolderStep($"folder.GetItemsAsync() done ({files.Count} file(s))");
 
-            var achxFile = await BrowserProjectLoader.TryLoadAsync(
-                files, projectManager, thumbnailService, selectedState);
-            LogOpenFolderStep($"BrowserProjectLoader.TryLoadAsync done (achxFile={achxFile?.Name ?? "null"})");
+            IEditorFile? achxFile;
+            try
+            {
+                var files = new List<IEditorFile>();
+                await foreach (var item in folder.GetItemsAsync())
+                    files.Add(item);
+                LogOpenFolderStep($"folder.GetItemsAsync() done ({files.Count} file(s))");
+
+                achxFile = await BrowserProjectLoader.TryLoadAsync(
+                    files, projectManager, thumbnailService, selectedState);
+            }
+            catch (JSException ex)
+            {
+                LogOpenFolderStep($"folder.GetItemsAsync() failed ({ex.Message}) -- falling back to named .achx picker");
+                achxFile = await LoadViaNamedAchxFallbackAsync(nativeDir);
+            }
+            LogOpenFolderStep($"achx resolution done (achxFile={achxFile?.Name ?? "null"})");
 
             var writeSuffix = " " + WritePermissionGate.FormatStatusSuffix(writeState);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserFolderWatcher.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserFolderWatcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
 using AnimationEditor.Core.IO;
 using Avalonia.Threading;
@@ -23,6 +24,7 @@ internal sealed class BrowserFolderWatcher : IDisposable
     private bool _seeded;
     private bool _pollInFlight;
     private bool _disposed;
+    private bool _enumerationFailed;
 
     /// <summary>Fires with the names of every .png whose size or last-modified time changed
     /// since the previous poll. Never fires on the very first poll (that just seeds the baseline).</summary>
@@ -35,11 +37,13 @@ internal sealed class BrowserFolderWatcher : IDisposable
         _timer.Tick += async (_, _) => await PollAsync();
     }
 
-    /// <summary>Seeds the baseline snapshot (reporting nothing) and starts polling.</summary>
+    /// <summary>Seeds the baseline snapshot (reporting nothing) and starts polling -- a no-op if
+    /// the seeding poll already found enumeration unsupported in this environment (#763).</summary>
     public async Task StartAsync()
     {
         await PollAsync();
-        _timer.Start();
+        if (!_enumerationFailed)
+            _timer.Start();
     }
 
     // Enumerating a folder and fetching each file's properties is async and can plausibly
@@ -72,6 +76,16 @@ internal sealed class BrowserFolderWatcher : IDisposable
 
             _seeded = true;
             _lastKnown = current;
+        }
+        catch (JSException ex)
+        {
+            // Same enumeration failure Open Folder itself can hit (#763) -- WASM is
+            // single-threaded, so letting this escape the DispatcherTimer.Tick handler would
+            // abort the whole runtime, not just watching. Watching this folder just isn't
+            // possible this session; disable it instead of retrying every tick forever.
+            Console.WriteLine($"[OpenFolder] folder watch disabled -- enumeration failed: {ex.Message}");
+            _enumerationFailed = true;
+            _timer.Stop();
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserProjectLoader.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserProjectLoader.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using AnimationEditor.App.Services;
 using AnimationEditor.Core;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.IO;
 using FlatRedBall2.Animation.Content;
 using SkiaSharp;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
@@ -72,6 +74,54 @@ internal static class BrowserProjectLoader
 
         // achxFile.Name has no real filesystem meaning here -- it's only the logical identity
         // ProjectManager.FileName exposes, and preParsed means it's never read from disk.
+        selectedState.Reset();
+        projectManager.LoadAnimationChain(new FilePath(achxFile.Name), acls, knownTextureSizes);
+        if (acls.AnimationChains.Count > 0)
+            selectedState.SelectedChain = acls.AnimationChains[0];
+
+        return achxFile;
+    }
+
+    /// <summary>
+    /// #763 fallback: loads from a single already-identified .achx file plus targeted
+    /// per-texture-name lookups via <paramref name="resolveTextureFile"/>, instead of a
+    /// pre-enumerated file list. Used when directory enumeration
+    /// (<c>dirHandle.entries()</c>) throws but named lookups (<c>getFileHandle</c>) on the same
+    /// handle still work. A texture name <paramref name="resolveTextureFile"/> can't resolve --
+    /// e.g. one living outside the granted folder, the separate cross-folder-texture problem --
+    /// is silently skipped rather than failing the whole load.
+    /// </summary>
+    public static async Task<IEditorFile> TryLoadFromNamedAchxAsync(
+        IEditorFile achxFile,
+        Func<string, Task<IEditorFile?>> resolveTextureFile,
+        ProjectManager projectManager,
+        ThumbnailService thumbnailService,
+        ISelectedState selectedState)
+    {
+        string achxText;
+        await using (var achxStream = await achxFile.OpenReadAsync())
+        using (var reader = new StreamReader(achxStream))
+            achxText = await reader.ReadToEndAsync();
+
+        var acls = AnimationChainListSave.FromString(achxText);
+        var textureNames = TextureListBuilder.GetAvailableTextures(acls);
+
+        var knownTextureSizes = await NamedTextureResolver.ResolveSizesAsync(textureNames, async name =>
+        {
+            var file = await resolveTextureFile(name);
+            if (file is null) return null;
+
+            await using var pngStream = await file.OpenReadAsync();
+            using var buffer = new MemoryStream();
+            await pngStream.CopyToAsync(buffer);
+
+            var bitmap = SKBitmap.Decode(buffer.ToArray());
+            if (bitmap is null) return null;
+
+            thumbnailService.SeedTexture(name, bitmap);
+            return (bitmap.Width, bitmap.Height);
+        });
+
         selectedState.Reset();
         projectManager.LoadAnimationChain(new FilePath(achxFile.Name), acls, knownTextureSizes);
         if (acls.AnimationChains.Count > 0)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderCompanionFileStore.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderCompanionFileStore.cs
@@ -28,21 +28,25 @@ internal sealed class NativeFolderCompanionFileStore : ICompanionFileStore
     public Task WriteAsync(string fileName, string contents) =>
         NativeFolderInterop.WriteFileBytesAsync(_dirHandle, fileName, Encoding.UTF8.GetBytes(contents));
 
+    /// <summary>
+    /// Fetches <paramref name="fileName"/> directly via <c>getFileHandle</c> instead of
+    /// pre-checking existence through directory enumeration -- enumeration
+    /// (<c>dirHandle.entries()</c>) can throw <c>NotFoundError</c> on some environments even
+    /// though this exact named lookup keeps working (issue #763). A missing file surfaces the
+    /// same <c>NotFoundError</c> from the named lookup itself, which this treats as "doesn't
+    /// exist yet" -- the same outcome the old enumeration precheck produced, just without
+    /// depending on enumeration succeeding.
+    /// </summary>
     public async Task<string?> TryReadAsync(string fileName)
     {
-        var names = await NativeFolderInterop.ListFileNamesAsync(_dirHandle);
-        var found = false;
-        foreach (var name in names)
+        try
         {
-            if (string.Equals(name, fileName, System.StringComparison.OrdinalIgnoreCase))
-            {
-                found = true;
-                break;
-            }
+            var bytes = await NativeFolderInterop.ReadFileBytesAsync(_dirHandle, fileName);
+            return Encoding.UTF8.GetString(bytes);
         }
-        if (!found) return null;
-
-        var bytes = await NativeFolderInterop.ReadFileBytesAsync(_dirHandle, fileName);
-        return Encoding.UTF8.GetString(bytes);
+        catch (JSException ex) when (ex.Message.Contains("NotFoundError"))
+        {
+            return null;
+        }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderInterop.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/NativeFolderInterop.cs
@@ -60,6 +60,9 @@ internal static partial class NativeFolderInterop
     [JSImport("fileInfo", ModuleName)]
     private static partial Task<string> FileInfoJsonAsync(JSObject dirHandle, string name);
 
+    [JSImport("pickAchxFile", ModuleName)]
+    public static partial Task<string?> PickAchxFileNameAsync(JSObject dirHandle);
+
     [JSImport("readFileBase64", ModuleName)]
     private static partial Task<string> ReadFileBase64JsAsync(JSObject dirHandle, string name);
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/nativeFolder.js
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/nativeFolder.js
@@ -161,6 +161,30 @@ export async function listFileNames(dirHandle) {
     return JSON.stringify(names);
 }
 
+/**
+ * #763 fallback: directory *enumeration* (dirHandle.entries()) can throw NotFoundError on some
+ * environments even though named lookups (getFileHandle) on the identical handle keep working
+ * (see listFileNames's doc comment above). When that happens, ask the user to pick the .achx
+ * directly instead of auto-discovering it via enumeration -- seeded with startIn so the picker
+ * opens already inside the folder just granted, no re-navigation required. Returns the picked
+ * file's name (resolved via the original dirHandle afterward, same as every other named lookup
+ * here), or null if the user cancels.
+ */
+export async function pickAchxFile(dirHandle) {
+    if (typeof globalThis.showOpenFilePicker !== "function") return null;
+    try {
+        const [fileHandle] = await globalThis.showOpenFilePicker({
+            startIn: dirHandle,
+            types: [{ description: "Animation Chain", accept: { "text/xml": [".achx"] } }],
+            excludeAcceptAllOption: true,
+        });
+        return fileHandle ? fileHandle.name : null;
+    } catch (e) {
+        if (e && e.name === "AbortError") return null;
+        throw e;
+    }
+}
+
 export async function fileInfo(dirHandle, name) {
     const fileHandle = await dirHandle.getFileHandle(name);
     const file = await fileHandle.getFile();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NamedTextureResolver.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NamedTextureResolver.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Resolves the pixel size of each texture name via an arbitrary async name-based lookup,
+/// skipping any name the lookup can't resolve instead of failing the whole batch. Backs the
+/// #763 fallback load path (targeted <c>getFileHandle(name)</c> fetches when directory
+/// enumeration throws) so a texture the lookup can't reach -- e.g. living outside a browser Open
+/// Folder grant, the separate cross-folder-texture problem -- is silently omitted rather than
+/// aborting the load.
+/// </summary>
+public static class NamedTextureResolver
+{
+    public static async Task<Dictionary<string, (int Width, int Height)>> ResolveSizesAsync(
+        IEnumerable<string> textureNames,
+        Func<string, Task<(int Width, int Height)?>> tryGetSize)
+    {
+        var result = new Dictionary<string, (int Width, int Height)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in textureNames)
+        {
+            var size = await tryGetSize(name);
+            if (size is not null)
+                result[name] = size.Value;
+        }
+        return result;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NamedTextureResolverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NamedTextureResolverTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class NamedTextureResolverTests
+{
+    [Fact]
+    public async Task ResolveSizesAsync_IncludesEveryNameTheResolverFinds()
+    {
+        var sizes = await NamedTextureResolver.ResolveSizesAsync(
+            new[] { "player.png", "enemy.png" },
+            name => Task.FromResult<(int Width, int Height)?>(name == "player.png" ? (32, 32) : (16, 16)));
+
+        Assert.Equal((32, 32), sizes["player.png"]);
+        Assert.Equal((16, 16), sizes["enemy.png"]);
+    }
+
+    [Fact]
+    public async Task ResolveSizesAsync_SkipsNamesTheResolverCannotFind()
+    {
+        // Models a name-based lookup that can't reach a texture -- e.g. the cross-folder-texture
+        // problem noted as separate/out-of-scope in issue #763 -- without throwing or aborting
+        // the rest of the load.
+        var sizes = await NamedTextureResolver.ResolveSizesAsync(
+            new[] { "player.png", "missing.png" },
+            name => Task.FromResult<(int Width, int Height)?>(name == "player.png" ? (32, 32) : null));
+
+        Assert.True(sizes.ContainsKey("player.png"));
+        Assert.False(sizes.ContainsKey("missing.png"));
+    }
+
+    [Fact]
+    public async Task ResolveSizesAsync_KeysAreCaseInsensitive()
+    {
+        var sizes = await NamedTextureResolver.ResolveSizesAsync(
+            new[] { "Player.png" },
+            _ => Task.FromResult<(int Width, int Height)?>((32, 32)));
+
+        Assert.True(sizes.ContainsKey("player.png"));
+    }
+}


### PR DESCRIPTION
Part of #763.

`dirHandle.entries()` can throw `NotFoundError` deterministically on some real folders/environments — confirmed live against a real project folder, and confirmed NOT transient (retry up to ~20s across two attempts, both failed identically). Root-cause investigation is fully documented in #763.

Fix: keep today's single-dialog Open Folder flow unchanged for everyone (enumeration still tried first). Only when enumeration actually throws, fall back to a native file-picker seeded via `startIn` to the already-granted folder (no re-navigation) so the user can identify the `.achx` by name; textures are then resolved one at a time via `getFileHandle(name)` (proven working — same call Save already uses) instead of directory listing.

Also:
- `BrowserFolderWatcher` now disables polling gracefully on the same failure instead of crashing.
- `NativeFolderCompanionFileStore.TryReadAsync` checks existence via `getFileHandle` directly instead of pre-enumerating.

**Out of scope (tracked separately, not conflated):** textures referenced from outside the granted folder tree — a real, confirmed-live gap for cross-folder texture references, but a distinct problem needing its own multi-root-grant design.

**Manually verified**: fallback picker appears and successfully loads against the real repro folder that failed 100% of the time before this fix.

Test coverage: new `NamedTextureResolver` (pure texture-size resolution by name) is unit-tested, TDD. The JS↔native-picker interop itself is untestable browser glue by established precedent in this codebase (no dedicated test project for `AnimationEditor.Browser`, native file pickers are a security boundary no test host can drive) — verified instead via live manual reproduction.