### PR TITLE
Stop animation system from touching shape IsVisible on existing shapes

### DIFF
--- a/frb-skills/animation/references/per-frame-shapes.md
+++ b/frb-skills/animation/references/per-frame-shapes.md
@@ -8,8 +8,10 @@ A shape **name** is *owned* by an `AnimationChainList` iff that name appears in 
 
 Each frame, the engine reconciles the chainlist's owned set:
 
-- Listed in this frame → shape is enabled (`IsVisible = true`, registered for default collision) and values are applied.
-- In the owned set but **not** listed in this frame → shape is hidden (`IsVisible = false`, removed from default collision). The instance persists for reuse; it isn't destroyed.
+- Listed in this frame → geometry values are applied and the shape is registered for default collision. `IsVisible` is untouched.
+- In the owned set but **not** listed in this frame → removed from default collision. The instance persists for reuse; it isn't destroyed. `IsVisible` is untouched.
+
+`IsVisible` is only ever set by the animation system once, at auto-creation time (see `AutoCreateShapes` below) — from then on it's entirely game code's to control. A shape you create and hide yourself stays hidden through animation playback; this is how you build collision-only hitboxes that never render.
 
 Shapes whose names are not in *any* chainlist's owned set are **never touched**. Body colliders are safe by absence — adding animation to an existing entity does not silently strip the body, no flag required.
 
@@ -21,7 +23,7 @@ Shapes whose names are not in *any* chainlist's owned set are **never touched**.
 
 ## AutoCreateShapes
 
-Default `true` on `AnimationChainList`. When a frame names a shape that doesn't yet exist on the entity, the engine instantiates it and attaches it. This is the ergonomic code path — no need to pre-declare every hitbox in `CustomInitialize`.
+Default `true` on `AnimationChainList`. When a frame names a shape that doesn't yet exist on the entity, the engine instantiates it, sets `IsVisible = true`, and attaches it. This is the ergonomic code path — no need to pre-declare every hitbox in `CustomInitialize`. If you want a collision-only shape that never renders, pre-declare it yourself with `IsVisible = false` instead of relying on auto-creation.
 
 Set `chainList.AutoCreateShapes = false` to make missing shapes a runtime error instead. Useful when you want typo detection.
 

--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -449,7 +449,7 @@ public class Sprite : IRenderable, IAttachable
             if (entry != null)
                 ApplyShapeEntry(name, entry);
             else
-                HideShapeIfPresent(name);
+                DisableCollisionIfPresent(name);
         }
     }
 
@@ -535,7 +535,7 @@ public class Sprite : IRenderable, IAttachable
 
     // Only disables collision — visibility is never the animation system's business once a shape
     // exists. A shape's IsVisible is entirely game code's to control (see issue #775).
-    private void HideShapeIfPresent(string name)
+    private void DisableCollisionIfPresent(string name)
     {
         var existing = Parent!.FindShapeByName(name);
         if (existing == null) return;

--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -467,6 +467,7 @@ public class Sprite : IRenderable, IAttachable
                             $"Animation frame references shape '{name}' which is not on the entity, and AutoCreateShapes is false.");
                     var r = new AARect { Name = name };
                     ApplyRectangle(r, rect);
+                    r.IsVisible = true;
                     Parent.Add(r);
                 }
                 else if (existing is AARect r)
@@ -490,6 +491,7 @@ public class Sprite : IRenderable, IAttachable
                             $"Animation frame references shape '{name}' which is not on the entity, and AutoCreateShapes is false.");
                     var c = new Circle { Name = name };
                     ApplyCircle(c, circle);
+                    c.IsVisible = true;
                     Parent.Add(c);
                 }
                 else if (existing is Circle c)
@@ -513,6 +515,7 @@ public class Sprite : IRenderable, IAttachable
                             $"Animation frame references shape '{name}' which is not on the entity, and AutoCreateShapes is false.");
                     var p = new Polygon { Name = name };
                     ApplyPolygon(p, poly);
+                    p.IsVisible = true;
                     Parent.Add(p);
                 }
                 else if (existing is Polygon p)
@@ -530,6 +533,8 @@ public class Sprite : IRenderable, IAttachable
         }
     }
 
+    // Only disables collision — visibility is never the animation system's business once a shape
+    // exists. A shape's IsVisible is entirely game code's to control (see issue #775).
     private void HideShapeIfPresent(string name)
     {
         var existing = Parent!.FindShapeByName(name);
@@ -537,27 +542,24 @@ public class Sprite : IRenderable, IAttachable
         switch (existing)
         {
             case AARect r:
-                r.IsVisible = false;
                 Parent.SetDefaultCollision(r, false);
                 break;
             case Circle c:
-                c.IsVisible = false;
                 Parent.SetDefaultCollision(c, false);
                 break;
             case Polygon p:
-                p.IsVisible = false;
                 Parent.SetDefaultCollision(p, false);
                 break;
         }
     }
 
+    // Geometry-only — callers that just created the shape set IsVisible = true themselves.
     private static void ApplyRectangle(AARect r, AnimationAARectFrame entry)
     {
         r.Width = entry.Width;
         r.Height = entry.Height;
         r.X = entry.RelativeX;
         r.Y = entry.RelativeY;
-        r.IsVisible = true;
     }
 
     private static void ApplyCircle(Circle c, AnimationCircleFrame entry)
@@ -565,7 +567,6 @@ public class Sprite : IRenderable, IAttachable
         c.Radius = entry.Radius;
         c.X = entry.RelativeX;
         c.Y = entry.RelativeY;
-        c.IsVisible = true;
     }
 
     private static void ApplyPolygon(Polygon p, AnimationPolygonFrame entry)
@@ -573,7 +574,6 @@ public class Sprite : IRenderable, IAttachable
         p.SetPoints(entry.Points);
         p.X = entry.RelativeX;
         p.Y = entry.RelativeY;
-        p.IsVisible = true;
     }
 
     // Rotation (radians) handed to SpriteBatch.Draw. SpriteBatch rotates corner offsets with the

--- a/tests/FlatRedBall2.Tests/Animation/SpriteAnimationShapesTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/SpriteAnimationShapesTests.cs
@@ -51,7 +51,7 @@ public class SpriteAnimationShapesTests
     }
 
     [Fact]
-    public void ApplyCurrentFrame_HitboxOnFrame_EnabledOnEntity()
+    public void ApplyCurrentFrame_HitboxOnFrame_ValuesAppliedVisibilityPreserved()
     {
         var entity = new Entity();
         var sword = new AARect { Name = "Sword", IsVisible = false };
@@ -68,7 +68,8 @@ public class SpriteAnimationShapesTests
         sprite.AnimationChains = list;
         sprite.PlayAnimation("Attack");
 
-        sword.IsVisible.ShouldBeTrue();
+        // Visibility is game code's to control — animation only touches geometry/collision.
+        sword.IsVisible.ShouldBeFalse();
         sword.Width.ShouldBe(30f);
         sword.Height.ShouldBe(10f);
         sword.X.ShouldBe(15f);
@@ -76,7 +77,7 @@ public class SpriteAnimationShapesTests
     }
 
     [Fact]
-    public void ApplyCurrentFrame_HitboxAbsentFromFrame_HiddenAndCollisionDisabled()
+    public void ApplyCurrentFrame_HitboxAbsentFromFrame_CollisionDisabledVisibilityUnchanged()
     {
         var entity = new Entity();
         var sprite = new Sprite();
@@ -98,15 +99,43 @@ public class SpriteAnimationShapesTests
         sword.ShouldNotBeNull();
         sword!.IsVisible.ShouldBeTrue();
 
-        // Advance to frame 1 — no Sword listed, must be hidden
+        // Advance to frame 1 — no Sword listed, collision disabled but visibility untouched
         sprite.AnimateSelf(0.15);
 
-        sword.IsVisible.ShouldBeFalse();
+        sword.IsVisible.ShouldBeTrue();
         entity.CollidesWith(new AARect { X = 0f, Y = 0f, Width = 100f, Height = 100f }).ShouldBeFalse();
     }
 
     [Fact]
-    public void ApplyCurrentFrame_CrossChainSwitchWithinChainList_HidesShapeNotInNewChain()
+    public void ApplyCurrentFrame_PreExistingShapeMarkedInvisible_VisibilityPreservedAcrossFrames()
+    {
+        // Regression guard for #775: a shape the game code created (not auto-created by the
+        // animation system) and explicitly hid must stay hidden through both frame states —
+        // present-in-frame (values applied) and absent-from-frame (collision disabled).
+        var entity = new Entity();
+        var sword = new AARect { Name = "Sword", IsVisible = false };
+        entity.Add(sword);
+
+        var sprite = new Sprite();
+        entity.Add(sprite);
+
+        var chain = ChainWithFrames("Attack",
+            Frame(0.1f, new AnimationAARectFrame { Name = "Sword", Width = 30f, Height = 10f }),
+            Frame(0.1f)); // second frame doesn't list Sword
+        var list = new AnimationChainList();
+        list.Add(chain);
+        sprite.AnimationChains = list;
+        sprite.PlayAnimation("Attack");
+
+        sword.IsVisible.ShouldBeFalse();
+
+        sprite.AnimateSelf(0.15);
+
+        sword.IsVisible.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ApplyCurrentFrame_CrossChainSwitchWithinChainList_DisablesCollisionNotInNewChain()
     {
         var entity = new Entity();
         var sprite = new Sprite();
@@ -131,8 +160,10 @@ public class SpriteAnimationShapesTests
 
         sprite.PlayAnimation("Idle");
 
-        // Sword is owned by the chainlist (Attack mentions it), Idle does not list it → hidden.
-        sword.IsVisible.ShouldBeFalse();
+        // Sword is owned by the chainlist (Attack mentions it), Idle does not list it → collision
+        // disabled, but visibility is never the animation system's business.
+        sword.IsVisible.ShouldBeTrue();
+        entity.CollidesWith(new AARect { X = 0f, Y = 0f, Width = 100f, Height = 100f }).ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `Sprite.ApplyRectangle`/`ApplyCircle`/`ApplyPolygon` no longer force `IsVisible = true` when applying geometry to a shape that already exists — only the create branches set it, once, at auto-creation.
- `HideShapeIfPresent` no longer sets `IsVisible = false`; frame absence only disables default collision.
- Result: a shape game code creates and hides (`IsVisible = false`) stays hidden through animation playback, so collision-only hitboxes are possible.

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — new/updated tests in `SpriteAnimationShapesTests.cs` reproduce the bug (failing before the fix) and pass after.
- [x] `dotnet build src/FlatRedBall2.csproj` — clean.

Closes #775