### PR TITLE
Fix cursor hit-test drift when window size != design resolution

### DIFF
--- a/src/Screen.cs
+++ b/src/Screen.cs
@@ -1163,6 +1163,7 @@ public class Screen : ILifecycleEvents
         foreach (var renderable in _gumRenderables)
         {
             if (!renderable.IsOverlay) continue;
+            if (!HasOverlayContent(renderable)) continue;
             var batch = renderable.Batch;
             if (batch != currentBatch)
             {
@@ -1174,6 +1175,13 @@ public class Screen : ILifecycleEvents
         }
         currentBatch?.End(spriteBatch);
     }
+
+    // OverlayRoot/PopupRoot/ModalRoot are registered as overlay renderables for every screen
+    // regardless of whether the game ever populates them. An empty one draws nothing, but Begin()
+    // still runs Gum's shared cursor-hit-test camera to overlayCamera's fixed 1:1 zoom — and since
+    // the overlay pass always runs last each frame, that permanently clobbers whatever zoom the
+    // preceding per-camera pass set (issue #824). Skipping empty overlays avoids the clobber.
+    internal static bool HasOverlayContent(GumRenderable renderable) => renderable.Visual.Children.Count > 0;
 
     // Fire-and-forget timed lifetimes — tracked alongside entities and ticked in Update.
     // Parallel-list (rather than a per-entity field) so the texture-overload helper can attach

--- a/src/UI/GumRenderBatch.cs
+++ b/src/UI/GumRenderBatch.cs
@@ -55,14 +55,31 @@ public class GumRenderBatch : IRenderBatch
     /// <inheritdoc/>
     public void Begin(SpriteBatch spriteBatch, Camera camera)
     {
-        // PixelsPerUnit folds together window-vs-resolution scale AND the FlatRedBall Camera.Zoom.
-        // We drive Gum rendering and Gum hit-testing from a single source — Renderer.Camera.Zoom —
+        // We drive Gum rendering and Gum hit-testing from a single source — Renderer.Camera —
         // which Gum's GetZoomAndMatrix bakes into basicEffect.View, and which
-        // Cursor.XRespectingGumZoomAndBounds reads directly when converting window pixels into
-        // canvas units. Pass null to GumBatch.Begin so we don't double-apply the scale on top
-        // of Camera.Zoom.
-        RenderingLibrary.SystemManagers.Default.Renderer.Camera.Zoom = ResolveZoom(camera);
+        // Cursor.XRespectingGumZoomAndBounds / Camera.ScreenToWorld read directly when converting
+        // window pixels into canvas units (ScreenToWorld is what Gum's own cursor hit-testing
+        // actually uses for FRB2-hosted UI). Pass null to GumBatch.Begin so we don't double-apply
+        // the scale on top of what we just set.
+        SyncCursorCamera(RenderingLibrary.SystemManagers.Default.Renderer.Camera, camera);
         _inner!.Begin(null);
+    }
+
+    /// <summary>
+    /// Syncs <paramref name="gumCamera"/> (Gum's own <c>RenderingLibrary.Camera</c>, a single object
+    /// shared by every <see cref="Begin"/> call in a frame) from this frame's FlatRedBall
+    /// <paramref name="camera"/>. Gum's cursor hit-testing reads <c>Zoom</c> and
+    /// <c>ClientWidth</c>/<c>ClientHeight</c>/<c>ClientLeft</c>/<c>ClientTop</c> off this object, so
+    /// all four must track the real viewport — not just <c>Zoom</c> — or hit-testing drifts from the
+    /// rendered position whenever window size != design resolution (issue #824).
+    /// </summary>
+    internal void SyncCursorCamera(RenderingLibrary.Camera gumCamera, Camera camera)
+    {
+        gumCamera.Zoom = ResolveZoom(camera);
+        gumCamera.ClientWidth = camera.Viewport.Width;
+        gumCamera.ClientHeight = camera.Viewport.Height;
+        gumCamera.ClientLeft = camera.Viewport.X;
+        gumCamera.ClientTop = camera.Viewport.Y;
     }
 
     /// <inheritdoc/>

--- a/tests/FlatRedBall2.Tests/GumHudTests.cs
+++ b/tests/FlatRedBall2.Tests/GumHudTests.cs
@@ -296,4 +296,34 @@ public class GumHudTests
         entityVisualsRoot.HasEvents.ShouldBeFalse();
     }
 
+    // Issue #824: OverlayRoot/PopupRoot/ModalRoot are registered as overlay renderables for every
+    // screen regardless of whether the game ever populates them. DrawOverlay used to Begin() every
+    // registered overlay unconditionally, including empty ones — and since the overlay pass always
+    // runs last each frame, an empty overlay's fixed 1:1 Begin() permanently clobbered the correct
+    // zoom that the preceding per-camera pass had set on Gum's shared cursor-hit-test camera.
+    // HasOverlayContent is the guard that lets DrawOverlay skip empty overlay roots.
+
+    [Fact]
+    public void HasOverlayContent_NoChildren_ReturnsFalse()
+    {
+        var screen = new TestScreen();
+        var emptyRoot = new ContainerRuntime();
+        screen.AddOverlayRoot(emptyRoot);
+        var renderable = screen.GumRenderables.First(r => r.Visual == emptyRoot);
+
+        Screen.HasOverlayContent(renderable).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasOverlayContent_HasChildren_ReturnsTrue()
+    {
+        var screen = new TestScreen();
+        var root = new ContainerRuntime();
+        root.Children.Add(new ContainerRuntime());
+        screen.AddOverlayRoot(root);
+        var renderable = screen.GumRenderables.First(r => r.Visual == root);
+
+        Screen.HasOverlayContent(renderable).ShouldBeTrue();
+    }
+
 }

--- a/tests/FlatRedBall2.Tests/UI/GumRenderBatchTests.cs
+++ b/tests/FlatRedBall2.Tests/UI/GumRenderBatchTests.cs
@@ -33,3 +33,53 @@ public class GumRenderBatchTests
         GumRenderBatch.ScreenSpaceInstance.ResolveZoom(camera).ShouldBe(2f, tolerance: 0.001f);
     }
 }
+
+// Issue #824: Gum's own cursor hit-testing (InteractiveGue.DoUiActivityRecursively) falls back to
+// RenderingLibrary.Camera.ScreenToWorld for FRB2-hosted UI, which reads Zoom AND
+// ClientWidth/ClientHeight/ClientLeft/ClientTop. GumRenderBatch.Begin only ever synced Zoom, so
+// hit-testing drifted from the rendered position whenever window size != design resolution.
+public class GumRenderBatchSyncCursorCameraTests
+{
+    [Fact]
+    public void SyncCursorCamera_WindowLargerThanDesignResolution_SyncsZoomAndClientBounds()
+    {
+        var camera = new Camera();
+        camera.ApplyToHostRect(new Viewport(0, 0, 3840, 2160), orthogonalHeight: 720);
+        var gumCamera = new RenderingLibrary.Camera();
+
+        GumRenderBatch.Instance.SyncCursorCamera(gumCamera, camera);
+
+        gumCamera.Zoom.ShouldBe(3f, tolerance: 0.001f);
+        gumCamera.ClientWidth.ShouldBe(3840);
+        gumCamera.ClientHeight.ShouldBe(2160);
+        gumCamera.ClientLeft.ShouldBe(0);
+        gumCamera.ClientTop.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SyncCursorCamera_NonZeroOriginViewport_SyncsClientLeftAndTop()
+    {
+        var camera = new Camera();
+        camera.ApplyToHostRect(new Viewport(100, 50, 1280, 720), orthogonalHeight: 720);
+        var gumCamera = new RenderingLibrary.Camera();
+
+        GumRenderBatch.Instance.SyncCursorCamera(gumCamera, camera);
+
+        gumCamera.ClientLeft.ShouldBe(100);
+        gumCamera.ClientTop.ShouldBe(50);
+    }
+
+    [Fact]
+    public void SyncCursorCamera_WindowMatchesDesignResolution_ZoomIsOne()
+    {
+        var camera = new Camera();
+        camera.ApplyToHostRect(new Viewport(0, 0, 1280, 720), orthogonalHeight: 720);
+        var gumCamera = new RenderingLibrary.Camera();
+
+        GumRenderBatch.Instance.SyncCursorCamera(gumCamera, camera);
+
+        gumCamera.Zoom.ShouldBe(1f, tolerance: 0.001f);
+        gumCamera.ClientWidth.ShouldBe(1280);
+        gumCamera.ClientHeight.ShouldBe(720);
+    }
+}


### PR DESCRIPTION
## Summary
Gum's shared `RenderingLibrary.Camera` (used for FRB2-hosted UI cursor hit-testing) only ever got `Zoom` synced, never `ClientWidth`/`ClientHeight`/`ClientLeft`/`ClientTop`. Separately, every `Screen`'s unconditional overlay pass (`OverlayRoot`/`PopupRoot`/`ModalRoot`) ran `Begin()` even when empty, and since it always runs last each frame, it permanently reset `Zoom` to the overlay camera's fixed 1:1 value — clobbering the correct zoom the main per-camera pass had just set. Together these made click regions drift from rendered position whenever window/backbuffer size != design resolution.

## Fix
- `GumRenderBatch.Begin` → extracted `SyncCursorCamera`, now syncing all four client-bounds fields alongside `Zoom`.
- `Screen.DrawOverlay` → skip `Begin()`/`Draw()` for overlay renderables with no children (`Screen.HasOverlayContent`), so an empty overlay pass can't clobber the main pass's zoom.

## Tests
5 new tests (3 `GumRenderBatchSyncCursorCameraTests`, 2 `HasOverlayContent` in `GumHudTests.cs`), written failing-first per TDD discipline. Full suite: 1393 passed, 0 failed.

Closes #824