### PR TITLE
Adopt NuGet Central Package Management to fix sibling version drift

### DIFF
--- a/.claude/skills/sample-project-setup/SKILL.md
+++ b/.claude/skills/sample-project-setup/SKILL.md
@@ -32,14 +32,16 @@ Copy the structure from an existing sample (e.g., `AnimationChainSample`). The m
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FlatRedBall2.csproj" />
   </ItemGroup>
 </Project>
 ```
+
+No `Version` attribute on either `PackageReference` — the repo uses NuGet Central Package Management, so every version is pinned once in the root `Directory.Packages.props`. If restore complains a package has no version, add it there instead of on the `PackageReference`.
 
 Do **not** pin `Apos.Shapes` — version flows transitively from the engine (`$(AposShapesVersion)` in `src/PrecompiledShaders/AposShapes.props`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The only relevant question is "is this the right design?" — never "will this b
 
 ## Key Files
 
-- Main project: `src/FlatRedBall2.csproj` (MonoGame.Framework.DesktopGL 3.8.*)
+- Main project: `src/FlatRedBall2.csproj` (MonoGame.Framework.DesktopGL, version pinned in the root `Directory.Packages.props`)
 - Code style: `.claude/code-style.md`
 - Deferred items: `design/TODOS.md`
 - Test project: `tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,62 @@
+<Project>
+  <!--
+    NuGet Central Package Management (CPM) for the main build graph: src/**, tests/**,
+    samples/**, diagnostics/**. Every PackageReference under those directories must omit its
+    Version attribute — the version lives here, in exactly one place, so sibling projects
+    (e.g. a sample's Common project and its Desktop head) can never resolve different exact
+    versions of the same package and hit a runtime FileNotFoundException (#776).
+
+    templates/frb2-desktop, templates/frb2-multiplatform, and tools/AnimationEditorAvalonia
+    each ship their OWN Directory.Packages.props and are NOT managed by this file — the
+    templates must be self-contained (they get scaffolded into a brand-new standalone repo),
+    and AnimationEditorAvalonia is an unrelated dependency graph (Avalonia/SkiaSharp).
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Several packages below are still pinned with a floating range (e.g. 0.16.*, 4.*) —
+         CPM blocks floating PackageVersion entries by default. -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!-- NU1507 recommends NuGet package source mapping whenever CPM is combined with more
+         than one configured package source (nuget.org + the private feed here). Adding source
+         mapping is a separate, bigger change; suppress the advisory instead. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
+  <!-- Single source of truth for $(AposShapesVersion); see that file before bumping it. -->
+  <Import Project="$(MSBuildThisFileDirectory)src/PrecompiledShaders/AposShapes.props" />
+
+  <ItemGroup>
+    <PackageVersion Include="AsepriteDotNet" Version="1.9.1" />
+    <PackageVersion Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
+    <PackageVersion Include="Apos.Shapes" Version="$(AposShapesVersion)" />
+    <PackageVersion Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
+    <PackageVersion Include="Gum.MonoGame" Version="2026.7.9.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.7.9.1-preview.1" />
+    <PackageVersion Include="Gum.KNI" Version="2026.7.9.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.7.9.1-preview.1" />
+    <PackageVersion Include="KernSmith.MonoGameGum" Version="0.16.*" />
+    <PackageVersion Include="KernSmith.KniGum" Version="0.16.*" />
+    <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+    <PackageVersion Include="MonoGame.Extended" Version="6.0.0" />
+    <PackageVersion Include="KNI.Extended" Version="6.0.0" />
+    <PackageVersion Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.*" />
+    <PackageVersion Include="Shouldly" Version="4.*" />
+    <PackageVersion Include="xunit" Version="2.9.*" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.*" />
+  </ItemGroup>
+</Project>

--- a/diagnostics/AposFillColorRepro/AposFillColorRepro.csproj
+++ b/diagnostics/AposFillColorRepro/AposFillColorRepro.csproj
@@ -11,10 +11,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
     <!-- Pinned to match FRB2's precompiled shader version ($(AposShapesVersion)). For shader hacking,
          swap this for a ProjectReference to your local Apos.Shapes source. -->
-    <PackageReference Include="Apos.Shapes" Version="0.6.10-alpha" />
+    <PackageReference Include="Apos.Shapes" />
   </ItemGroup>
 </Project>

--- a/frb-skills/multiplatform-conversion/SKILL.md
+++ b/frb-skills/multiplatform-conversion/SKILL.md
@@ -45,12 +45,14 @@ XNA framework packages must be conditioned per TFM — the engine's transitive f
 
 ```xml
 <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-  <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+  <PackageReference Include="nkast.Xna.Framework.Game" />
 </ItemGroup>
 <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-  <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
+  <PackageReference Include="MonoGame.Framework.DesktopGL" />
 </ItemGroup>
 ```
+
+No `Version` attribute — the repo uses NuGet Central Package Management, so versions are pinned once in `Directory.Packages.props`, not per `PackageReference`.
 
 Common must NOT add `MonoGame.Content.Builder.Task` or `Apos.Shapes` — those belong on the heads that drive content compilation.
 

--- a/samples/AnimationChainSample/AnimationChainSample.csproj
+++ b/samples/AnimationChainSample/AnimationChainSample.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\AnimationChain.MonoGame\AnimationChain.MonoGame.csproj" />

--- a/samples/GumFormsPopupTest/GumFormsPopupTest.csproj
+++ b/samples/GumFormsPopupTest/GumFormsPopupTest.csproj
@@ -10,8 +10,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FlatRedBall2.csproj" />

--- a/samples/PlatformKing/PlatformKing.BlazorGL/PlatformKing.BlazorGL.csproj
+++ b/samples/PlatformKing/PlatformKing.BlazorGL/PlatformKing.BlazorGL.csproj
@@ -20,24 +20,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Content" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" />
+    <PackageReference Include="nkast.Xna.Framework.Media" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" />
+    <PackageReference Include="nkast.Xna.Framework.XR" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" />
     <!-- Required to compile KniContentReference items (e.g. Apos.Shapes.KNI's apos-shapes.fx) into XNB. -->
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/PlatformKing/PlatformKing.Common/PlatformKing.Common.csproj
+++ b/samples/PlatformKing/PlatformKing.Common/PlatformKing.Common.csproj
@@ -16,13 +16,13 @@
 
   <!-- net8.0 → KNI backend (nkast XNA). net10.0 → MonoGame backend (DesktopGL). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/PlatformKing/PlatformKing.Desktop/PlatformKing.Desktop.csproj
+++ b/samples/PlatformKing/PlatformKing.Desktop/PlatformKing.Desktop.csproj
@@ -16,8 +16,8 @@
        src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
        wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ShmupSpace/ShmupSpace.BlazorGL/ShmupSpace.BlazorGL.csproj
+++ b/samples/ShmupSpace/ShmupSpace.BlazorGL/ShmupSpace.BlazorGL.csproj
@@ -20,24 +20,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Content" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" />
+    <PackageReference Include="nkast.Xna.Framework.Media" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" />
+    <PackageReference Include="nkast.Xna.Framework.XR" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" />
     <!-- Required to compile KniContentReference items (e.g. Apos.Shapes.KNI's apos-shapes.fx) into XNB. -->
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ShmupSpace/ShmupSpace.Common/ShmupSpace.Common.csproj
+++ b/samples/ShmupSpace/ShmupSpace.Common/ShmupSpace.Common.csproj
@@ -16,13 +16,13 @@
 
   <!-- net8.0 → KNI backend (nkast XNA). net10.0 → MonoGame backend (DesktopGL). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ShmupSpace/ShmupSpace.Desktop/ShmupSpace.Desktop.csproj
+++ b/samples/ShmupSpace/ShmupSpace.Desktop/ShmupSpace.Desktop.csproj
@@ -16,8 +16,8 @@
        src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
        wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
+++ b/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
@@ -19,23 +19,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Content" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" />
+    <PackageReference Include="nkast.Xna.Framework.Media" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" />
+    <PackageReference Include="nkast.Xna.Framework.XR" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Solitaire/Solitaire.Common/Solitaire.Common.csproj
+++ b/samples/Solitaire/Solitaire.Common/Solitaire.Common.csproj
@@ -16,13 +16,13 @@
 
   <!-- net8.0 -> KNI backend (nkast XNA). net10.0 -> MonoGame backend (DesktopGL). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Solitaire/Solitaire.Desktop/Solitaire.Desktop.csproj
+++ b/samples/Solitaire/Solitaire.Desktop/Solitaire.Desktop.csproj
@@ -16,8 +16,8 @@
        src/PrecompiledShaders/AposShapes.props). The precompiled apos-shapes.xnb shader is
        wired up by AposShapesPrecompiled.props, imported at the top of this file. -->
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Solitaire/Solitaire.Tests/Solitaire.Tests.csproj
+++ b/samples/Solitaire/Solitaire.Tests/Solitaire.Tests.csproj
@@ -5,10 +5,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.*" />
-    <PackageReference Include="Shouldly" Version="4.*" />
-    <PackageReference Include="xunit" Version="2.9.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.*">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
+++ b/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001">
+    <PackageReference Include="nkast.Xna.Framework">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001">
+    <PackageReference Include="nkast.Xna.Framework.Graphics">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
+++ b/src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
+    <PackageReference Include="MonoGame.Framework.DesktopGL">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj
+++ b/src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj
@@ -21,10 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
     <!-- Brings in the nkast.Wasm.* JS shim packages whose static assets frb-host.js loads -->
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <!-- Single source of truth for $(AposShapesVersion); see that file before bumping it. -->
-  <Import Project="PrecompiledShaders/AposShapes.props" />
+  <!--
+    $(AposShapesVersion) comes from PrecompiledShaders/AposShapes.props, imported by the repo
+    root's Directory.Packages.props (which every project in this build graph picks up
+    automatically) — see that file before bumping the version.
+  -->
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -55,8 +58,8 @@
 
   <!-- Backend-agnostic packages -->
   <ItemGroup>
-    <PackageReference Include="AsepriteDotNet" Version="1.9.1" />
-    <PackageReference Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
+    <PackageReference Include="AsepriteDotNet" />
+    <PackageReference Include="FlatRedBall.InterpolationCore" />
   </ItemGroup>
 
   <!--
@@ -71,30 +74,30 @@
 
   <!-- MonoGame backend -->
   <ItemGroup Condition="'$(Backend)' == 'MonoGame'">
-    <PackageReference Include="Apos.Shapes" Version="$(AposShapesVersion)" />
-    <PackageReference Include="Gum.MonoGame" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="Gum.Shapes.MonoGame" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="KernSmith.MonoGameGum" Version="0.16.*" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
+    <PackageReference Include="Apos.Shapes" />
+    <PackageReference Include="Gum.MonoGame" />
+    <PackageReference Include="Gum.Shapes.MonoGame" />
+    <PackageReference Include="KernSmith.MonoGameGum" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Extended" Version="6.0.0" />
+    <PackageReference Include="MonoGame.Extended" />
   </ItemGroup>
 
   <!-- KNI backend (Blazor WebAssembly + future mobile targets) -->
   <ItemGroup Condition="'$(Backend)' == 'Kni'">
-    <PackageReference Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
-    <PackageReference Include="Gum.KNI" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="Gum.Shapes.KNI" Version="2026.7.9.1-preview.1" />
-    <PackageReference Include="KernSmith.KniGum" Version="0.16.*" />
-    <PackageReference Include="KNI.Extended" Version="6.0.0" />
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageReference Include="Apos.Shapes.KNI" />
+    <PackageReference Include="Gum.KNI" />
+    <PackageReference Include="Gum.Shapes.KNI" />
+    <PackageReference Include="KernSmith.KniGum" />
+    <PackageReference Include="KNI.Extended" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Content" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" />
+    <PackageReference Include="nkast.Xna.Framework.Media" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/frb2-desktop/Directory.Packages.props
+++ b/templates/frb2-desktop/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+  <!--
+    Self-contained CPM file for this template — do NOT reference the repo root's
+    Directory.Packages.props. `dotnet new` scaffolds this template's content/ folder into a
+    brand-new standalone repo, so every version this template needs must live here.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- FlatRedBall2.MonoGame is pinned to "*-*" (any prerelease) — CPM blocks floating
+         PackageVersion entries by default. -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!-- NU1507 recommends NuGet package source mapping whenever CPM is combined with more
+         than one configured package source. Suppress the advisory rather than take on
+         source mapping here. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FlatRedBall2.MonoGame" Version="*-*" />
+    <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+  </ItemGroup>
+</Project>

--- a/templates/frb2-desktop/MyGame.Common/MyGame.Common.csproj
+++ b/templates/frb2-desktop/MyGame.Common/MyGame.Common.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>MyGame</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FlatRedBall2.MonoGame" Version="*-*" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="FlatRedBall2.MonoGame" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
 </Project>

--- a/templates/frb2-desktop/MyGame.Desktop/MyGame.Desktop.csproj
+++ b/templates/frb2-desktop/MyGame.Desktop/MyGame.Desktop.csproj
@@ -15,8 +15,8 @@
        FlatRedBall2.MonoGame (see $(AposShapesVersion) in the engine's AposShapes.props).
        Precompiled apos-shapes.xnb is wired by templates/build/AposShapesPrecompiled.props. -->
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
 
   <Import Project="..\build\AposShapesPrecompiled.props" />

--- a/templates/frb2-multiplatform/Directory.Packages.props
+++ b/templates/frb2-multiplatform/Directory.Packages.props
@@ -1,0 +1,38 @@
+<Project>
+  <!--
+    Self-contained CPM file for this template — do NOT reference the repo root's
+    Directory.Packages.props or templates/frb2-desktop's. `dotnet new` scaffolds this
+    template's content/ folder into a brand-new standalone repo, so every version this
+    template needs must live here.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- FlatRedBall2.Kni / FlatRedBall2.MonoGame are pinned to "*-*" (any prerelease) — CPM
+         blocks floating PackageVersion entries by default. -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!-- NU1507 recommends NuGet package source mapping whenever CPM is combined with more
+         than one configured package source. Suppress the advisory rather than take on
+         source mapping here. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FlatRedBall2.Kni" Version="*-*" />
+    <PackageVersion Include="FlatRedBall2.MonoGame" Version="*-*" />
+    <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+    <PackageVersion Include="nkast.Xna.Framework" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageVersion Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" />
+  </ItemGroup>
+</Project>

--- a/templates/frb2-multiplatform/MyGame.BlazorGL/MyGame.BlazorGL.csproj
+++ b/templates/frb2-multiplatform/MyGame.BlazorGL/MyGame.BlazorGL.csproj
@@ -17,24 +17,24 @@
   <!-- KNI XNA + Blazor host packages. The version pin must match the JS shim version
        in wwwroot/frb-host.js (`v = '8.0.11'`). -->
   <ItemGroup>
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Audio" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Media" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Game" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" />
-    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" Version="4.2.9001.1" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Content" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="nkast.Xna.Framework.Audio" />
+    <PackageReference Include="nkast.Xna.Framework.Media" />
+    <PackageReference Include="nkast.Xna.Framework.Input" />
+    <PackageReference Include="nkast.Xna.Framework.Game" />
+    <PackageReference Include="nkast.Xna.Framework.Devices" />
+    <PackageReference Include="nkast.Xna.Framework.Storage" />
+    <PackageReference Include="nkast.Xna.Framework.XR" />
+    <PackageReference Include="nkast.Kni.Platform.Blazor.GL" />
     <!-- Required to compile KniContentReference items into XNB. -->
-    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" Version="4.2.9001" />
+    <PackageReference Include="nkast.Xna.Framework.Content.Pipeline.Builder" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/frb2-multiplatform/MyGame.Common/MyGame.Common.csproj
+++ b/templates/frb2-multiplatform/MyGame.Common/MyGame.Common.csproj
@@ -22,12 +22,12 @@
 
   <!-- net8.0 -> KNI backend (browser/WASM, future KNI mobile). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="FlatRedBall2.Kni" Version="*-*" />
+    <PackageReference Include="FlatRedBall2.Kni" />
   </ItemGroup>
 
   <!-- net10.0 -> MonoGame backend (desktop). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="FlatRedBall2.MonoGame" Version="*-*" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="FlatRedBall2.MonoGame" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
   </ItemGroup>
 </Project>

--- a/templates/frb2-multiplatform/MyGame.Desktop/MyGame.Desktop.csproj
+++ b/templates/frb2-multiplatform/MyGame.Desktop/MyGame.Desktop.csproj
@@ -15,8 +15,8 @@
        FlatRedBall2.MonoGame (see $(AposShapesVersion) in the engine's AposShapes.props).
        Precompiled apos-shapes.xnb is wired by templates/build/AposShapesPrecompiled.props. -->
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" />
   </ItemGroup>
 
   <Import Project="..\build\AposShapesPrecompiled.props" />

--- a/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
+++ b/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
@@ -10,11 +10,11 @@
     pull them in directly here for type resolution (e.g. Texture2D in AnimationFrame).
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
-    <PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="nkast.Xna.Framework" />
+    <PackageReference Include="nkast.Xna.Framework.Graphics" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/AnimationChain.MonoGame.Tests/AnimationChain.MonoGame.Tests.csproj
+++ b/tests/AnimationChain.MonoGame.Tests/AnimationChain.MonoGame.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj
+++ b/tests/FlatRedBall2.Tests/FlatRedBall2.Tests.csproj
@@ -5,14 +5,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsepriteDotNet" Version="1.9.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.*" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*">
+    <PackageReference Include="AsepriteDotNet" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.*" />
-    <PackageReference Include="xunit" Version="2.9.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.*">
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tools/AnimationEditorAvalonia/Directory.Packages.props
+++ b/tools/AnimationEditorAvalonia/Directory.Packages.props
@@ -1,0 +1,39 @@
+<Project>
+  <!--
+    Self-contained CPM file for the Animation Editor tool — isolated from the repo root's
+    Directory.Packages.props on purpose. This tool has its own unrelated dependency graph
+    (Avalonia/SkiaSharp) and is not part of the main src/tests/samples build.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Microsoft.Extensions.* and NJsonSchema are pinned with a floating range (e.g. 9.*) —
+         CPM blocks floating PackageVersion entries by default. -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!-- NU1507 recommends NuGet package source mapping whenever CPM is combined with more
+         than one configured package source. This project's Directory.Build.props promotes
+         all warnings to errors, so this advisory would otherwise fail the build. Suppress it
+         rather than take on source mapping here. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Browser" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="NJsonSchema" Version="11.*" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.7" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+</Project>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -37,18 +37,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
-    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.7" />
-    <PackageReference Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Svg.Controls.Skia.Avalonia" />
+    <PackageReference Include="SkiaSharp" />
   </ItemGroup>
 
   <!--

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/AnimationEditor.Browser.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/AnimationEditor.Browser.csproj
@@ -33,14 +33,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageReference Include="Avalonia.Browser" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="SkiaSharp" />
     <!-- Phase 7 (#644) spike: confirm Svg.Controls.Skia.Avalonia's SVG rendering survives a
          net10.0-browser WASM publish before committing to the full icon rollout. See
          docs/BROWSER_ICON_SYSTEM_DECISION.md. -->
-    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.7" />
+    <PackageReference Include="Svg.Controls.Skia.Avalonia" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/AnimationEditor.Core.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/AnimationEditor.Views.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/AnimationEditor.Views.csproj
@@ -23,11 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="SkiaSharp" />
     <!-- Phase 7 (#644): shared SVG toolbar/spinner icons; see ThemeIconResources.axaml. -->
-    <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.7" />
+    <PackageReference Include="Svg.Controls.Skia.Avalonia" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AnimationEditor.App.Tests.csproj
@@ -11,17 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Headless.XUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationEditor.Core.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="NJsonSchema" Version="11.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="NJsonSchema" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/AnimationEditor.DocScreenshots.csproj
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/AnimationEditor.DocScreenshots.csproj
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Headless.XUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationEditor.Views.Tests.csproj
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationEditor.Views.Tests.csproj
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Headless.XUnit" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Sibling projects (e.g. a sample's Common project and its Desktop head) pinned the same NuGet package independently via floating ranges (`3.8.*`), so they could restore different exact versions and hit a runtime `FileNotFoundException` when the Common assembly's version didn't match what Desktop copied. This adopts NuGet Central Package Management (CPM) across four independent, self-contained `Directory.Packages.props` files:

- **Root** (`Directory.Packages.props`) — `src/**`, `tests/**`, `samples/**`, `diagnostics/**`.
- **`templates/frb2-desktop/Directory.Packages.props`** — the desktop-only `dotnet new` template, self-contained (scaffolds into a standalone repo).
- **`templates/frb2-multiplatform/Directory.Packages.props`** — the desktop+BlazorGL template, self-contained.
- **`tools/AnimationEditorAvalonia/Directory.Packages.props`** — the Avalonia tool's unrelated dependency graph.

Every `PackageReference` in each group drops its `Version` attribute; a stray `Version=` is now a build error, so a green build is real proof of the migration.

Other changes:
- Removed `src/FlatRedBall2.csproj`'s now-redundant direct import of `AposShapes.props` — the root `Directory.Packages.props` imports it once for every project in that group already, to resolve `$(AposShapesVersion)`.
- Added `CentralPackageFloatingVersionsEnabled` to each `Directory.Packages.props` that still needs a floating range (e.g. `0.16.*`, `9.*`, `*-*`).
- Suppressed `NU1507` (NuGet's package-source-mapping advisory, which fires whenever CPM is combined with 2+ package sources) — out of scope here.
- Updated the `sample-project-setup` and `multiplatform-conversion` skill docs' csproj templates to match (they showed the old `Version="3.8.*"` pattern, which would have reintroduced the bug).
- Consolidated version-decision notes: `MonoGame.Framework.DesktopGL`/`.Content.Builder.Task` → `3.8.4.1` exact (matching the templates); `Microsoft.NET.Test.Sdk`/`xunit`/`xunit.runner.visualstudio` → the most specific range already used in each group.

## Test-First Discipline
This is a build-configuration change with no runtime behavior to unit-test — it only affects how MSBuild/NuGet resolves package versions. Verified directly instead: `dotnet restore`/`build`/`test` on all 4 groups — the engine + all test projects, every sample's Desktop/BlazorGL/Common/Tests heads (PlatformKing, ShmupSpace, Solitaire, AnimationChainSample, GumFormsPopupTest), both `dotnet-new` templates, and the full AnimationEditorAvalonia solution including its WASM browser head — all succeed with zero errors, and zero warnings for AnimationEditorAvalonia (which has `TreatWarningsAsErrors`). Nothing is left untested.

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)