### PR TITLE
Restore sidebar tool tab after leaving PNG viewer (#686)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -562,6 +562,8 @@ public partial class MainWindow : Window
     private bool _sidebarCollapsedForPng;
     private GridLength _savedTreeRowHeight = new(2, GridUnitType.Star);
     private GridLength _savedSplitterRowHeight = new(4, GridUnitType.Pixel);
+    // Tool tab selected before Diff was forced for a PNG preview (#686) — restored when returning to achx.
+    private TabItem? _sidebarTabBeforePng;
 
     /// <summary>
     /// Collapses the animation-editing sidebar surfaces for a read-only PNG-preview tab (issue #604)
@@ -585,6 +587,8 @@ public partial class MainWindow : Window
             InspectorTab.IsVisible = false;
             HistoryTab.IsVisible = false;
             FilesTab.IsVisible = false;
+            // Remember the achx tool tab so returning from Diff restores Files/History/etc. (#686).
+            _sidebarTabBeforePng = SidebarTabs.SelectedItem as TabItem;
             // Diff is the only PNG surface; select it before hiding Files so the strip never shows
             // a hidden selected tab (blank content).
             DiffBlameTab.IsVisible = true;
@@ -599,11 +603,15 @@ public partial class MainWindow : Window
             InspectorTab.IsVisible = true;
             HistoryTab.IsVisible = true;
             FilesTab.IsVisible = true;
-            // A now-hidden PNG tab can't stay selected or the strip would show blank content — fall
-            // back to the Inspector, the achx editor's default surface.
-            if (ReferenceEquals(SidebarTabs.SelectedItem, DiffBlameTab))
-                SidebarTabs.SelectedItem = InspectorTab;
+            // Diff must not stay selected once hidden (#604). Prefer the tab that was active before
+            // the PNG forced Diff (#686); fall back to Inspector when that tab is gone or invalid.
+            var restore = _sidebarTabBeforePng;
+            SidebarTabs.SelectedItem =
+                restore is { IsVisible: true } && !ReferenceEquals(restore, DiffBlameTab)
+                    ? restore
+                    : InspectorTab;
             DiffBlameTab.IsVisible = false;
+            _sidebarTabBeforePng = null;
         }
         _sidebarCollapsedForPng = png;
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
@@ -1,11 +1,14 @@
 using AnimationEditor.App.Controls;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -238,6 +241,52 @@ public class PngTabTests
             Assert.True(window.FindControl<TabItem>("HistoryTab")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("FilesTab")!.IsVisible);   // Files comes back for the achx editor
             Assert.True(window.FindControl<Grid>("LeftPanelGrid")!.RowDefinitions[0].Height.Value > 0);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task OpenAchxAfterPng_RestoresPriorSidebarTab()
+    {
+        // #686: opening a PNG forces the Diff sidebar tab; returning to the achx tab must restore
+        // whichever tool tab (Files/Textures, History, …) was selected beforehand — not hard-reset
+        // to Inspector.
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var achxPath = WriteAchx(dir, "hero.achx");
+            await window.OpenFileAsTab(achxPath);
+            Dispatcher.UIThread.RunJobs();
+
+            var filesTab = window.FindControl<TabItem>("FilesTab")!;
+            var sidebar = window.FindControl<TabControl>("SidebarTabs")!;
+            sidebar.SelectedItem = filesTab;
+            Assert.Same(filesTab, sidebar.SelectedItem);
+
+            window.OpenPngAsTab(WritePng(dir, "sheet.png"));
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var tabManager = (TabManager)typeof(MainWindow)
+                .GetField("_tabManager", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                .GetValue(window)!;
+            var achxTab = tabManager.Tabs.First(t => t.Path == new FilePath(achxPath));
+            var activateMethod = typeof(MainWindow)
+                .GetMethod("ActivateTabAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            await (Task)activateMethod.Invoke(window, [achxTab])!;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Same(filesTab, sidebar.SelectedItem);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Leaving a PNG viewer tab no longer hard-resets the sidebar to Inspector; `SetSidebarForPng` saves and restores the prior tool tab (Textures/Files, History, etc.).
- Adds a headless regression test covering the #686 repro (Textures → PNG → back to `.achx`).

Closes #686

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ --filter FullyQualifiedName~OpenAchxAfterPng_RestoresPriorSidebarTab`
- [ ] Manual: open `D:\Downloads\asd.achx`, select Textures, double-click `AnimatedSpritesheet.png`, switch back to the `.achx` tab — Textures should stay selected