### PR TITLE
Generalize sprite ground-contact-point docs (RelativeY/RelativeX)

### DIFF
--- a/frb-skills/animation/references/achx-authoring.md
+++ b/frb-skills/animation/references/achx-authoring.md
@@ -74,8 +74,13 @@ Each `<AnimationChain>` is a named sequence of frames.
 | `TopCoordinate` | Yes | — | Top edge of source rectangle in pixels |
 | `BottomCoordinate` | Yes | — | Bottom edge of source rectangle in pixels |
 | `FlipHorizontal` | No | `false` | Mirror the frame horizontally — used for left-facing variants |
-| `RelativeY` | No | `0` | Vertical offset from entity origin in world units. For a 16x32 character with origin at the feet, use `16` (half height) to center the sprite |
+| `RelativeX` | No | `0` | Horizontal offset from entity origin — sprites already draw X-centered, so this is usually `0`. See Ground-Contact Point below |
+| `RelativeY` | No | `0` | Marks the frame's ground-contact point above the entity origin — set by eye to match the art, not computed from sprite height. See Ground-Contact Point below |
 | `ShapesSave` | No | — | Per-frame collision shapes (not yet implemented in FRB2 — present in the XML format for forward compatibility with FRB1 files) |
+
+### Ground-Contact Point
+
+`RelativeY` marks where a frame's visual ground contact sits relative to the entity origin — it is not derived from sprite height. Flush-bottom (half-height, e.g. `16` on a 32px-tall frame) is only correct for a strictly side-on camera (Mario-style platformers), where the sprite's bounding-box bottom *is* the ground-contact point. Any camera with vertical tilt — a top-down RPG, isometric, or a platformer with a downward-tilted camera (Donkey Kong Country-style) — shows a sliver of the ground plane, so the contact point sits somewhere inside the bounding box and has to be set by eye per frame. `RelativeX` stays `0` in almost all cases since sprites already draw X-centered on the entity; only an asymmetric frame (a lunging attack, an off-center pivot) needs a nonzero value.
 
 ### Coordinate System
 

--- a/frb-skills/animation/references/achx-authoring.md
+++ b/frb-skills/animation/references/achx-authoring.md
@@ -82,6 +82,8 @@ Each `<AnimationChain>` is a named sequence of frames.
 
 `RelativeY` marks where a frame's visual ground contact sits relative to the entity origin — it is not derived from sprite height. Flush-bottom (half-height, e.g. `16` on a 32px-tall frame) is only correct for a strictly side-on camera (Mario-style platformers), where the sprite's bounding-box bottom *is* the ground-contact point. Any camera with vertical tilt — a top-down RPG, isometric, or a platformer with a downward-tilted camera (Donkey Kong Country-style) — shows a sliver of the ground plane, so the contact point sits somewhere inside the bounding box and has to be set by eye per frame. `RelativeX` stays `0` in almost all cases since sprites already draw X-centered on the entity; only an asymmetric frame (a lunging attack, an off-center pivot) needs a nonzero value.
 
+For a top-down game specifically: author every frame's origin (Animation Editor's origin crosshair, or the Adjust Offsets tool) at the center of the character's feet at ground level — where the feet meet the floor, horizontally centered. Once every frame agrees on that point, the entity's `X`/`Y` *is* that ground position, with no offset math at the call site — moving a character to a new level's spawn point is just `entity.X = doorwayX; entity.Y = doorwayY`.
+
 ### Coordinate System
 
 Coordinates are **pixel positions** on the source texture, measured from the **top-left corner** (standard image coordinates):

--- a/frb-skills/platformer-movement/SKILL.md
+++ b/frb-skills/platformer-movement/SKILL.md
@@ -133,7 +133,7 @@ The `!_platformer.IsApplyingJump` guard prevents the air jump from triggering du
 
 ## Entity Origin and Shape Offset
 
-In platformers, an entity's Y position represents **the feet** (the bottom of the character). This means collision shapes and sprites must be offset upward so their bottom edge aligns with Y=0 on the entity:
+In platformers, an entity's Y position represents **the feet** — the point collision resolves ground contact against. The **collision shape** must be offset upward so its bottom edge is flush with Y=0; this is non-negotiable, it's what "standing on the ground" means physically:
 
 ```csharp
 // For a 12×28 collision box, offset Y by half the height so the bottom sits at the entity's feet
@@ -146,9 +146,9 @@ var collisionBox = new AARect
 Add(collisionBox);
 ```
 
-The same applies to sprites — the `.achx` template uses `<RelativeY>16</RelativeY>` on a 32-pixel-tall character for exactly this reason (16 = half of 32).
+**The sprite's `RelativeY` is different — it's art, not physics.** It only needs to match the shape's flush-bottom offset for a strictly side-on camera (Mario-style). A platformer with a tilted camera (Donkey Kong Country-style) shows a sliver of the ground plane, so the sprite's ground-contact point sits inside its bounding box and must be set by eye — see `animation` skill's `references/achx-authoring.md` (Ground-Contact Point section). `RelativeX` stays `0` in both cases since sprites already draw X-centered.
 
-**If you skip this offset**, the character's feet will not align with the ground.
+**If you skip the shape offset**, the character's feet will not align with the ground.
 
 ## Collision Setup
 


### PR DESCRIPTION
## Summary
- `achx-authoring.md`: `RelativeY` was documented as a half-height formula. Reframed as the frame's ground-contact point, set by eye — half-height/flush-bottom is only correct for a strictly side-on camera. Added the missing `RelativeX` row (usually `0`, X-centered), plus a concrete top-down rule: author the origin at the center of the feet at ground level so entity `X`/`Y` is directly usable as the spawn/ground position.
- `platformer-movement/SKILL.md`: split the collision-shape offset (mandatory physics, always flush) from the sprite's `RelativeY` (art, only flush for a side-on camera — diverges for a tilted-camera platformer like Donkey Kong Country).

Closes #765 — not implementing the issue's suggested `SpriteOffsetX/Y` read-back pattern. That pattern was working around a mis-authored sprite anchor; the real fix is authoring `RelativeX/RelativeY` (or the Animation Editor origin) at the correct ground-contact point in the first place, which these skill updates now document.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>