### PR TITLE
Document Kni Blazor.GL audio pitch/sample-rate gotchas

### DIFF
--- a/frb-skills/multiplatform-conversion/SKILL.md
+++ b/frb-skills/multiplatform-conversion/SKILL.md
@@ -185,8 +185,10 @@ Reference: `AutoEvalKniBlazorSample.BlazorGL`. Each sample's `.BlazorGL` head ow
 3. `dotnet run --project GameName.Desktop/` plays the original game unchanged.
 4. `dotnet run --project GameName.BlazorGL/` serves the dev URL; canvas fills viewport; resizing the window keeps rendering correct (proves `AllowUserResizing` is set).
 
-## Known limitations (as of 2026-04-25)
+## Known limitations (as of 2026-07-30)
 
 - **Tiled external tileset/image resolution on WASM is broken.** `TileMap` itself loads via `TitleContainer.OpenStream`, but `MonoGame.Extended`'s parser still uses `File.IO` for external TSX and image references inside the TMX. Symptom: `External tileset 'Foo.tsx' could not be found`. Tracked in `design/TODOS.md` until upstream exposes a resource-resolution callback or we route around it. A game with no Tiled content (e.g. `samples/ShmupSpace/`) is unaffected.
 - **No gamepad polling guarantee on web.** Browser gamepad APIs require a connected-device gesture before reporting state.
 - **Audio gated by user gesture.** Browsers block audio playback until the user interacts with the page once. Have a "click to start" affordance if music plays on screen entry.
+- **`DynamicSoundEffectInstance` sample rate must match the browser's `AudioContext` rate on Blazor.GL, or `SubmitBuffer` throws** (`Sample rate 44100 does not match AudioContext sample rate 48000`). Desktop OpenAL resamples any source rate for free; Blazor.GL does not, and Kni exposes no public way to read the actual `AudioContext` rate (feature-requested: kniEngine/kni#2690). Until that lands, fall back to a couple of common candidate rates (48000, then 44100) and retry on failure.
+- **`Pitch` on `SoundEffectInstance`/`DynamicSoundEffectInstance` throws on Blazor.GL** with the currently-published Kni NuGet packages. Fixed upstream (kniEngine/kni#2614, #2615) but not yet released — confirmed via `diagnostics/MusicPitchWebSpike`. Re-check once Kni cuts a release containing both.


### PR DESCRIPTION
## Summary
Docs-only. Found while investigating #799: two gotchas invisible from the API surface, now in `multiplatform-conversion`'s Known Limitations.

- `DynamicSoundEffectInstance` needs its sample rate to match the browser's `AudioContext` rate on Blazor.GL, or `SubmitBuffer` throws. No public way to query the actual rate (filed kniEngine/kni#2690).
- `Pitch` on `SoundEffectInstance`/`DynamicSoundEffectInstance` throws on Blazor.GL with currently-published Kni packages. Fixed upstream (kniEngine/kni#2614, #2615), not yet released.

Note: this branch is linked to #799 via `gh issue develop`, so merging will auto-close #799 again even though this is docs-only, not the fix. Reopen it after merging, same as after #807.

## Test plan
N/A — docs only.