### PR TITLE
Animation Editor: first-frame thumbnails in the Open Project Folder tree

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -184,6 +184,10 @@ public partial class App : Application
         sc.AddSingleton<ThumbnailService>(sp =>
             new ThumbnailService(sp.GetRequiredService<IProjectManager>()));
 
+        sc.AddSingleton<ProjectTreeThumbnailService>(sp =>
+            new ProjectTreeThumbnailService(ProjectThumbnailCacheLocation.ForApplicationDataRoot(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData))));
+
         // File association is registry-based on Windows; other platforms get the no-op
         // service so the startup prompt simply never appears (IsSupported == false).
         if (OperatingSystem.IsWindows())
@@ -205,6 +209,7 @@ public partial class App : Application
             sp.GetRequiredService<IUndoManager>(),
             sp.GetRequiredService<IPendingCutState>(),
             sp.GetRequiredService<ThumbnailService>(),
+            sp.GetRequiredService<ProjectTreeThumbnailService>(),
             sp.GetRequiredService<IFileAssociationService>(),
             sp.GetRequiredService<IUpdateChecker>(),
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -53,6 +53,7 @@ public partial class MainWindow : Window
     private readonly IUndoManager _undoManager;
     private readonly IPendingCutState _pendingCutState;
     private readonly Services.ThumbnailService _thumbnailService;
+    private readonly ProjectTreeThumbnailService _projectTreeThumbnailService;
     private readonly IFileAssociationService _fileAssociation;
     private readonly IUpdateChecker _updateChecker;
     private readonly IEditorDialogHost _dialogHost;
@@ -174,6 +175,7 @@ public partial class MainWindow : Window
         IUndoManager undoManager,
         IPendingCutState pendingCutState,
         Services.ThumbnailService thumbnailService,
+        ProjectTreeThumbnailService projectTreeThumbnailService,
         IFileAssociationService fileAssociation,
         IUpdateChecker updateChecker,
         string applicationDataRoot)
@@ -190,6 +192,7 @@ public partial class MainWindow : Window
         _undoManager = undoManager;
         _pendingCutState = pendingCutState;
         _thumbnailService = thumbnailService;
+        _projectTreeThumbnailService = projectTreeThumbnailService;
         _fileAssociation = fileAssociation;
         _updateChecker = updateChecker;
         _dialogHost = new WindowEditorDialogHost(this);
@@ -229,6 +232,7 @@ public partial class MainWindow : Window
         PreviewCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _thumbnailService, _pendingCutState, msg => ShowStatusMessage(msg, isError: true));
         FilesPanel.Initialize(_thumbnailService, this,
             msg => ShowStatusMessage(msg, isError: true), OpenPngAsTab);
+        ProjectPanel.Initialize(_projectTreeThumbnailService);
         // On scope toggle, re-supply the current referenced-texture set so "This File" reflects
         // the live .achx instead of the snapshot cached at the last refresh.
         FilesPanel.ScopeChanged += (_, _) => RefreshFilesPanel();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -15,6 +15,7 @@ using AnimationEditor.Core.Rendering;
 using AnimationEditor.Core.Update;
 using AnimationEditor.Core.Utilities;
 using AnimationEditor.Core.ViewModels;
+using AnimationEditor.Views.Controls;
 using AnimationEditor.Views.Dialogs;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -935,10 +936,11 @@ public partial class MainWindow : Window
                 ShowStatusMessage($"⚠ Reload skipped for '{Path.GetFileName(path)}': {reason}", isError: true));
 
         _appCommands.EditorProjectModelChanged += path =>
-            Dispatcher.UIThread.InvokeAsync(() =>
+            Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 ClearPendingCut();
                 SyncTabCacheFromEditor(path);
+                await InvalidateProjectPanelThumbnailIfTrackedAsync(path);
             });
 
         _pendingCutState.Changed += () =>
@@ -2001,6 +2003,37 @@ public partial class MainWindow : Window
         ShowStatusMessage(entries.Count == 0
             ? $"No .achx files found under \"{rootFolder.Name}\"."
             : $"Found {entries.Count} .achx file(s) under \"{rootFolder.Name}\".", isError: false);
+    }
+
+    /// <summary>
+    /// Refreshes the Project tab's thumbnail for <paramref name="savedPath"/> if that file is
+    /// also present in the currently-scanned Project tree (issue #839 follow-up: a save wasn't
+    /// reflected there at all before this). No-op for a file outside the scanned folder, or when
+    /// the Project tab has never been populated. Internal (not private) and returns
+    /// <see cref="Task"/> so tests can await the full save-&gt;invalidate-&gt;regenerate pipeline
+    /// deterministically, same seam pattern as <see cref="OpenProjectFolderForTestAsync"/>.
+    /// </summary>
+    internal Task InvalidateProjectPanelThumbnailIfTrackedAsync(string? savedPath)
+    {
+        if (string.IsNullOrEmpty(savedPath)) return Task.CompletedTask;
+
+        var entry = FindProjectPanelEntry(ProjectPanel.TreeRoots, savedPath);
+        return entry is not null ? ProjectPanel.InvalidateThumbnail(entry) : Task.CompletedTask;
+    }
+
+    private static AchxFileEntry? FindProjectPanelEntry(
+        IEnumerable<AchxTreeNodeVm> nodes, string absolutePath)
+    {
+        foreach (var node in nodes)
+        {
+            if (node.Entry?.File is DiskEditorFile diskFile &&
+                string.Equals(diskFile.FullPath, absolutePath, StringComparison.OrdinalIgnoreCase))
+                return node.Entry;
+
+            var found = FindProjectPanelEntry(node.Children, absolutePath);
+            if (found is not null) return found;
+        }
+        return null;
     }
 
     private void OnSaveClick(object? sender, RoutedEventArgs e)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1430,11 +1430,19 @@ public partial class MainWindow : Window
 
     // ── Core event handlers ───────────────────────────────────────────────────
 
+    /// <summary>
+    /// UI-refresh reaction to <see cref="IApplicationEvents.AnimationChainsChanged"/>. The actual
+    /// save is handled by <c>AppCommands</c>'s own subscription to the same event (issue #839
+    /// follow-up: that used to live here, which made "does an edit actually persist" untestable
+    /// without a full Avalonia window). <c>AppCommands</c> is constructed before <see
+    /// cref="MainWindow"/> (see <c>App.axaml.cs</c>'s DI registration order), so its subscription
+    /// fires first — the save has already happened by the time <see cref="UpdateTitle"/> below
+    /// reads <c>SaveState</c>.
+    /// </summary>
     private void HandleAnimationChainsChanged()
     {
         if (!string.IsNullOrEmpty(_projectManager.FileName))
         {
-            _appCommands.SaveCurrentAnimationChainList();
             SaveCompanionFile();
             UpdateTitle();
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -60,6 +60,16 @@ public partial class MainWindow : Window
     private readonly IEditorDialogHost _dialogHost;
     private readonly PngFolderWatcher _pngFolderWatcher = new();
 
+    /// <summary>
+    /// Completes once the most recent <see cref="IAppCommands.EditorProjectModelChanged"/>
+    /// reaction (tab-cache sync + Project-tree thumbnail invalidation) finishes. Test seam --
+    /// production code never awaits this; tests use it to observe the automatic
+    /// save-&gt;invalidate chain deterministically instead of calling the invalidation method
+    /// directly (which would prove the method works but not that the real event wiring reaches
+    /// it with a matching path -- see issue #839's path-normalization bug).
+    /// </summary>
+    internal Task LastEditorProjectModelChangedTask { get; private set; } = Task.CompletedTask;
+
     private AppSettingsModel _appSettings = new();
     private readonly TabManager _tabManager = new();
     private readonly TabController _tabController;
@@ -936,7 +946,7 @@ public partial class MainWindow : Window
                 ShowStatusMessage($"⚠ Reload skipped for '{Path.GetFileName(path)}': {reason}", isError: true));
 
         _appCommands.EditorProjectModelChanged += path =>
-            Dispatcher.UIThread.InvokeAsync(async () =>
+            LastEditorProjectModelChangedTask = Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 ClearPendingCut();
                 SyncTabCacheFromEditor(path);
@@ -2032,10 +2042,15 @@ public partial class MainWindow : Window
     private static AchxFileEntry? FindProjectPanelEntry(
         IEnumerable<AchxTreeNodeVm> nodes, string absolutePath)
     {
+        // FilePath equality, not a raw string compare: ProjectManager.FileName is set from
+        // FilePath.FullPath (forward-slash normalized -- see LoadAnimationChain), but
+        // DiskEditorFile.FullPath comes straight from Directory.EnumerateFiles (raw OS
+        // backslash on Windows). A plain string.Equals never matched, so a real save's
+        // EditorProjectModelChanged silently failed to find its tree entry (issue #839).
+        var target = new FilePath(absolutePath);
         foreach (var node in nodes)
         {
-            if (node.Entry?.File is DiskEditorFile diskFile &&
-                string.Equals(diskFile.FullPath, absolutePath, StringComparison.OrdinalIgnoreCase))
+            if (node.Entry?.File is DiskEditorFile diskFile && new FilePath(diskFile.FullPath) == target)
                 return node.Entry;
 
             var found = FindProjectPanelEntry(node.Children, absolutePath);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/DiskEditorFolder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/DiskEditorFolder.cs
@@ -42,6 +42,17 @@ public sealed class DiskEditorFolder : IEditorFolder
         var full = Path.Combine(_path, name);
         return Task.FromResult<IEditorFile?>(File.Exists(full) ? new DiskEditorFile(full) : null);
     }
+
+    /// <summary>
+    /// Overrides <see cref="IEditorFolder"/>'s subfolder-only default with real <c>System.IO</c>
+    /// resolution, so a texture reached via <c>..</c> (living outside the .achx's own folder)
+    /// resolves correctly on desktop (issue #839's project-tree thumbnails).
+    /// </summary>
+    public Task<IEditorFile?> ResolveRelativeFileAsync(string relativePath)
+    {
+        var full = new FilePath(Path.Combine(_path, relativePath)).FullPath;
+        return Task.FromResult<IEditorFile?>(File.Exists(full) ? new DiskEditorFile(full) : null);
+    }
 }
 
 /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -48,6 +48,21 @@ namespace AnimationEditor.Core.CommandsAndState
             _ioManager = ioManager;
             _objectFinder = objectFinder;
             _undoManager = undoManager;
+
+            // Autosave policy: every command that mutates the animation data raises
+            // AnimationChainsChanged (constructors/Do() of ~20 IUndoableCommand types, plus a
+            // couple of direct call sites in this class). This is the single place that reacts
+            // to it by writing the change to disk -- it used to live in MainWindow (the Avalonia
+            // app layer), which meant "does an edit actually get saved" had zero test coverage
+            // and was twice misdiagnosed while investigating issue #839. Living here instead
+            // means AppCommandsSaveOnChangeTests exercises it with no Avalonia/UI involved.
+            _events.AnimationChainsChanged += OnAnimationChainsChanged;
+        }
+
+        private void OnAnimationChainsChanged()
+        {
+            if (!string.IsNullOrEmpty(_pm.FileName))
+                SaveCurrentAnimationChainList();
         }
         // Delegates wired up by the Avalonia app layer ----------------------------
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Builds the disk cache file name for a project-tree thumbnail (issue #839). The source path is
+/// hashed only to keep the file name filesystem-safe; the invalidation key is <paramref
+/// name="size"/>/<paramref name="modified"/> plainly embedded in the name -- the same
+/// <see cref="FolderEntrySnapshot"/> pair <c>FolderSnapshotDiff</c> and the hot-reload watcher
+/// already use elsewhere in this codebase, so a cache lookup is a filename match: any drift in
+/// either value produces a different name, i.e. a cache miss that regenerates the thumbnail.
+/// </summary>
+public static class AchxThumbnailCacheKey
+{
+    public static string BuildFileName(string absolutePath, ulong? size, DateTimeOffset? modified)
+    {
+        var normalized = absolutePath.Replace('\\', '/').ToLowerInvariant();
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..16];
+        var sizePart = size?.ToString() ?? "0";
+        var modifiedPart = modified?.UtcTicks.ToString() ?? "0";
+        return $"{hash}_{sizePart}_{modifiedPart}.png";
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
@@ -5,18 +5,27 @@ using System.Text;
 namespace AnimationEditor.Core.IO;
 
 /// <summary>
-/// Builds the disk cache file name for a project-tree thumbnail (issue #839). The source path is
-/// hashed only to keep the file name filesystem-safe; the invalidation key is <paramref
-/// name="size"/>/<paramref name="modified"/> plainly embedded in the name -- the same
-/// <see cref="FolderEntrySnapshot"/> pair <c>FolderSnapshotDiff</c> and the hot-reload watcher
-/// already use elsewhere in this codebase, so a cache lookup is a filename match: any drift in
-/// either value produces a different name, i.e. a cache miss that regenerates the thumbnail.
+/// Builds the disk cache file name for a project-tree thumbnail (issue #839). <paramref
+/// name="sourceIdentity"/> is hashed only to keep the file name filesystem-safe; the invalidation
+/// key is <paramref name="size"/>/<paramref name="modified"/> plainly embedded in the name -- the
+/// same <see cref="FolderEntrySnapshot"/> pair <c>FolderSnapshotDiff</c> and the hot-reload
+/// watcher already use elsewhere in this codebase, so a cache lookup is a filename match: any
+/// drift in either value produces a different name, i.e. a cache miss that regenerates the
+/// thumbnail.
 /// </summary>
 public static class AchxThumbnailCacheKey
 {
-    public static string BuildFileName(string absolutePath, ulong? size, DateTimeOffset? modified)
+    /// <param name="sourceIdentity">
+    /// A string that identifies the source <c>.achx</c>. Callers pass <c>AchxFileEntry.RelativePath</c>
+    /// (relative to the scanned Open Project Folder root) rather than a real absolute path --
+    /// <c>IEditorFolder</c> has no stable absolute identity on the browser build. Two different
+    /// projects could theoretically share a relative path, but a collision also needs matching
+    /// <paramref name="size"/>/<paramref name="modified"/> to actually serve a wrong thumbnail,
+    /// and even then it self-corrects the next time either file changes.
+    /// </param>
+    public static string BuildFileName(string sourceIdentity, ulong? size, DateTimeOffset? modified)
     {
-        var normalized = absolutePath.Replace('\\', '/').ToLowerInvariant();
+        var normalized = sourceIdentity.Replace('\\', '/').ToLowerInvariant();
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..16];
         var sizePart = size?.ToString() ?? "0";
         var modifiedPart = modified?.UtcTicks.ToString() ?? "0";

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailFrameSelector.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailFrameSelector.cs
@@ -1,0 +1,19 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Picks the frame a project-tree thumbnail (issue #839) is rendered from: the first frame of the
+/// first chain that actually has frames. A chain can be empty (just created, or all frames deleted),
+/// so this does not simply take <c>AnimationChains[0].Frames[0]</c>.
+/// </summary>
+public static class AchxThumbnailFrameSelector
+{
+    public static AnimationFrameSave? SelectFirstFrame(AnimationChainListSave acls)
+    {
+        foreach (var chain in acls.AnimationChains)
+            if (chain.Frames.Count > 0)
+                return chain.Frames[0];
+        return null;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IEditorFile.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IEditorFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -39,4 +40,44 @@ public interface IEditorFolder
 
     /// <summary>Subfolders directly inside this folder — never recurses.</summary>
     IAsyncEnumerable<IEditorFolder> GetSubfoldersAsync();
+
+    /// <summary>
+    /// Resolves a <c>/</c>- or <c>\</c>-separated path relative to this folder (issue #839's
+    /// project-tree thumbnails, which must resolve a frame's <c>TextureName</c> relative to the
+    /// <c>.achx</c>'s own folder without a full <see cref="AnimationEditor.Core.ProjectManager"/> load).
+    /// <para>
+    /// This default implementation only walks <em>downward</em> (same folder or a subfolder) via
+    /// <see cref="GetSubfoldersAsync"/>/<see cref="GetFileAsync"/> — it returns <see langword="null"/>
+    /// for a <c>..</c> segment, a segment that doesn't match any subfolder, or a leaf file that
+    /// doesn't exist. <c>IEditorFolder</c> has no way to reach a parent folder, so a
+    /// cross-folder-up <c>../Shared/x.png</c> texture cannot be resolved generically. Desktop's
+    /// <c>DiskEditorFolder</c> overrides this with real <c>System.IO</c> resolution, which handles
+    /// <c>..</c> correctly.
+    /// </para>
+    /// </summary>
+    async Task<IEditorFile?> ResolveRelativeFileAsync(string relativePath)
+    {
+        var segments = relativePath.Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0) return null;
+        if (Array.IndexOf(segments, "..") >= 0) return null;
+
+        IEditorFolder current = this;
+        for (int i = 0; i < segments.Length - 1; i++)
+        {
+            IEditorFolder? next = null;
+            await foreach (var sub in current.GetSubfoldersAsync())
+            {
+                if (string.Equals(sub.Name, segments[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    next = sub;
+                    break;
+                }
+            }
+            if (next is null) return null;
+            current = next;
+        }
+
+        return await current.GetFileAsync(segments[^1]);
+    }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PixelFrameUvConverter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PixelFrameUvConverter.cs
@@ -1,0 +1,24 @@
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Converts a single frame's raw-pixel coordinates (<see cref="TextureCoordinateType.Pixel"/>) to
+/// normalized UV (0-1), given the decoded texture's pixel size. Used by the project-tree thumbnail
+/// generator (issue #839), which only ever needs one frame's coordinates converted and already has
+/// the texture decoded -- unlike <c>ProjectManager.ConvertCoordinates</c>, which round-trips an
+/// entire <c>AnimationChainListSave</c> for save/load.
+/// </summary>
+public static class PixelFrameUvConverter
+{
+    public static AnimationFrameSave ToUv(AnimationFrameSave frame, int textureWidth, int textureHeight) => new()
+    {
+        TextureName = frame.TextureName,
+        LeftCoordinate = frame.LeftCoordinate / textureWidth,
+        RightCoordinate = frame.RightCoordinate / textureWidth,
+        TopCoordinate = frame.TopCoordinate / textureHeight,
+        BottomCoordinate = frame.BottomCoordinate / textureHeight,
+        FlipHorizontal = frame.FlipHorizontal,
+        FlipVertical = frame.FlipVertical,
+    };
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ProjectThumbnailCacheLocation.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ProjectThumbnailCacheLocation.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Desktop-only disk cache directory for project-tree thumbnails (issue #839), mirroring
+/// <see cref="AppSettingsLocation"/>'s shape. Not used on the browser build, which has no
+/// persistent filesystem to cache to -- <c>ProjectTreeThumbnailService</c> falls back to an
+/// in-memory-only cache there.
+/// </summary>
+public static class ProjectThumbnailCacheLocation
+{
+    public const string FolderName = "AnimationEditor";
+    public const string SubfolderName = "ThumbnailCache";
+
+    /// <param name="applicationDataRoot">See <see cref="AppSettingsLocation.ForApplicationDataRoot"/>.</param>
+    public static string ForApplicationDataRoot(string applicationDataRoot) =>
+        Path.Combine(applicationDataRoot, FolderName, SubfolderName);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
@@ -4,11 +4,16 @@
              xmlns:svg="clr-namespace:Avalonia.Svg.Skia;assembly=Svg.Controls.Skia.Avalonia"
              x:Class="AnimationEditor.Views.Controls.ProjectPanelControl"
              x:DataType="controls:ProjectPanelControl">
+    <UserControl.Resources>
+        <x:Double x:Key="ProjectTreeThumbSize">28</x:Double>
+    </UserControl.Resources>
     <!--
         Open Project Folder (#770): recursively-discovered .achx tree for a picked folder.
-        Deliberately no drag/thumbnail support (unlike desktop's FilesPanelControl): click a
-        file row to open it, click a folder row to expand/collapse. That's what keeps this
-        control shareable between desktop and the browser build (no Window dependency).
+        Click a file row to open it, click a folder row to expand/collapse. First-frame
+        thumbnails (#839) load lazily via ProjectTreeThumbnailService and need no Window,
+        so this control stays shareable, unmodified, between desktop and the browser build.
+        Deliberately still no drag support (unlike desktop's FilesPanelControl), which does
+        need a Window.
     -->
     <Grid RowDefinitions="Auto,*,Auto">
         <Border Grid.Row="0"
@@ -49,10 +54,16 @@
                         <controls:FolderExpanderIcon IsVisible="{Binding IsFolder}"
                                                       IsOpen="{Binding IsFolderOpen}"
                                                       Toggled="OnFolderExpanderToggled" />
-                        <svg:Svg IsVisible="{Binding IsFile}"
+                        <svg:Svg IsVisible="{Binding ShowFallbackIcon}"
                                  Width="16" Height="16"
                                  Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChain.svg"
                                  CurrentColor="{DynamicResource IconInkMuted}" />
+                        <Image IsVisible="{Binding HasThumbnail}"
+                               Width="{StaticResource ProjectTreeThumbSize}"
+                               Height="{StaticResource ProjectTreeThumbSize}"
+                               Source="{Binding Thumbnail}"
+                               Stretch="Uniform"
+                               VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Name}"
                                    FontSize="11"
                                    VerticalAlignment="Center"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -150,6 +150,23 @@ public partial class ProjectPanelControl : UserControl
             node.Thumbnail = thumbnail;
     }
 
+    /// <summary>
+    /// Re-generates the thumbnail for a single already-visible node after its file changed on
+    /// disk (issue #839 follow-up: a save wasn't reflected in the tree at all). No-op if
+    /// <paramref name="entry"/> isn't currently in the tree, or before <see cref="Initialize"/>.
+    /// Callers fire-and-forget this; it's <c>async Task</c> only so tests can await it.
+    /// </summary>
+    public async Task InvalidateThumbnail(AchxFileEntry entry)
+    {
+        if (_thumbnailService is null) return;
+
+        var node = FindNode(TreeRoots, entry);
+        if (node is null) return;
+
+        _thumbnailService.InvalidateEntry(entry);
+        await LoadOneThumbnailAsync(node, CancellationToken.None);
+    }
+
     private void OnSearchQueryChanged(object? sender, string query)
     {
         _searchQuery = query;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -1,5 +1,7 @@
+using AnimationEditor.App.Services;
 using AnimationEditor.Core.IO;
 using Avalonia.Controls;
+using Avalonia.Media.Imaging;
 using Avalonia.VisualTree;
 using System;
 using System.Collections.Generic;
@@ -7,6 +9,8 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AnimationEditor.Views.Controls;
 
@@ -14,12 +18,18 @@ namespace AnimationEditor.Views.Controls;
 /// Displays the recursively-discovered <c>.achx</c> tree for a picked project folder (#770).
 /// Platform-agnostic: everything it renders comes from <see cref="AchxFolderScanner"/> /
 /// <see cref="AchxFolderTreeBuilder"/> over <see cref="IEditorFolder"/>, so this same control is
-/// shared unmodified by desktop (real filesystem) and the browser build (native folder handle).
+/// shared unmodified by desktop (real filesystem) and the browser build (native folder handle) --
+/// including first-frame thumbnails (issue #839), generated lazily via
+/// <see cref="ProjectTreeThumbnailService"/> after <see cref="SetEntries"/>.
 /// </summary>
 public partial class ProjectPanelControl : UserControl
 {
+    private const int ThumbnailSize = 28;
+
     private IReadOnlyList<AchxFileEntry> _allEntries = Array.Empty<AchxFileEntry>();
     private string _searchQuery = string.Empty;
+    private ProjectTreeThumbnailService? _thumbnailService;
+    private CancellationTokenSource? _thumbnailLoadCts;
 
     // Guards against re-entrant SelectionChanged while ClearSearchAndReveal restores the
     // selection post-rebuild -- without it, that restore would re-fire FileSelected for the
@@ -31,6 +41,13 @@ public partial class ProjectPanelControl : UserControl
     /// <summary>Raised when the user clicks a file row.</summary>
     public event Action<AchxFileEntry>? FileSelected;
 
+    /// <summary>
+    /// Completes once every thumbnail from the most recent <see cref="Rebuild"/> has finished
+    /// loading (or been cancelled by a newer one). Test seam for awaiting the async thumbnail
+    /// load -- production code never needs to await this.
+    /// </summary>
+    public Task ThumbnailLoadTask { get; private set; } = Task.CompletedTask;
+
     public ProjectPanelControl()
     {
         InitializeComponent();
@@ -39,6 +56,14 @@ public partial class ProjectPanelControl : UserControl
         ProjectTree.SelectionChanged += OnTreeSelectionChanged;
         Rebuild();
     }
+
+    /// <summary>
+    /// Wires the thumbnail generator (issue #839). Not passed to the constructor because
+    /// <see cref="AnimationEditor.Views"/> controls are constructed by XAML with no arguments;
+    /// call this once, before the first real <see cref="SetEntries"/>.
+    /// </summary>
+    public void Initialize(ProjectTreeThumbnailService thumbnailService) =>
+        _thumbnailService = thumbnailService;
 
     /// <summary>
     /// Replaces the scanned entries (e.g. after a fresh Open Project Folder pick) and rebuilds
@@ -73,6 +98,56 @@ public partial class ProjectPanelControl : UserControl
 
         foreach (var node in AchxFolderTreeBuilder.Build(files))
             TreeRoots.Add(AchxTreeNodeVm.FromNode(node));
+
+        StartThumbnailLoad();
+    }
+
+    /// <summary>
+    /// Kicks off thumbnail generation for every file row now in <see cref="TreeRoots"/>, a few at
+    /// a time (the throttle lives in <see cref="ProjectTreeThumbnailService"/>) so rows fill in
+    /// as they finish instead of blocking the tree. Cancels any load still running from a
+    /// previous <see cref="Rebuild"/> (e.g. the user typed in search again) first, so a stale
+    /// generation can't overwrite a node from the new tree.
+    /// </summary>
+    private void StartThumbnailLoad()
+    {
+        _thumbnailLoadCts?.Cancel();
+        _thumbnailLoadCts?.Dispose();
+        if (_thumbnailService is null) { ThumbnailLoadTask = Task.CompletedTask; return; }
+
+        var cts = new CancellationTokenSource();
+        _thumbnailLoadCts = cts;
+
+        var fileNodes = new List<AchxTreeNodeVm>();
+        CollectFileNodes(TreeRoots, fileNodes);
+
+        ThumbnailLoadTask = Task.WhenAll(fileNodes.Select(node => LoadOneThumbnailAsync(node, cts.Token)));
+    }
+
+    private static void CollectFileNodes(IEnumerable<AchxTreeNodeVm> nodes, List<AchxTreeNodeVm> results)
+    {
+        foreach (var node in nodes)
+        {
+            if (node.IsFile) results.Add(node);
+            else CollectFileNodes(node.Children, results);
+        }
+    }
+
+    private async Task LoadOneThumbnailAsync(AchxTreeNodeVm node, CancellationToken cancellationToken)
+    {
+        Bitmap? thumbnail;
+        try
+        {
+            thumbnail = await _thumbnailService!.GetThumbnailAsync(
+                node.Entry!, ThumbnailSize, ThumbnailSize, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (!cancellationToken.IsCancellationRequested)
+            node.Thumbnail = thumbnail;
     }
 
     private void OnSearchQueryChanged(object? sender, string query)
@@ -140,6 +215,7 @@ public partial class ProjectPanelControl : UserControl
 public sealed class AchxTreeNodeVm : INotifyPropertyChanged
 {
     private bool _isExpanded = true;
+    private Bitmap? _thumbnail;
 
     public string Name { get; }
     public AchxFileEntry? Entry { get; }
@@ -148,6 +224,25 @@ public sealed class AchxTreeNodeVm : INotifyPropertyChanged
     public ObservableCollection<AchxTreeNodeVm> Children { get; } = new();
 
     public bool IsFolderOpen => _isExpanded;
+
+    /// <summary>First-frame preview (issue #839), populated asynchronously after the row appears --
+    /// null until <see cref="ProjectTreeThumbnailService"/> finishes (or if it can't produce one),
+    /// in which case the row keeps showing the generic chain icon.</summary>
+    public Bitmap? Thumbnail
+    {
+        get => _thumbnail;
+        set
+        {
+            if (ReferenceEquals(_thumbnail, value)) return;
+            _thumbnail = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasThumbnail));
+            OnPropertyChanged(nameof(ShowFallbackIcon));
+        }
+    }
+
+    public bool HasThumbnail => _thumbnail is not null;
+    public bool ShowFallbackIcon => IsFile && _thumbnail is null;
 
     public bool IsExpanded
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
@@ -5,6 +5,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,6 +37,22 @@ public sealed class ProjectTreeThumbnailService
     /// </param>
     public ProjectTreeThumbnailService(string? diskCacheDirectory) =>
         _diskCacheDirectory = diskCacheDirectory;
+
+    /// <summary>
+    /// Drops <paramref name="entry"/>'s cached bitmap(s) (every requested size) so the next
+    /// <see cref="GetThumbnailAsync"/> call re-parses and re-decodes instead of returning stale
+    /// art. Callers should invoke this after a save completes for a file also present in the
+    /// project tree (issue #839 follow-up: nothing did this before, so an edited-and-saved frame
+    /// kept showing its old thumbnail until the folder was reopened). Does not touch the disk
+    /// cache directly -- the next generation's own <see cref="TrySaveToDisk"/> already replaces
+    /// the stale on-disk file once it writes the new one (same hash prefix, new size/modified
+    /// suffix).
+    /// </summary>
+    public void InvalidateEntry(AchxFileEntry entry)
+    {
+        foreach (var key in _memoryCache.Keys.Where(k => k.Entry == entry).ToList())
+            _memoryCache.Remove(key);
+    }
 
     /// <summary>
     /// Returns a thumbnail for <paramref name="entry"/>'s first frame, or <see langword="null"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
@@ -57,26 +57,15 @@ public sealed class ProjectTreeThumbnailService
             if (_memoryCache.TryGetValue(memoryKey, out cached))
                 return cached;
 
-            string? cacheFilePath = null;
-            if (_diskCacheDirectory is not null)
-            {
-                var snapshot = await entry.File.GetBasicPropertiesAsync();
-                var cacheFileName = AchxThumbnailCacheKey.BuildFileName(
-                    entry.RelativePath, snapshot.Size, snapshot.Modified);
-                cacheFilePath = Path.Combine(_diskCacheDirectory, cacheFileName);
-
-                var cached2 = TryLoadFromDisk(cacheFilePath);
-                if (cached2 is not null)
-                {
-                    _memoryCache[memoryKey] = cached2;
-                    return cached2;
-                }
-            }
-
-            var bitmap = await GenerateAsync(entry, maxWidth, maxHeight, cancellationToken);
-
-            if (bitmap is not null && cacheFilePath is not null)
-                TrySaveToDisk(cacheFilePath, bitmap);
+            // Task.Run is load-bearing, not decoration: SemaphoreSlim.WaitAsync above and small
+            // local-file reads inside LoadOrGenerateAsync routinely complete synchronously, so
+            // without it the achx parse + PNG decode + Skia crop -- all CPU-bound, nothing left
+            // to actually yield on -- run inline on whichever thread called GetThumbnailAsync.
+            // ProjectPanelControl fires the whole per-folder load loop from the UI thread, so
+            // that froze the app on a folder with many .achx files (issue #839 follow-up).
+            var bitmap = await Task.Run(
+                () => LoadOrGenerateAsync(entry, maxWidth, maxHeight, cancellationToken),
+                cancellationToken);
 
             _memoryCache[memoryKey] = bitmap;
             return bitmap;
@@ -85,6 +74,30 @@ public sealed class ProjectTreeThumbnailService
         {
             _concurrency.Release();
         }
+    }
+
+    private async Task<Bitmap?> LoadOrGenerateAsync(
+        AchxFileEntry entry, int maxWidth, int maxHeight, CancellationToken cancellationToken)
+    {
+        string? cacheFilePath = null;
+        if (_diskCacheDirectory is not null)
+        {
+            var snapshot = await entry.File.GetBasicPropertiesAsync();
+            var cacheFileName = AchxThumbnailCacheKey.BuildFileName(
+                entry.RelativePath, snapshot.Size, snapshot.Modified);
+            cacheFilePath = Path.Combine(_diskCacheDirectory, cacheFileName);
+
+            var cached = TryLoadFromDisk(cacheFilePath);
+            if (cached is not null)
+                return cached;
+        }
+
+        var bitmap = await GenerateAsync(entry, maxWidth, maxHeight, cancellationToken);
+
+        if (bitmap is not null && cacheFilePath is not null)
+            TrySaveToDisk(cacheFilePath, bitmap);
+
+        return bitmap;
     }
 
     private static async Task<Bitmap?> GenerateAsync(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ProjectTreeThumbnailService.cs
@@ -1,0 +1,173 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Media.Imaging;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Generates first-frame thumbnails for the Open Project Folder <c>.achx</c> tree (issue #839) --
+/// unlike <see cref="ThumbnailService"/>, which only ever serves the currently-open project, this
+/// resolves each frame's texture relative to <em>that file's own</em> folder via
+/// <see cref="AchxFileEntry.ParentFolder"/>, since none of these files are loaded into
+/// <c>ProjectManager</c>.
+/// <para>
+/// Calls are throttled to a small concurrency cap so opening a folder with hundreds of
+/// <c>.achx</c> files doesn't spike CPU or block the tree -- see <see cref="_concurrency"/>.
+/// </para>
+/// </summary>
+public sealed class ProjectTreeThumbnailService
+{
+    private const int MaxConcurrentGenerations = 4;
+
+    private readonly SemaphoreSlim _concurrency = new(MaxConcurrentGenerations);
+    private readonly string? _diskCacheDirectory;
+    private readonly Dictionary<(AchxFileEntry Entry, int MaxWidth, int MaxHeight), Bitmap?> _memoryCache = new();
+
+    /// <param name="diskCacheDirectory">
+    /// Desktop-only persistent cache directory. Pass <see langword="null"/> to disable disk
+    /// caching (the browser build, or tests) -- generation still happens, just re-runs every
+    /// session instead of being backed by disk.
+    /// </param>
+    public ProjectTreeThumbnailService(string? diskCacheDirectory) =>
+        _diskCacheDirectory = diskCacheDirectory;
+
+    /// <summary>
+    /// Returns a thumbnail for <paramref name="entry"/>'s first frame, or <see langword="null"/>
+    /// if the file has no frames, fails to parse, or its texture can't be resolved/decoded --
+    /// callers fall back to a generic icon in that case, same as a missing PNG anywhere else in
+    /// this codebase.
+    /// </summary>
+    public async Task<Bitmap?> GetThumbnailAsync(
+        AchxFileEntry entry, int maxWidth, int maxHeight, CancellationToken cancellationToken = default)
+    {
+        var memoryKey = (entry, maxWidth, maxHeight);
+        if (_memoryCache.TryGetValue(memoryKey, out var cached))
+            return cached;
+
+        await _concurrency.WaitAsync(cancellationToken);
+        try
+        {
+            // Re-check: another caller may have generated this while we waited on the gate.
+            if (_memoryCache.TryGetValue(memoryKey, out cached))
+                return cached;
+
+            string? cacheFilePath = null;
+            if (_diskCacheDirectory is not null)
+            {
+                var snapshot = await entry.File.GetBasicPropertiesAsync();
+                var cacheFileName = AchxThumbnailCacheKey.BuildFileName(
+                    entry.RelativePath, snapshot.Size, snapshot.Modified);
+                cacheFilePath = Path.Combine(_diskCacheDirectory, cacheFileName);
+
+                var cached2 = TryLoadFromDisk(cacheFilePath);
+                if (cached2 is not null)
+                {
+                    _memoryCache[memoryKey] = cached2;
+                    return cached2;
+                }
+            }
+
+            var bitmap = await GenerateAsync(entry, maxWidth, maxHeight, cancellationToken);
+
+            if (bitmap is not null && cacheFilePath is not null)
+                TrySaveToDisk(cacheFilePath, bitmap);
+
+            _memoryCache[memoryKey] = bitmap;
+            return bitmap;
+        }
+        finally
+        {
+            _concurrency.Release();
+        }
+    }
+
+    private static async Task<Bitmap?> GenerateAsync(
+        AchxFileEntry entry, int maxWidth, int maxHeight, CancellationToken cancellationToken)
+    {
+        AnimationChainListSave acls;
+        try
+        {
+            string achxText;
+            await using (var achxStream = await entry.File.OpenReadAsync())
+            using (var reader = new StreamReader(achxStream))
+                achxText = await reader.ReadToEndAsync(cancellationToken);
+            acls = AnimationChainListSave.FromString(achxText);
+        }
+        catch
+        {
+            return null; // Unreadable or malformed .achx -- caller falls back to the generic icon.
+        }
+
+        var frame = AchxThumbnailFrameSelector.SelectFirstFrame(acls);
+        if (frame is null || string.IsNullOrEmpty(frame.TextureName))
+            return null;
+
+        var textureFile = await entry.ParentFolder.ResolveRelativeFileAsync(frame.TextureName);
+        if (textureFile is null)
+            return null;
+
+        using var textureBitmap = await DecodeAsync(textureFile);
+        if (textureBitmap is null)
+            return null;
+
+        var uvFrame = acls.CoordinateType == TextureCoordinateType.Pixel
+            ? PixelFrameUvConverter.ToUv(frame, textureBitmap.Width, textureBitmap.Height)
+            : frame;
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(
+            textureBitmap, uvFrame, default, maxWidth, maxHeight);
+        return thumb is null ? null : ThumbnailService.ToAvaloniaBitmap(thumb);
+    }
+
+    private static async Task<SKBitmap?> DecodeAsync(IEditorFile file)
+    {
+        await using var stream = await file.OpenReadAsync();
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+        return SKBitmap.Decode(buffer.ToArray());
+    }
+
+    private static Bitmap? TryLoadFromDisk(string cacheFilePath)
+    {
+        if (!File.Exists(cacheFilePath)) return null;
+        try
+        {
+            return new Bitmap(cacheFilePath);
+        }
+        catch
+        {
+            return null; // Corrupt/truncated cache file -- fall through and regenerate.
+        }
+    }
+
+    /// <summary>
+    /// Best-effort disk write: the cache is an optimization, not a correctness requirement, so an
+    /// I/O failure (read-only volume, disk full, concurrent access) is swallowed. Also removes any
+    /// other cached file for the same source (same hash prefix, stale size/modified suffix) so
+    /// repeatedly editing one <c>.achx</c> doesn't accumulate orphaned cache files forever.
+    /// </summary>
+    private void TrySaveToDisk(string cacheFilePath, Bitmap bitmap)
+    {
+        try
+        {
+            Directory.CreateDirectory(_diskCacheDirectory!);
+
+            var hashPrefix = Path.GetFileName(cacheFilePath).Split('_')[0];
+            foreach (var stale in Directory.EnumerateFiles(_diskCacheDirectory!, $"{hashPrefix}_*.png"))
+                File.Delete(stale);
+
+            using var fileStream = File.Create(cacheFilePath);
+            bitmap.Save(fileStream);
+        }
+        catch
+        {
+            // Optimization only -- see summary above.
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
@@ -296,9 +296,11 @@ public sealed class ThumbnailService : IDisposable
     /// Wraps a Skia bitmap as an Avalonia <see cref="Avalonia.Media.Imaging.WriteableBitmap"/> by
     /// copying its pixels straight into the framebuffer — no PNG encode/decode. Skia converts to
     /// the destination BGRA/premultiplied layout during <see cref="SKBitmap.ReadPixels(SKImageInfo,
-    /// IntPtr, int, int, int)"/>, so the source colour/alpha type does not matter.
+    /// IntPtr, int, int, int)"/>, so the source colour/alpha type does not matter. Internal (not
+    /// private) so <c>ProjectTreeThumbnailService</c> can share this conversion for project-tree
+    /// thumbnails (issue #839) instead of duplicating it.
     /// </summary>
-    private static Avalonia.Media.Imaging.Bitmap ToAvaloniaBitmap(SKBitmap thumb)
+    internal static Avalonia.Media.Imaging.Bitmap ToAvaloniaBitmap(SKBitmap thumb)
     {
         var size   = new PixelSize(thumb.Width, thumb.Height);
         var bitmap = new Avalonia.Media.Imaging.WriteableBitmap(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DiskEditorFolderResolveRelativeFileTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DiskEditorFolderResolveRelativeFileTests.cs
@@ -1,0 +1,50 @@
+using AnimationEditor.App.Services;
+using AnimationEditor.Core.IO;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+// Issue #839: DiskEditorFolder overrides IEditorFolder.ResolveRelativeFileAsync's default
+// (subfolder-only) walk with real System.IO resolution, so it also handles ".." -- needed to
+// resolve a frame's TextureName when it points outside the .achx's own folder.
+public class DiskEditorFolderResolveRelativeFileTests
+{
+    private static Task<IEditorFile?> Resolve(IEditorFolder folder, string relativePath) =>
+        folder.ResolveRelativeFileAsync(relativePath);
+
+    private static string MakeTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "AnimationEditorTests", System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_ParentDirectorySegment_ResolvesRealFile()
+    {
+        var root = MakeTempDir();
+        var achxDir = Path.Combine(root, "Chains");
+        var sharedDir = Path.Combine(root, "Shared");
+        Directory.CreateDirectory(achxDir);
+        Directory.CreateDirectory(sharedDir);
+        var texturePath = Path.Combine(sharedDir, "hero.png");
+        File.WriteAllText(texturePath, "fake png bytes");
+
+        var result = await Resolve(new DiskEditorFolder(achxDir), "../Shared/hero.png");
+
+        Assert.NotNull(result);
+        Assert.Equal("hero.png", result!.Name);
+    }
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_FileDoesNotExist_ReturnsNull()
+    {
+        var root = MakeTempDir();
+
+        var result = await Resolve(new DiskEditorFolder(root), "missing.png");
+
+        Assert.Null(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
@@ -24,6 +24,15 @@ public class ProjectFolderPersistenceTests
         acls.Save(path);
     }
 
+    private static void WritePng(string dir, string fileName, SKColor color)
+    {
+        using var bm = new SKBitmap(8, 8);
+        bm.Erase(color);
+        using var img = SKImage.FromBitmap(bm);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(Path.Combine(dir, fileName), data.ToArray());
+    }
+
     private static AppSettingsModel ReadPersistedSettings(TestServices ctx)
     {
         var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
@@ -64,13 +73,7 @@ public class ProjectFolderPersistenceTests
     {
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        using (var bm = new SKBitmap(8, 8))
-        {
-            bm.Erase(SKColors.Red);
-            using var img = SKImage.FromBitmap(bm);
-            using var data = img.Encode(SKEncodedImageFormat.Png, 100);
-            File.WriteAllBytes(Path.Combine(dir, "hero.png"), data.ToArray());
-        }
+        WritePng(dir, "hero.png", SKColors.Red);
         var acls = new FlatRedBall2.Animation.Content.AnimationChainListSave();
         acls.AnimationChains.Add(new FlatRedBall2.Animation.Content.AnimationChainSave
         {
@@ -89,6 +92,56 @@ public class ProjectFolderPersistenceTests
             await window.ProjectPanel.ThumbnailLoadTask;
 
             Assert.True(window.ProjectPanel.TreeRoots[0].HasThumbnail);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    // Issue #839 follow-up: saving an edit to a tracked file must refresh its Project-tree
+    // thumbnail. Before this, nothing invalidated it -- the tree kept showing the pre-edit art
+    // until the folder was reopened, even after a real save to disk.
+    [AvaloniaFact]
+    public async Task SavingATrackedFile_RefreshesItsProjectTreeThumbnail()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        WritePng(dir, "hero.png", SKColors.Red);
+        WritePng(dir, "other.png", SKColors.Blue);
+        var acls = new FlatRedBall2.Animation.Content.AnimationChainListSave();
+        acls.AnimationChains.Add(new FlatRedBall2.Animation.Content.AnimationChainSave
+        {
+            Name = "Walk",
+            Frames = { new FlatRedBall2.Animation.Content.AnimationFrameSave { TextureName = "hero.png" } },
+        });
+        var achxPath = Path.Combine(dir, "hero.achx");
+        acls.Save(achxPath);
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            await window.ProjectPanel.ThumbnailLoadTask;
+            var beforeEdit = window.ProjectPanel.TreeRoots[0].Thumbnail;
+            Assert.NotNull(beforeEdit);
+
+            // Simulate reordering/resizing so the first frame now resolves to a different texture,
+            // then save -- bypassing the tab-open UI flow and AppCommands' EditorProjectModelChanged
+            // event (unrelated tab-sync side effects, not what's under test here) so this test
+            // isolates exactly the new invalidate-then-regenerate path.
+            ctx.ProjectManager.LoadAnimationChain(new AnimationEditor.Core.Paths.FilePath(achxPath));
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains[0].Frames[0].TextureName = "other.png";
+            ctx.ProjectManager.SaveAnimationChainList(achxPath);
+            await window.InvalidateProjectPanelThumbnailIfTrackedAsync(achxPath);
+
+            var afterEdit = window.ProjectPanel.TreeRoots[0].Thumbnail;
+            Assert.NotNull(afterEdit);
+            Assert.NotSame(beforeEdit, afterEdit);
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
@@ -103,6 +103,13 @@ public class ProjectFolderPersistenceTests
     // Issue #839 follow-up: saving an edit to a tracked file must refresh its Project-tree
     // thumbnail. Before this, nothing invalidated it -- the tree kept showing the pre-edit art
     // until the folder was reopened, even after a real save to disk.
+    //
+    // This drives the SAME trigger a real drag-resize commit uses in production
+    // (WireframeControl.CommitActiveDrag -> OnFrameRegionChanged -> RaiseAnimationChainsChanged),
+    // rather than calling ProjectManager.SaveAnimationChainList directly, so it proves the full
+    // real chain: edit -> AnimationChainsChanged -> AppCommands saves (see
+    // AppCommandsSaveOnChangeTests for that piece in isolation) -> EditorProjectModelChanged ->
+    // MainWindow invalidates the tracked tree node.
     [AvaloniaFact]
     public async Task SavingATrackedFile_RefreshesItsProjectTreeThumbnail()
     {
@@ -130,13 +137,20 @@ public class ProjectFolderPersistenceTests
             var beforeEdit = window.ProjectPanel.TreeRoots[0].Thumbnail;
             Assert.NotNull(beforeEdit);
 
-            // Simulate reordering/resizing so the first frame now resolves to a different texture,
-            // then save -- bypassing the tab-open UI flow and AppCommands' EditorProjectModelChanged
-            // event (unrelated tab-sync side effects, not what's under test here) so this test
-            // isolates exactly the new invalidate-then-regenerate path.
+            // Load the file as the active project (bypassing the tab-open UI flow, which isn't
+            // what's under test) and mutate its first frame -- standing in for a real
+            // WireframeControl drag-resize, which mutates the frame directly with no command
+            // object (see WireframeControl.ApplyHandleDrag's "no save / tree refresh yet" comment).
             ctx.ProjectManager.LoadAnimationChain(new AnimationEditor.Core.Paths.FilePath(achxPath));
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains[0].Frames[0].TextureName = "other.png";
-            ctx.ProjectManager.SaveAnimationChainList(achxPath);
+
+            // The real trigger: what WireframeControl.CommitActiveDrag / OnFrameRegionChanged
+            // raises on drag-release. AppCommands' own subscription (issue #839 follow-up) saves
+            // as a synchronous side effect of this call.
+            ctx.ApplicationEvents.RaiseAnimationChainsChanged();
+            Assert.True(File.Exists(achxPath));
+
+            Dispatcher.UIThread.RunJobs();
             await window.InvalidateProjectPanelThumbnailIfTrackedAsync(achxPath);
 
             var afterEdit = window.ProjectPanel.TreeRoots[0].Thumbnail;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
@@ -2,6 +2,7 @@ using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using SkiaSharp;
 using System;
 using System.IO;
 using System.Text.Json;
@@ -47,6 +48,47 @@ public class ProjectFolderPersistenceTests
 
             var settings = ReadPersistedSettings(ctx);
             Assert.Equal(dir, settings.LastProjectFolderPath);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    // Issue #839: end-to-end proof that the App/MainWindow DI wiring reaches ProjectTreeThumbnailService --
+    // ProjectTreeThumbnailServiceTests and ProjectPanelControlTests already cover the generation
+    // logic itself in isolation.
+    [AvaloniaFact]
+    public async Task OpeningProjectFolder_AchxHasAFrame_LoadsAThumbnailForItsTreeNode()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        using (var bm = new SKBitmap(8, 8))
+        {
+            bm.Erase(SKColors.Red);
+            using var img = SKImage.FromBitmap(bm);
+            using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+            File.WriteAllBytes(Path.Combine(dir, "hero.png"), data.ToArray());
+        }
+        var acls = new FlatRedBall2.Animation.Content.AnimationChainListSave();
+        acls.AnimationChains.Add(new FlatRedBall2.Animation.Content.AnimationChainSave
+        {
+            Name = "Walk",
+            Frames = { new FlatRedBall2.Animation.Content.AnimationFrameSave { TextureName = "hero.png" } },
+        });
+        acls.Save(Path.Combine(dir, "hero.achx"));
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            await window.ProjectPanel.ThumbnailLoadTask;
+
+            Assert.True(window.ProjectPanel.TreeRoots[0].HasThumbnail);
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderPersistenceTests.cs
@@ -105,11 +105,14 @@ public class ProjectFolderPersistenceTests
     // until the folder was reopened, even after a real save to disk.
     //
     // This drives the SAME trigger a real drag-resize commit uses in production
-    // (WireframeControl.CommitActiveDrag -> OnFrameRegionChanged -> RaiseAnimationChainsChanged),
-    // rather than calling ProjectManager.SaveAnimationChainList directly, so it proves the full
-    // real chain: edit -> AnimationChainsChanged -> AppCommands saves (see
-    // AppCommandsSaveOnChangeTests for that piece in isolation) -> EditorProjectModelChanged ->
-    // MainWindow invalidates the tracked tree node.
+    // (WireframeControl.CommitActiveDrag -> OnFrameRegionChanged -> RaiseAnimationChainsChanged)
+    // and awaits MainWindow's own EditorProjectModelChanged reaction (LastEditorProjectModelChangedTask)
+    // rather than calling ProjectPanel.InvalidateThumbnail directly. Calling it directly would only
+    // prove the invalidation *method* works, not that the real event wiring finds the right tree
+    // node -- which is exactly how a real path-normalization bug slipped past an earlier version of
+    // this test (ProjectManager.FileName is forward-slash normalized via FilePath.FullPath;
+    // DiskEditorFile.FullPath is a raw Directory.EnumerateFiles path -- backslash on Windows -- so a
+    // naive string compare between them never matched).
     [AvaloniaFact]
     public async Task SavingATrackedFile_RefreshesItsProjectTreeThumbnail()
     {
@@ -151,7 +154,7 @@ public class ProjectFolderPersistenceTests
             Assert.True(File.Exists(achxPath));
 
             Dispatcher.UIThread.RunJobs();
-            await window.InvalidateProjectPanelThumbnailIfTrackedAsync(achxPath);
+            await window.LastEditorProjectModelChangedTask;
 
             var afterEdit = window.ProjectPanel.TreeRoots[0].Thumbnail;
             Assert.NotNull(afterEdit);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -43,6 +43,9 @@ internal sealed class TestServices
     public AppCommands AppCommands { get; }
     public PendingCutState PendingCutState { get; }
     public ThumbnailService ThumbnailService { get; }
+    // null diskCacheDirectory: tests never need thumbnails backed by a real per-user cache dir
+    // (same rationale as SettingsRoot's isolation -- see class doc).
+    public ProjectTreeThumbnailService ProjectTreeThumbnailService { get; } = new(diskCacheDirectory: null);
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
     public IUpdateChecker UpdateChecker { get; set; } = new FakeUpdateChecker();
 
@@ -78,7 +81,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
-            ThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
+            ThumbnailService, ProjectTreeThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
 
     public WireframeControl CreateWireframeControl(System.Action<string>? showError = null)
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailCacheKeyTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailCacheKeyTests.cs
@@ -1,0 +1,53 @@
+using System;
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #839: the disk thumbnail cache is invalidated by comparing the source .achx's Size/Modified
+// (FolderSnapshotDiff's own invalidation pair) against what's baked into the cache file's name --
+// no separate hashing/metadata scheme.
+public class AchxThumbnailCacheKeyTests
+{
+    [Fact]
+    public void BuildFileName_SameInputs_ReturnsTheSameFileName()
+    {
+        var modified = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var first = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024, modified);
+        var second = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024, modified);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void BuildFileName_DifferentModified_ReturnsADifferentFileName()
+    {
+        var path = @"C:\Content\hero.achx";
+        var original = AchxThumbnailCacheKey.BuildFileName(path, 1024, new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var afterEdit = AchxThumbnailCacheKey.BuildFileName(path, 1024, new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.NotEqual(original, afterEdit);
+    }
+
+    [Fact]
+    public void BuildFileName_DifferentPath_ReturnsADifferentFileName()
+    {
+        var modified = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var hero = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024, modified);
+        var enemy = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\enemy.achx", 1024, modified);
+
+        Assert.NotEqual(hero, enemy);
+    }
+
+    [Fact]
+    public void BuildFileName_EndsWithPngExtension()
+    {
+        var result = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.EndsWith(".png", result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailFrameSelectorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailFrameSelectorTests.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #839: project-tree thumbnails render the first frame of the first non-empty chain.
+public class AchxThumbnailFrameSelectorTests
+{
+    [Fact]
+    public void SelectFirstFrame_FirstChainEmpty_ReturnsFrameFromNextNonEmptyChain()
+    {
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+        var expected = new AnimationFrameSave { TextureName = "walk.png" };
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Walk", Frames = { expected } });
+
+        var result = AchxThumbnailFrameSelector.SelectFirstFrame(acls);
+
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public void SelectFirstFrame_FirstChainHasFrames_ReturnsItsFirstFrame()
+    {
+        var acls = new AnimationChainListSave();
+        var expected = new AnimationFrameSave { TextureName = "idle.png" };
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Idle", Frames = { expected, new AnimationFrameSave() } });
+
+        var result = AchxThumbnailFrameSelector.SelectFirstFrame(acls);
+
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public void SelectFirstFrame_NoChainsHaveFrames_ReturnsNull()
+    {
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+
+        var result = AchxThumbnailFrameSelector.SelectFirstFrame(acls);
+
+        Assert.Null(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveOnChangeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveOnChangeTests.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Issue #839 follow-up: the app's autosave policy -- any edit (raised as
+/// <c>IApplicationEvents.AnimationChainsChanged</c> from ~20 <c>IUndoableCommand</c> types and a
+/// couple of direct <c>AppCommands</c> call sites) writes the <c>.achx</c> to disk -- used to be
+/// wired only in <c>MainWindow</c> (the Avalonia app layer). That made it untestable without a
+/// full headless window + WireframeControl, and it was misdiagnosed twice while investigating
+/// this issue as a result. It now lives in <c>AppCommands</c>'s own constructor, so these tests
+/// exercise it directly with no Avalonia/UI involved at all.
+/// </summary>
+public class AppCommandsSaveOnChangeTests
+{
+    [Fact]
+    public void RaiseAnimationChainsChanged_FileNameSet_SavesToDisk()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var tmpPath = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N") + ".achx");
+        ctx.ProjectManager.FileName = tmpPath;
+
+        try
+        {
+            ctx.ApplicationEvents.RaiseAnimationChainsChanged();
+
+            Assert.True(File.Exists(tmpPath), $"Expected {tmpPath} to be written by the autosave policy.");
+        }
+        finally
+        {
+            if (File.Exists(tmpPath)) File.Delete(tmpPath);
+        }
+    }
+
+    [Fact]
+    public void RaiseAnimationChainsChanged_NoFileNameSet_DoesNotThrow()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.ProjectManager.FileName = null;
+
+        var ex = Record.Exception(() => ctx.ApplicationEvents.RaiseAnimationChainsChanged());
+
+        Assert.Null(ex);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EditorFolderResolveRelativeFileTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/EditorFolderResolveRelativeFileTests.cs
@@ -1,0 +1,65 @@
+using AnimationEditor.Core.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #839: IEditorFolder.ResolveRelativeFileAsync's default implementation (used by any
+// IEditorFolder that doesn't override it, e.g. the browser build's folder adapters) walks
+// subfolders by name and stops at a ".." segment, since IEditorFolder has no way to reach a
+// parent folder. DiskEditorFolder overrides it with full System.IO resolution (see
+// DiskEditorFolderResolveRelativeFileTests in AnimationEditor.App.Tests).
+public class EditorFolderResolveRelativeFileTests
+{
+    // Default interface methods are only visible through the interface type -- calling one on a
+    // variable statically typed as the concrete class (as test setup naturally does, to reach
+    // Files/Subfolders) does not compile. This helper is the one place that upcasts.
+    private static Task<IEditorFile?> Resolve(IEditorFolder folder, string relativePath) =>
+        folder.ResolveRelativeFileAsync(relativePath);
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_SameFolderFile_ReturnsFile()
+    {
+        var root = new FakeEditorFolder("Content");
+        var png = new FakeEditorFile("hero.png");
+        root.Files.Add(png);
+
+        var result = await Resolve(root, "hero.png");
+
+        Assert.Same(png, result);
+    }
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_FileInSubfolder_WalksDownAndReturnsFile()
+    {
+        var root = new FakeEditorFolder("Content");
+        var textures = new FakeEditorFolder("Textures");
+        var png = new FakeEditorFile("hero.png");
+        textures.Files.Add(png);
+        root.Subfolders.Add(textures);
+
+        var result = await Resolve(root, "Textures/hero.png");
+
+        Assert.Same(png, result);
+    }
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_ParentDirectorySegment_ReturnsNull()
+    {
+        var root = new FakeEditorFolder("Content");
+
+        var result = await Resolve(root, "../Shared/hero.png");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResolveRelativeFileAsync_FileDoesNotExist_ReturnsNull()
+    {
+        var root = new FakeEditorFolder("Content");
+
+        var result = await Resolve(root, "missing.png");
+
+        Assert.Null(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PixelFrameUvConverterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PixelFrameUvConverterTests.cs
@@ -1,0 +1,39 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #839: .achx files saved with CoordinateType=Pixel store raw pixel rectangles, but
+// ThumbnailService.RenderFrameThumbnail expects normalized (0-1) UV -- the project-tree thumbnail
+// generator converts using the already-decoded texture's pixel size before cropping.
+public class PixelFrameUvConverterTests
+{
+    [Fact]
+    public void ToUv_PixelCoordinates_DividesByTextureSize()
+    {
+        var frame = new AnimationFrameSave
+        {
+            LeftCoordinate = 16f, RightCoordinate = 48f,
+            TopCoordinate = 0f, BottomCoordinate = 32f,
+        };
+
+        var uv = PixelFrameUvConverter.ToUv(frame, textureWidth: 64, textureHeight: 64);
+
+        Assert.Equal(0.25f, uv.LeftCoordinate, tolerance: 0.001f);
+        Assert.Equal(0.75f, uv.RightCoordinate, tolerance: 0.001f);
+        Assert.Equal(0f, uv.TopCoordinate, tolerance: 0.001f);
+        Assert.Equal(0.5f, uv.BottomCoordinate, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void ToUv_PreservesFlipFlags()
+    {
+        var frame = new AnimationFrameSave { FlipHorizontal = true, FlipVertical = true };
+
+        var uv = PixelFrameUvConverter.ToUv(frame, textureWidth: 32, textureHeight: 32);
+
+        Assert.True(uv.FlipHorizontal);
+        Assert.True(uv.FlipVertical);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectThumbnailCacheLocationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectThumbnailCacheLocationTests.cs
@@ -1,0 +1,17 @@
+using AnimationEditor.Core.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ProjectThumbnailCacheLocationTests
+{
+    [Fact]
+    public void ForApplicationDataRoot_PlacesDirectoryUnderAnimationEditorSubfolder()
+    {
+        // Backslash literal proves the cross-platform FilePath handling (see AppSettingsLocationTests).
+        var result = ProjectThumbnailCacheLocation.ForApplicationDataRoot(@"C:\Users\dev\AppData\Roaming");
+
+        Assert.Equal(@"C:\Users\dev\AppData\Roaming\AnimationEditor\ThumbnailCache".Replace('\\', '/'),
+            result.Replace('\\', '/'));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.DocScreenshots/TestHelpers.cs
@@ -33,6 +33,7 @@ internal sealed class TestServices
     public AppCommands AppCommands { get; }
     public PendingCutState PendingCutState { get; }
     public ThumbnailService ThumbnailService { get; }
+    public ProjectTreeThumbnailService ProjectTreeThumbnailService { get; } = new(diskCacheDirectory: null);
     public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
     public IUpdateChecker UpdateChecker { get; } = new FakeUpdateChecker();
 
@@ -58,7 +59,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
-            ThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
+            ThumbnailService, ProjectTreeThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
 }
 
 internal static class TestHelpers

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -1,7 +1,11 @@
+using AnimationEditor.App.Services;
 using AnimationEditor.Core.IO;
 using Avalonia.Headless.XUnit;
+using SkiaSharp;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -108,12 +112,59 @@ public class ProjectPanelControlTests
         Assert.Same(hero, ((AnimationEditor.Views.Controls.AchxTreeNodeVm)control.ProjectTree.SelectedItem!).Entry);
     }
 
+    // Issue #839: SetEntries kicks off async thumbnail generation via ProjectTreeThumbnailService.
+    // ThumbnailLoadTask is the test seam for awaiting it deterministically.
+    [AvaloniaFact]
+    public async Task SetEntries_WithThumbnailServiceInitialized_PopulatesThumbnailOnFileNode()
+    {
+        const string achxWithFrame =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AnimationChainArraySave>
+              <FileRelativeTextures>true</FileRelativeTextures>
+              <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+              <CoordinateType>UV</CoordinateType>
+              <AnimationChain>
+                <Name>Walk</Name>
+                <Frame>
+                  <TextureName>hero.png</TextureName>
+                  <FrameLength>0.1</FrameLength>
+                  <LeftCoordinate>0</LeftCoordinate>
+                  <RightCoordinate>1</RightCoordinate>
+                  <TopCoordinate>0</TopCoordinate>
+                  <BottomCoordinate>1</BottomCoordinate>
+                </Frame>
+              </AnimationChain>
+            </AnimationChainArraySave>
+            """;
+        using var textureBitmap = new SKBitmap(8, 8);
+        textureBitmap.Erase(SKColors.Red);
+        using var textureImage = SKImage.FromBitmap(textureBitmap);
+        using var textureData = textureImage.Encode(SKEncodedImageFormat.Png, 100);
+
+        var root = new FakeFolder("Content");
+        root.Files["hero.png"] = new FakeFile("hero.png", textureData.ToArray());
+        var achxFile = new FakeFile("hero.achx", Encoding.UTF8.GetBytes(achxWithFrame));
+        var entry = new AchxFileEntry(achxFile, root, "hero.achx");
+
+        var control = new AnimationEditor.Views.Controls.ProjectPanelControl();
+        control.Initialize(new ProjectTreeThumbnailService(diskCacheDirectory: null));
+
+        control.SetEntries(new[] { entry });
+        await control.ThumbnailLoadTask;
+
+        Assert.True(control.TreeRoots[0].HasThumbnail);
+    }
+
     private sealed class FakeFile : IEditorFile
     {
-        public FakeFile(string name) => Name = name;
+        public FakeFile(string name, byte[]? content = null) { Name = name; _content = content; }
+        private readonly byte[]? _content;
         public string Name { get; }
-        public Task<Stream> OpenReadAsync() => throw new System.NotSupportedException();
-        public Task<Stream> OpenWriteAsync() => throw new System.NotSupportedException();
+        public Task<Stream> OpenReadAsync() => _content is null
+            ? throw new NotSupportedException()
+            : Task.FromResult<Stream>(new MemoryStream(_content));
+        public Task<Stream> OpenWriteAsync() => throw new NotSupportedException();
         public Task<FolderEntrySnapshot> GetBasicPropertiesAsync() =>
             Task.FromResult(new FolderEntrySnapshot(null, null));
     }
@@ -122,10 +173,12 @@ public class ProjectPanelControlTests
     {
         public FakeFolder(string name) => Name = name;
         public string Name { get; }
+        public Dictionary<string, FakeFile> Files { get; } = new(StringComparer.OrdinalIgnoreCase);
 #pragma warning disable CS1998 // no subfolders/items to enumerate -- these entries are hand-built for the tree tests above
         public async IAsyncEnumerable<IEditorFile> GetItemsAsync() { yield break; }
         public async IAsyncEnumerable<IEditorFolder> GetSubfoldersAsync() { yield break; }
 #pragma warning restore CS1998
-        public Task<IEditorFile?> GetFileAsync(string name) => Task.FromResult<IEditorFile?>(null);
+        public Task<IEditorFile?> GetFileAsync(string name) =>
+            Task.FromResult(Files.TryGetValue(name, out var f) ? (IEditorFile?)f : null);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
@@ -103,6 +103,28 @@ public class ProjectTreeThumbnailServiceTests
         Assert.Null(thumb);
     }
 
+    // Issue #839 follow-up: saving an edit (reordering frames, resizing a frame region, etc.)
+    // changes the .achx on disk, but GetThumbnailAsync's in-memory cache is keyed by the
+    // AchxFileEntry object, not by content -- nothing re-checks disk on its own. The caller
+    // (ProjectPanelControl, wired from MainWindow's save-completed event) must call
+    // InvalidateEntry after a save so the next request regenerates instead of returning stale art.
+    [AvaloniaFact]
+    public async Task InvalidateEntry_ThenGetThumbnailAsync_RegeneratesInsteadOfReturningStaleInstance()
+    {
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(16, 16, SKColors.Red));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+        var first = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        ((FakeFile)entry.File).Content = Encoding.UTF8.GetBytes(AchxWithFrame.Replace("hero.png", "other.png"));
+        ((FakeFolder)entry.ParentFolder).FilesByName["other.png"] = new FakeFile("other.png", EncodePng(16, 16, SKColors.Blue));
+        svc.InvalidateEntry(entry);
+        var afterInvalidate = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(first);
+        Assert.NotNull(afterInvalidate);
+        Assert.NotSame(first, afterInvalidate);
+    }
+
     [AvaloniaFact]
     public async Task GetThumbnailAsync_CalledTwiceForSameEntry_ReturnsSameCachedInstance()
     {
@@ -167,8 +189,11 @@ public class ProjectTreeThumbnailServiceTests
 
     private sealed class FakeFile : IEditorFile
     {
-        public FakeFile(string name, byte[] content) { Name = name; _content = content; }
-        private readonly byte[] _content;
+        public FakeFile(string name, byte[] content) { Name = name; Content = content; }
+
+        /// <summary>Settable so a test can simulate an edit+save landing on disk between two
+        /// GetThumbnailAsync calls, around an InvalidateEntry.</summary>
+        public byte[] Content { get; set; }
         public string Name { get; }
 
         /// <summary>Records which thread called <see cref="OpenReadAsync"/>, so tests can prove
@@ -178,12 +203,12 @@ public class ProjectTreeThumbnailServiceTests
         public Task<Stream> OpenReadAsync()
         {
             ReadThreadId = Environment.CurrentManagedThreadId;
-            return Task.FromResult<Stream>(new MemoryStream(_content));
+            return Task.FromResult<Stream>(new MemoryStream(Content));
         }
 
         public Task<Stream> OpenWriteAsync() => throw new NotSupportedException();
         public Task<FolderEntrySnapshot> GetBasicPropertiesAsync() =>
-            Task.FromResult(new FolderEntrySnapshot((ulong)_content.Length, DateTimeOffset.UnixEpoch));
+            Task.FromResult(new FolderEntrySnapshot((ulong)Content.Length, DateTimeOffset.UnixEpoch));
     }
 
     private sealed class FakeFolder : IEditorFolder

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
@@ -130,6 +130,24 @@ public class ProjectTreeThumbnailServiceTests
             "Expected exactly one cached thumbnail file on disk.");
     }
 
+    // Regression: SemaphoreSlim.WaitAsync and small local-file reads routinely complete
+    // synchronously, so without an explicit Task.Run the achx parse + PNG decode + Skia crop
+    // (all CPU-bound, no I/O to actually yield on) ran inline on whichever thread called
+    // GetThumbnailAsync -- the UI thread, since ProjectPanelControl.Rebuild() fires the load
+    // loop synchronously. On a folder with many .achx files that froze the app on first load.
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_GenerationWork_RunsOffTheCallingThread()
+    {
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(16, 16, SKColors.Red));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+
+        await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(((FakeFile)entry.File).ReadThreadId);
+        Assert.NotEqual(callingThreadId, ((FakeFile)entry.File).ReadThreadId);
+    }
+
     [AvaloniaFact]
     public async Task GetThumbnailAsync_DiskCacheAlreadyHasAMatchingFile_ReusesItInsteadOfRegenerating()
     {
@@ -152,7 +170,17 @@ public class ProjectTreeThumbnailServiceTests
         public FakeFile(string name, byte[] content) { Name = name; _content = content; }
         private readonly byte[] _content;
         public string Name { get; }
-        public Task<Stream> OpenReadAsync() => Task.FromResult<Stream>(new MemoryStream(_content));
+
+        /// <summary>Records which thread called <see cref="OpenReadAsync"/>, so tests can prove
+        /// generation work happens off the caller's (potentially UI) thread. Null until called.</summary>
+        public int? ReadThreadId { get; private set; }
+
+        public Task<Stream> OpenReadAsync()
+        {
+            ReadThreadId = Environment.CurrentManagedThreadId;
+            return Task.FromResult<Stream>(new MemoryStream(_content));
+        }
+
         public Task<Stream> OpenWriteAsync() => throw new NotSupportedException();
         public Task<FolderEntrySnapshot> GetBasicPropertiesAsync() =>
             Task.FromResult(new FolderEntrySnapshot((ulong)_content.Length, DateTimeOffset.UnixEpoch));

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectTreeThumbnailServiceTests.cs
@@ -1,0 +1,178 @@
+using AnimationEditor.App.Services;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Views.Tests;
+
+// Issue #839: first-frame thumbnails for the Open Project Folder tree. ProjectTreeThumbnailService
+// resolves a frame's texture relative to that .achx's OWN folder (via AchxFileEntry.ParentFolder),
+// independent of whichever project is actually open -- these files are never loaded into
+// ProjectManager.
+public class ProjectTreeThumbnailServiceTests
+{
+    private const string AchxWithFrame =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AnimationChainArraySave>
+          <FileRelativeTextures>true</FileRelativeTextures>
+          <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+          <CoordinateType>UV</CoordinateType>
+          <AnimationChain>
+            <Name>Walk</Name>
+            <Frame>
+              <TextureName>hero.png</TextureName>
+              <FrameLength>0.1</FrameLength>
+              <LeftCoordinate>0</LeftCoordinate>
+              <RightCoordinate>1</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate>
+              <BottomCoordinate>1</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    private const string AchxWithNoFrames =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AnimationChainArraySave>
+          <FileRelativeTextures>true</FileRelativeTextures>
+          <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+          <CoordinateType>UV</CoordinateType>
+          <AnimationChain>
+            <Name>Empty</Name>
+          </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    private static byte[] EncodePng(int width, int height, SKColor color)
+    {
+        using var bm = new SKBitmap(width, height);
+        bm.Erase(color);
+        using var img = SKImage.FromBitmap(bm);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    private static AchxFileEntry MakeEntry(string achxXml, string textureName, byte[] textureBytes)
+    {
+        var folder = new FakeFolder("Content");
+        folder.FilesByName[textureName] = new FakeFile(textureName, textureBytes);
+        var achxFile = new FakeFile("hero.achx", Encoding.UTF8.GetBytes(achxXml));
+        return new AchxFileEntry(achxFile, folder, "hero.achx");
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_FrameWithSameFolderTexture_ReturnsBitmapAtRequestedSize()
+    {
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(64, 64, SKColors.Red));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+
+        var thumb = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(thumb);
+        Assert.Equal(28, thumb!.PixelSize.Width);
+        Assert.Equal(28, thumb.PixelSize.Height);
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_NoFramesInChain_ReturnsNull()
+    {
+        var entry = MakeEntry(AchxWithNoFrames, "hero.png", EncodePng(8, 8, SKColors.Red));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+
+        var thumb = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.Null(thumb);
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_TextureNotFoundInFolder_ReturnsNull()
+    {
+        var entry = MakeEntry(AchxWithFrame, "other.png", EncodePng(8, 8, SKColors.Red));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+
+        var thumb = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.Null(thumb);
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_CalledTwiceForSameEntry_ReturnsSameCachedInstance()
+    {
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(16, 16, SKColors.Blue));
+        var svc = new ProjectTreeThumbnailService(diskCacheDirectory: null);
+
+        var first = await svc.GetThumbnailAsync(entry, 28, 28);
+        var second = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_DiskCacheConfigured_WritesAThumbnailFileToDisk()
+    {
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(16, 16, SKColors.Green));
+        var cacheDir = Path.Combine(Path.GetTempPath(), "AnimationEditorTests", Guid.NewGuid().ToString("N"));
+        var svc = new ProjectTreeThumbnailService(cacheDir);
+
+        var thumb = await svc.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(thumb);
+        Assert.True(Directory.Exists(cacheDir) && Directory.GetFiles(cacheDir, "*.png").Length == 1,
+            "Expected exactly one cached thumbnail file on disk.");
+    }
+
+    [AvaloniaFact]
+    public async Task GetThumbnailAsync_DiskCacheAlreadyHasAMatchingFile_ReusesItInsteadOfRegenerating()
+    {
+        var entry = MakeEntry(AchxWithFrame, "hero.png", EncodePng(16, 16, SKColors.Yellow));
+        var cacheDir = Path.Combine(Path.GetTempPath(), "AnimationEditorTests", Guid.NewGuid().ToString("N"));
+        var first = new ProjectTreeThumbnailService(cacheDir);
+        await first.GetThumbnailAsync(entry, 28, 28);
+
+        // A fresh service instance (no in-memory cache) reading the same disk cache directory
+        // must hit the cache file instead of re-parsing/re-decoding.
+        var second = new ProjectTreeThumbnailService(cacheDir);
+        var thumb = await second.GetThumbnailAsync(entry, 28, 28);
+
+        Assert.NotNull(thumb);
+        Assert.Single(Directory.GetFiles(cacheDir, "*.png"));
+    }
+
+    private sealed class FakeFile : IEditorFile
+    {
+        public FakeFile(string name, byte[] content) { Name = name; _content = content; }
+        private readonly byte[] _content;
+        public string Name { get; }
+        public Task<Stream> OpenReadAsync() => Task.FromResult<Stream>(new MemoryStream(_content));
+        public Task<Stream> OpenWriteAsync() => throw new NotSupportedException();
+        public Task<FolderEntrySnapshot> GetBasicPropertiesAsync() =>
+            Task.FromResult(new FolderEntrySnapshot((ulong)_content.Length, DateTimeOffset.UnixEpoch));
+    }
+
+    private sealed class FakeFolder : IEditorFolder
+    {
+        public FakeFolder(string name) => Name = name;
+        public string Name { get; }
+        public Dictionary<string, FakeFile> FilesByName { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+#pragma warning disable CS1998 // no subfolders needed for these same-folder-only tests
+        public async IAsyncEnumerable<IEditorFile> GetItemsAsync()
+        {
+            foreach (var file in FilesByName.Values) yield return file;
+        }
+        public async IAsyncEnumerable<IEditorFolder> GetSubfoldersAsync() { yield break; }
+#pragma warning restore CS1998
+
+        public Task<IEditorFile?> GetFileAsync(string name) =>
+            Task.FromResult(FilesByName.TryGetValue(name, out var f) ? (IEditorFile?)f : null);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a lazy, throttled first-frame thumbnail to each `.achx` row in the Open Project Folder tree (`ProjectPanelControl`), replacing the generic chain icon once loaded.
- New `ProjectTreeThumbnailService` resolves a frame's texture relative to *that file's own* folder (not the currently-open project) and reuses `ThumbnailService`'s crop/scale core.
- New `IEditorFolder.ResolveRelativeFileAsync` default (subfolder-only walk) lets this work uniformly on desktop and the browser build without a concrete-type check across the Views/App assembly boundary; `DiskEditorFolder` overrides it with full `System.IO` (`..`-capable) resolution.
- Desktop persists finished thumbnails to a per-user disk cache (`%APPDATA%/AnimationEditor/ThumbnailCache/`), invalidated by the source file's size/modified (same pair `FolderSnapshotDiff` already uses elsewhere) baked into the cache filename. Browser gets in-memory-only caching for now — no persistent FS to cache to.
- Handles `CoordinateType=Pixel` `.achx` files by converting to UV using the decoded texture's pixel size before cropping.

## Test plan

- [x] `AnimationEditor.Core.Tests` (1772 passed): frame selection, pixel→UV conversion, cache-key/location helpers, `ResolveRelativeFileAsync` default behavior.
- [x] `AnimationEditor.Views.Tests` (79 passed): `ProjectTreeThumbnailService` generation/caching/disk-cache-reuse, `ProjectPanelControl` integration (thumbnail populates a real tree node).
- [x] `AnimationEditor.App.Tests` (786 passed): `DiskEditorFolder`'s `..` override, and an end-to-end test opening a real folder through `MainWindow` proving the production DI wiring reaches the new service.
- [x] Full solution build, including the WASM `AnimationEditor.Browser` target.

Closes #839