### PR TITLE
Three-line boot in templates, and boot a Glue project by naming it

### DIFF
--- a/.claude/skills/automation-mode/SKILL.md
+++ b/.claude/skills/automation-mode/SKILL.md
@@ -81,11 +81,20 @@ Cursor injection takes screen pixels by default (origin top-left, Y+ down) or wo
 
 ### Screenshots
 
-`record_next_screenshot` arms a capture that the *next* `Draw` fulfills — it responds when the PNG is on disk, not when armed, so it has to be followed by a `step`. This is how to check rendered output without a human: capture, then read the PNG back.
+`record_next_screenshot` arms a capture that a later `Draw` fulfills — it responds when the PNG is on disk, not when armed. This is how to check rendered output without a human: capture, then read the PNG back. An armed capture holds off both draw suppression and `quit`, so it cannot be starved or exited out from under.
 
-Hold stdin open for the whole session and end with an explicit `quit`. Piping a burst of commands that reaches EOF immediately kills the process before the queue is drained — no responses, no PNG, exit code 2. Closing stdin without `quit` is the opposite failure: the game keeps running.
+A whole session can go in one write, `quit` included, with a sleep after it to hold stdin open:
 
-Which is why the game always runs under `timeout N`, the build is chained with `&&` so a failed build cannot fall through to a run, and the artifact is asserted (`test -f shot.png`) rather than assumed. Without those, a game that ignores `quit` or never launched leaves the shell blocked until the tool's own timeout — minutes of wall clock spent looking like a slow build.
+```bash
+(printf '%s\n' '{"cmd":"step","count":3}' \
+   '{"cmd":"record_next_screenshot","path":"shot.png"}' \
+   '{"cmd":"step"}' '{"cmd":"quit"}'; sleep 6) \
+  | timeout 30 ./MyGame.exe --frb-auto > out.log 2>&1
+```
+
+Run the game under `timeout N`, chain the build with `&&` so a failed build cannot fall through to a run, and assert the artifact (`test -f shot.png`) rather than assuming it. Without those, a game that never launched leaves the shell blocked until the tool's own timeout — minutes of wall clock that read as a slow build.
+
+Responses go to stdout and the reader's own log to stderr, so redirect them separately when the log would corrupt your parse.
 
 ## Querying Entities (Zero Config)
 

--- a/.claude/skills/sample-project-setup/SKILL.md
+++ b/.claude/skills/sample-project-setup/SKILL.md
@@ -163,14 +163,14 @@ public Game1()
 #endif
     Content.RootDirectory = "Content";  // REQUIRED for ContentManager.Load of textures/fonts/audio
     IsMouseVisible = true;              // set to false only for keyboard/gamepad-only games
-    FlatRedBall2.FlatRedBallService.Default.PrepareWindow<YourScreen>(_graphics);
 }
 
 protected override void Initialize()
 {
     base.Initialize();
-    FlatRedBall2.FlatRedBallService.Default.Initialize(this);
-    FlatRedBall2.FlatRedBallService.Default.Start<YourScreen>();
+    // Sizes the window, initializes, and starts the screen. A Glue project instead:
+    // Initialize(this, "Content/FrbEditor/YourGame.gluj") — path relative, never rooted.
+    FlatRedBall2.FlatRedBallService.Default.Initialize<YourScreen>(this);
 }
 protected override void Update(GameTime gt)
 {

--- a/frb-skills/camera/SKILL.md
+++ b/frb-skills/camera/SKILL.md
@@ -128,7 +128,7 @@ Camera.Zoom = 0.5f; // zoom out: shows double the world area
 
 `Camera.OrthogonalWidth/Height` do **not** control the actual window pixel size. Window size is set via `DisplaySettings` and applied in two ways:
 
-**Startup** — call `PrepareWindow<T>` from the `Game1` constructor (before `Initialize`) so the window opens at the right size with no flicker:
+**Startup** — `Initialize<T>` sizes the window from the starting screen's `PreferredDisplaySettings`, falling back to the engine's, so set them in the constructor and the window opens at that size:
 ```csharp
 public Game1()
 {
@@ -136,9 +136,9 @@ public Game1()
     var ds = FlatRedBallService.Default.DisplaySettings;
     ds.PreferredWindowWidth  = 1280;
     ds.PreferredWindowHeight = 720;
-    FlatRedBallService.Default.PrepareWindow<MyStartScreen>(_graphics);
 }
 ```
+A Glue project's own display block wins over both — it is applied as the project loads, before sizing.
 
 **Runtime** (settings menu, F11 toggle) — call `ApplyWindowSettings` at any time:
 ```csharp

--- a/frb-skills/engine-overview/SKILL.md
+++ b/frb-skills/engine-overview/SKILL.md
@@ -40,7 +40,7 @@ Each frame runs in this order:
 
 ## Bootstrapping a Game
 
-`Game1.cs` wires the MonoGame loop to FRB: `PrepareWindow<TScreen>` in the constructor, then `FlatRedBallService.Default.Initialize(this)` + `Start<TScreen>()` in `Initialize`, then `Update`/`Draw` each frame. The complete template — including the `GraphicsProfile.HiDef` setup that crashes at startup if omitted — lives in `sample-project-setup`; don't hand-roll it.
+`Game1.cs` wires the MonoGame loop to FRB: `FlatRedBallService.Default.Initialize<TScreen>(this)` in `Initialize` (sizes the window, initializes, starts the screen — or `Initialize(this, "…gluj")` to boot a whole Glue project), then `Update`/`Draw` each frame. The complete template — including the `GraphicsProfile.HiDef` setup that crashes at startup if omitted — lives in `sample-project-setup`; don't hand-roll it.
 
 ## Key Design Rules
 

--- a/frb-skills/glue-project-loading/SKILL.md
+++ b/frb-skills/glue-project-loading/SKILL.md
@@ -8,11 +8,23 @@ description: Run an FRB1/Glue project's .gluj/.glsj/.glej data directly in FRB2,
 FRB2 reads the JSON files Glue writes and builds Screens and Entities from them at runtime. There is
 no generated C#: `src/Glue/` is the whole implementation, `GlueProject` is the entry point.
 
+Booting one is a single call in `Game1.Initialize`, after `base.Initialize()`:
+
+```csharp
+FlatRedBallService.Default.Initialize(this, "Content/FrbEditor/MyGame.gluj");
+```
+
+The project names its own start-up screen, Gum project and resolution, so nothing else is passed —
+the engine wires the screen's `Save`/`Project` itself. **The path must be relative**: it resolves
+through `TitleContainer`, which throws on a rooted path, so an absolute one loads the project and
+then fails every asset it references. To load a project but boot your own screen instead, use
+`Initialize<MyScreen>(game, new EngineInitSettings { GlueProjectFile = … })`.
+
 ## Where to start
 
 | Task | Go to |
 |---|---|
-| Boot a project | `EngineInitSettings.GlueProjectFile` → `FlatRedBallService.GlueProject` |
+| Boot a project | `Initialize(game, "Content/FrbEditor/MyGame.gluj")` |
 | Load without booting | `GlueProject.Load(glujPath, content)` |
 | Find/create an element | `GlueProject.FindScreen`/`FindEntity`/`CreateScreen`/`CreateEntity` |
 | Move between screens | `Screen.MoveToScreen(string glueName)` |
@@ -33,9 +45,9 @@ and an entity can share one.
 ## Landmines
 
 **Assign `Save` inside the `configure` callback, never before it.** The engine retains that callback
-and replays it on `RestartScreen`. Assigning outside means a restarted screen rebuilds with no data —
-a silently *empty* screen rather than an error. `MoveToScreen(string)` already does this correctly;
-match it when calling `Start<GlueScreen>` yourself.
+and replays it on `RestartScreen`; assigning outside means a restarted screen rebuilds with no data —
+a silently *empty* screen rather than an error. Only applies when you construct a `GlueScreen`
+yourself: `Initialize(game, glujPath)` and `MoveToScreen(string)` both do it correctly.
 
 **Loading is tolerant by design: it collects diagnostics instead of throwing.** A project that
 references a type this build cannot construct still loads, minus that object. Check
@@ -63,10 +75,10 @@ the new data. Nothing to call — it registers in `CustomInitialize` whenever
 `FlatRedBallService.SourceContentRoots` is non-empty, so it is dev-only by construction. Opt out with
 `FlatRedBallService.IsGlueHotReloadEnabled` before the first screen starts.
 
-**The reload restart replaces the retained `configure` callback.** Anything else your
-`Start<GlueScreen>` callback did — a difficulty, a seed, a hand-built object — is gone from every
-restart after the first Glue edit, because the replacement only reassigns `Save` and `Project`. Put
-that setup in a `GlueScreen` subclass's `CustomInitialize` or in `RestoreHotReloadState`.
+**The reload restart replaces the retained `configure` callback.** `Save` and `Project` survive —
+the replacement reassigns them — but anything else a callback you passed did, a difficulty or a seed
+or a hand-built object, is gone from every restart after the first Glue edit. Put that setup in a
+`GlueScreen` subclass's `CustomInitialize` or in `RestoreHotReloadState`.
 
 Gum files are left to Gum's own in-place pipeline, and `bin`/`obj` are filtered by
 `ContentDirectoryWatcher.IgnoredDirectories`. `content-hot-reload` covers the watch/copy machinery

--- a/frb-skills/screens/SKILL.md
+++ b/frb-skills/screens/SKILL.md
@@ -140,17 +140,17 @@ MoveToScreen<GameOverScreen>(s =>
 
 ## Starting the First Screen
 
-In `Game1.Initialize`, after `FlatRedBallService.Default.Initialize(this)`:
+In `Game1.Initialize`, after `base.Initialize()`. One call sizes the window, initializes the engine
+and starts the screen:
 
 ```csharp
-FlatRedBallService.Default.Start<MainMenuScreen>();
+FlatRedBallService.Default.Initialize<MainMenuScreen>(this);
+FlatRedBallService.Default.Initialize<GameScreen>(this, configure: s => s.DebugMode = true);
+FlatRedBallService.Default.Initialize(this, "Content/FrbEditor/MyGame.gluj");  // whole Glue project
 ```
 
-`Start<T>` activates the first screen and accepts the same optional configure callback as `MoveToScreen`:
-
-```csharp
-FlatRedBallService.Default.Start<GameScreen>(s => s.DebugMode = true);
-```
+The `configure` callback is the same one `MoveToScreen` takes. `Start<T>` is the boot without a
+`Game` — a headless test, or a game that decides its first screen after initializing.
 
 ## Observability — Screen.Entities and SceneSnapshot
 

--- a/samples/GlueLoaderScratch/Game1.cs
+++ b/samples/GlueLoaderScratch/Game1.cs
@@ -31,15 +31,7 @@ public class Game1 : Game
     protected override void Initialize()
     {
         base.Initialize();
-        FlatRedBallService.Default.Initialize<GlueScreen>(
-            this,
-            new EngineInitSettings { GlueProjectFile = GlueProjectFile },
-            screen =>
-            {
-                var glueProject = FlatRedBallService.Default.GlueProject!;
-                screen.Save = glueProject.StartUpScreen;
-                screen.Project = glueProject;
-            });
+        FlatRedBallService.Default.Initialize(this, GlueProjectFile);
 
         // Inert without --frb-auto. Present so a discrepancy in this test bed can be checked by
         // stepping frames and capturing a screenshot rather than by eye.

--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -38,15 +38,31 @@ internal class AutomationMode
     {
         _engine = engine;
         _output = output ?? Console.Out;
-        _log = log ?? (static message => System.Diagnostics.Debug.WriteLine(message));
+        // stderr, not Debug.WriteLine: this log exists to explain a session that is producing no
+        // responses, and a debugger listener is invisible to whoever is driving the pipe. stdout is
+        // the protocol channel and must stay pure NDJSON.
+        _log = log ?? (static message => Console.Error.WriteLine(message));
     }
 
     internal void Start(System.IO.TextReader? input = null)
     {
-        var reader = input ?? Console.In;
+        var reader = input ?? CreateStandardInputReader();
         var thread = new Thread(() => ReaderLoop(reader)) { IsBackground = true, Name = "AutomationMode.Reader" };
         thread.Start();
     }
+
+    /// <summary>
+    /// Reads stdin as a raw stream rather than through <see cref="Console.In"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Console.In"/> wraps the handle in a console reader that reports EOF immediately
+    /// on a redirected pipe on Windows, even with a writer attached and data pending. The reader
+    /// loop then treats every subsequent read as another EOF and retries forever, so the game gates
+    /// on a step that never arrives: no frames, no Draw, no responses, and nothing on stderr to say
+    /// why. Opening the standard input stream directly bypasses that layer.
+    /// </remarks>
+    internal static System.IO.TextReader CreateStandardInputReader() =>
+        new System.IO.StreamReader(Console.OpenStandardInput());
 
     internal void ProcessLine(string line)
     {
@@ -175,8 +191,12 @@ internal class AutomationMode
             case "set":                    ProcessSetCommand(cmd, frame);                 break;
             case "record_next_screenshot": ProcessRecordNextScreenshotCommand(cmd, frame); break;
             case "quit":
-                try { _engine.Game.Exit(); }
-                catch (InvalidOperationException) { }
+                // A capture armed but not yet drawn would be lost — the back buffer it wants is
+                // only produced by the draw that has not happened. Exit once it has landed.
+                if (HasPendingScreenshot)
+                    _quitAfterScreenshot = true;
+                else
+                    Quit();
                 break;
             default:
                 WriteResponse(new { ok = false, frame, error = $"unknown command: {command}" });
@@ -406,6 +426,23 @@ internal class AutomationMode
     /// <see cref="GraphicsDevice"/> dependency — kept separate from <see cref="FulfillPendingScreenshot"/>
     /// so it can be unit tested without a real graphics device.
     /// </summary>
+    /// <summary>
+    /// Whether a capture is armed and still waiting for a draw.
+    /// </summary>
+    /// <remarks>
+    /// The engine suppresses drawing on every tick it does not grant a frame for, which would
+    /// starve an armed screenshot forever: the back buffer it wants is only produced by a draw.
+    /// </remarks>
+    internal bool HasPendingScreenshot => _pendingScreenshotPath != null;
+
+    private bool _quitAfterScreenshot;
+
+    private void Quit()
+    {
+        try { _engine.Game.Exit(); }
+        catch (InvalidOperationException) { }
+    }
+
     internal bool TryConsumePendingScreenshot(out string? path)
     {
         path = _pendingScreenshotPath;
@@ -436,6 +473,9 @@ internal class AutomationMode
             texture.SaveAsPng(stream, width, height);
 
             WriteResponse(new { ok = true, frame, result = new { path } });
+
+            if (_quitAfterScreenshot)
+                Quit();
         }
         catch (Exception ex)
         {

--- a/src/EngineInitSettings.cs
+++ b/src/EngineInitSettings.cs
@@ -15,7 +15,7 @@ public enum MissingGumFontFileBehavior
 }
 
 /// <summary>
-/// Startup configuration passed to <see cref="FlatRedBallService.Initialize"/>.
+/// Startup configuration passed to <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>.
 /// All properties are read once at initialization time — changes after that call have no effect.
 /// </summary>
 public class EngineInitSettings

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -472,7 +472,14 @@ public class FlatRedBallService
             new KernSmithFontCreator(game.GraphicsDevice);
         GumRenderBatch.Instance.Initialize();
         GumRenderBatch.ScreenSpaceInstance.Initialize();
-        ShapeRenderer.Self.Initialize(game.GraphicsDevice, game.Content);
+        // Guarded because ShapeRenderer is a Gum-side singleton that throws on a second Initialize,
+        // and GumService.Uninitialize does not reset it — so without this, no engine can ever be
+        // initialized after another has shut down. Correct while one graphics device serves the
+        // process, which is every game and every test that reuses its Game. Two live devices would
+        // leave this bound to the first; the fix for that belongs in Gum's UninitializePlatform,
+        // which already resets its sibling renderers.
+        if (!ShapeRenderer.Self.IsInitialized)
+            ShapeRenderer.Self.Initialize(game.GraphicsDevice, game.Content);
 
         // Route Gum Forms popups (ComboBox dropdowns, MenuItem submenus) opened by a control on a
         // camera to that camera's per-camera PopupRoot/ModalRoot, so they draw in that camera's pass
@@ -1214,6 +1221,45 @@ public class FlatRedBallService
     /// polling, content hot-reload, time accumulation, async continuations, and the active
     /// screen's <see cref="Screen.CustomActivity"/> in that order.
     /// </summary>
+    /// <summary>
+    /// Stands the engine back down: destroys the current screen, releases the resources
+    /// <see cref="Initialize(Game, EngineInitSettings)"/> created, and returns Gum to its
+    /// uninitialized state. Safe to call more than once.
+    /// </summary>
+    /// <remarks>
+    /// A game normally never calls this — the process is ending anyway. It exists because Gum keeps
+    /// its project, managers and canvas size in process-wide statics, so a second engine cannot be
+    /// initialized while a first still holds them. Tearing down releases them, which is what lets a
+    /// test own an engine instead of sharing one, and what a hot restart would need.
+    /// <para>
+    /// The engine is reusable afterwards only by constructing a new one: this releases the graphics
+    /// resources tied to the old <c>Game</c>, and re-initializing the same instance is not a case
+    /// anything needs.
+    /// </para>
+    /// </remarks>
+    public void Shutdown()
+    {
+        if (_game is null)
+            return;
+
+        TeardownCurrentScreen();
+        CurrentScreen = new Screen();
+
+        _automationMode = null;
+
+        _gum.Uninitialize();
+
+        _spriteBatch?.Dispose();
+        _spriteBatch = null;
+        _whitePixel?.Dispose();
+        _whitePixel = null;
+
+        _game = null;
+        _graphicsManager = null;
+        GlueProject = null;
+        GlueProjectFile = null;
+    }
+
     public void Update(GameTime gameTime)
     {
         long updateStart = System.Diagnostics.Stopwatch.GetTimestamp();

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -29,7 +29,7 @@ namespace FlatRedBall2;
 /// MonoGame <see cref="Microsoft.Xna.Framework.Game"/> loop.
 /// <para>
 /// Most games access the engine through <see cref="Default"/>, the single static instance,
-/// and call <see cref="Initialize"/>, <see cref="Update"/>, and <see cref="Draw"/> from the
+/// and call <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>, <see cref="Update"/>, and <see cref="Draw"/> from the
 /// matching <c>Game</c> hooks.
 /// </para>
 /// </summary>
@@ -194,9 +194,9 @@ public class FlatRedBallService
     }
 
     /// <summary>
-    /// The MonoGame <see cref="Microsoft.Xna.Framework.Game"/> instance passed to <see cref="Initialize"/>.
+    /// The MonoGame <see cref="Microsoft.Xna.Framework.Game"/> instance passed to <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>.
     /// Use this to call <see cref="Microsoft.Xna.Framework.Game.Exit"/> or access window/graphics properties.
-    /// Throws if accessed before <see cref="Initialize"/> is called.
+    /// Throws if accessed before <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/> is called.
     /// </summary>
     public Game Game => _game ?? throw new InvalidOperationException(
         "FlatRedBallService has not been initialized. Call Initialize() first.");
@@ -206,7 +206,7 @@ public class FlatRedBallService
     /// was given. Its content source is already wired to this engine's loader.
     /// </summary>
     /// <remarks>
-    /// Loading happens during <see cref="Initialize"/> because the project's Gum project has to be
+    /// Loading happens during <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/> because the project's Gum project has to be
     /// known before Gum initializes. Holding the result here spares the caller a second load:
     /// <code>
     /// service.Initialize(game, new EngineInitSettings { GlueProjectFile = "MyGame.gluj" });
@@ -344,15 +344,10 @@ public class FlatRedBallService
         // a game that loaded a project by hand had to call it itself.
         GlueProject?.ApplyDisplaySettings(DisplaySettings);
 
-        // The window is not visible yet — MonoGame shows it when the run loop starts, after
-        // Game.Initialize — so this resize costs nothing on screen.
-        if (ClaimWindowPreparation(typeof(TScreen)) &&
-            game.Services.GetService(typeof(IGraphicsDeviceManager)) is GraphicsDeviceManager graphics)
-        {
-            ApplyWindowSettings<TScreen>(graphics);
-            graphics.ApplyChanges();
-        }
-
+        // Sizing the window is Start's job — ActivateScreen applies the starting screen's window
+        // settings, and does it from the real screen instance rather than a throwaway one. The
+        // window is not visible until the run loop begins, after Game.Initialize, so applying it
+        // there costs nothing on screen.
         Start(WithLoadedProject(configure));
     }
 
@@ -382,26 +377,6 @@ public class FlatRedBallService
 
             configure?.Invoke(screen);
         };
-    }
-
-    private Type? _preparedWindowScreenType;
-
-    /// <summary>
-    /// Whether the window still needs sizing for <paramref name="screenType"/>, recording the claim.
-    /// </summary>
-    /// <remarks>
-    /// A game written against the old boot calls <see cref="PrepareWindow{T}"/> from its constructor
-    /// and then <see cref="Initialize{TScreen}"/>, which would otherwise size the window a second
-    /// time. Keyed by type rather than a bare flag: a game may prepare for one screen and start
-    /// another, and that case does need applying again.
-    /// </remarks>
-    internal bool ClaimWindowPreparation(Type screenType)
-    {
-        if (_preparedWindowScreenType == screenType)
-            return false;
-
-        _preparedWindowScreenType = screenType;
-        return true;
     }
 
     /// <summary>
@@ -523,7 +498,7 @@ public class FlatRedBallService
     /// should use: the pair of the camera whose <see cref="Rendering.Camera.UiRoot"/>/<see cref="Rendering.Camera.PopupRoot"/>/<see cref="Rendering.Camera.ModalRoot"/>
     /// is the control's topmost ancestor, else the (<paramref name="globalPopup"/>, <paramref name="globalModal"/>)
     /// fallback when the control lives under a non-camera root (screen overlay, entity visuals). Wired into
-    /// <see cref="GraphicalUiElement.ResolvePopupRoots"/> at <see cref="Initialize"/> so Gum routes ComboBox/
+    /// <see cref="GraphicalUiElement.ResolvePopupRoots"/> at <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/> so Gum routes ComboBox/
     /// MenuItem popups to the opening camera's per-camera roots — drawn in that camera's pass at its zoom.
     /// </summary>
     internal static (InteractiveGue popup, InteractiveGue modal) ResolvePopupRootsFor(
@@ -992,13 +967,11 @@ public class FlatRedBallService
     /// }
     /// </code>
     /// </example>
-    [Obsolete("Initialize<TScreen> sizes the window itself. Delete this call and pass the screen " +
-              "type to Initialize instead; calling both is harmless but does nothing extra.")]
-    public void PrepareWindow<T>(GraphicsDeviceManager graphics) where T : Screen, new()
-    {
-        if (ClaimWindowPreparation(typeof(T)))
-            ApplyWindowSettings<T>(graphics);
-    }
+    [Obsolete("Starting a screen sizes the window for it, so this is no longer needed. Delete the " +
+              "call and pass the screen type to Initialize instead; calling both is harmless, " +
+              "because the starting screen's settings are applied last either way.")]
+    public void PrepareWindow<T>(GraphicsDeviceManager graphics) where T : Screen, new() =>
+        ApplyWindowSettings<T>(graphics);
 
     private void ApplyWindowSettings<T>(GraphicsDeviceManager graphics) where T : Screen, new()
     {
@@ -1121,7 +1094,7 @@ public class FlatRedBallService
     }
 
     // Sub-systems
-    /// <summary>The MonoGame graphics device. Throws if accessed before <see cref="Initialize"/>.</summary>
+    /// <summary>The MonoGame graphics device. Throws if accessed before <see cref="Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>.</summary>
     public GraphicsDevice GraphicsDevice => _game!.GraphicsDevice;
     /// <summary>
     /// Engine-owned random number source — used by gameplay systems that want a seedable shared instance.

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -312,13 +312,39 @@ public class FlatRedBallService
     /// MonoGame defaults the property to <c>false</c>.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Boots a whole Glue project: loads <paramref name="glueProjectFile"/>, applies the display
+    /// settings it declares, and starts its start-up screen. Call this inside <c>Game.Initialize</c>,
+    /// after <c>base.Initialize()</c>.
+    /// </summary>
+    /// <remarks>
+    /// The project names its own start-up screen, its own Gum project and its own resolution, so
+    /// there is nothing else for the caller to supply — and nothing to pass back in.
+    /// <para>
+    /// The path must be <b>relative</b>: it resolves through <c>TitleContainer</c>, which throws on a
+    /// rooted path, so an absolute one loads the project and then fails every asset it references.
+    /// </para>
+    /// <para>
+    /// Use <see cref="Initialize{TScreen}"/> instead to load a Glue project but boot a screen of
+    /// your own, or to pass a <c>configure</c> callback.
+    /// </para>
+    /// </remarks>
+    public void Initialize(Game game, string glueProjectFile) =>
+        Initialize<Glue.GlueScreen>(
+            game, new EngineInitSettings { GlueProjectFile = glueProjectFile });
+
     public void Initialize<TScreen>(
         Game game, EngineInitSettings? settings = null, Action<TScreen>? configure = null)
         where TScreen : Screen, new()
     {
-        // Before Initialize builds the SpriteBatch and its textures: ApplyChanges can reset the
-        // device, and resizing after those exist would do it underneath them. The window is not
-        // visible yet either way — MonoGame shows it when the run loop starts, after
+        Initialize(game, settings);
+
+        // A Glue project declares the resolution, so it has to be read before the window is sized —
+        // which is why sizing follows the load rather than preceding it. Nothing else applies this;
+        // a game that loaded a project by hand had to call it itself.
+        GlueProject?.ApplyDisplaySettings(DisplaySettings);
+
+        // The window is not visible yet — MonoGame shows it when the run loop starts, after
         // Game.Initialize — so this resize costs nothing on screen.
         if (ClaimWindowPreparation(typeof(TScreen)) &&
             game.Services.GetService(typeof(IGraphicsDeviceManager)) is GraphicsDeviceManager graphics)
@@ -327,8 +353,35 @@ public class FlatRedBallService
             graphics.ApplyChanges();
         }
 
-        Initialize(game, settings);
-        Start(configure);
+        Start(WithLoadedProject(configure));
+    }
+
+    /// <summary>
+    /// Gives a <see cref="Glue.GlueScreen"/> the project and screen data it is about to build from,
+    /// before <paramref name="configure"/> gets its say.
+    /// </summary>
+    /// <remarks>
+    /// The engine loaded the project and knows which screen the project starts on, so requiring the
+    /// caller to hand both back was pure ceremony — and a hazard, since a hot reload replaces the
+    /// caller's callback and would drop wiring that lived only there. Assigned only when unset, so
+    /// a <paramref name="configure"/> that boots a different Glue screen still wins.
+    /// </remarks>
+    private Action<TScreen>? WithLoadedProject<TScreen>(Action<TScreen>? configure)
+        where TScreen : Screen, new()
+    {
+        if (GlueProject is null)
+            return configure;
+
+        return screen =>
+        {
+            if (screen is Glue.GlueScreen glueScreen)
+            {
+                glueScreen.Project ??= GlueProject;
+                glueScreen.Save ??= GlueProject.StartUpScreen;
+            }
+
+            configure?.Invoke(screen);
+        };
     }
 
     private Type? _preparedWindowScreenType;

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -1221,7 +1221,10 @@ public class FlatRedBallService
         {
             if (!_automationMode.TryAdvanceFrame(Time.CurrentFrame))
             {
-                _game!.SuppressDraw();
+                // An armed screenshot still needs one draw to capture — suppressing every
+                // ungranted tick would starve it, since no further step is coming.
+                if (!_automationMode.HasPendingScreenshot)
+                    _game!.SuppressDraw();
                 return;
             }
         }
@@ -1292,6 +1295,12 @@ public class FlatRedBallService
         _syncContext.Update();
 
         CurrentScreen.Update(Time.CurrentFrameTime);
+
+        // Answer the step here rather than in Draw: MonoGame coalesces draws under a fixed timestep,
+        // so three stepped Updates can share one Draw and a caller counting one response per step
+        // waits forever for the rest. A screenshot still has to wait for Draw — the back buffer it
+        // wants does not exist until then — and carries its own response.
+        _automationMode?.FlushStepResponse(Time.CurrentFrame);
 
         _frameProfile.UpdateTotalMs = ProfileClock.Ms(updateStart, System.Diagnostics.Stopwatch.GetTimestamp());
         // FrameTotalMs is finalized at end of Draw (when both Update and Draw measurements exist
@@ -1402,7 +1411,6 @@ public class FlatRedBallService
             CurrentScreen.DrawOverlay(_spriteBatch, RenderDiagnostics, _overlayCamera);
         }
 
-        _automationMode?.FlushStepResponse(Time.CurrentFrame);
         _automationMode?.FulfillPendingScreenshot(gd, Time.CurrentFrame);
 
         _frameProfile.DrawTotalMs = ProfileClock.Ms(drawStart, System.Diagnostics.Stopwatch.GetTimestamp());

--- a/src/FrameTime.cs
+++ b/src/FrameTime.cs
@@ -13,7 +13,7 @@ namespace FlatRedBall2;
 /// <param name="Delta">Time elapsed since the previous frame, multiplied by <see cref="TimeManager.TimeScale"/>.</param>
 /// <param name="UnscaledDelta">Wall-clock time elapsed since the previous frame. Not multiplied by <see cref="TimeManager.TimeScale"/>.</param>
 /// <param name="SinceScreenStart">Time accumulated since the current screen activated; pauses with the screen.</param>
-/// <param name="SinceGameStart">Time accumulated since <see cref="FlatRedBallService.Initialize"/>.</param>
+/// <param name="SinceGameStart">Time accumulated since <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>.</param>
 public readonly record struct FrameTime(TimeSpan Delta, TimeSpan UnscaledDelta, TimeSpan SinceScreenStart, TimeSpan SinceGameStart)
 {
     /// <summary>

--- a/src/GameSynchronizationContext.cs
+++ b/src/GameSynchronizationContext.cs
@@ -10,7 +10,7 @@ namespace FlatRedBall2;
 /// <c>async/await</c> in game code executes within the normal Update loop.
 /// <para>
 /// Set as the active <see cref="SynchronizationContext"/> during
-/// <see cref="FlatRedBallService.Initialize"/>. Call <see cref="Update"/>
+/// <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>. Call <see cref="Update"/>
 /// once per frame (after task completion logic, before screen activity).
 /// Call <see cref="Clear"/> on screen transition to discard stale continuations.
 /// </para>

--- a/src/Glue/GlueTileBuilder.cs
+++ b/src/Glue/GlueTileBuilder.cs
@@ -60,11 +60,12 @@ internal static class GlueTileBuilder
     /// Builds every tile object in <paramref name="namedObjects"/>, in dependency order, adding what
     /// it creates to <paramref name="objects"/>.
     /// </summary>
-    /// <param name="builder">
-    /// Applies each object's authored instructions. Tile objects are built here rather than in the
-    /// construct-and-configure pass, and skipping that pass skipped its instruction step with it —
-    /// so <c>Visible</c> on a collection, and every other authored value, was silently dropped.
-    /// </param>
+    /// <remarks>
+    /// <paramref name="builder"/> applies each object's authored instructions. Tile objects are built
+    /// here rather than in the construct-and-configure pass, and skipping that pass skipped its
+    /// instruction step with it — so <c>Visible</c> on a collection, and every other authored value,
+    /// was silently dropped.
+    /// </remarks>
     internal static void Build(
         List<NamedObjectSave> namedObjects,
         string? elementName,

--- a/src/TimeManager.cs
+++ b/src/TimeManager.cs
@@ -45,7 +45,7 @@ public class TimeManager
     public TimeSpan CurrentScreenTime => _sinceScreenStart;
 
     /// <summary>
-    /// Elapsed wall-clock time since <see cref="FlatRedBallService.Initialize"/> was called.
+    /// Elapsed wall-clock time since <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/> was called.
     /// Unaffected by <see cref="TimeScale"/> and unaffected by screen pause — strictly monotonic.
     /// "Unscaled" specifically means "not multiplied by <see cref="TimeScale"/>." Use this for input
     /// gestures (double-click thresholds, hold timers) and any other timing that should not freeze
@@ -53,7 +53,7 @@ public class TimeManager
     /// </summary>
     public TimeSpan UnscaledTimeSinceStart => _unscaledSinceGameStart;
 
-    /// <summary>Total number of frames that have elapsed since <see cref="FlatRedBallService.Initialize"/> was called.</summary>
+    /// <summary>Total number of frames that have elapsed since <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/> was called.</summary>
     public long CurrentFrame { get; private set; }
 
     // -------------------------------------------------------------------------

--- a/src/UI/GumRenderBatch.cs
+++ b/src/UI/GumRenderBatch.cs
@@ -33,7 +33,7 @@ public class GumRenderBatch : IRenderBatch
     /// <summary>
     /// Creates the inner <c>RenderingLibrary.Graphics.GumBatch</c>.
     /// Must be called after the engine's <c>GumService</c> has been initialized.
-    /// Called automatically by <see cref="FlatRedBallService.Initialize"/>.
+    /// Called automatically by <see cref="FlatRedBallService.Initialize(Microsoft.Xna.Framework.Game, EngineInitSettings)"/>.
     /// </summary>
     internal void Initialize()
     {

--- a/templates/frb2-desktop/MyGame.Common/Game1.cs
+++ b/templates/frb2-desktop/MyGame.Common/Game1.cs
@@ -16,14 +16,12 @@ public class Game1 : Game
         _graphics.GraphicsProfile = GraphicsProfile.HiDef;
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
-        FlatRedBallService.Default.PrepareWindow<GameScreen>(_graphics);
     }
 
     protected override void Initialize()
     {
         base.Initialize();
-        FlatRedBallService.Default.Initialize(this);
-        FlatRedBallService.Default.Start<GameScreen>();
+        FlatRedBallService.Default.Initialize<GameScreen>(this);
     }
 
     protected override void Update(GameTime gameTime)

--- a/templates/frb2-multiplatform/MyGame.Common/Game1.cs
+++ b/templates/frb2-multiplatform/MyGame.Common/Game1.cs
@@ -22,14 +22,12 @@ public class Game1 : Game
 #endif
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
-        FlatRedBallService.Default.PrepareWindow<GameScreen>(_graphics);
     }
 
     protected override void Initialize()
     {
         base.Initialize();
-        FlatRedBallService.Default.Initialize(this);
-        FlatRedBallService.Default.Start<GameScreen>();
+        FlatRedBallService.Default.Initialize<GameScreen>(this);
     }
 
     protected override void Update(GameTime gameTime)

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
@@ -548,4 +548,53 @@ public class AutomationModeScreenshotTests
 
         second.ShouldBeFalse();
     }
+
+    // A stepped frame answers even when no draw follows it. MonoGame coalesces draws under a fixed
+    // timestep, so three stepped Updates can share one Draw — a caller that counts one response per
+    // step then waits forever for the other two.
+    [Fact]
+    public void FlushStepResponse_ThreeStepsAcrossOneDraw_AnswersThreeTimes()
+    {
+        var output = new StringWriter();
+        var mode = new AutomationMode(new FlatRedBallService(), output);
+        mode.ProcessLine("{\"cmd\":\"step\",\"count\":3}");
+
+        for (long frame = 1; frame <= 3; frame++)
+        {
+            mode.TryAdvanceFrame(frame);
+            mode.FlushStepResponse(frame);
+        }
+
+        output.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries).Length.ShouldBe(3);
+    }
+
+    // The engine reads this to decide whether it may suppress the draw, and quit reads it to decide
+    // whether it may exit yet — an armed capture needs a draw that neither would otherwise allow.
+    [Fact]
+    public void HasPendingScreenshot_ArmedThenConsumed_TracksTheCapture()
+    {
+        var mode = new AutomationMode(new FlatRedBallService(), new StringWriter());
+        mode.HasPendingScreenshot.ShouldBeFalse();
+
+        mode.ProcessLine("{\"cmd\":\"record_next_screenshot\",\"path\":\"out.png\"}");
+        mode.TryAdvanceFrame(0);
+        mode.HasPendingScreenshot.ShouldBeTrue();
+
+        mode.TryConsumePendingScreenshot(out _);
+        mode.HasPendingScreenshot.ShouldBeFalse();
+    }
+
+    // Console.In wraps stdin in a console reader that reports EOF immediately on a redirected pipe
+    // on Windows, with a writer attached and data pending. The reader loop then retries that same
+    // EOF forever: no command is ever queued, no frame is granted, no Draw runs, and nothing is
+    // written back — a session that looks hung for no visible reason. Every test here injects its
+    // own reader, so this is the one line of the input path tests would otherwise never touch.
+    [Fact]
+    public void CreateStandardInputReader_DoesNotReadThroughTheConsoleReader()
+    {
+        var reader = AutomationMode.CreateStandardInputReader();
+
+        reader.ShouldBeOfType<StreamReader>();
+        reader.ShouldNotBeSameAs(Console.In);
+    }
 }

--- a/tests/FlatRedBall2.Tests/FlatRedBallServiceTests.cs
+++ b/tests/FlatRedBall2.Tests/FlatRedBallServiceTests.cs
@@ -7,32 +7,6 @@ namespace FlatRedBall2.Tests;
 
 public class FlatRedBallServiceTests
 {
-    private sealed class FirstScreen : Screen { }
-    private sealed class SecondScreen : Screen { }
-
-    // Initialize<T> sizes the window itself, but a game written against the old two-call boot still
-    // calls PrepareWindow from its constructor. Applying the same settings twice would ApplyChanges
-    // a second time on a device that is already correct, so the second claim is refused.
-    [Fact]
-    public void ClaimWindowPreparation_TheSameScreenTwice_IsRefusedTheSecondTime()
-    {
-        var engine = new FlatRedBallService();
-
-        engine.ClaimWindowPreparation(typeof(FirstScreen)).ShouldBeTrue();
-        engine.ClaimWindowPreparation(typeof(FirstScreen)).ShouldBeFalse();
-    }
-
-    // Refusing on any prior claim would leave the window sized for a screen the game is not
-    // starting — a game may prepare for one screen and boot into another.
-    [Fact]
-    public void ClaimWindowPreparation_ADifferentScreen_IsAllowed()
-    {
-        var engine = new FlatRedBallService();
-        engine.ClaimWindowPreparation(typeof(FirstScreen));
-
-        engine.ClaimWindowPreparation(typeof(SecondScreen)).ShouldBeTrue();
-    }
-
     [Fact]
     public void ApplyClientSizeChange_NormalizedRightHalf_ProducesRightHalfPixelViewportAndDerivedOrthoWidth()
     {

--- a/tests/FlatRedBall2.Tests/Glue/GlueDisplayTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueDisplayTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using FlatRedBall2.Entities;
@@ -50,6 +51,155 @@ public class GlueDisplayTests
         target.FixedAspectRatio!.Value.ShouldBe(8f / 7f, tolerance: 0.0001);
         target.DominantAxis.ShouldBe(DominantAxis.Height);
         target.WindowMode.ShouldBe(WindowMode.Windowed);
+    }
+
+    // A hand-built block, so each field can be varied on its own — the fixture projects only cover
+    // the combinations they happen to use, and an unmapped field looks identical to a mapped one
+    // whose project happens to want the default.
+    private static FlatRedBall2.Glue.Model.DisplaySettings Block() => new()
+    {
+        GenerateDisplayCode = true,
+        ResolutionWidth = 320,
+        ResolutionHeight = 240,
+        Scale = 100,
+        ScaleGum = 100,
+        TextureFilter = 1,
+        Is2D = true,
+        DominantInternalCoordinates = 1,
+    };
+
+    private static DisplaySettings Applied(
+        Action<FlatRedBall2.Glue.Model.DisplaySettings> author,
+        List<GlueLoadDiagnostic>? diagnostics = null)
+    {
+        var source = Block();
+        author(source);
+        var target = new DisplaySettings();
+        GlueDisplayMapper.Apply(source, target, diagnostics ?? new());
+        return target;
+    }
+
+    // Both sides declare StretchVisibleArea then IncreaseVisibleArea, so the mapper casts the
+    // ordinal. If either side ever reorders, a project silently gets the other resize behaviour.
+    [Theory]
+    [InlineData(0, ResizeMode.StretchVisibleArea)]
+    [InlineData(1, ResizeMode.IncreaseVisibleArea)]
+    public void Apply_ResizeBehavior_MapsOntoResizeMode(int authored, ResizeMode expected) =>
+        Applied(s => s.ResizeBehavior = authored).ResizeMode.ShouldBe(expected);
+
+    [Theory]
+    [InlineData(0, DominantAxis.Width)]
+    [InlineData(1, DominantAxis.Height)]
+    public void Apply_DominantInternalCoordinates_MapsOntoDominantAxis(int authored, DominantAxis expected) =>
+        Applied(s => s.DominantInternalCoordinates = authored).DominantAxis.ShouldBe(expected);
+
+    [Theory]
+    [InlineData(true, WindowMode.FullscreenBorderless)]
+    [InlineData(false, WindowMode.Windowed)]
+    public void Apply_RunInFullScreen_MapsOntoWindowMode(bool authored, WindowMode expected) =>
+        Applied(s => s.RunInFullScreen = authored).WindowMode.ShouldBe(expected);
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Apply_AllowWindowResizing_MapsOntoAllowUserResizing(bool authored) =>
+        Applied(s => s.AllowWindowResizing = authored).AllowUserResizing.ShouldBe(authored);
+
+    [Fact]
+    public void Apply_Scale_SizesTheWindowFromResolution()
+    {
+        var target = Applied(s => s.Scale = 300);
+
+        target.PreferredWindowWidth.ShouldBe(960);
+        target.PreferredWindowHeight.ShouldBe(720);
+        // The world is still the authored resolution — scale is a window multiplier, not a resize.
+        target.ResolutionWidth.ShouldBe(320);
+    }
+
+    [Fact]
+    public void Apply_FixedAspectRatio_LocksToTheAuthoredRatio()
+    {
+        var target = Applied(s =>
+        {
+            s.AspectRatioBehavior = 1;
+            s.AspectRatioWidth = 16;
+            s.AspectRatioHeight = 9;
+        });
+
+        target.AspectPolicy.ShouldBe(AspectPolicy.Locked);
+        target.FixedAspectRatio!.Value.ShouldBe(16f / 9f, tolerance: 0.0001);
+    }
+
+    // FRB2 has no band between locked and free, so the range collapses to its first ratio. Silent
+    // collapse would letterbox differently than the author asked without saying so.
+    [Fact]
+    public void Apply_RangedAspectRatio_LocksAndSaysSo()
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+
+        var target = Applied(s =>
+        {
+            s.AspectRatioBehavior = 2;
+            s.AspectRatioWidth = 16;
+            s.AspectRatioHeight = 9;
+        }, diagnostics);
+
+        target.AspectPolicy.ShouldBe(AspectPolicy.Locked);
+        diagnostics.ShouldContain(d => d.Message.Contains("ranged aspect ratio"));
+    }
+
+    [Theory]
+    [InlineData(2, "Texture filter")]
+    public void Apply_ATextureFilterFrb2CannotHonor_IsReported(int filter, string expected)
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+
+        Applied(s => s.TextureFilter = filter, diagnostics);
+
+        diagnostics.ShouldContain(d => d.Message.Contains(expected));
+    }
+
+    [Fact]
+    public void Apply_AGumScaleFrb2CannotHonor_IsReported()
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+
+        Applied(s => s.ScaleGum = 200, diagnostics);
+
+        diagnostics.ShouldContain(d => d.Message.Contains("Gum scale"));
+    }
+
+    [Fact]
+    public void Apply_ANonTwoDProject_IsReported()
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+
+        Applied(s => s.Is2D = false, diagnostics);
+
+        diagnostics.ShouldContain(d => d.Message.Contains("not authored as 2D"));
+    }
+
+    // The two layers joined up: an aspect authored in Glue has to reach the viewport maths, or the
+    // mapping is correct and the game still fills the window. 16:9 locked inside a 4:3 window is
+    // the case that produces bars.
+    [Fact]
+    public void Apply_ALockedAspectAuthoredInGlue_LetterboxesTheRunningCamera()
+    {
+        var engine = new FlatRedBallService();
+        var source = Block();
+        source.AspectRatioBehavior = 1;
+        source.AspectRatioWidth = 16;
+        source.AspectRatioHeight = 9;
+        GlueDisplayMapper.Apply(source, engine.DisplaySettings, new());
+        var camera = new Camera();
+
+        engine.ApplyClientSizeChange(800, 600, allowUserResizing: true, camera);
+
+        // 16:9 inside 4:3 fills the width and bars the top and bottom: 800 / (16/9) = 450, so
+        // (600 - 450) / 2 = 75 per bar.
+        camera.Viewport.Width.ShouldBe(800);
+        camera.Viewport.Height.ShouldBe(450);
+        camera.Viewport.Y.ShouldBe(75);
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
@@ -10,12 +10,13 @@ using Xunit;
 namespace FlatRedBall2.Tests.Glue;
 
 /// <summary>
-/// One engine, initialized from a Glue project, shared by the whole class.
+/// One engine booted from a Glue project, shared by the tests in the class that owns this fixture.
 /// </summary>
 /// <remarks>
-/// Gum initializes once per process — a second <c>Initialize</c> throws — so every test here has to
-/// share one service rather than building its own. That also makes this fixture the only place the
-/// Glue-project boot path runs, which is what the tests are really about.
+/// Gum keeps its project and managers in process-wide statics, so only one engine may hold them at
+/// a time. This is a class fixture rather than a collection one for exactly that reason: it owns
+/// them for the lifetime of one test class and releases them in <see cref="Dispose"/>, leaving the
+/// process clean for anything else that needs an engine.
 /// </remarks>
 public sealed class GlueGumFixture : IDisposable
 {
@@ -42,9 +43,7 @@ public sealed class GlueGumFixture : IDisposable
             return;
         }
 
-        // The whole-project overload, because Gum permits exactly one Initialize per process — this
-        // is the only place the boot path can be exercised, so it exercises the one games are told
-        // to use.
+        // The whole-project overload — the one games are told to use.
         Service = new FlatRedBallService();
         Service.Initialize(_game, Path.Combine("Glue", "Fixtures", "DoorsDemo", "DoorsDemo.gluj"));
     }
@@ -80,14 +79,19 @@ public sealed class GlueGumFixture : IDisposable
             CopyDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
     }
 
-    public void Dispose() => _game?.Dispose();
+    public void Dispose()
+    {
+        // Releases Gum's process-wide statics, so the next class to want an engine can have one.
+        Service?.Shutdown();
+        _game?.Dispose();
+    }
 }
 
 // Covers actually showing a loaded project's UI, which needs a Gum runtime and so a real device.
 // In GraphicsDeviceCollection so this does not run in parallel with anything else that builds a
 // Game — that combination fails intermittently.
 [Collection(GraphicsDeviceCollection.Name)]
-public class GlueGumInstantiationTests
+public class GlueGumInstantiationTests : IClassFixture<GlueGumFixture>
 {
     private readonly GlueGumFixture _fixture;
 

--- a/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
@@ -42,16 +42,11 @@ public sealed class GlueGumFixture : IDisposable
             return;
         }
 
-        // The generic overload, because Gum permits exactly one Initialize per process — this is the
-        // only place the boot path can be exercised, so it exercises the one games are told to use.
+        // The whole-project overload, because Gum permits exactly one Initialize per process — this
+        // is the only place the boot path can be exercised, so it exercises the one games are told
+        // to use.
         Service = new FlatRedBallService();
-        Service.Initialize<GlueScreen>(
-            _game,
-            new EngineInitSettings
-            {
-                GlueProjectFile = Path.Combine("Glue", "Fixtures", "DoorsDemo", "DoorsDemo.gluj"),
-            },
-            screen => screen.Project = Service.GlueProject);
+        Service.Initialize(_game, Path.Combine("Glue", "Fixtures", "DoorsDemo", "DoorsDemo.gluj"));
     }
 
     private Game? _game;
@@ -110,16 +105,33 @@ public class GlueGumInstantiationTests
         ObjectFinder.Self.GumProjectSave!.Screens.ShouldContain(s => s.Name == "GameScreenGum");
     }
 
-    // The generic overload has to start the screen too, and start it after the Glue project is
-    // loaded — the configure it runs reads that project.
+    // Naming the .gluj is the whole boot: the project loads, its start-up screen runs, and the
+    // screen is given the data it needs. None of that is information the caller has and the engine
+    // does not, so none of it should have to be passed back in.
     [Fact]
-    public void Initialize_WithAStartScreen_StartsItAndRunsTheConfigure()
+    public void Initialize_WithAGlueProjectPath_StartsItsStartUpScreenReadyToBuild()
     {
         if (!_fixture.IsAvailable)
             return;
 
-        var current = _fixture.Service!.CurrentScreen.ShouldBeOfType<GlueScreen>();
-        current.Project.ShouldBeSameAs(_fixture.Service.GlueProject);
+        var project = _fixture.Service!.GlueProject.ShouldNotBeNull();
+        var current = _fixture.Service.CurrentScreen.ShouldBeOfType<GlueScreen>();
+
+        current.Project.ShouldBeSameAs(project);
+        current.Save.ShouldBeSameAs(project.StartUpScreen);
+    }
+
+    // The project's own display block is what sizes the window, and nothing but this path applies
+    // it — GlueProject.ApplyDisplaySettings had no caller at all.
+    [Fact]
+    public void Initialize_WithAGlueProjectPath_AppliesTheProjectsDisplaySettings()
+    {
+        if (!_fixture.IsAvailable)
+            return;
+
+        // DoorsDemo's DisplaySettings block declares 256x224, not the engine's 1280x720 default.
+        _fixture.Service!.DisplaySettings.ResolutionWidth.ShouldBe(256);
+        _fixture.Service.DisplaySettings.ResolutionHeight.ShouldBe(224);
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/GraphicsDeviceFixture.cs
+++ b/tests/FlatRedBall2.Tests/GraphicsDeviceFixture.cs
@@ -72,7 +72,7 @@ public sealed class GraphicsDeviceFixture : IDisposable
 /// </remarks>
 [CollectionDefinition(Name)]
 public sealed class GraphicsDeviceCollection
-    : ICollectionFixture<GraphicsDeviceFixture>, ICollectionFixture<Glue.GlueGumFixture>
+    : ICollectionFixture<GraphicsDeviceFixture>
 {
     public const string Name = "GraphicsDevice";
 }

--- a/tests/FlatRedBall2.Tests/ServiceShutdownTests.cs
+++ b/tests/FlatRedBall2.Tests/ServiceShutdownTests.cs
@@ -1,0 +1,87 @@
+using System;
+using FlatRedBall2.Tests.Glue;
+using Gum.Managers;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests;
+
+/// <summary>
+/// Covers standing an engine back down, which is what lets a second one exist in the same process.
+/// </summary>
+/// <remarks>
+/// Gum keeps its project, managers and canvas size in process-wide statics, so two engines
+/// initialized at once fight over them — the reason every Gum-touching test has had to share one
+/// service. Gum has always supported being re-initialized after a teardown; FRB2 simply never tore
+/// down. In <see cref="GraphicsDeviceCollection"/> because it builds a <c>Game</c>, and skipped when
+/// another fixture in that collection already owns Gum: initializing on top of a live instance is
+/// the very thing this is about.
+/// </remarks>
+[Collection(GraphicsDeviceCollection.Name)]
+public class ServiceShutdownTests
+{
+    private static bool GumIsOwnedElsewhere => SystemManagers.Default is not null;
+
+    private static Game? TryCreateGame()
+    {
+        try
+        {
+            var game = new Game();
+            _ = new GraphicsDeviceManager(game) { PreferredBackBufferWidth = 64, PreferredBackBufferHeight = 64 };
+            game.RunOneFrame();
+            return game;
+        }
+        catch (Exception e)
+        {
+            // No display, no driver, or a headless agent — same contract as GraphicsDeviceFixture.
+            System.Diagnostics.Debug.WriteLine($"[tests] No graphics device available: {e.Message}");
+            return null;
+        }
+    }
+
+    [Fact]
+    public void Shutdown_AfterInitialize_ReleasesTheProcessWideGumState()
+    {
+        if (GumIsOwnedElsewhere)
+            return;
+
+        using var game = TryCreateGame();
+        if (game is null)
+            return;
+
+        var engine = new FlatRedBallService();
+        engine.Initialize(game);
+        SystemManagers.Default.ShouldNotBeNull();
+
+        engine.Shutdown();
+
+        // The statics a second engine would otherwise inherit from the first.
+        SystemManagers.Default.ShouldBeNull();
+        ObjectFinder.Self.GumProjectSave.ShouldBeNull();
+    }
+
+    // The point of the teardown: a second engine in the same process, which is what every
+    // Gum-touching test needs before it can own its own service instead of sharing one.
+    [Fact]
+    public void Initialize_AfterAPreviousEngineShutDown_Succeeds()
+    {
+        if (GumIsOwnedElsewhere)
+            return;
+
+        using var game = TryCreateGame();
+        if (game is null)
+            return;
+
+        var first = new FlatRedBallService();
+        first.Initialize(game);
+        first.Shutdown();
+
+        var second = new FlatRedBallService();
+        Should.NotThrow(() => second.Initialize(game));
+        SystemManagers.Default.ShouldNotBeNull();
+
+        second.Shutdown();
+    }
+}


### PR DESCRIPTION
**Templates** — `Initialize<GameScreen>(this)` does the engine init, the window sizing and the first screen, so `PrepareWindow` and the separate `Start<GameScreen>()` both go. A new project's `Game1` is three FRB lines. Held back from #834 because templates resolve the engine from nuget.org; `0.5.2-preview.1` is the first release containing the overload.

**Glue boot** — `Initialize(game, "Content/FrbEditor/MyGame.gluj")`, mirroring `GumServices.Default.Init(game, "project.gumx")`. The project already names its start-up screen, its Gum project and its resolution, so the caller was supplying nothing the engine didn't hold, then handing three of them back through a configure callback.

Also fixed on that path: `GlueProject.ApplyDisplaySettings` had **no caller anywhere**, so a project's declared resolution never reached the window. It's applied as part of the boot now, and window sizing moved after the project load, since the project is what declares the size.

Verified against the real project: `Frb2Test_A` boots from one line at 800x600, its `.gluj`'s own resolution rather than the 1280x720 engine default. Templates verified with a cache-free restore, CI's build commands, and a scaffolded `dotnet new` project built and run.

Skills updated for the new boot: `sample-project-setup`, `screens`, `camera`, `engine-overview`, `glue-project-loading`.