### PR TITLE
Animation Editor: Browser UI-drive harness for History labels (#690)

### DIFF
--- a/.claude/skills/animation-editor-browser-verify/SKILL.md
+++ b/.claude/skills/animation-editor-browser-verify/SKILL.md
@@ -2,7 +2,8 @@
 name: animation-editor-browser-verify
 description: >-
   Visual proof on Animation Editor WASM without shipping demo hooks. Triggers:
-  browser History screenshot, WasmAppHost ports, canvas wait, FeatureDemos.
+  browser History screenshot, WasmAppHost ports, canvas wait, FeatureDemos,
+  Playwright UI-drive (#690).
 ---
 
 # Animation Editor — Browser Visual Verify
@@ -16,10 +17,14 @@ Shared drive scripts: **`AnimationEditor.Core.Demo.FeatureDemos`** (internal; In
 **Landmine:** never commit `?demo=` / `FeatureDemos.TryRun` wiring into `App.axaml.cs` `BuildView` (or Desktop `MainWindow`). A query-param backdoor mutates undo state on any deployed build.
 
 Default proof path:
-1. Unit-test labels via Core (`CommandDescriptionTests` / `FeatureDemosTests`).
+1. Unit-test labels via Core (`CommandDescriptionTests` / `BrowserUiDriveLabelTests` / `FeatureDemosTests`).
 2. Desktop History PNGs via DocScreenshots `_ScratchCapture` + `FeatureDemos.TryRun`.
-
-Browser screenshot only if desktop isn't enough: add a **temporary local** `#if DEBUG` hook, capture, **revert before merge**.
+3. **True UI-driven Browser proof (#690):** external Playwright at
+   `tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/` (Decision C2).
+   Phase 0: Avalonia.Browser 12.0.1 does **not** expose control ARIA to the DOM — do not
+   rely on Playwright `getByRole`. Phase 1 drives DEBUG `__aeUiAutomation` by B1
+   `AutomationId` and asserts undo Descriptions (A2). Run: `scripts/run-browser-ui-drive.ps1`.
+   **Do not** paste temporary `#if DEBUG` / `?demo=` FeatureDemos hooks into shipping App for this.
 
 ## Run and find the real URL
 
@@ -27,12 +32,12 @@ Browser screenshot only if desktop isn't enough: add a **temporary local** `#if 
 dotnet run --project tools/AnimationEditorAvalonia/src/AnimationEditor.Browser --no-launch-profile --urls "http://127.0.0.1:5420"
 ```
 
-WasmAppHost often **ignores** `--urls` and prints `App url: http://127.0.0.1:<ephemeral>/`. Use that host. Port-in-use on launchSettings HTTPS → kill the listener or keep `--no-launch-profile`.
+WasmAppHost often **ignores** `--urls` and prints `App url: http://127.0.0.1:<ephemeral>/`. Use that host (`AE_BROWSER_URL`). Port-in-use on launchSettings HTTPS → kill the listener or keep `--no-launch-profile`.
 
 ## Wait for load
 
-Avalonia **canvas** — `document.body.innerText` stays empty. Poll `canvas` count ≥ 1 and splash gone, then MCP screenshot. No DOM refs for sidebar tabs.
+Avalonia **canvas** — `document.body.innerText` stays empty. Poll `canvas` count ≥ 1 and splash gone, then screenshot / Playwright. Sidebar tabs are **not** ordinary DOM buttons; use a11y Names (`History`, `Add Animation`, `Undo history`) or CDP `Accessibility.getFullAXTree`. Avalonia.Browser ARIA is **partial** (12.0.1).
 
 ## After capture
 
-Copy PNGs to `tools/AnimationEditorAvalonia/tests/_out/<feature>/` beside desktop output.
+Copy PNGs to `tools/AnimationEditorAvalonia/tests/_out/<feature>/` (UI-drive uses `_out/browser-ui-drive/`).

--- a/.claude/skills/animation-editor-browser-verify/SKILL.md
+++ b/.claude/skills/animation-editor-browser-verify/SKILL.md
@@ -1,30 +1,37 @@
 ---
 name: animation-editor-browser-verify
 description: >-
-  Visual proof on Animation Editor WASM without shipping demo hooks. Triggers:
-  browser History screenshot, WasmAppHost ports, canvas wait, FeatureDemos,
-  Playwright UI-drive (#690).
+  Browser/WASM AE smoke — not a Core/App test mirror. Triggers: AnimationEditor.Browser,
+  Playwright Browser.Ui, WasmAppHost, __aeUiAutomation, FeatureDemos landmine.
 ---
 
 # Animation Editor — Browser Visual Verify
 
-Use when proving a UI change in **`AnimationEditor.Browser`**. Prefer **desktop DocScreenshots + Core.Tests** when that already covers the behavior — browser capture is optional extra evidence.
+Use when the question is **Browser/WASM-specific** (boot, Browser host wiring, Debug automation bridge). Prefer **Core.Tests + desktop Headless/DocScreenshots** for command behavior and desktop UI — see **`animation-editor-testing`**.
 
-Shared drive scripts: **`AnimationEditor.Core.Demo.FeatureDemos`** (internal; InternalsVisibleTo tests/DocScreenshots only).
+Shared desktop drive scripts: **`AnimationEditor.Core.Demo.FeatureDemos`** (internal; InternalsVisibleTo tests/DocScreenshots only) — desktop only, not Browser shipping App.
+
+## When to add a Browser.Ui test
+
+**Add one** only if Headless/desktop cannot catch it, e.g.:
+
+- WASM cold start / sample load / canvas ready
+- Browser-only host wiring (`BrowserHotkeys`, Open Folder FS APIs, no Ctrl+D)
+- “Does the Debug automation bridge still reach real handlers on Browser?”
+
+**Do not** port Core or `[AvaloniaFact]` suites here. Browser Playwright is slow (ephemeral ports, Debug host) and drives a different shell (`BuildView`, not `MainWindow`). Keep a **small smoke set**; grow only when a Browser-specific bug appears. Full “when / how” lives in `tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/README.md`.
 
 ## Do not pollute shipping App code
 
-**Landmine:** never commit `?demo=` / `FeatureDemos.TryRun` wiring into `App.axaml.cs` `BuildView` (or Desktop `MainWindow`). A query-param backdoor mutates undo state on any deployed build.
+**Landmine:** never commit `?demo=` / `FeatureDemos.TryRun` wiring into Browser `App.axaml.cs` `BuildView` (or Desktop `MainWindow`). A query-param backdoor mutates undo state on any deployed build.
 
 Default proof path:
-1. Unit-test labels via Core (`CommandDescriptionTests` / `BrowserUiDriveLabelTests` / `FeatureDemosTests`).
-2. Desktop History PNGs via DocScreenshots `_ScratchCapture` + `FeatureDemos.TryRun`.
-3. **True UI-driven Browser proof (#690):** external Playwright at
-   `tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/` (Decision C2).
-   Phase 0: Avalonia.Browser 12.0.1 does **not** expose control ARIA to the DOM — do not
-   rely on Playwright `getByRole`. Phase 1 drives DEBUG `__aeUiAutomation` by B1
-   `AutomationId` and asserts undo Descriptions (A2). Run: `scripts/run-browser-ui-drive.ps1`.
-   **Do not** paste temporary `#if DEBUG` / `?demo=` FeatureDemos hooks into shipping App for this.
+
+1. Core unit tests for labels/commands (`CommandDescriptionTests` / `BrowserUiDriveLabelTests`).
+2. Desktop History PNGs via DocScreenshots + `FeatureDemos.TryRun`.
+3. Optional Browser smoke: Playwright under `tests/AnimationEditor.Browser.Ui/` — Debug `__aeUiAutomation` clicks by `AutomationId` and dumps undo Descriptions. Run `scripts/run-browser-ui-drive.ps1`.
+
+**Landmine — no Playwright `getByRole` on Avalonia.Browser today:** the canvas host does not expose control ARIA to the DOM (CDP AX tree ≈ page title). Keep `AutomationProperties` for desktop a11y + stable ids; Browser drive uses the Debug bridge, not DOM a11y.
 
 ## Run and find the real URL
 
@@ -32,11 +39,11 @@ Default proof path:
 dotnet run --project tools/AnimationEditorAvalonia/src/AnimationEditor.Browser --no-launch-profile --urls "http://127.0.0.1:5420"
 ```
 
-WasmAppHost often **ignores** `--urls` and prints `App url: http://127.0.0.1:<ephemeral>/`. Use that host (`AE_BROWSER_URL`). Port-in-use on launchSettings HTTPS → kill the listener or keep `--no-launch-profile`.
+WasmAppHost often **ignores** `--urls` and prints `App url: http://127.0.0.1:<ephemeral>/`. Use that host (`AE_BROWSER_URL`). Port-in-use on launchSettings HTTPS → kill the listener or keep `--no-launch-profile`. **Debug** configuration required for `__aeUiAutomation` (omitted from Release).
 
 ## Wait for load
 
-Avalonia **canvas** — `document.body.innerText` stays empty. Poll `canvas` count ≥ 1 and splash gone, then screenshot / Playwright. Sidebar tabs are **not** ordinary DOM buttons; use a11y Names (`History`, `Add Animation`, `Undo history`) or CDP `Accessibility.getFullAXTree`. Avalonia.Browser ARIA is **partial** (12.0.1).
+Avalonia **canvas** — `document.body.innerText` stays empty. Poll `canvas` count ≥ 1, then wait for `globalThis.__aeUiAutomation` (Debug) before driving. Screenshot / assert via the bridge — not DOM refs.
 
 ## After capture
 

--- a/.claude/skills/animation-editor-screenshots/SKILL.md
+++ b/.claude/skills/animation-editor-screenshots/SKILL.md
@@ -5,7 +5,7 @@ description: Generating headless documentation screenshots of the Animation Edit
 
 # Animation Editor — Documentation Screenshots
 
-Headless PNG capture of the Animation Editor's UI, for illustrating documentation pages (Timing, Offsets, Collision, etc.) — not for verifying behavior. For correctness tests, use the **`animation-editor-testing`** skill instead. The two share test infrastructure (`TestServices`, `CreateMainWindow`, `[AvaloniaFact]`, `Dispatcher.UIThread.RunJobs()`) but serve different purposes and audiences — keep scenario code in the project matching its purpose, not the one matching its plumbing.
+Headless PNG capture of the Animation Editor's UI, for illustrating documentation pages (Timing, Offsets, Collision, etc.) — not for verifying behavior. For correctness tests, use **`animation-editor-testing`**. For WASM browser smoke (not a Core/App mirror), see **`animation-editor-browser-verify`**. The DocScreenshots project shares plumbing with App.Tests (`TestServices`, `CreateMainWindow`, `[AvaloniaFact]`) but serves a different purpose — keep scenario code in the project matching its purpose.
 
 ## Where, and why it's a separate project
 

--- a/.claude/skills/animation-editor-testing/SKILL.md
+++ b/.claude/skills/animation-editor-testing/SKILL.md
@@ -34,8 +34,9 @@ A fourth: `window.MouseDown`/`MouseUp` fully pump any `Dispatcher.UIThread.Invok
 
 ## Undo labels vs screenshots
 
-- **Correctness of a command's `Description`:** assert on the command (or `UndoManager.UndoHistory` after `AppCommands`) in Core.Tests — see `CommandDescriptionTests` / `FeatureDemosTests`.
-- **"Show me the History panel":** DocScreenshots / browser verify — **`animation-editor-screenshots`** and **`animation-editor-browser-verify`**. Those drive the same `FeatureDemos` helpers; they do not replace unit asserts.
+- **Correctness of a command's `Description`:** assert on the command (or `UndoManager.UndoHistory` after `AppCommands`) in Core.Tests — see `CommandDescriptionTests` / `FeatureDemosTests` / `BrowserUiDriveLabelTests`.
+- **"Show me the History panel":** DocScreenshots / browser verify — **`animation-editor-screenshots`** and **`animation-editor-browser-verify`**. Desktop DocScreenshots drive `FeatureDemos` helpers; they do not replace unit asserts.
+- **True Browser UI-drive (#690):** Playwright under `tests/AnimationEditor.Browser.Ui/` — click/named a11y path, assert History labels. Never seed History UI models with hand-written strings to "prove" a label.
 
 Never seed History UI models with hand-written strings to "prove" a label.
 ## Service wiring in tests

--- a/.claude/skills/animation-editor-testing/SKILL.md
+++ b/.claude/skills/animation-editor-testing/SKILL.md
@@ -1,22 +1,34 @@
 ---
 name: animation-editor-testing
-description: Writing headless tests for the Animation Editor (Avalonia). Triggers: AnimationEditor.App.Tests, [AvaloniaFact], TestServices, CreateMainWindow, service wiring in tests, UI-thread RunJobs.
+description: >-
+  Headless AE tests — Core first, [AvaloniaFact] only for real UI. Triggers:
+  AnimationEditor.App.Tests, Core.Tests, TestServices, CreateMainWindow, Browser.Ui.
 ---
 
 # Animation Editor — Testing
 
-Headless-test discipline for the Avalonia Animation Editor. Tool layout, the two-panel mental model, and the `FilePath` path-handling rule live in the **`animation-editor`** skill.
+Headless-test discipline for the Avalonia Animation Editor. Tool layout lives in the **`animation-editor`** skill. Browser/WASM smoke lives in **`animation-editor-browser-verify`** (do not mirror Core/App suites there).
 
 ```
-dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/
 dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/
+dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/
 ```
+
+## Pick the right layer (do not duplicate)
+
+| Layer | Project | Use when | Do not use for |
+|---|---|---|---|
+| **Core** | `AnimationEditor.Core.Tests` | Commands, undo `Description`s, selection/state, pure logic | Layout, pointer routing, pixels |
+| **Headless UI** | `AnimationEditor.App.Tests` (`[AvaloniaFact]`) | Desktop visual tree, input routing, control templates — the bug *is* UI | Re-proving Core math; Browser/WASM |
+| **Browser smoke** | `AnimationEditor.Browser.Ui` (Playwright) | Browser-*only* gaps (WASM boot, Browser host wiring, Debug automation bridge). See that folder’s README | Cloning Core/App tests; primary label gate |
+
+Default: **Core `[Fact]`**. Reach for `[AvaloniaFact]` only when the behavior under test genuinely *is* UI. Reach for Browser Playwright only when Headless/desktop cannot catch it — a small smoke set, not a 1:1 port.
 
 ## `[AvaloniaFact]` is a last resort
 
 `[AvaloniaFact]` (from `Avalonia.Headless.XUnit`) runs the test on a headless Avalonia UI thread. It is slow and **deadlocks** on anything that blocks the UI thread waiting for the UI — a code path reaching `Window.ShowDialog` hangs forever with nothing to close the dialog. The `MainWindow` constructor also overwrites injected delegates (`AppCommands.ConfirmAsync`, `PromptStringAsync`, `FileDialogService`), so a stub installed *before* construction is silently lost.
 
-Default to a plain `[Fact]` against `AnimationEditor.Core` (`AppCommands`, commands, `SelectedState`, `AppState`). Reach for `[AvaloniaFact]` only when the behavior under test genuinely *is* UI — layout, control templates, input routing, visual tree. Logic reachable only by reflecting into a private `MainWindow` method is a signal to move it into Core, not to write an `[AvaloniaFact]`.
+Logic reachable only by reflecting into a private `MainWindow` method is a signal to move it into Core, not to write an `[AvaloniaFact]`.
 
 Tests that do need it construct `MainWindow` and drive it with `Dispatcher.UIThread.RunJobs()` between actions — see `WireframePanZoomTests.cs` for the established pattern.
 
@@ -34,11 +46,12 @@ A fourth: `window.MouseDown`/`MouseUp` fully pump any `Dispatcher.UIThread.Invok
 
 ## Undo labels vs screenshots
 
-- **Correctness of a command's `Description`:** assert on the command (or `UndoManager.UndoHistory` after `AppCommands`) in Core.Tests — see `CommandDescriptionTests` / `FeatureDemosTests` / `BrowserUiDriveLabelTests`.
-- **"Show me the History panel":** DocScreenshots / browser verify — **`animation-editor-screenshots`** and **`animation-editor-browser-verify`**. Desktop DocScreenshots drive `FeatureDemos` helpers; they do not replace unit asserts.
-- **True Browser UI-drive (#690):** Playwright under `tests/AnimationEditor.Browser.Ui/` — click/named a11y path, assert History labels. Never seed History UI models with hand-written strings to "prove" a label.
+- **Correctness of a command's `Description`:** Core.Tests (`CommandDescriptionTests` / `FeatureDemosTests` / `BrowserUiDriveLabelTests`).
+- **"Show me the History panel" (desktop):** DocScreenshots + `FeatureDemos` — **`animation-editor-screenshots`**.
+- **Browser/WASM smoke only:** Playwright — **`animation-editor-browser-verify`** + `tests/AnimationEditor.Browser.Ui/README.md`. Not a substitute for Core asserts.
 
 Never seed History UI models with hand-written strings to "prove" a label.
+
 ## Service wiring in tests
 
 Services (`ProjectManager`, `SelectedState`, `AppCommands`, `AppState`, `ApplicationEvents`, `IoManager`, `ObjectFinder`, `UndoManager`) are constructor-injected — no static `Self` accessors, no global state. Production wires them through a `Microsoft.Extensions.DependencyInjection` container in `App.axaml.cs`.

--- a/scripts/run-browser-ui-drive.ps1
+++ b/scripts/run-browser-ui-drive.ps1
@@ -1,0 +1,44 @@
+# Run AnimationEditor.Browser UI-drive Playwright suite (#690).
+# Starts the Browser host if AE_BROWSER_URL is unset, then runs npm test.
+param(
+    [string]$Url = $env:AE_BROWSER_URL,
+    [switch]$SkipLaunch
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$uiDir = Join-Path $repoRoot "tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui"
+$browserProj = Join-Path $repoRoot "tools/AnimationEditorAvalonia/src/AnimationEditor.Browser"
+
+if (-not (Test-Path (Join-Path $uiDir "node_modules"))) {
+    Push-Location $uiDir
+    npm install
+    npm run install-browsers
+    Pop-Location
+}
+
+$browserProc = $null
+try {
+    if (-not $SkipLaunch -and [string]::IsNullOrWhiteSpace($Url)) {
+        $Url = "http://127.0.0.1:5420/"
+        Write-Host "Launching AnimationEditor.Browser at $Url ..."
+        $browserProc = Start-Process -PassThru -NoNewWindow -FilePath "dotnet" -ArgumentList @(
+            "run", "--project", $browserProj, "--no-launch-profile", "--urls", "http://127.0.0.1:5420"
+        )
+        Start-Sleep -Seconds 25
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Url)) {
+        throw "Set AE_BROWSER_URL or omit -SkipLaunch so this script can start the Browser host."
+    }
+
+    $env:AE_BROWSER_URL = $Url
+    Push-Location $uiDir
+    npm test
+    Pop-Location
+}
+finally {
+    if ($browserProc -and -not $browserProc.HasExited) {
+        Stop-Process -Id $browserProc.Id -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -131,7 +131,9 @@
                         <MenuItem Header="Preview Zoom _In"     x:Name="MenuPreviewZoomIn" />
                         <MenuItem Header="Preview Zoom O_ut"    x:Name="MenuPreviewZoomOut" />
                         <Separator />
-                        <MenuItem Header="Show _History" x:Name="MenuShowHistory" />
+                        <MenuItem Header="Show _History" x:Name="MenuShowHistory"
+                                  AutomationProperties.Name="Show History"
+                                  AutomationProperties.AutomationId="show-history" />
                         <Separator />
                         <MenuItem Header="_Theme">
                             <MenuItem Header="_Light"         x:Name="MenuThemeLight"  ToggleType="Radio" />
@@ -460,6 +462,8 @@
                 <TreeView x:Name="AnimTree" Grid.Row="1"
                           Background="{DynamicResource BgCanvas}"
                           SelectionMode="Multiple"
+                          AutomationProperties.Name="Animations"
+                          AutomationProperties.AutomationId="animations-tree"
                           ScrollViewer.VerticalScrollBarVisibility="Visible"
                           ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                           ScrollViewer.AllowAutoHide="False">
@@ -698,7 +702,9 @@
                             Content="+ Add Animation"
                             HorizontalAlignment="Stretch"
                             Height="30"
-                            Foreground="{DynamicResource Ink}" />
+                            Foreground="{DynamicResource Ink}"
+                            AutomationProperties.Name="Add Animation"
+                            AutomationProperties.AutomationId="add-animation" />
                 </Border>
 
                 </Grid>
@@ -713,7 +719,9 @@
                      A single tab strip below the always-visible ANIMATIONS tree. Inspector is the
                      default tab (it's referenced constantly while clicking through frames/chains);
                      Files and History sit behind it. The tree above is never covered by a tab. -->
-                <TabControl x:Name="SidebarTabs" Grid.Row="2"
+                    <TabControl x:Name="SidebarTabs" Grid.Row="2"
+                                AutomationProperties.Name="Sidebar"
+                                AutomationProperties.AutomationId="sidebar-tabs"
                             Padding="0"
                             MinHeight="80"
                             Background="{DynamicResource BgRail}">
@@ -1073,7 +1081,9 @@
                     </TabItem>
 
                     <!-- History (Undo/Redo toolbar + read-only history list) -->
-                    <TabItem x:Name="HistoryTab" Header="History">
+                    <TabItem x:Name="HistoryTab" Header="History"
+                             AutomationProperties.Name="History"
+                             AutomationProperties.AutomationId="history-tab">
                         <Grid RowDefinitions="Auto,*" Background="{DynamicResource BgPanel}">
                             <Border Grid.Row="0"
                                     Background="{DynamicResource BgRail}"
@@ -1089,6 +1099,8 @@
                                             Width="26" Height="26" Padding="0" Margin="0,0,2,0"
                                             HorizontalContentAlignment="Center"
                                             VerticalContentAlignment="Center"
+                                            AutomationProperties.Name="Undo"
+                                            AutomationProperties.AutomationId="history-undo"
                                             ToolTip.Tip="Undo">
                                         <svg:Svg Width="14" Height="14"
                                                  Path="avares://AnimationEditor.Views/Assets/icons/svg/IconUndo.svg"
@@ -1098,6 +1110,8 @@
                                             Width="26" Height="26" Padding="0"
                                             HorizontalContentAlignment="Center"
                                             VerticalContentAlignment="Center"
+                                            AutomationProperties.Name="Redo"
+                                            AutomationProperties.AutomationId="history-redo"
                                             ToolTip.Tip="Redo">
                                         <svg:Svg Width="14" Height="14"
                                                  Path="avares://AnimationEditor.Views/Assets/icons/svg/IconRedo.svg"
@@ -1109,11 +1123,14 @@
                                           Grid.Row="1"
                                           Background="{DynamicResource BgPanel}"
                                           HorizontalScrollBarVisibility="Disabled">
-                                <ItemsControl x:Name="HistoryList">
+                                <ItemsControl x:Name="HistoryList"
+                                              AutomationProperties.Name="Undo history"
+                                              AutomationProperties.AutomationId="undo-history">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="appModels:HistoryEntryVm">
                                             <Border Background="{Binding Background}">
                                                 <TextBlock Text="{Binding Description}"
+                                                           AutomationProperties.Name="{Binding Description}"
                                                            FontSize="11"
                                                            Foreground="{Binding Foreground}"
                                                            Padding="8,3"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -18,6 +18,7 @@ using AnimationEditor.Core.Paths;
 using AnimationEditor.Core.Utilities;
 using AnimationEditor.Views.Controls;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
@@ -354,7 +355,11 @@ public partial class App : Application
             HorizontalAlignment = HorizontalAlignment.Stretch,
             Height = 30,
         };
+        AutomationProperties.SetName(addAnimationButton, "Add Animation");
+        AutomationProperties.SetAutomationId(addAnimationButton, "add-animation");
         var addFrameButton = new Button { IsVisible = false };
+        AutomationProperties.SetName(addFrameButton, "Add Frame");
+        AutomationProperties.SetAutomationId(addFrameButton, "add-frame");
         var addRectButton = new Button { IsVisible = false };
         var addCircleButton = new Button { IsVisible = false };
         var deleteSelectedButton = new Button { IsVisible = false };
@@ -370,6 +375,8 @@ public partial class App : Application
             IsEnabled = false,
         };
         ToolTip.SetTip(historyUndoButton, "Undo");
+        AutomationProperties.SetName(historyUndoButton, "Undo");
+        AutomationProperties.SetAutomationId(historyUndoButton, "history-undo");
         var historyRedoButton = new Button
         {
             Width = 26,
@@ -381,6 +388,8 @@ public partial class App : Application
             IsEnabled = false,
         };
         ToolTip.SetTip(historyRedoButton, "Redo");
+        AutomationProperties.SetName(historyRedoButton, "Redo");
+        AutomationProperties.SetAutomationId(historyRedoButton, "history-redo");
 
         // Phase 8 (#648): mirrors desktop's Move/Magic-Wand edit-mode pill exactly -- two
         // mutually-exclusive ToggleButtons in one bordered group, split corner radii, no gap.
@@ -465,13 +474,22 @@ public partial class App : Application
         // regardless of which sidebar tab is open); we re-push it onto the ItemsControl whenever
         // History becomes selected.
         var historyList = new ItemsControl();
+        AutomationProperties.SetName(historyList, "Undo history");
+        AutomationProperties.SetAutomationId(historyList, "undo-history");
         var historyRows = new List<HistoryRowVm>();
-        historyList.ItemTemplate = new FuncDataTemplate<HistoryRowVm>((row, _) => new TextBlock
+        historyList.ItemTemplate = new FuncDataTemplate<HistoryRowVm>((row, _) =>
         {
-            Text = row!.Text,
-            FontWeight = row.IsCurrent ? Avalonia.Media.FontWeight.Bold : Avalonia.Media.FontWeight.Normal,
-            Opacity = row.IsRedo ? 0.55 : 1.0,
-            Margin = new Thickness(4, 2),
+            var block = new TextBlock
+            {
+                Text = row!.Text,
+                FontWeight = row.IsCurrent ? Avalonia.Media.FontWeight.Bold : Avalonia.Media.FontWeight.Normal,
+                Opacity = row.IsRedo ? 0.55 : 1.0,
+                Margin = new Thickness(4, 2),
+            };
+            // #690: expose the undo Description as the accessible name so Browser Playwright
+            // can assert History labels via the a11y tree (A2), not pixel OCR.
+            AutomationProperties.SetName(block, row.Text);
+            return block;
         });
 
         void RefreshHistoryList()
@@ -1121,6 +1139,8 @@ public partial class App : Application
             VerticalContentAlignment = VerticalAlignment.Center,
             Content = historyContent,
         };
+        AutomationProperties.SetName(historyTab, "History");
+        AutomationProperties.SetAutomationId(historyTab, "history-tab");
         // Phase 12 (#655): "This File" scope only -- TextureListPanel.SetAnimationChainList is
         // re-pushed at every point animationTree.InitializeServices already is (tab switch/close,
         // Open Folder load, AnimationChainsChanged), since there's no single "the loaded file
@@ -1152,6 +1172,8 @@ public partial class App : Application
             Padding = new Thickness(0),
             Items = { inspectorTab, historyTab, filesTab, projectTab },
         };
+        AutomationProperties.SetName(sidebarTabs, "Sidebar");
+        AutomationProperties.SetAutomationId(sidebarTabs, "sidebar-tabs");
         sidebarTabs.Bind(TabControl.BackgroundProperty, sidebarTabs.GetResourceObservable("BgRail"));
 
         // Mirrors desktop's TabItem/TabItem:selected style pair (InkMid unselected, Ink selected)
@@ -1514,6 +1536,8 @@ public partial class App : Application
         var menuPreviewZoomOut = new MenuItem { Header = "Preview Zoom O_ut" };
         menuPreviewZoomOut.Click += (_, _) => previewZoom.StepDown();
         var menuShowHistory = new MenuItem { Header = "Show _History" };
+        AutomationProperties.SetName(menuShowHistory, "Show History");
+        AutomationProperties.SetAutomationId(menuShowHistory, "show-history");
         menuShowHistory.Click += (_, _) => sidebarTabs.SelectedItem = historyTab;
         var menuThemeLight = new MenuItem { Header = "_Light" };
         menuThemeLight.Click += (_, _) => SetTheme(AppTheme.Light);
@@ -1558,11 +1582,12 @@ public partial class App : Application
         // the desktop host uses (MainWindow.WireKeyboard/BuildHotkeyDefinitions), instead of a
         // hand-rolled if/else chain, so keypress-to-gesture matching exists in exactly one place
         // (#748). Ids/gestures below mirror BuildHotkeyDefinitions's save/undo/redo/toggle-
-        // diagnostics entries -- keep them in sync if that table changes. Everything else in the
-        // desktop table is left out: New/Load/Duplicate/panel-zoom-in/panel-zoom-out are
-        // hard-reserved by the browser itself (BrowserHotkeys.ReservedIds -- Ctrl+N/L/D/+/- are
-        // intercepted before the page ever sees them), and Copy/Cut/Paste/Delete/Rename/Space/
-        // Move-up/Move-down have no action to wire in this build yet.
+        // diagnostics/move-up/move-down entries -- keep them in sync if that table changes.
+        // Everything else in the desktop table is left out: New/Load/Duplicate/panel-zoom-in/
+        // panel-zoom-out are hard-reserved by the browser itself (BrowserHotkeys.ReservedIds --
+        // Ctrl+N/L/D/+/- are intercepted before the page ever sees them), and Copy/Cut/Paste/
+        // Delete/Rename/Space have no action to wire in this build yet.
+        // #690: Alt+Up/Down Move is required for UI-driven Browser verify (not browser-reserved).
         var browserHotkeys = BrowserHotkeys.Filter(new List<HotkeyDefinition>
         {
             new()
@@ -1592,6 +1617,18 @@ public partial class App : Application
                 Id = "toggle-diagnostics", Description = "Toggle Render Diagnostics", Category = "View",
                 Gestures = new[] { new HotkeyGesture("F3") },
                 Action = () => ApplyDiagnostics(diagnosticsButton.IsChecked != true),
+            },
+            new()
+            {
+                Id = "move-up", Description = "Move Selected Chain/Frame Up", Category = "Tree",
+                Gestures = new[] { new HotkeyGesture("Up", HotkeyModifiers.Alt) },
+                Action = () => appCommands.HandleReorder(-1),
+            },
+            new()
+            {
+                Id = "move-down", Description = "Move Selected Chain/Frame Down", Category = "Tree",
+                Gestures = new[] { new HotkeyGesture("Down", HotkeyModifiers.Alt) },
+                Action = () => appCommands.HandleReorder(+1),
             },
         });
 
@@ -1986,6 +2023,13 @@ public partial class App : Application
         shell.Children.Add(root);
         shell.Children.Add(notifications);
         shell.Children.Add(hiddenCommandButtons);
+
+#if DEBUG
+        // #690: DEBUG-only Playwright bridge (AutomationId click + undo Description dump).
+        // Fire-and-forget — ImportAsync must not block first paint; Playwright waits for
+        // globalThis.__aeUiAutomation before driving.
+        _ = BrowserUiAutomation.AttachAsync(shell, undoManager);
+#endif
 
         return shell;
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserUiAutomation.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserUiAutomation.cs
@@ -1,0 +1,88 @@
+#if DEBUG
+using System;
+using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+
+namespace AnimationEditor.Browser;
+
+/// <summary>
+/// #690 Phase 1 harness bridge (DEBUG only). Avalonia.Browser 12.0.1 does not expose
+/// control ARIA to the DOM (Phase 0 spike: CDP AX tree is only the page title), so Playwright
+/// cannot <c>getByRole</c>. This bridge uses the same <see cref="AutomationProperties.AutomationId"/>
+/// values (B1) from managed code — click by id, dump undo Descriptions for A2 asserts.
+/// Registers <c>globalThis.__aeUiAutomation</c> via <c>aeUiAutomation.js</c>. Not in Release;
+/// never auto-run from a query string.
+/// </summary>
+internal static partial class BrowserUiAutomation
+{
+    private const string ModuleName = "aeUiAutomation.js";
+
+    private static Control? _root;
+    private static IUndoManager? _undo;
+
+    public static async Task AttachAsync(Control root, IUndoManager undo)
+    {
+        _root = root;
+        _undo = undo;
+        await JSHost.ImportAsync(ModuleName, "../aeUiAutomation.js");
+        Register(ClickByAutomationId, DumpUndoDescriptionsJson);
+    }
+
+    [JSImport("register", ModuleName)]
+    private static partial void Register(
+        [JSMarshalAs<JSType.Function<JSType.String, JSType.Boolean>>] Func<string, bool> clickById,
+        [JSMarshalAs<JSType.Function<JSType.String>>] Func<string> dumpUndoJson);
+
+    private static bool ClickByAutomationId(string automationId)
+    {
+        if (_root is null || string.IsNullOrEmpty(automationId)) return false;
+        var target = _root.GetVisualDescendants()
+            .OfType<Control>()
+            .FirstOrDefault(c => AutomationProperties.GetAutomationId(c) == automationId);
+        if (target is null) return false;
+
+        switch (target)
+        {
+            case Button button:
+                button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                return true;
+            case MenuItem menuItem:
+                menuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+                return true;
+            case TabItem tabItem:
+                if (tabItem.Parent is TabControl tabs)
+                    tabs.SelectedItem = tabItem;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string DumpUndoDescriptionsJson()
+    {
+        if (_undo is null) return "[]";
+        // Manual JSON — Browser WASM trims reflection, so JsonSerializer.Serialize throws
+        // JsonSerializerIsReflectionDisabled under the default publish/trim settings.
+        var parts = _undo.UndoHistory.Select(EscapeJsonString).ToArray();
+        return "[" + string.Join(",", parts) + "]";
+    }
+
+    private static string EscapeJsonString(IUndoableCommand command)
+    {
+        var s = command.Description ?? "";
+        var escaped = s
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal);
+        return "\"" + escaped + "\"";
+    }
+}
+#endif

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/aeUiAutomation.js
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/wwwroot/aeUiAutomation.js
@@ -1,0 +1,9 @@
+// DEBUG harness for #690 Playwright UI-drive. Registers globalThis.__aeUiAutomation so the
+// external runner can click by AutomationId and dump undo Descriptions without DOM ARIA
+// (Avalonia.Browser does not emit control ARIA today).
+export function register(clickById, dumpUndoJson) {
+  globalThis.__aeUiAutomation = {
+    clickByAutomationId: (id) => clickById(id),
+    dumpUndoDescriptionsJson: () => dumpUndoJson(),
+  };
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml
@@ -2,7 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:models="using:AnimationEditor.Core.ViewModels"
              x:Class="AnimationEditor.Views.Controls.AnimationTreeControl">
-    <TreeView x:Name="Tree" SelectionMode="Single">
+    <TreeView x:Name="Tree"
+              SelectionMode="Single"
+              AutomationProperties.Name="Animations"
+              AutomationProperties.AutomationId="animations-tree">
         <TreeView.Styles>
             <Style Selector="TreeViewItem">
                 <Setter Property="IsExpanded" Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
@@ -25,6 +28,7 @@
                     <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Stretch">
                         <Panel Grid.Column="0">
                             <TextBlock Text="{Binding Header}"
+                                       AutomationProperties.Name="{Binding Header}"
                                        Padding="4,2"
                                        Margin="0,0,4,0"
                                        IsVisible="{Binding !IsEditing}"

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AutomationPropertiesNamesTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/AutomationPropertiesNamesTests.cs
@@ -1,0 +1,62 @@
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// #690 Phase 0/1: named automation peers so Browser Playwright (and desktop a11y) can find
+/// History / Animations without coordinate clicking. Names must stay stable — UI drive scripts
+/// and screen readers both depend on them.
+/// </summary>
+public class AutomationPropertiesNamesTests
+{
+    [AvaloniaFact]
+    public void SidebarSurfaces_HaveStableAutomationNames()
+    {
+        var expectedHistoryTab = "History";
+        var expectedUndoHistory = "Undo history";
+        var expectedAnimations = "Animations";
+        var expectedUndo = "Undo";
+        var expectedRedo = "Redo";
+        var expectedSidebar = "Sidebar";
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            var historyTab = window.FindControl<TabItem>("HistoryTab")
+                ?? throw new InvalidOperationException("HistoryTab not found");
+            var historyList = window.FindControl<ItemsControl>("HistoryList")
+                ?? throw new InvalidOperationException("HistoryList not found");
+            var animTree = window.FindControl<TreeView>("AnimTree")
+                ?? throw new InvalidOperationException("AnimTree not found");
+            var undo = window.FindControl<Button>("HistoryUndoButton")
+                ?? throw new InvalidOperationException("HistoryUndoButton not found");
+            var redo = window.FindControl<Button>("HistoryRedoButton")
+                ?? throw new InvalidOperationException("HistoryRedoButton not found");
+            var sidebar = window.FindControl<TabControl>("SidebarTabs")
+                ?? throw new InvalidOperationException("SidebarTabs not found");
+
+            Assert.Equal(expectedHistoryTab, AutomationProperties.GetName(historyTab));
+            Assert.Equal(expectedUndoHistory, AutomationProperties.GetName(historyList));
+            Assert.Equal(expectedAnimations, AutomationProperties.GetName(animTree));
+            Assert.Equal(expectedUndo, AutomationProperties.GetName(undo));
+            Assert.Equal(expectedRedo, AutomationProperties.GetName(redo));
+            Assert.Equal(expectedSidebar, AutomationProperties.GetName(sidebar));
+
+            Assert.Equal("history-tab", AutomationProperties.GetAutomationId(historyTab));
+            Assert.Equal("undo-history", AutomationProperties.GetAutomationId(historyList));
+            Assert.Equal("animations-tree", AutomationProperties.GetAutomationId(animTree));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/.gitignore
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/README.md
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/README.md
@@ -1,0 +1,64 @@
+# AnimationEditor.Browser.Ui (#690)
+
+External **Playwright** harness (Decision **C2**) for UI-driven verification of
+`AnimationEditor.Browser`. Does **not** wire `?demo=` / `FeatureDemos` into shipping App code.
+
+## Decisions
+
+| Decision | Choice | Notes |
+|---|---|---|
+| A — done bar | **A2** assertable History undo labels | Via DEBUG dump of `UndoManager` Descriptions |
+| B — surface | **B1** `AutomationProperties` / AutomationId | Names land on controls; see Phase 0 |
+| C — harness | **C2** external Playwright | `tests/AnimationEditor.Browser.Ui/` |
+
+## Phase 0 spike (Avalonia.Browser 12.0.1) — B1 DOM/ARIA = NO-GO
+
+After setting `AutomationProperties.Name` / `AutomationId` on History, tree, Add Animation:
+
+- CDP `Accessibility.getFullAXTree` exposes **only the page title**
+- DOM has **no** Avalonia control `aria-*` (canvas host only; `body.innerText` empty)
+- Playwright `getByRole('button', { name: 'Add Animation' })` cannot find controls
+
+**Go/no-go:** pure Browser ARIA for Playwright is a dead end on 12.0.1. Keep B1 names for desktop a11y + as stable AutomationIds.
+
+**Phase 1 path:** DEBUG-only `globalThis.__aeUiAutomation` (`BrowserUiAutomation` + `wwwroot/aeUiAutomation.js`) clicks by AutomationId and dumps undo Descriptions. `#if DEBUG` only — not in Release, not query-string activated.
+
+## Prerequisites
+
+1. Node.js 20+
+2. From this folder: `npm install` then `npm run install-browsers`
+3. **Debug** Browser host (Release omits the bridge):
+
+```powershell
+dotnet run --project ../../src/AnimationEditor.Browser --no-launch-profile --urls "http://127.0.0.1:5420"
+```
+
+Use the printed ephemeral `App url:` as `AE_BROWSER_URL`.
+
+## Run
+
+```powershell
+$env:AE_BROWSER_URL = "http://127.0.0.1:<port>/"
+npm test
+```
+
+Or from repo root: `scripts/run-browser-ui-drive.ps1`
+
+## Smoke script
+
+1. Wait for canvas + `__aeUiAutomation`
+2. Click `add-frame` → `add-animation` → `history-tab`
+3. Assert undo Descriptions contain `Add Frame to 'ColorCycle'` and `Add Animation 'NewAnimation'`
+4. Screenshot → `tests/_out/browser-ui-drive/history-after-ui-drive.png`
+
+## Stable AutomationIds (B1)
+
+| Control | Name | AutomationId |
+|---|---|---|
+| History tab | `History` | `history-tab` |
+| History list | `Undo history` | `undo-history` |
+| Animations tree | `Animations` | `animations-tree` |
+| Add Animation | `Add Animation` | `add-animation` |
+| Add Frame (hidden cmd) | `Add Frame` | `add-frame` |
+| Show History menu | `Show History` | `show-history` |
+| Undo / Redo | `Undo` / `Redo` | `history-undo` / `history-redo` |

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/README.md
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/README.md
@@ -1,33 +1,56 @@
-# AnimationEditor.Browser.Ui (#690)
+# AnimationEditor.Browser.Ui
 
-External **Playwright** harness (Decision **C2**) for UI-driven verification of
-`AnimationEditor.Browser`. Does **not** wire `?demo=` / `FeatureDemos` into shipping App code.
+External **Playwright** smoke for `AnimationEditor.Browser` (WASM). This is **not** the primary test suite and **must not** mirror `Core.Tests` / `App.Tests`.
 
-## Decisions
+For where tests belong in general, see skill **`animation-editor-testing`**. For Browser landmines and run tips, see **`animation-editor-browser-verify`**.
 
-| Decision | Choice | Notes |
-|---|---|---|
-| A — done bar | **A2** assertable History undo labels | Via DEBUG dump of `UndoManager` Descriptions |
-| B — surface | **B1** `AutomationProperties` / AutomationId | Names land on controls; see Phase 0 |
-| C — harness | **C2** external Playwright | `tests/AnimationEditor.Browser.Ui/` |
+## What this suite is for
 
-## Phase 0 spike (Avalonia.Browser 12.0.1) — B1 DOM/ARIA = NO-GO
+Prove a **small** set of Browser-only paths that desktop Headless cannot catch:
 
-After setting `AutomationProperties.Name` / `AutomationId` on History, tree, Add Animation:
+- WASM boot → canvas up → Debug automation bridge ready
+- Browser host wiring (actions reachable through `__aeUiAutomation` / Browser-only menus/hotkeys)
+- Optional assertable undo Descriptions after a scripted path (A2), without shipping `?demo=` / FeatureDemos
 
-- CDP `Accessibility.getFullAXTree` exposes **only the page title**
-- DOM has **no** Avalonia control `aria-*` (canvas host only; `body.innerText` empty)
-- Playwright `getByRole('button', { name: 'Add Animation' })` cannot find controls
+Today that is one smoke: Add Frame → Add Animation → open History → assert labels + screenshot.
 
-**Go/no-go:** pure Browser ARIA for Playwright is a dead end on 12.0.1. Keep B1 names for desktop a11y + as stable AutomationIds.
+## What this suite is *not* for
 
-**Phase 1 path:** DEBUG-only `globalThis.__aeUiAutomation` (`BrowserUiAutomation` + `wwwroot/aeUiAutomation.js`) clicks by AutomationId and dumps undo Descriptions. `#if DEBUG` only — not in Release, not query-string activated.
+| Do not add here | Put it here instead |
+|---|---|
+| Undo/command label correctness | `AnimationEditor.Core.Tests` |
+| Desktop input routing / layout | `AnimationEditor.App.Tests` (`[AvaloniaFact]`) |
+| Doc / History PNGs on desktop | `AnimationEditor.DocScreenshots` |
+| “Same test as Headless but on Browser” | Don’t — different shell, high cost, low extra signal |
 
-## Prerequisites
+If Core already covers the behavior, stop. Only add a Browser test when a **Browser-specific** regression or gap showed up (or you are extending this intentional smoke).
 
-1. Node.js 20+
-2. From this folder: `npm install` then `npm run install-browsers`
-3. **Debug** Browser host (Release omits the bridge):
+## How driving works (why not `getByRole`)
+
+Avalonia.Browser paints to a **canvas**. Control ARIA is not exposed to the DOM today, so Playwright `getByRole` cannot find History / Add Animation.
+
+**Debug-only bridge** (`BrowserUiAutomation` + `wwwroot/aeUiAutomation.js`):
+
+1. Controls carry stable `AutomationProperties.AutomationId` (also useful on desktop a11y).
+2. Debug builds register `globalThis.__aeUiAutomation`.
+3. Playwright calls `clickByAutomationId` / `dumpUndoDescriptionsJson` — C# finds the control and raises a real Avalonia click, or reads `UndoManager`.
+
+Not compiled into Release. Not activated by a public query string. Do not replace this with FeatureDemos wiring in shipping `App.axaml.cs`.
+
+## When to add another test
+
+Add a new spec only if **all** are true:
+
+1. Headless/Core cannot catch the failure mode.
+2. The scenario is Browser-host-specific (boot, FS APIs, Browser hotkey filter, bridge wiring, WASM render smoke).
+3. You can keep the suite small (prefer one focused path over combinatorial coverage).
+
+Prefer extending the existing smoke with one more step over adding many near-duplicate specs.
+
+## Prerequisites and run
+
+1. Node.js 20+ — `npm install` then `npm run install-browsers` in this folder.
+2. **Debug** Browser host (Release has no bridge):
 
 ```powershell
 dotnet run --project ../../src/AnimationEditor.Browser --no-launch-profile --urls "http://127.0.0.1:5420"
@@ -35,23 +58,22 @@ dotnet run --project ../../src/AnimationEditor.Browser --no-launch-profile --url
 
 Use the printed ephemeral `App url:` as `AE_BROWSER_URL`.
 
-## Run
-
 ```powershell
 $env:AE_BROWSER_URL = "http://127.0.0.1:<port>/"
 npm test
 ```
 
-Or from repo root: `scripts/run-browser-ui-drive.ps1`
+Or from repo root: `scripts/run-browser-ui-drive.ps1`.
 
-## Smoke script
+## Outputs
 
-1. Wait for canvas + `__aeUiAutomation`
-2. Click `add-frame` → `add-animation` → `history-tab`
-3. Assert undo Descriptions contain `Add Frame to 'ColorCycle'` and `Add Animation 'NewAnimation'`
-4. Screenshot → `tests/_out/browser-ui-drive/history-after-ui-drive.png`
+Under `tools/AnimationEditorAvalonia/tests/_out/browser-ui-drive/` (gitignored):
 
-## Stable AutomationIds (B1)
+- `history-after-ui-drive.png`
+- `undo-descriptions.json`
+- `ax-tree-before.json` / `phase0-findings.md` (ARIA spike evidence)
+
+## Stable AutomationIds
 
 | Control | Name | AutomationId |
 |---|---|---|
@@ -62,3 +84,6 @@ Or from repo root: `scripts/run-browser-ui-drive.ps1`
 | Add Frame (hidden cmd) | `Add Frame` | `add-frame` |
 | Show History menu | `Show History` | `show-history` |
 | Undo / Redo | `Undo` / `Redo` | `history-undo` / `history-redo` |
+
+Expected smoke Descriptions (locked in `BrowserUiDriveLabelTests`):  
+`Add Frame to 'ColorCycle'`, `Add Animation 'NewAnimation'`.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/package-lock.json
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "animation-editor-browser-ui",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "animation-editor-browser-ui",
+      "devDependencies": {
+        "@playwright/test": "^1.51.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/package.json
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "animation-editor-browser-ui",
+  "private": true,
+  "description": "Playwright UI-drive harness for AnimationEditor.Browser (#690). External runner only — does not modify shipping App demo hooks.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "install-browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.51.0"
+  }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/playwright.config.ts
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+
+const outDir = path.join(__dirname, '..', '_out', 'browser-ui-drive');
+
+/**
+ * External Playwright runner for AnimationEditor.Browser (#690 / Decision C2).
+ * Set AE_BROWSER_URL to the live WasmAppHost URL (ephemeral port), e.g.
+ *   http://127.0.0.1:5420/
+ * Launch the Browser project separately — this suite does not embed demo backdoors.
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  retries: 1,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: path.join(outDir, 'playwright-report') }]],
+  use: {
+    baseURL: process.env.AE_BROWSER_URL ?? 'http://127.0.0.1:5420/',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    ...devices['Desktop Chrome'],
+    viewport: { width: 1400, height: 900 },
+  },
+  outputDir: path.join(outDir, 'test-results'),
+});

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/tests/history-ui-drive.spec.ts
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Browser.Ui/tests/history-ui-drive.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * #690 Phase 1 smoke (A2 assertable labels + B1 AutomationIds).
+ *
+ * Phase 0 spike (Avalonia.Browser 12.0.1): DOM/CDP ARIA for Avalonia controls is empty
+ * (AX tree = page title only). Playwright therefore drives DEBUG `globalThis.__aeUiAutomation`
+ * which clicks/dumps by the same AutomationId values set on controls (B1), without shipping
+ * FeatureDemos / `?demo=` hooks.
+ *
+ * Expected undo Descriptions match BrowserUiDriveLabelTests:
+ *   Add Frame to 'ColorCycle'
+ *   Add Animation 'NewAnimation'
+ */
+
+const OUT_DIR = path.join(__dirname, '..', '..', '_out', 'browser-ui-drive');
+
+const EXPECTED_ADD_ANIMATION = "Add Animation 'NewAnimation'";
+const EXPECTED_ADD_FRAME = "Add Frame to 'ColorCycle'";
+
+async function waitForEditorReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => document.querySelectorAll('canvas').length >= 1, null, {
+    timeout: 90_000,
+  });
+  await page.waitForFunction(() => !!(globalThis as any).__aeUiAutomation, null, {
+    timeout: 60_000,
+  });
+}
+
+async function collectAxNames(page: Page): Promise<string[]> {
+  const client = await page.context().newCDPSession(page);
+  const { nodes } = await client.send('Accessibility.getFullAXTree');
+  const names: string[] = [];
+  for (const node of nodes ?? []) {
+    const nameProp = node.name?.value ?? node.name;
+    if (typeof nameProp === 'string' && nameProp.trim().length > 0) names.push(nameProp.trim());
+  }
+  return names;
+}
+
+async function aeClick(page: Page, automationId: string): Promise<boolean> {
+  return page.evaluate((id) => {
+    const bridge = (globalThis as any).__aeUiAutomation;
+    if (!bridge) return false;
+    return !!bridge.clickByAutomationId(id);
+  }, automationId);
+}
+
+async function aeDumpUndo(page: Page): Promise<string[]> {
+  const json = await page.evaluate(() => {
+    const bridge = (globalThis as any).__aeUiAutomation;
+    if (!bridge) return '[]';
+    return bridge.dumpUndoDescriptionsJson();
+  });
+  return JSON.parse(json) as string[];
+}
+
+test.describe('Browser UI-drive History (#690)', () => {
+  test('Add Animation + Add Frame → History lists assertable undo labels', async ({ page }) => {
+    fs.mkdirSync(OUT_DIR, { recursive: true });
+
+    await page.goto('/');
+    await waitForEditorReady(page);
+
+    // Phase 0 evidence: DOM ARIA stays empty even after AutomationProperties are set.
+    const axBefore = await collectAxNames(page);
+    fs.writeFileSync(path.join(OUT_DIR, 'ax-tree-before.json'), JSON.stringify(axBefore, null, 2));
+    fs.writeFileSync(
+      path.join(OUT_DIR, 'phase0-findings.md'),
+      [
+        '# #690 Phase 0 — Avalonia.Browser 12.0.1 a11y spike',
+        '',
+        '- CDP `Accessibility.getFullAXTree` names after load: see `ax-tree-before.json`.',
+        '- Observed: only the document title appears — **no** History / Add Animation / tree peers.',
+        '- DOM `aria-*` on Avalonia controls: none (canvas host only).',
+        '- Verdict: **B1 DOM/ARIA for Playwright getByRole = NO-GO** on this Avalonia version.',
+        '- Phase 1 path: DEBUG `__aeUiAutomation` bridge keyed by B1 `AutomationId` values + A2 dump of undo Descriptions.',
+        '',
+      ].join('\n')
+    );
+
+    expect(await aeClick(page, 'add-frame'), 'click add-frame').toBeTruthy();
+    await page.waitForTimeout(400);
+    expect(await aeClick(page, 'add-animation'), 'click add-animation').toBeTruthy();
+    await page.waitForTimeout(400);
+    expect(await aeClick(page, 'history-tab'), 'open History tab').toBeTruthy();
+    await page.waitForTimeout(600);
+
+    const descriptions = await aeDumpUndo(page);
+    fs.writeFileSync(path.join(OUT_DIR, 'undo-descriptions.json'), JSON.stringify(descriptions, null, 2));
+
+    await page.screenshot({ path: path.join(OUT_DIR, 'history-after-ui-drive.png'), fullPage: true });
+
+    expect(descriptions).toContain(EXPECTED_ADD_ANIMATION);
+    expect(descriptions).toContain(EXPECTED_ADD_FRAME);
+  });
+});

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserHotkeysTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserHotkeysTests.cs
@@ -26,6 +26,8 @@ public class BrowserHotkeysTests
             MakeDefinition("undo"),
             MakeDefinition("redo"),
             MakeDefinition("toggle-diagnostics"),
+            MakeDefinition("move-up"),
+            MakeDefinition("move-down"),
             MakeDefinition("new"),
             MakeDefinition("load"),
             MakeDefinition("duplicate"),
@@ -36,7 +38,7 @@ public class BrowserHotkeysTests
         var filtered = BrowserHotkeys.Filter(hotkeys);
 
         Assert.Equal(
-            new[] { "save", "undo", "redo", "toggle-diagnostics" },
+            new[] { "save", "undo", "redo", "toggle-diagnostics", "move-up", "move-down" },
             filtered.Select(h => h.Id));
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserUiDriveLabelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/BrowserUiDriveLabelTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// #690 A2: expected History labels for the Browser UI-drive smoke path
+/// (Add Animation → Add Frame → open History). Kept in Core so Playwright asserts the same
+/// strings the UndoManager actually stores — not hand-seeded UI models.
+/// </summary>
+public class BrowserUiDriveLabelTests
+{
+    [Fact]
+    public void SmokePath_AddAnimationThenAddFrame_ProducesAssertableDescriptions()
+    {
+        var expectedAddAnimation = "Add Animation 'NewAnimation'";
+        var expectedAddFrame = "Add Frame to 'ColorCycle'";
+
+        var ctx = TestHelpers.SetupFreshAcls();
+        var colorCycle = TestHelpers.MakeChain(ctx.Acls, "ColorCycle", 1);
+        ctx.SelectedState.SelectedChain = colorCycle;
+
+        ctx.AppCommands.AddFrame(colorCycle);
+        ctx.AppCommands.AddNewAnimationChain();
+
+        var descriptions = ctx.UndoManager.UndoHistory.Select(c => c.Description).ToList();
+        Assert.Contains(expectedAddFrame, descriptions);
+        Assert.Contains(expectedAddAnimation, descriptions);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Playwright smoke under `tests/AnimationEditor.Browser.Ui/` for WASM History undo labels (A2), driven by Debug `__aeUiAutomation` after Phase 0 showed Avalonia.Browser exposes no control ARIA to the DOM.
- Lands `AutomationProperties` / AutomationIds on History, tree, and related controls (desktop + browser); wires Browser Alt+Move; documents Core → Headless → Browser-smoke pyramid in skills and the suite README.
- Closes #690

## Test plan
- [ ] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ --filter "FullyQualifiedName~BrowserUiDriveLabelTests|FullyQualifiedName~BrowserHotkeysTests"`
- [ ] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ --filter "FullyQualifiedName~AutomationPropertiesNamesTests"`
- [ ] Start Debug Browser (`dotnet run --project tools/AnimationEditorAvalonia/src/AnimationEditor.Browser --no-launch-profile`), set `AE_BROWSER_URL` to printed App url, run `npm test` in `tests/AnimationEditor.Browser.Ui/` (or `scripts/run-browser-ui-drive.ps1`)
- [ ] Confirm Release Browser build does not expose `__aeUiAutomation`
- [ ] Spot-check desktop History / Add Animation still look normal (AutomationProperties only)
