### PR TITLE
List the runnable project first in the templates' .slnx

### DIFF
--- a/templates/frb2-desktop/MyGame.slnx
+++ b/templates/frb2-desktop/MyGame.slnx
@@ -1,4 +1,4 @@
 <Solution>
-  <Project Path="MyGame.Common/MyGame.Common.csproj" />
   <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" />
+  <Project Path="MyGame.Common/MyGame.Common.csproj" />
 </Solution>

--- a/templates/frb2-multiplatform/MyGame.slnx
+++ b/templates/frb2-multiplatform/MyGame.slnx
@@ -1,5 +1,5 @@
 <Solution>
-  <Project Path="MyGame.Common/MyGame.Common.csproj" />
   <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" />
   <Project Path="MyGame.BlazorGL/MyGame.BlazorGL.csproj" />
+  <Project Path="MyGame.Common/MyGame.Common.csproj" />
 </Solution>

--- a/tests/FlatRedBall2.Tests/Packaging/TemplatePackageReferenceTests.cs
+++ b/tests/FlatRedBall2.Tests/Packaging/TemplatePackageReferenceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Shouldly;
 using Xunit;
@@ -46,6 +47,24 @@ public class TemplatePackageReferenceTests
         var csproj = File.ReadAllText(Path.Combine(RepoRoot, relativeCsprojPath));
 
         csproj.ShouldContain("AposShapesPrecompiled.props");
+    }
+
+    // Visual Studio picks the first project in the .slnx as the default startup project, so a
+    // freshly created project that lists the class library first cannot be run without the user
+    // changing that first.
+    [Theory]
+    [InlineData("templates/frb2-desktop/MyGame.slnx")]
+    [InlineData("templates/frb2-multiplatform/MyGame.slnx")]
+    public void TemplateSolution_ListsARunnableProjectFirstAndCommonLast(string relativeSlnxPath)
+    {
+        var projects = Regex.Matches(
+                File.ReadAllText(Path.Combine(RepoRoot, relativeSlnxPath)),
+                @"<Project\s+Path=""([^""]+)""")
+            .Select(match => match.Groups[1].Value)
+            .ToList();
+
+        projects.First().ShouldContain("MyGame.Desktop");
+        projects.Last().ShouldContain("MyGame.Common");
     }
 
     private static string RepoRoot => RepoRootForTests;


### PR DESCRIPTION
Visual Studio takes the first project in the solution as the default startup project, so a project created from either template opened with `MyGame.Common` (a class library) selected and could not be run until the user changed it. Desktop now comes first, Common last.

Verified by installing the template and running `dotnet new frb2-desktop`. Regression test pins the ordering for both templates.

Only affects newly created projects — an already-generated solution needs the swap by hand.