### PR TITLE
Fix overlapping selected frames compounding fill alpha to solid blue

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -92,30 +92,34 @@ public class WireframeControl : TextureViewport
     {
         var s = (WireframeSnapshot)snapshot;
 
-        // Frame region rectangles
-        using var frameFill = new SKPaint { Style = SKPaintStyle.Fill };
+        // Frame region rectangles. Fills are batched per selection tier (#817): drawing each
+        // frame's semi-transparent fill directly onto the canvas compounds alpha via normal
+        // SrcOver blending wherever frames overlap (e.g. a whole-chain selection with duplicate
+        // UV rects), saturating toward solid blue. Instead, each tier's fills are drawn opaque
+        // into an offscreen layer (SaveLayerAlpha) — overlapping opaque draws are idempotent —
+        // then the whole layer composites onto the canvas once at the tier's target alpha.
         using var frameStroke = new SKPaint { Style = SKPaintStyle.Stroke, StrokeWidth = 1f };
+        using var solidFill = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(80, 160, 255, 255) };
 
         float revealInflation = RevealAnimation.InflationPixels(s.SelectionRevealProgress);
 
+        var screenRects = new List<(SKRect Sr, bool IsSelected)>(s.Frames.Count);
         foreach (var (bounds, isSelected) in s.Frames)
         {
             var sr = SnapToScreen(bounds, s);
-            if (isSelected)
-            {
-                frameFill.Color = new SKColor(80, 160, 255, 45);
-                frameStroke.Color = new SKColor(80, 160, 255, 230);
-                // One-shot reveal (#542): fixed screen-space pixels (not a multiplier of the
-                // box's own size) so the pop stays visible at any zoom level.
-                if (revealInflation > 0f)
-                    sr = InflateBy(sr, revealInflation);
-            }
-            else
-            {
-                frameFill.Color = new SKColor(80, 160, 255, 18);
-                frameStroke.Color = new SKColor(80, 160, 255, 120);
-            }
-            canvas.DrawRect(sr, frameFill);
+            // One-shot reveal (#542): fixed screen-space pixels (not a multiplier of the box's
+            // own size) so the pop stays visible at any zoom level.
+            if (isSelected && revealInflation > 0f)
+                sr = InflateBy(sr, revealInflation);
+            screenRects.Add((sr, isSelected));
+        }
+
+        DrawFillLayer(canvas, screenRects, solidFill, isSelected: true, alpha: 45);
+        DrawFillLayer(canvas, screenRects, solidFill, isSelected: false, alpha: 18);
+
+        foreach (var (sr, isSelected) in screenRects)
+        {
+            frameStroke.Color = isSelected ? new SKColor(80, 160, 255, 230) : new SKColor(80, 160, 255, 120);
             canvas.DrawRect(sr, frameStroke);
         }
 
@@ -174,6 +178,32 @@ public class WireframeControl : TextureViewport
             using var dotPaint = new SKPaint { Color = new SKColor(255, 220, 0, 230) };
             canvas.DrawCircle(ox, oy, 2f, dotPaint);
         }
+    }
+
+    /// <summary>
+    /// Draws every rect in <paramref name="rects"/> matching <paramref name="isSelected"/> as an
+    /// opaque fill into an offscreen layer, then composites that layer onto <paramref name="canvas"/>
+    /// once at <paramref name="alpha"/> (#817). No-ops when no rect in this tier exists, so the
+    /// layer is never allocated for an empty pass.
+    /// </summary>
+    private static void DrawFillLayer(
+        SKCanvas canvas, List<(SKRect Sr, bool IsSelected)> rects, SKPaint solidFill, bool isSelected, byte alpha)
+    {
+        bool any = false;
+        foreach (var (_, sel) in rects)
+        {
+            if (sel == isSelected) { any = true; break; }
+        }
+        if (!any) return;
+
+        using var layerPaint = new SKPaint { Color = new SKColor(255, 255, 255, alpha) };
+        canvas.SaveLayer(layerPaint);
+        foreach (var (sr, sel) in rects)
+        {
+            if (sel == isSelected)
+                canvas.DrawRect(sr, solidFill);
+        }
+        canvas.Restore();
     }
 
     private static readonly SKColor HoverLabelBackground = new(80, 160, 255, 235);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/VisualRenderTests.cs
@@ -376,6 +376,83 @@ public class VisualRenderTests
     }
 
     /// <summary>
+    /// Regression (#817): two frames with identical, fully-overlapping UV rects both drawn
+    /// selected (whole-chain selection highlights every frame) must NOT compound their fill
+    /// alpha into a darker/more-saturated blue than a single selected frame — the fill is a
+    /// single highlight over the region, not one layer per overlapping frame.
+    /// </summary>
+    [AvaloniaFact]
+    public void WireframeOverlappingSelectedFrames_FillDoesNotCompound()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var png = Path.Combine(dir, "white.png");
+        try
+        {
+            WriteColorPng(png, SKColors.White, size: 64);
+
+            // Single-frame baseline.
+            var ctxSingle = ResetSingletons();
+            var frame0 = new AnimationFrameSave
+            {
+                TextureName      = "white.png",
+                LeftCoordinate   = 0f, TopCoordinate    = 0f,
+                RightCoordinate  = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave()
+            };
+            var chainSingle = new AnimationChainSave { Name = "Single" };
+            chainSingle.Frames.Add(frame0);
+            ctxSingle.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainSingle);
+            ctxSingle.SelectedState.SelectedChain = chainSingle;   // whole-chain select → IsSelected=true
+
+            var ctrlSingle = ctxSingle.CreateWireframeControl();
+            ctrlSingle.LoadTexture(png);
+            ctrlSingle.CenterFitForSize(128, 128);
+            ctrlSingle.RefreshFrames();
+            using var bmSingle = ctrlSingle.RenderToBitmap(128, 128);
+            var pxSingle = bmSingle.GetPixel(30, 30);
+
+            // Two frames, identical UV rects (fully overlapping), whole-chain selected → both
+            // draw the same selected fill over the same screen rect.
+            var ctxDouble = ResetSingletons();
+            var frame1 = new AnimationFrameSave
+            {
+                TextureName      = "white.png",
+                LeftCoordinate   = 0f, TopCoordinate    = 0f,
+                RightCoordinate  = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave()
+            };
+            var frame2 = new AnimationFrameSave
+            {
+                TextureName      = "white.png",
+                LeftCoordinate   = 0f, TopCoordinate    = 0f,
+                RightCoordinate  = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave()
+            };
+            var chainDouble = new AnimationChainSave { Name = "Double" };
+            chainDouble.Frames.Add(frame1);
+            chainDouble.Frames.Add(frame2);
+            ctxDouble.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chainDouble);
+            ctxDouble.SelectedState.SelectedChain = chainDouble;
+
+            var ctrlDouble = ctxDouble.CreateWireframeControl();
+            ctrlDouble.LoadTexture(png);
+            ctrlDouble.CenterFitForSize(128, 128);
+            ctrlDouble.RefreshFrames();
+            using var bmDouble = ctrlDouble.RenderToBitmap(128, 128);
+            var pxDouble = bmDouble.GetPixel(30, 30);
+
+            // Two overlapping selected frames should look identical to one — the highlight is
+            // per-region, not per-frame. Before the fix this compounds (R drops further, e.g.
+            // ~224 for one frame vs. ~199 for two), which this assertion catches.
+            Assert.True(Math.Abs(pxSingle.Red - pxDouble.Red) <= 1,
+                $"Overlapping selected frames should not compound fill alpha; " +
+                $"single R={pxSingle.Red}, double R={pxDouble.Red}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
     /// GetFrameRects reports IsSelected=true only for the frame that matches
     /// SelectedState.SelectedFrame — proving the agent can read selection state
     /// from the control's metadata API.


### PR DESCRIPTION
## Summary
- Overlapping selected frames (whole-chain selection, duplicate UV rects) drew each frame's semi-transparent fill directly, and SkiaSharp's SrcOver blending compounded the alpha into solid blue.
- Fills for each selection tier (selected/unselected) now draw opaque into an offscreen layer (`SaveLayer`) and composite once at the target alpha; outlines still draw per-frame.

## Test plan
- [x] New regression test `WireframeOverlappingSelectedFrames_FillDoesNotCompound` (confirmed it fails on pre-fix code: single R=224 vs double R=199)
- [x] Full `AnimationEditor.App.Tests` suite passes (770/770)

Closes #817