### PR TITLE
Add LinuxVideoDriver: prefer Wayland with X11 fallback

### DIFF
--- a/design/TODOS.md
+++ b/design/TODOS.md
@@ -4,6 +4,12 @@
 
 Open work only. When an item ships, delete it — don't leave a "landed" breadcrumb. Design decisions and historical context that outlive a TODO belong in skill files, XML docs, or commit messages, not here.
 
+## Wire templates' Program.cs to LinuxVideoDriver.ApplyWaylandFallback()
+
+`FlatRedBall2.Utilities.LinuxVideoDriver.ApplyWaylandFallback()` (added in `src/Utilities/LinuxVideoDriver.cs`) sets `SDL_VIDEODRIVER=wayland,x11` on Linux so games run on native Wayland with an automatic X11 fallback, instead of always going through XWayland. The templates' `MyGame.Desktop/Program.cs` (`frb2-desktop` and `frb2-multiplatform`) should call it as the first line before `new MyGame.Game1()`, but can't yet: the templates resolve `FlatRedBall2.MonoGame`/`FlatRedBall2.Kni` as a floating NuGet package from nuget.org, and the latest published release predates this API. Once a release containing `LinuxVideoDriver` is published, add the call to both templates' `Program.cs`.
+
+Known caveats to flag in that follow-up, not solved by the helper itself: SDL2 on Wayland needs `libdecor` for window borders/titlebar, or the window comes up borderless (the `wayland,x11` fallback won't catch this since Wayland itself still succeeds); and fractional-scaling compositors can rescale the window, since MonoGame/SDL2 HiDPI support on Wayland is imperfect.
+
 ## Remove templates' precompiled Apos.Shapes shader workaround
 
 `templates/frb2-desktop` and `templates/frb2-multiplatform` still import `build/AposShapesPrecompiled.props` and ship precompiled `apos-shapes.xnb` files, even though the engine itself dropped this workaround once Apos.Shapes 0.7.2+ started embedding its shader in the assembly. The templates can't drop it yet because they resolve `FlatRedBall2.MonoGame`/`FlatRedBall2.Kni` as a floating NuGet package from nuget.org (not this repo's source), and the latest published release still depends on a pre-0.7.2 Apos.Shapes.

--- a/src/Utilities/LinuxVideoDriver.cs
+++ b/src/Utilities/LinuxVideoDriver.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace FlatRedBall2.Utilities;
+
+/// <summary>
+/// Decides the SDL_VIDEODRIVER value that makes a Linux build prefer native Wayland,
+/// falling back to X11 (via SDL's comma-separated driver list) when Wayland isn't
+/// available, without overriding a value the user already set.
+/// </summary>
+/// <remarks>
+/// MonoGame/KNI's <c>Game</c> constructor calls SDL_Init before any engine code runs, so
+/// <see cref="ApplyWaylandFallback"/> must be called at the very top of <c>Program.cs</c>,
+/// before constructing the game. Calling it later (e.g. from <c>CustomInitialize</c>) has
+/// no effect, since SDL has already picked a video driver by then.
+/// </remarks>
+public static class LinuxVideoDriver
+{
+    /// <summary>
+    /// Returns the SDL_VIDEODRIVER value to set, or null if nothing should change.
+    /// Pure decision logic, separated from <see cref="ApplyWaylandFallback"/> so it can be
+    /// unit tested without touching real environment variables or the OS platform.
+    /// </summary>
+    /// <param name="isLinux">Whether the current OS is Linux.</param>
+    /// <param name="existingSdlVideoDriver">The current value of the SDL_VIDEODRIVER environment variable, if any.</param>
+    public static string? GetVideoDriverToSet(bool isLinux, string? existingSdlVideoDriver)
+    {
+        if (!isLinux || !string.IsNullOrEmpty(existingSdlVideoDriver))
+        {
+            return null;
+        }
+
+        return "wayland,x11";
+    }
+
+    /// <summary>
+    /// Sets SDL_VIDEODRIVER to prefer Wayland with an X11 fallback on Linux, unless it's
+    /// already set. No-op on non-Linux platforms. Must be called before constructing the
+    /// <c>Game</c> instance; see the remarks on <see cref="LinuxVideoDriver"/>.
+    /// </summary>
+    public static void ApplyWaylandFallback()
+    {
+        var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        var existing = Environment.GetEnvironmentVariable("SDL_VIDEODRIVER");
+        var toSet = GetVideoDriverToSet(isLinux, existing);
+
+        if (toSet != null)
+        {
+            Environment.SetEnvironmentVariable("SDL_VIDEODRIVER", toSet);
+        }
+    }
+}

--- a/src/Utilities/LinuxVideoDriver.cs
+++ b/src/Utilities/LinuxVideoDriver.cs
@@ -46,7 +46,15 @@ public static class LinuxVideoDriver
 
         if (toSet != null)
         {
-            Environment.SetEnvironmentVariable("SDL_VIDEODRIVER", toSet);
+            // Environment.SetEnvironmentVariable only updates .NET's own private
+            // environment-variable table, not the process's real C environment. SDL2 is a
+            // native library that reads SDL_VIDEODRIVER via libc getenv(), so it would never
+            // observe a value set through Environment.SetEnvironmentVariable. Call libc's
+            // setenv() directly so the value is visible to native code in this process.
+            setenv("SDL_VIDEODRIVER", toSet, overwrite: 1);
         }
     }
+
+    [DllImport("libc", EntryPoint = "setenv", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int setenv(string name, string value, int overwrite);
 }

--- a/tests/FlatRedBall2.Tests/Utilities/LinuxVideoDriverTests.cs
+++ b/tests/FlatRedBall2.Tests/Utilities/LinuxVideoDriverTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using FlatRedBall2.Utilities;
 using Shouldly;
 using Xunit;
@@ -6,6 +7,28 @@ namespace FlatRedBall2.Tests.Utilities;
 
 public class LinuxVideoDriverTests
 {
+    // Environment.SetEnvironmentVariable only updates .NET's private environment table, not
+    // the process's real C environment that a native library (SDL2, via getenv()) reads.
+    // ApplyWaylandFallback must go through libc setenv() instead, so this checks the value via
+    // getenv() directly rather than Environment.GetEnvironmentVariable. Only meaningful on
+    // Linux (the divergence between the two stores is Unix-specific); no-ops elsewhere so the
+    // suite still passes on a Windows dev box.
+    [Fact]
+    public void ApplyWaylandFallback_OnLinuxWithNoExistingValue_SetsRealProcessEnvironment()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return;
+        }
+
+        LinuxVideoDriver.ApplyWaylandFallback();
+
+        Marshal.PtrToStringAnsi(getenv("SDL_VIDEODRIVER")).ShouldBe("wayland,x11");
+
+        [DllImport("libc", EntryPoint = "getenv", CallingConvention = CallingConvention.Cdecl)]
+        static extern System.IntPtr getenv(string name);
+    }
+
     [Fact]
     public void GetVideoDriverToSet_NotLinux_ReturnsNull()
     {

--- a/tests/FlatRedBall2.Tests/Utilities/LinuxVideoDriverTests.cs
+++ b/tests/FlatRedBall2.Tests/Utilities/LinuxVideoDriverTests.cs
@@ -1,0 +1,32 @@
+using FlatRedBall2.Utilities;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Utilities;
+
+public class LinuxVideoDriverTests
+{
+    [Fact]
+    public void GetVideoDriverToSet_NotLinux_ReturnsNull()
+    {
+        var result = LinuxVideoDriver.GetVideoDriverToSet(isLinux: false, existingSdlVideoDriver: null);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetVideoDriverToSet_LinuxWithNoExistingValue_ReturnsWaylandWithX11Fallback()
+    {
+        var result = LinuxVideoDriver.GetVideoDriverToSet(isLinux: true, existingSdlVideoDriver: null);
+
+        result.ShouldBe("wayland,x11");
+    }
+
+    [Fact]
+    public void GetVideoDriverToSet_LinuxWithExistingValue_ReturnsNullToRespectOverride()
+    {
+        var result = LinuxVideoDriver.GetVideoDriverToSet(isLinux: true, existingSdlVideoDriver: "x11");
+
+        result.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Closes #805

Adds `FlatRedBall2.Utilities.LinuxVideoDriver`, a static helper that sets `SDL_VIDEODRIVER=wayland,x11` on Linux so SDL tries native Wayland first and falls back to X11 automatically (comma-separated driver list), instead of always going through XWayland translation. Respects an already-set `SDL_VIDEODRIVER` (power-user override).

Decision logic (`GetVideoDriverToSet`) is a pure function, unit tested; `ApplyWaylandFallback()` is the thin OS/env wiring around it.

Must be called at the very top of `Program.cs`, before `new Game1()` — MonoGame/KNI's `Game` ctor calls `SDL_Init` before any engine code runs, so setting the var later has no effect.

**Bug found and fixed during manual verification (WSL2/WSLg):** the first version called `Environment.SetEnvironmentVariable`, which on Linux only updates .NET's own private environment table, not the process's real C environment. SDL2 is native code that reads `SDL_VIDEODRIVER` via libc `getenv()`, so it never saw the write — silent no-op. Fixed by P/Invoking libc `setenv()` directly. Added a Linux-guarded test that checks the value via `getenv()` (not `Environment.GetEnvironmentVariable`) so this can't regress; it no-ops on non-Linux dev boxes and runs for real in CI (`ubuntu-latest`).

**Templates not wired up yet.** `frb2-desktop`/`frb2-multiplatform` resolve `FlatRedBall2.MonoGame`/`FlatRedBall2.Kni` from published NuGet, which predates this API — wiring `Program.cs` now would break the "Build dotnet new templates" CI step. Tracked as a TODO to pick up once a release containing this API is published, same pattern as the existing Apos.Shapes TODO.

Not solved here (flagged in the TODO for whoever does the template wiring): SDL2 on Wayland needs `libdecor` for window borders or you get a borderless window; fractional-scaling compositors can still rescale the window since MonoGame/SDL2 HiDPI on Wayland is imperfect.

## Test plan
- [x] Unit tests for `GetVideoDriverToSet` (not-Linux, Linux+unset, Linux+already-set) and for `ApplyWaylandFallback`'s real process-environment effect
- [x] Full engine test suite green (1207 tests), engine builds clean on both TFMs
- [x] Manually verified end-to-end under WSL2 (Ubuntu 24.04, WSLg) with a throwaway harness referencing this repo's actual `LinuxVideoDriver.cs`, P/Invoking real SDL2 (`libSDL2-2.0.so.0`) to read back which video driver SDL actually picked:
  - Fix applied, Wayland available, no override → SDL picks `wayland`
  - Fix applied, `SDL_VIDEODRIVER=x11` pre-set → respected, stays `x11`
  - Fix not applied (baseline) → SDL defaults to `x11` (XWayland) — confirms this is a real problem
  - Fix applied, Wayland unavailable (`XDG_RUNTIME_DIR` pointed at an empty dir, simulating an aged system) → falls back to `x11` as intended