### PR TITLE
Runtime: apply Multiply color op + sticky channel resolution

### DIFF
--- a/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
+++ b/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
@@ -200,8 +200,20 @@ public class AnimationChainListSave
         {
             var chain = new AnimationChain { Name = chainSave.Name };
 
+            // Sticky color resolution: a frame that omits a channel inherits the most recent
+            // explicitly-set value from an earlier frame in this chain, rather than resetting to
+            // null. Mirrors the Animation Editor's EffectiveFrameColor.ResolveAll.
+            int? stickyRed = null, stickyGreen = null, stickyBlue = null, stickyAlpha = null;
+            ColorOperation? stickyOperation = null;
+
             foreach (var frameSave in chainSave.Frames)
             {
+                stickyRed       = frameSave.Red           ?? stickyRed;
+                stickyGreen     = frameSave.Green         ?? stickyGreen;
+                stickyBlue      = frameSave.Blue          ?? stickyBlue;
+                stickyAlpha     = frameSave.Alpha         ?? stickyAlpha;
+                stickyOperation = frameSave.ColorOperation ?? stickyOperation;
+
                 var frame = new AnimationFrame
                 {
                     TextureName = frameSave.TextureName,
@@ -211,11 +223,11 @@ public class AnimationChainListSave
                     FlipDiagonal = frameSave.FlipDiagonal,
                     RelativeX = frameSave.RelativeX,
                     RelativeY = frameSave.RelativeY,
-                    Red = frameSave.Red,
-                    Green = frameSave.Green,
-                    Blue = frameSave.Blue,
-                    Alpha = frameSave.Alpha,
-                    ColorOperation = frameSave.ColorOperation,
+                    Red = stickyRed,
+                    Green = stickyGreen,
+                    Blue = stickyBlue,
+                    Alpha = stickyAlpha,
+                    ColorOperation = stickyOperation,
                 };
 
                 frame.Texture = loadTexture(frameSave);

--- a/src/AnimationChain.MonoGame/Content/AnimationFrameSave.cs
+++ b/src/AnimationChain.MonoGame/Content/AnimationFrameSave.cs
@@ -38,19 +38,23 @@ public class AnimationFrameSave
     /// <summary>Per-frame Y offset.</summary>
     public float RelativeY;
 
-    /// <summary>Per-frame red color channel (0-255). <c>null</c> means unset/not authored.</summary>
+    /// <summary>
+    /// Per-frame red color channel (0-255) as authored on this specific frame. <c>null</c> means
+    /// this frame didn't set it — <see cref="AnimationChainListSave.ToAnimationChainList"/> resolves
+    /// the "sticky" runtime value (inherited from an earlier frame) onto <c>AnimationFrame.Red</c>.
+    /// </summary>
     public int? Red;
 
-    /// <summary>Per-frame green color channel (0-255). <c>null</c> means unset/not authored.</summary>
+    /// <summary>Per-frame green color channel (0-255) as authored on this specific frame. See <see cref="Red"/>.</summary>
     public int? Green;
 
-    /// <summary>Per-frame blue color channel (0-255). <c>null</c> means unset/not authored.</summary>
+    /// <summary>Per-frame blue color channel (0-255) as authored on this specific frame. See <see cref="Red"/>.</summary>
     public int? Blue;
 
-    /// <summary>Per-frame alpha/transparency channel (0-255). <c>null</c> means unset/not authored.</summary>
+    /// <summary>Per-frame alpha/transparency channel (0-255) as authored on this specific frame. See <see cref="Red"/>.</summary>
     public int? Alpha;
 
-    /// <summary>How the color channels combine with the texture. <c>null</c> means none.</summary>
+    /// <summary>How the color channels combine with the texture, as authored on this specific frame. See <see cref="Red"/>.</summary>
     public ColorOperation? ColorOperation;
 
     /// <summary>Per-frame shape definitions. <c>null</c> when no shapes are defined.</summary>

--- a/src/AnimationChain.MonoGame/Content/ColorOperation.cs
+++ b/src/AnimationChain.MonoGame/Content/ColorOperation.cs
@@ -1,17 +1,24 @@
+using Microsoft.Xna.Framework.Graphics;
+
 namespace FlatRedBall.AnimationChain;
 
 /// <summary>
 /// How a frame's per-frame color (<c>AnimationFrame.Red</c>/<c>AnimationFrame.Green</c>/
 /// <c>AnimationFrame.Blue</c>) combines with the sprite's texture. A <c>null</c> operation
-/// means none. Authored in the Animation Editor and stored in the .achx; whether a given
-/// runtime applies it is that runtime's choice — <see cref="SpriteBatchExtensions.DrawAnimation"/>
-/// does not apply it automatically.
+/// means none. Authored in the Animation Editor and stored in the .achx.
 /// </summary>
 public enum ColorOperation
 {
-    /// <summary>Multiply the texture by the color (darken / colorize). White is the identity.</summary>
+    /// <summary>
+    /// Multiply the texture by the color (darken / colorize). White is the identity. Applied
+    /// automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/>.
+    /// </summary>
     Multiply,
 
-    /// <summary>Add the color to the texture (brighten / glow / flash). Black is the identity.</summary>
+    /// <summary>
+    /// Add the color to the texture (brighten / glow / flash). Black is the identity. Not yet
+    /// applied at runtime — <see cref="SpriteBatch"/> can only multiply texture color, not offset
+    /// it, so this needs a custom shader. Authored data only for now.
+    /// </summary>
     Add,
 }

--- a/src/AnimationChain.MonoGame/Runtime/AnimationFrame.cs
+++ b/src/AnimationChain.MonoGame/Runtime/AnimationFrame.cs
@@ -48,37 +48,33 @@ public class AnimationFrame
     public float RelativeY;
 
     /// <summary>
-    /// Per-frame red color channel (0-255). <c>null</c> means unset/not authored. Not applied
-    /// automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/> — available for game
-    /// code to use.
+    /// Per-frame red color channel (0-255), already resolved for the "sticky" .achx semantic (an
+    /// omitted channel inherits the last frame that set it — see <see cref="AchxLoader"/>).
+    /// <c>null</c> means no frame in this chain ever set it. Applied automatically by
+    /// <see cref="SpriteBatchExtensions.DrawAnimation"/> when <see cref="ColorOperation"/> is
+    /// <see cref="FlatRedBall.AnimationChain.ColorOperation.Multiply"/> — see <see cref="AnimationFrameColor.Apply"/>.
     /// </summary>
     public int? Red;
 
-    /// <summary>
-    /// Per-frame green color channel (0-255). <c>null</c> means unset/not authored. Not applied
-    /// automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/> — available for game
-    /// code to use.
-    /// </summary>
+    /// <summary>Per-frame green color channel (0-255), sticky-resolved. See <see cref="Red"/>.</summary>
     public int? Green;
 
-    /// <summary>
-    /// Per-frame blue color channel (0-255). <c>null</c> means unset/not authored. Not applied
-    /// automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/> — available for game
-    /// code to use.
-    /// </summary>
+    /// <summary>Per-frame blue color channel (0-255), sticky-resolved. See <see cref="Red"/>.</summary>
     public int? Blue;
 
     /// <summary>
-    /// Per-frame alpha/transparency channel (0-255). <c>null</c> means unset/not authored. Not
-    /// applied automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/> — available for
-    /// game code to use.
+    /// Per-frame alpha/transparency channel (0-255), sticky-resolved. <c>null</c> means no frame in
+    /// this chain ever set it. Independent of <see cref="ColorOperation"/> — always applied by
+    /// <see cref="SpriteBatchExtensions.DrawAnimation"/> when set. See <see cref="Red"/>.
     /// </summary>
     public int? Alpha;
 
     /// <summary>
-    /// How the color channels combine with the texture. <c>null</c> means none. Not applied
-    /// automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/> — available for game
-    /// code to use.
+    /// How <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/> combine with the texture,
+    /// sticky-resolved. <c>null</c> means none. <see cref="FlatRedBall.AnimationChain.ColorOperation.Multiply"/>
+    /// is applied automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/>;
+    /// <see cref="FlatRedBall.AnimationChain.ColorOperation.Add"/> is authored data only for now — it needs a
+    /// custom shader, since <see cref="Microsoft.Xna.Framework.Graphics.SpriteBatch"/> can only multiply texture color, not offset it.
     /// </summary>
     public ColorOperation? ColorOperation;
 

--- a/src/AnimationChain.MonoGame/Runtime/AnimationFrameColor.cs
+++ b/src/AnimationChain.MonoGame/Runtime/AnimationFrameColor.cs
@@ -1,0 +1,49 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace FlatRedBall.AnimationChain;
+
+/// <summary>
+/// Applies an <see cref="AnimationFrame"/>'s authored color channels to a base draw
+/// <see cref="Color"/>. Used by <see cref="SpriteBatchExtensions.DrawAnimation"/>.
+/// </summary>
+public static class AnimationFrameColor
+{
+    /// <summary>
+    /// Combines <paramref name="frame"/>'s color channels with <paramref name="baseColor"/> and
+    /// returns the resulting <see cref="Color"/> to pass to <see cref="SpriteBatch"/>'s draw call.
+    /// <para>
+    /// <see cref="ColorOperation.Multiply"/> scales R/G/B by <see cref="AnimationFrame.Red"/>/
+    /// <see cref="AnimationFrame.Green"/>/<see cref="AnimationFrame.Blue"/> (unset channels default
+    /// to 255, the identity). <see cref="ColorOperation.Add"/> is not yet applied at runtime — it
+    /// needs a custom shader, since <see cref="SpriteBatch"/> can only multiply, not offset, texture
+    /// color — so RGB passes through unchanged when a frame's operation is <c>Add</c> or <c>null</c>.
+    /// </para>
+    /// <para>
+    /// <see cref="AnimationFrame.Alpha"/> is independent of <see cref="AnimationFrame.ColorOperation"/>
+    /// and always scales the base color's alpha when set.
+    /// </para>
+    /// </summary>
+    public static Color Apply(AnimationFrame frame, Color baseColor)
+    {
+        var result = baseColor;
+
+        if (frame.ColorOperation == ColorOperation.Multiply)
+        {
+            int r = System.Math.Clamp(frame.Red ?? 255, 0, 255);
+            int g = System.Math.Clamp(frame.Green ?? 255, 0, 255);
+            int b = System.Math.Clamp(frame.Blue ?? 255, 0, 255);
+            result.R = (byte)(result.R * r / 255);
+            result.G = (byte)(result.G * g / 255);
+            result.B = (byte)(result.B * b / 255);
+        }
+
+        if (frame.Alpha.HasValue)
+        {
+            int a = System.Math.Clamp(frame.Alpha.Value, 0, 255);
+            result.A = (byte)(result.A * a / 255);
+        }
+
+        return result;
+    }
+}

--- a/src/AnimationChain.MonoGame/SpriteBatchExtensions.cs
+++ b/src/AnimationChain.MonoGame/SpriteBatchExtensions.cs
@@ -23,7 +23,13 @@ public static class SpriteBatchExtensions
     /// <param name="spriteBatch">Must be between <see cref="SpriteBatch.Begin"/> and <see cref="SpriteBatch.End"/>.</param>
     /// <param name="player">The player whose <see cref="AnimationPlayer.CurrentFrame"/> will be drawn.</param>
     /// <param name="position">Top-left draw position in screen pixels (before per-frame offset).</param>
-    /// <param name="color">Tint color. Use <see cref="Color.White"/> for no tint.</param>
+    /// <param name="color">
+    /// Base tint color. Use <see cref="Color.White"/> for no tint. The frame's authored
+    /// <see cref="AnimationFrame.Red"/>/<see cref="AnimationFrame.Green"/>/<see cref="AnimationFrame.Blue"/>
+    /// are multiplied into this when <see cref="AnimationFrame.ColorOperation"/> is
+    /// <see cref="ColorOperation.Multiply"/>, and <see cref="AnimationFrame.Alpha"/> is always
+    /// multiplied into this color's alpha when set. See <see cref="AnimationFrameColor.Apply"/>.
+    /// </param>
     /// <param name="origin">
     /// Pivot point within the source rectangle, in pixels. Defaults to <see cref="Vector2.Zero"/>
     /// (top-left). Pass <c>new Vector2(width/2, height/2)</c> for center-origin drawing.
@@ -54,7 +60,7 @@ public static class SpriteBatchExtensions
             frame.Texture,
             drawPos,
             frame.SourceRectangle,
-            color,
+            AnimationFrameColor.Apply(frame, color),
             0f,
             origin,
             scale,

--- a/tests/AnimationChain.MonoGame.Tests/AnimationChainListSaveRoundTripTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AnimationChainListSaveRoundTripTests.cs
@@ -130,4 +130,71 @@ public class AnimationChainListSaveRoundTripTests
         Assert.Equal(255, frame.Alpha);
         Assert.Equal(ColorOperation.Add, frame.ColorOperation);
     }
+
+    // #793: an omitted channel on a later frame is "sticky" - it holds whatever an earlier frame
+    // in the same chain last set, rather than resetting to null/none.
+    [Fact]
+    public void ToAnimationChainList_LaterFrameOmitsChannel_InheritsEarlierFramesValue()
+    {
+        const string achx = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AnimationChainArraySave>
+              <FileRelativeTextures>false</FileRelativeTextures>
+              <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+              <CoordinateType>UV</CoordinateType>
+              <AnimationChain>
+                <Name>Flash</Name>
+                <Frame>
+                  <TextureName>t.png</TextureName>
+                  <FrameLength>0.1</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate><RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>
+                  <Red>200</Red>
+                  <ColorOperation>Multiply</ColorOperation>
+                </Frame>
+                <Frame>
+                  <TextureName>t.png</TextureName>
+                  <FrameLength>0.1</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate><RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>
+                  <Green>100</Green>
+                </Frame>
+              </AnimationChain>
+            </AnimationChainArraySave>
+            """;
+        var save = AnimationChainListSave.FromFile("f.achx", XmlStream(achx));
+        var list = save.ToAnimationChainList(_ => null);
+        var secondFrame = list["Flash"]![1];
+
+        Assert.Equal(200, secondFrame.Red);
+        Assert.Equal(100, secondFrame.Green);
+        Assert.Equal(ColorOperation.Multiply, secondFrame.ColorOperation);
+    }
+
+    [Fact]
+    public void ToAnimationChainList_ChannelNeverAuthored_StaysNull()
+    {
+        var save = AnimationChainListSave.FromFile("f.achx", XmlStream("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <AnimationChainArraySave>
+              <FileRelativeTextures>false</FileRelativeTextures>
+              <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+              <CoordinateType>UV</CoordinateType>
+              <AnimationChain>
+                <Name>Idle</Name>
+                <Frame>
+                  <TextureName>t.png</TextureName>
+                  <FrameLength>0.1</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate><RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate><BottomCoordinate>1</BottomCoordinate>
+                </Frame>
+              </AnimationChain>
+            </AnimationChainArraySave>
+            """));
+        var list = save.ToAnimationChainList(_ => null);
+        var frame = list["Idle"]![0];
+
+        Assert.Null(frame.Red);
+        Assert.Null(frame.ColorOperation);
+    }
 }

--- a/tests/AnimationChain.MonoGame.Tests/AnimationFrameColorTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AnimationFrameColorTests.cs
@@ -1,0 +1,93 @@
+using FlatRedBall.AnimationChain;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace AnimationChain.MonoGame.Tests;
+
+public class AnimationFrameColorTests
+{
+    [Fact]
+    public void Apply_NoColorOperation_ReturnsBaseColorUnchanged()
+    {
+        var frame = new AnimationFrame { Red = 128, Green = 10, Blue = 10 };
+
+        var result = AnimationFrameColor.Apply(frame, Color.White);
+
+        Assert.Equal(Color.White, result);
+    }
+
+    [Fact]
+    public void Apply_Multiply_ScalesBaseColorByChannels()
+    {
+        var frame = new AnimationFrame
+        {
+            ColorOperation = ColorOperation.Multiply,
+            Red = 128,
+            Green = 255,
+            Blue = 0,
+        };
+
+        var result = AnimationFrameColor.Apply(frame, Color.White);
+
+        Assert.Equal(128, result.R);
+        Assert.Equal(255, result.G);
+        Assert.Equal(0, result.B);
+    }
+
+    [Fact]
+    public void Apply_MultiplyWithUnsetChannel_UsesIdentityDefault()
+    {
+        // Blue never authored -> identity for Multiply is 255 (no change).
+        var frame = new AnimationFrame
+        {
+            ColorOperation = ColorOperation.Multiply,
+            Red = 0,
+        };
+
+        var result = AnimationFrameColor.Apply(frame, new Color(200, 200, 200, 255));
+
+        Assert.Equal(0, result.R);
+        Assert.Equal(200, result.G);
+        Assert.Equal(200, result.B);
+    }
+
+    [Fact]
+    public void Apply_MultiplyWithNegativeChannel_ClampsToZeroInsteadOfWrapping()
+    {
+        var frame = new AnimationFrame
+        {
+            ColorOperation = ColorOperation.Multiply,
+            Red = -50,
+        };
+
+        var result = AnimationFrameColor.Apply(frame, Color.White);
+
+        Assert.Equal(0, result.R);
+    }
+
+    [Fact]
+    public void Apply_AlphaSet_AppliesIndependentlyOfColorOperation()
+    {
+        var frame = new AnimationFrame { Alpha = 128 };
+
+        var result = AnimationFrameColor.Apply(frame, Color.White);
+
+        Assert.Equal(128, result.A);
+        Assert.Equal(255, result.R);
+    }
+
+    [Fact]
+    public void Apply_AddOperation_DoesNotChangeRgb()
+    {
+        // Add is not yet implemented at runtime (requires a custom shader) - RGB passes through.
+        var frame = new AnimationFrame
+        {
+            ColorOperation = ColorOperation.Add,
+            Red = 200,
+        };
+
+        var result = AnimationFrameColor.Apply(frame, Color.White);
+
+        Assert.Equal(Color.White.R, result.R);
+    }
+}


### PR DESCRIPTION
## Summary
- `ToAnimationChainList` now resolves the .achx "sticky" channel semantic (omitted channel inherits the last frame's explicit value), matching the Animation Editor's preview.
- `SpriteBatchExtensions.DrawAnimation` automatically applies `Multiply` (RGB) and `Alpha` (independent of operation) via new `AnimationFrameColor.Apply`, clamping channels to avoid the byte-wraparound bug from #791.
- `Add` is left as authored-only data — `SpriteBatch` can only multiply texture color, not offset it; a custom shader is a follow-up.

Closes #793

## Test plan
- [x] `dotnet test tests/AnimationChain.MonoGame.Tests/` — 58 passed, incl. new sticky-resolution and `AnimationFrameColor.Apply` tests (Multiply scaling, identity defaults, negative-channel clamping, alpha independence, Add pass-through)
- [x] `dotnet build src/AnimationChain.MonoGame/...` and `src/FlatRedBall2.csproj` — 0 new warnings