### PR TITLE
Bump Gum to 2026.7.25.1-preview.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,10 +36,10 @@
     <PackageVersion Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
     <PackageVersion Include="Apos.Shapes" Version="$(AposShapesVersion)" />
     <PackageVersion Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
-    <PackageVersion Include="Gum.MonoGame" Version="2026.7.22.1" />
-    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.7.22.1" />
-    <PackageVersion Include="Gum.KNI" Version="2026.7.22.1" />
-    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.7.22.1" />
+    <PackageVersion Include="Gum.MonoGame" Version="2026.7.25.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.7.25.1-preview.1" />
+    <PackageVersion Include="Gum.KNI" Version="2026.7.25.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.7.25.1-preview.1" />
     <!-- KernSmith moved from a 0.x scheme to the same date-based versioning as Gum, tracking
          Gum's release cadence 1:1. 0.16.0 was its last 0.x release, so a floating "0.16.*" no
          longer matches anything published; pin exactly like the Gum.* packages above. -->

--- a/samples/Solitaire/Solitaire.Common/Screens/GameScreen.cs
+++ b/samples/Solitaire/Solitaire.Common/Screens/GameScreen.cs
@@ -395,8 +395,8 @@ public class GameScreen : Screen
 
     private (float worldX, float worldY) SlotWorldCenter(GraphicalUiElement slot)
     {
-        float canvasX = slot.AbsoluteLeft + slot.GetAbsoluteWidth() / 2f;
-        float canvasY = slot.AbsoluteTop + slot.GetAbsoluteHeight() / 2f;
+        float canvasX = slot.AbsoluteLeft + slot.AbsoluteWidth / 2f;
+        float canvasY = slot.AbsoluteTop + slot.AbsoluteHeight / 2f;
         float worldX = canvasX - Camera.OrthogonalWidth / 2f;
         float worldY = Camera.OrthogonalHeight / 2f - canvasY;
         return (worldX, worldY);
@@ -506,8 +506,8 @@ public class GameScreen : Screen
     private bool CursorOver(GraphicalUiElement slot, Vector2 world)
     {
         var (cx, cy) = SlotWorldCenter(slot);
-        float halfW = slot.GetAbsoluteWidth() / 2f;
-        float halfH = slot.GetAbsoluteHeight() / 2f;
+        float halfW = slot.AbsoluteWidth / 2f;
+        float halfH = slot.AbsoluteHeight / 2f;
         return world.X >= cx - halfW && world.X <= cx + halfW
             && world.Y >= cy - halfH && world.Y <= cy + halfH;
     }
@@ -637,8 +637,8 @@ public class GameScreen : Screen
     private bool IsCursorOverTableauColumn(GraphicalUiElement slot, TableauPile pile, Vector2 world)
     {
         var (cx, cy) = SlotWorldCenter(slot);
-        float halfW = slot.GetAbsoluteWidth() / 2f;
-        float halfH = slot.GetAbsoluteHeight() / 2f;
+        float halfW = slot.AbsoluteWidth / 2f;
+        float halfH = slot.AbsoluteHeight / 2f;
 
         // Compute the bottom of the visible stack.
         float bottomY = cy - halfH;


### PR DESCRIPTION
Closes #787

Follow-up to #785/#786 (Gum 2026.7.22.1). A fresh Gum preview was published from Gum's current HEAD; bump to 2026.7.25.1-preview.1 to pick it up before cutting a FlatRedBall2 release. KernSmith stays at 2026.7.22.1.

Also migrated Solitaire's one hand-written call site off `GetAbsoluteWidth()`/`GetAbsoluteHeight()`, obsoleted in this Gum release in favor of `AbsoluteWidth`/`AbsoluteHeight` properties.

Verified: engine builds clean (net8.0 KNI + net10.0 MonoGame), full test suite passes (1188/1188), and every Desktop/BlazorGL sample builds with 0 errors.