### PR TITLE
Fix fall-speed clamp not updating after double jump on context swap

### DIFF
--- a/frb-skills/input-system/SKILL.md
+++ b/frb-skills/input-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: input-system
-description: "Input System in FlatRedBall2. Use when working with keyboard, mouse, cursor, gamepad, touch input, key bindings, or input handling. Covers IKeyboard, ICursor, IGamepad, KeyboardInput2D, KeyboardPressableInput, GamepadInput2D, GamepadPressableInput, and I2DInput/IPressableInput interfaces."
+description: "Input System in FlatRedBall2. Use when working with keyboard, mouse, cursor, gamepad, touch input, key bindings, or input handling. Covers IKeyboard, ICursor, IGamepad, KeyboardInput2D, KeyboardPressableInput, GamepadInput2D, GamepadDPadInput2D, GamepadPressableInput, and I2DInput/IPressableInput interfaces."
 ---
 
 # Input System in FlatRedBall2
@@ -139,7 +139,12 @@ _movement = new GamepadInput2D(pad0, GamepadAxis.LeftStickX, GamepadAxis.LeftSti
     .Or(new GamepadInput2D(pad1, GamepadAxis.LeftStickX, GamepadAxis.LeftStickY));
 ```
 
-The d-pad is exposed as four buttons (`Buttons.DPadLeft/Right/Up/Down`), not as axes — there is no `GamepadAxis.DPadX/Y`. To drive a `GamepadInput2D` from the d-pad, wrap the four buttons in your own `I2DInput` implementation.
+The d-pad is exposed as four buttons (`Buttons.DPadLeft/Right/Up/Down`), not as axes — there is no `GamepadAxis.DPadX/Y`. Use `GamepadDPadInput2D` for d-pad movement, and `.Or()` it with `GamepadInput2D` so the analog stick and d-pad both work:
+
+```csharp
+_movement = new GamepadInput2D(pad, GamepadAxis.LeftStickX, GamepadAxis.LeftStickY)
+    .Or(new GamepadDPadInput2D(pad));
+```
 
 The same applies to `IPressableInput` via `.Or(other)` — any two pressable inputs merge into one.
 

--- a/samples/PlatformKing/PlatformKing.Common/Entities/Player.cs
+++ b/samples/PlatformKing/PlatformKing.Common/Entities/Player.cs
@@ -59,11 +59,16 @@ public class Player : Entity, IPlatformerEntity
         Add(_body);
 
         var keyboard = Engine.Input.Keyboard;
+        var gamepad = Engine.Input.GetGamepad(0);
+        // Polling gamepad 0 is safe even with nothing plugged in — IGamepad returns
+        // zeroed/unpressed state until a controller connects, so no "is connected" gate needed.
         _platformer.MovementInput =
             new KeyboardInput2D(keyboard, Keys.Left, Keys.Right, Keys.Up, Keys.Down)
-            .Or(new KeyboardInput2D(keyboard, Keys.A, Keys.D, Keys.W, Keys.S));
+            .Or(new KeyboardInput2D(keyboard, Keys.A, Keys.D, Keys.W, Keys.S))
+            .Or(new GamepadInput2D(gamepad, GamepadAxis.LeftStickX, GamepadAxis.LeftStickY));
         _platformer.JumpInput =
-            new KeyboardPressableInput(keyboard, Keys.Space);
+            new KeyboardPressableInput(keyboard, Keys.Space)
+            .Or(new GamepadPressableInput(gamepad, Buttons.A));
 
         _normalConfig = PlatformerConfig.FromJson("Content/player.platformer.json");
         _waterConfig = PlatformerConfig.FromJson("Content/player.water.platformer.json");

--- a/samples/PlatformKing/PlatformKing.Common/Entities/Player.cs
+++ b/samples/PlatformKing/PlatformKing.Common/Entities/Player.cs
@@ -65,7 +65,8 @@ public class Player : Entity, IPlatformerEntity
         _platformer.MovementInput =
             new KeyboardInput2D(keyboard, Keys.Left, Keys.Right, Keys.Up, Keys.Down)
             .Or(new KeyboardInput2D(keyboard, Keys.A, Keys.D, Keys.W, Keys.S))
-            .Or(new GamepadInput2D(gamepad, GamepadAxis.LeftStickX, GamepadAxis.LeftStickY));
+            .Or(new GamepadInput2D(gamepad, GamepadAxis.LeftStickX, GamepadAxis.LeftStickY))
+            .Or(new GamepadDPadInput2D(gamepad));
         _platformer.JumpInput =
             new KeyboardPressableInput(keyboard, Keys.Space)
             .Or(new GamepadPressableInput(gamepad, Buttons.A));

--- a/src/Input/GamepadDPadInput2D.cs
+++ b/src/Input/GamepadDPadInput2D.cs
@@ -1,0 +1,45 @@
+using Microsoft.Xna.Framework.Input;
+
+namespace FlatRedBall2.Input;
+
+/// <summary>
+/// Adapts a gamepad's D-pad to an <see cref="I2DInput"/>. The D-pad is exposed as four buttons
+/// (not axes — there is no <see cref="GamepadAxis"/> for it), so this fills the same role for
+/// D-pad input that <see cref="KeyboardInput2D"/> fills for keyboard input.
+/// </summary>
+/// <remarks>
+/// Y+ is up: holding <see cref="Buttons.DPadUp"/> reports <c>Y = +1</c>, matching world-space
+/// coordinates. Not normalized to unit length. Combine with <see cref="GamepadInput2D"/> (analog
+/// stick) via <see cref="I2DInputExtensions.Or"/> so both control schemes work together.
+/// </remarks>
+public class GamepadDPadInput2D : I2DInput
+{
+    private readonly IGamepad _gamepad;
+
+    /// <param name="gamepad">The source gamepad. Obtain via <c>Engine.Input.GetGamepad(index)</c>.</param>
+    public GamepadDPadInput2D(IGamepad gamepad) => _gamepad = gamepad;
+
+    /// <summary>−1 if only D-pad left is held, +1 if only D-pad right is held, 0 otherwise (including both held).</summary>
+    public float X
+    {
+        get
+        {
+            var x = 0f;
+            if (_gamepad.IsButtonDown(Buttons.DPadLeft))  x -= 1f;
+            if (_gamepad.IsButtonDown(Buttons.DPadRight)) x += 1f;
+            return x;
+        }
+    }
+
+    /// <summary>+1 if only D-pad up is held (Y+ up), −1 if only D-pad down is held, 0 otherwise (including both held).</summary>
+    public float Y
+    {
+        get
+        {
+            var y = 0f;
+            if (_gamepad.IsButtonDown(Buttons.DPadDown)) y -= 1f;
+            if (_gamepad.IsButtonDown(Buttons.DPadUp))   y += 1f;
+            return y;
+        }
+    }
+}

--- a/src/Movement/PlatformerBehavior.cs
+++ b/src/Movement/PlatformerBehavior.cs
@@ -128,9 +128,12 @@ public class PlatformerBehavior
     /// </summary>
     public PlatformerValues? AfterDoubleJump { get; set; }
 
-    // Tracks which air slot is currently active. Null = using AirMovement. Set to AfterDoubleJump
-    // after the first air jump (when AfterDoubleJump != null). Reset to null on landing.
-    private PlatformerValues? _activeAirValues;
+    // Tracks whether the first air jump has fired since the last landing. Resolved against
+    // AfterDoubleJump fresh every frame (falling back to AirMovement) rather than caching the
+    // PlatformerValues reference directly — a context swap (e.g. entering water) can null out
+    // AfterDoubleJump via PlatformerConfig.ApplyTo, and a cached reference would keep pointing at
+    // the orphaned pre-swap values instead of picking up the new context's AirMovement.
+    private bool _usedAirJumpSlot;
 
     /// <summary>True while climbing a snapping ladder (X-locked). False for fence climbs and when not climbing.</summary>
     public bool IsOnLadder => IsClimbing && _lockedLadderX.HasValue;
@@ -403,7 +406,7 @@ public class PlatformerBehavior
 
         var current = IsClimbing
             ? ClimbingMovement!
-            : (IsOnGround ? (GroundMovement ?? AirMovement) : (_activeAirValues ?? AirMovement));
+            : (IsOnGround ? (GroundMovement ?? AirMovement) : (_usedAirJumpSlot ? (AfterDoubleJump ?? AirMovement) : AirMovement));
 
         if (!IsOnGround || IsClimbing) CurrentSlope = 0f;
         float effectiveMaxSpeedX = ComputeSlopeAdjustedMaxSpeed(current, inputX);
@@ -500,7 +503,7 @@ public class PlatformerBehavior
         }
         else
         {
-            if (IsOnGround) _activeAirValues = null;
+            if (IsOnGround) _usedAirJumpSlot = false;
 
             // C. Apply gravity
             entity.AccelerationY = -current.Gravity;
@@ -565,15 +568,14 @@ public class PlatformerBehavior
             if (!groundJumpFiredThisFrame && !dropThroughTriggered
                 && justPressed && !IsOnGround && !IsApplyingJump)
             {
-                var airValues = _activeAirValues ?? AirMovement;
+                var airValues = _usedAirJumpSlot ? (AfterDoubleJump ?? AirMovement) : AirMovement;
                 if (airValues.JumpVelocity > 0f)
                 {
                     entity.VelocityY = airValues.JumpVelocity;
                     _jumpStartTime = time.SinceGameStart;
                     _jumpValues = airValues;
                     IsApplyingJump = airValues.JumpApplyLength > TimeSpan.Zero;
-                    if (_activeAirValues == null && AfterDoubleJump != null)
-                        _activeAirValues = AfterDoubleJump;
+                    _usedAirJumpSlot = true;
                     airJumpFired = true;
                 }
             }

--- a/tests/FlatRedBall2.Tests/Input/InputTests.cs
+++ b/tests/FlatRedBall2.Tests/Input/InputTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FlatRedBall2.Input;
 using Microsoft.Xna.Framework.Input;
 using Shouldly;
@@ -208,6 +209,55 @@ public class GamepadPressableInputTests
         var input = new GamepadPressableInput(fake, Buttons.A);
 
         input.WasJustReleased.ShouldBeTrue();
+    }
+}
+
+// --- GamepadDPadInput2D ---
+
+file sealed class FakeDPadGamepad : IGamepad
+{
+    private readonly HashSet<Buttons> _down = new();
+
+    public void Hold(Buttons button) => _down.Add(button);
+
+    public bool IsButtonDown(Buttons button) => _down.Contains(button);
+    public bool WasButtonJustPressed(Buttons button) => false;
+    public bool WasButtonJustReleased(Buttons button) => false;
+    public float GetAxis(GamepadAxis axis) => 0f;
+}
+
+public class GamepadDPadInput2DTests
+{
+    [Fact]
+    public void X_DPadLeftHeld_ReturnsNegativeOne()
+    {
+        var fake = new FakeDPadGamepad();
+        fake.Hold(Buttons.DPadLeft);
+        var input = new GamepadDPadInput2D(fake);
+
+        input.X.ShouldBe(-1f);
+    }
+
+    [Fact]
+    public void X_DPadRightHeld_ReturnsPositiveOne()
+    {
+        var fake = new FakeDPadGamepad();
+        fake.Hold(Buttons.DPadRight);
+        var input = new GamepadDPadInput2D(fake);
+
+        input.X.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void Y_DPadUpHeld_ReturnsPositiveOne()
+    {
+        // Y+ is up by convention (matches world-space coordinates) — the most likely source of
+        // a sign-flip bug if this adapter were ever rewritten.
+        var fake = new FakeDPadGamepad();
+        fake.Hold(Buttons.DPadUp);
+        var input = new GamepadDPadInput2D(fake);
+
+        input.Y.ShouldBe(1f);
     }
 }
 

--- a/tests/FlatRedBall2.Tests/Movement/PlatformerBehaviorAirJumpTests.cs
+++ b/tests/FlatRedBall2.Tests/Movement/PlatformerBehaviorAirJumpTests.cs
@@ -209,6 +209,39 @@ public class PlatformerBehaviorAirJumpTests
         entity.VelocityY.ShouldBe(airJumpVelocity);
     }
 
+    // ── Context swap mid-air (e.g. entering water) ──────────────────────────
+
+    [Fact]
+    public void AirJump_AfterDoubleJump_WhenAfterDoubleJumpSlotIsClearedMidAir_FallSpeedClampUsesAirMovement()
+    {
+        // Reproduces #784: after a double jump, AfterDoubleJump becomes the active slot. If a
+        // context swap (e.g. entering water) then clears AfterDoubleJump — same pattern as
+        // PlatformerConfig.ApplyTo when the new context's JSON has no afterDoubleJump block —
+        // the fall-speed clamp must fall back to AirMovement's (now water's) MaxFallSpeed
+        // instead of clinging to the stale, now-orphaned AfterDoubleJump values.
+        var afterDoubleJump = new PlatformerValues { MaxSpeedX = 120f, Gravity = 700f, MaxFallSpeed = 800f, JumpVelocity = 0f };
+        var jump = new PressableInput();
+        var platformer = MakePlatformer(jump, airJumpVelocity: 300f, afterDoubleJump: afterDoubleJump);
+        var (entity, _) = MakeAirborneEntity();
+
+        platformer.Update(entity, Frame()); // airborne, no jump
+
+        jump.Press();
+        platformer.Update(entity, Frame()); // double jump fires, _activeAirValues = afterDoubleJump
+
+        // Simulate falling back down, then swapping to a context (water) whose config has no
+        // afterDoubleJump slot — PlatformerConfig.ApplyTo sets AfterDoubleJump = null and lowers
+        // AirMovement.MaxFallSpeed, exactly like the water JSON in the PlatformKing sample.
+        jump.Release();
+        entity.VelocityY = -2000f; // far below any config's max fall speed
+        platformer.AfterDoubleJump = null;
+        platformer.AirMovement.MaxFallSpeed = 50f;
+
+        platformer.Update(entity, Frame());
+
+        entity.VelocityY.ShouldBe(-50f);
+    }
+
     // ── Fell off ground ──────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #784

`PlatformerBehavior` cached `AfterDoubleJump`'s `PlatformerValues` instance by reference in `_activeAirValues` the moment an air jump fired, and never re-resolved it. When a context swap (e.g. entering water) nulls `AfterDoubleJump` via `PlatformerConfig.ApplyTo` (water's JSON has no `afterDoubleJump` block), the cached reference kept pointing at the orphaned pre-swap values — so `MaxFallSpeed` stayed frozen at the land value instead of following the swap into water, the way `AirMovement`-driven fields already did. Single-jump mode was unaffected since it always reads `AirMovement` directly.

Fix: replaced the cached reference with a bool flag that re-resolves `AfterDoubleJump ?? AirMovement` every frame. Side effect (intentional): if the new context doesn't define an `afterDoubleJump` slot, the double-jump lockout doesn't carry over either — matches `ApplyTo`'s documented "absent slot = disabled" semantics.

TDD: added `AirJump_AfterDoubleJump_WhenAfterDoubleJumpSlotIsClearedMidAir_FallSpeedClampUsesAirMovement` to `PlatformerBehaviorAirJumpTests.cs`, confirmed it failed (`-800` instead of `-50`) before the fix. Full suite: 1189/1189 passing. PlatformKing sample builds clean.

**Also included** (found during manual testing):
- Wired gamepad 0 as an additional input source in PlatformKing's `Player.cs` — controller previously did nothing since only keyboard was wired.
- Added `GamepadDPadInput2D` (engine, `src/Input/`) — the d-pad is four buttons, not an axis, so `GamepadInput2D` can't read it. Mirrors `KeyboardInput2D`'s button-to-axis mapping; combine with the stick via `.Or()`. TDD'd (`GamepadDPadInput2DTests`). Updated `frb-skills/input-system` to document it instead of the old "hand-roll your own wrapper" guidance.

Final suite: 1192/1192 passing.