### PR TITLE
Bump Gum/KernSmith packages to 2026.7.22.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
   -->
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Several packages below are still pinned with a floating range (e.g. 0.16.*, 4.*) —
+    <!-- Several packages below are still pinned with a floating range (e.g. 4.*, 2.9.*) —
          CPM blocks floating PackageVersion entries by default. -->
     <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     <!-- NU1507 recommends NuGet package source mapping whenever CPM is combined with more
@@ -36,12 +36,15 @@
     <PackageVersion Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
     <PackageVersion Include="Apos.Shapes" Version="$(AposShapesVersion)" />
     <PackageVersion Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
-    <PackageVersion Include="Gum.MonoGame" Version="2026.7.9.1-preview.1" />
-    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.7.9.1-preview.1" />
-    <PackageVersion Include="Gum.KNI" Version="2026.7.9.1-preview.1" />
-    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.7.9.1-preview.1" />
-    <PackageVersion Include="KernSmith.MonoGameGum" Version="0.16.*" />
-    <PackageVersion Include="KernSmith.KniGum" Version="0.16.*" />
+    <PackageVersion Include="Gum.MonoGame" Version="2026.7.22.1" />
+    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.7.22.1" />
+    <PackageVersion Include="Gum.KNI" Version="2026.7.22.1" />
+    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.7.22.1" />
+    <!-- KernSmith moved from a 0.x scheme to the same date-based versioning as Gum, tracking
+         Gum's release cadence 1:1. 0.16.0 was its last 0.x release, so a floating "0.16.*" no
+         longer matches anything published; pin exactly like the Gum.* packages above. -->
+    <PackageVersion Include="KernSmith.MonoGameGum" Version="2026.7.22.1" />
+    <PackageVersion Include="KernSmith.KniGum" Version="2026.7.22.1" />
     <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
     <PackageVersion Include="MonoGame.Extended" Version="6.0.0" />

--- a/design/TODOS.md
+++ b/design/TODOS.md
@@ -53,6 +53,7 @@ Known categories:
 - **`CS0108` / `CS0114` — generated Gum control classes hide inherited members** (`MenuItem.MenuItemCategoryState`, `PasswordBox.Placeholder`, others). These come out of Gum's codegen; fix is upstream in Gum (emit `new` / `override` keyword) or a codegen-template tweak the consumer can apply. Track separately from engine work.
 - **Nullability warnings inside `tests/`.** The two `EntityVector2TweenTests`/`EntityColorTweenTests` `CS8600`/`CS8625` patterns in test code that aren't covered by `Nullable=enable`. Easy mechanical fix.
 - **Gum source warnings** (when project-referenced, not packaged). Out of scope here — they only appear during in-place Gum debugging and aren't shipped.
+- **`CS0618` — obsolete `MonoGameGum.GueDeriving.*` / `TryGetFrameworkElementByName` usage in Solitaire's `*.Generated.cs` files** (added by the Gum 2026.7.22.1 bump, which deprecated those in favor of `Gum.GueDeriving.*` / `FindFormsControl<T>`). These come out of Gum's own codegen template, same as the `CS0108`/`CS0114` item above — fix upstream in Gum's codegen (or regenerate once it's updated), not by hand-editing generated files.
 
 Do this as a sweep, not piecemeal: a single PR that drives the engine and sample warning count to zero, then promotes warnings to errors in CI so regressions are caught.
 


### PR DESCRIPTION
Closes #785

Gum.MonoGame/Gum.Shapes.MonoGame/Gum.KNI/Gum.Shapes.KNI were pinned to a preview build (2026.7.9.1-preview.1); KernSmith.MonoGameGum/KernSmith.KniGum were floating on `0.16.*`, a scheme KernSmith no longer publishes (it moved to Gum's date-based versioning). All six bumped to the latest matching release, 2026.7.22.1, exact-pinned.

Verified: engine builds clean (net8.0 KNI + net10.0 MonoGame), full test suite passes (1188/1188), and every Desktop/BlazorGL sample builds with 0 errors. Solitaire's Gum-codegen output picks up new `CS0618` warnings from `MonoGameGum.GueDeriving`/`TryGetFrameworkElementByName` being obsoleted upstream — logged in `design/TODOS.md` next to the existing Gum-codegen warning item since the real fix is in Gum's codegen template, not hand-editing generated files.