### PR TITLE
Allow negative R/G/B in Animation Editor color channels

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -22,6 +22,10 @@ For writing tests against the editor — headless Avalonia, service wiring, the 
 - **A field the editor exposes does not obligate any runtime to apply it.** Store the data in the format; whether a given runtime renders it is that runtime's choice. Do not gate adding a frame field on FRB2 (or any single runtime) implementing it — e.g. per-frame `Red`/`Green`/`Blue` are authored and stored for game code to consume, while FRB2's `SpriteBatch` path never applies them itself.
 - **The preview is a reference rendering, not a per-runtime contract.** The bottom panel renders with SkiaSharp (`PreviewControl`, `SKCanvas`/`SKColorFilter` in `DrawFrameCore`), so it will diverge from what a MonoGame/FNA/FRB1 runtime produces for the same file. That divergence is inherent to a general-purpose tool and is not a bug — pick a sensible canonical interpretation. "The preview might not match a runtime" is never a reason to withhold an authoring feature.
 
+## Negative R/G/B is allowed — Multiply clamps it, Add uses it as subtract
+
+`Red`/`Green`/`Blue` are plain `int?` (`Animation.Content/AnimationFrameSave.cs`) with no engine-side range check, and the FRB2 runtime never applies these fields at all (see above), so the only place a range matters is the preview. The inspector's `PropRed`/`PropGreen`/`PropBlue` `NumericUpDown`s (`MainWindow.axaml`) allow -255..255; `PropAlpha` stays 0..255 since alpha is a separate straight-opacity value, not part of a `ColorOperation`. In `FrameColorFilter.Create` (`AnimationEditor.Views/FrameColorFilter.cs`), **Add**'s Skia color-matrix offset is signed, so a negative value subtracts and clamps at the final pixel for free. **Multiply** packs the channel into a `byte` for `SKColor`, so it explicitly `Math.Clamp`s to 0 first — an unclamped negative `int`→`byte` cast wraps (`-10` becomes `246`) instead of darkening. Keep that clamp if you touch this method.
+
 ## Project layout
 
 ```

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -945,19 +945,19 @@
                                                         <TextBlock Text="R" VerticalAlignment="Center"
                                                                    Foreground="{DynamicResource Accent}" FontSize="11" FontWeight="SemiBold" />
                                                         <NumericUpDown x:Name="PropRed" Grid.Column="1" MinWidth="66"
-                                                                       Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                                                       Minimum="-255" Maximum="255" Increment="1" FormatString="0" />
                                                     </Grid>
                                                     <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                         <TextBlock Text="G" VerticalAlignment="Center"
                                                                    Foreground="{DynamicResource Ok}" FontSize="11" FontWeight="SemiBold" />
                                                         <NumericUpDown x:Name="PropGreen" Grid.Column="1" MinWidth="66"
-                                                                       Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                                                       Minimum="-255" Maximum="255" Increment="1" FormatString="0" />
                                                     </Grid>
                                                     <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                         <TextBlock Text="B" VerticalAlignment="Center"
                                                                    Foreground="{DynamicResource AccentCool}" FontSize="11" FontWeight="SemiBold" />
                                                         <NumericUpDown x:Name="PropBlue" Grid.Column="1" MinWidth="66"
-                                                                       Minimum="0" Maximum="255" Increment="1" FormatString="0" />
+                                                                       Minimum="-255" Maximum="255" Increment="1" FormatString="0" />
                                                     </Grid>
                                                     <Grid ColumnDefinitions="14,*" MinWidth="86" Margin="0,0,8,4">
                                                         <TextBlock Text="A" VerticalAlignment="Center"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/FrameColorFilter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/FrameColorFilter.cs
@@ -20,8 +20,10 @@ public static class FrameColorFilter
         switch (operation)
         {
             case ColorOperation.Multiply:
+                // Channels feed an SKColor byte, so a negative value must clamp to 0 here — an
+                // unclamped negative int->byte cast wraps (-10 becomes 246) instead of darkening.
                 return SKColorFilter.CreateBlendMode(
-                    new SKColor((byte)(r ?? 255), (byte)(g ?? 255), (byte)(b ?? 255), 255),
+                    new SKColor((byte)Math.Clamp(r ?? 255, 0, 255), (byte)Math.Clamp(g ?? 255, 0, 255), (byte)Math.Clamp(b ?? 255, 0, 255), 255),
                     SKBlendMode.Modulate);
             case ColorOperation.Add:
                 // A Plus blend can't do this: it blends in premultiplied space, so an alpha-0 color adds

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameColorFilterTests.cs
@@ -84,4 +84,26 @@ public class FrameColorFilterTests
 
         AssertNear(128, result.Alpha);
     }
+
+    [Fact]
+    public void Create_Add_NegativeValueDarkensAndClampsAtZero()
+    {
+        // Add's color-matrix offset is signed math, so a negative value should subtract.
+        using var filter = FrameColorFilter.Create(ColorOperation.Add, -60, -200, 0);
+        var result = Apply(filter, new SKColor(100, 100, 100, 255));
+
+        AssertNear(40, result.Red);   // 100 - 60
+        AssertNear(0, result.Green);  // 100 - 200 clamps to 0
+        AssertNear(100, result.Blue); // +0
+    }
+
+    [Fact]
+    public void Create_Multiply_NegativeValueClampsToZeroInsteadOfWrapping()
+    {
+        // The channel feeds an SKColor byte; an unclamped negative int would wrap (e.g. -10 -> 246).
+        using var filter = FrameColorFilter.Create(ColorOperation.Multiply, -10, null, null);
+        var result = Apply(filter, new SKColor(200, 200, 200, 255));
+
+        AssertNear(0, result.Red);
+    }
 }


### PR DESCRIPTION
## Summary
- Inspector R/G/B `NumericUpDown`s now allow -255..255 (alpha stays 0-255 — it's straight opacity, not part of a `ColorOperation`)
- `FrameColorFilter.Create`'s Multiply branch now clamps to 0 before the byte cast, since Add already handles negative correctly via its Skia color-matrix offset

Closes #791

## Test plan
- [x] `FrameColorFilterTests`: added negative-Add (subtracts, clamps at 0) and negative-Multiply (clamps instead of wrapping) cases — both fail without the fix, pass with it
- [x] Full solution build (`dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx`) — 0 warnings, 0 errors
- [ ] Manual: open the Animation Editor, set a frame's R/G channel negative under Add and confirm the preview darkens as expected