### PR TITLE
Animation Editor: make Name batch-editable for rect/circle multi-select

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4260,6 +4260,36 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// Shows <paramref name="names"/>'s shared value in <paramref name="control"/>, or blanks it with
+    /// a "(mixed)" placeholder when the selection disagrees on Name — same convention as
+    /// <see cref="SetValueOrMixed"/>. When <paramref name="disableForCollision"/> is true (two or more
+    /// selected shapes share a frame), the field is disabled instead: applying one literal name to
+    /// shapes in the same frame would collide, since shape names only need to be unique per-frame.
+    /// </summary>
+    private static void SetNameOrMixed(TextBox control, IReadOnlyList<string> names, bool disableForCollision)
+    {
+        if (disableForCollision)
+        {
+            control.IsEnabled = false;
+            control.Text = null;
+            control.PlaceholderText = "(multiple — same frame)";
+            return;
+        }
+
+        control.IsEnabled = true;
+        if (names.Distinct().Count() == 1)
+        {
+            control.Text = names[0];
+            control.PlaceholderText = null;
+        }
+        else
+        {
+            control.Text = null;
+            control.PlaceholderText = "(mixed)";
+        }
+    }
+
     private void RefreshPropertyPanel()
     {
         _suppressPropRefresh = true;
@@ -4365,13 +4395,14 @@ public partial class MainWindow : Window
             {
                 // Multi-selected rects can disagree on a property, same as multi-selected frames
                 // (#571) — show that field blank with a "(mixed)" placeholder instead of one rect's
-                // value; editing it then applies the new value to every selected rect. Name has no
-                // legitimate "mixed" display since it isn't numeric, so it's just disabled instead
-                // (see ApplyRectProps for why a shared literal name isn't applied across a batch).
+                // value; editing it then applies the new value to every selected rect. Name follows
+                // the same pattern: shape names only need to be unique within a frame (not across
+                // frames), so batch-renaming is safe unless two selected rects share a frame — see
+                // SetNameOrMixed and ApplyRectProps.
                 var rects = _selectedState.SelectedRectangles;
-                bool rectsMulti = rects.Count > 1;
-                PropRectName.IsEnabled = !rectsMulti;
-                PropRectName.Text = rectsMulti ? "(multiple)" : (rect.Name ?? "");
+                bool rectsCollide = rects.Count > 1 &&
+                    _appCommands.HasSameFrameNameCollision(rects.Cast<object>().ToList());
+                SetNameOrMixed(PropRectName, rects.Select(r => r.Name ?? "").ToList(), rectsCollide);
                 SetValueOrMixed(PropRectX, rects.Select(r => (decimal)r.X).ToList());
                 SetValueOrMixed(PropRectY, rects.Select(r => (decimal)r.Y).ToList());
                 SetValueOrMixed(PropRectScaleX, rects.Select(r => (decimal)r.ScaleX).ToList());
@@ -4381,9 +4412,9 @@ public partial class MainWindow : Window
             if (circ is not null)
             {
                 var circles = _selectedState.SelectedCircles;
-                bool circlesMulti = circles.Count > 1;
-                PropCircleName.IsEnabled = !circlesMulti;
-                PropCircleName.Text = circlesMulti ? "(multiple)" : (circ.Name ?? "");
+                bool circlesCollide = circles.Count > 1 &&
+                    _appCommands.HasSameFrameNameCollision(circles.Cast<object>().ToList());
+                SetNameOrMixed(PropCircleName, circles.Select(c => c.Name ?? "").ToList(), circlesCollide);
                 SetValueOrMixed(PropCircleX, circles.Select(c => (decimal)c.X).ToList());
                 SetValueOrMixed(PropCircleY, circles.Select(c => (decimal)c.Y).ToList());
                 SetValueOrMixed(PropCircleRadius, circles.Select(c => (decimal)c.Radius).ToList());
@@ -4500,15 +4531,16 @@ public partial class MainWindow : Window
         var rects = _selectedState.SelectedRectangles;
         if (rects.Count == 0) return;
 
-        // A null component here means "still showing (mixed), not edited" — leave that axis alone
-        // per-rect. Name is only applied for a single selected rect: propagating one literal name
-        // to every rect in a multi-selection would clobber their distinct names (PropRectName is
-        // disabled in RefreshPropertyPanel whenever more than one rect is selected).
+        // A null component here means "still showing (mixed)/disabled, not edited" — leave that
+        // field alone per-rect. PropRectName.Text is null exactly when RefreshPropertyPanel just
+        // showed "(mixed)" or disabled the field for a same-frame collision (SetNameOrMixed); once
+        // the user types, Text becomes non-null and applies to every selected rect (safe as long as
+        // no two share a frame — SetNameOrMixed disables the field for that case).
         float? x = PropRectX.Value.HasValue ? (float)PropRectX.Value.Value : null;
         float? y = PropRectY.Value.HasValue ? (float)PropRectY.Value.Value : null;
         float? scaleX = PropRectScaleX.Value.HasValue ? (float)PropRectScaleX.Value.Value : null;
         float? scaleY = PropRectScaleY.Value.HasValue ? (float)PropRectScaleY.Value.Value : null;
-        string? name = rects.Count == 1 ? (PropRectName.Text ?? "") : null;
+        string? name = PropRectName.Text;
 
         _appCommands.SetRectPropsBulk(rects, name, x, y, scaleX, scaleY);
     }
@@ -4519,11 +4551,11 @@ public partial class MainWindow : Window
         var circles = _selectedState.SelectedCircles;
         if (circles.Count == 0) return;
 
-        // See ApplyRectProps for the null-means-"don't touch" / single-selection-only-name semantics.
+        // See ApplyRectProps for the null-means-"don't touch" / same-frame-collision semantics.
         float? x = PropCircleX.Value.HasValue ? (float)PropCircleX.Value.Value : null;
         float? y = PropCircleY.Value.HasValue ? (float)PropCircleY.Value.Value : null;
         float? radius = PropCircleRadius.Value.HasValue ? (float)PropCircleRadius.Value.Value : null;
-        string? name = circles.Count == 1 ? (PropCircleName.Text ?? "") : null;
+        string? name = PropCircleName.Text;
 
         _appCommands.SetCirclePropsBulk(circles, name, x, y, radius);
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
+using AnimationEditor.Core.Utilities;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
@@ -1691,6 +1692,10 @@ namespace AnimationEditor.Core.CommandsAndState
                 },
                 this, _events, _objectFinder, "Edit Circles"));
         }
+
+        /// <inheritdoc cref="IAppCommands.HasSameFrameNameCollision"/>
+        public bool HasSameFrameNameCollision(IReadOnlyList<object> shapes) =>
+            ShapeFrameLookup.HasSameFrameCollision(_pm.AnimationChainListSave, shapes);
 
         // ── Paste (clipboard → project) ───────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -286,18 +286,28 @@ namespace AnimationEditor.Core.CommandsAndState
         /// undoable operation — the multi-select counterpart to <see cref="SetRectProps"/>. Rects may
         /// belong to different frames. <paramref name="name"/> and each numeric parameter may be
         /// <c>null</c> to leave that field untouched per-rect (its own existing value survives) —
-        /// used when the inspector field is showing "(mixed)", or (for name) when more than one
-        /// rect is selected and applying one literal name to every rect would clobber their
-        /// distinct names. See <see cref="SetFrameRelative"/> for why <c>null</c> is unambiguous here.
+        /// used when the inspector field is showing "(mixed)". Applying one literal
+        /// <paramref name="name"/> to every rect is safe as long as no two rects share a frame (shape
+        /// names only need to be unique within a frame); callers should check
+        /// <see cref="HasSameFrameNameCollision"/> before passing a non-null name for a multi-selection.
+        /// See <see cref="SetFrameRelative"/> for why <c>null</c> is unambiguous here.
         /// </summary>
         void SetRectPropsBulk(IReadOnlyList<AARectSave> rects, string? name, float? x, float? y, float? scaleX, float? scaleY);
 
         /// <summary>
         /// Sets Name/X/Y/Radius on every circle in <paramref name="circles"/> as a single undoable
         /// operation — the multi-select counterpart to <see cref="SetCircleProps"/>. See
-        /// <see cref="SetRectPropsBulk"/> for the null-means-"don't touch" semantics.
+        /// <see cref="SetRectPropsBulk"/> for the null-means-"don't touch" semantics and the
+        /// same-frame name-collision caveat.
         /// </summary>
         void SetCirclePropsBulk(IReadOnlyList<CircleSave> circles, string? name, float? x, float? y, float? radius);
+
+        /// <summary>
+        /// True when two or more of <paramref name="shapes"/> (AARectSave and/or CircleSave) are
+        /// owned by the same frame — batch-applying one literal name to all of them would collide,
+        /// since shape names only need to be unique within a frame, not across frames.
+        /// </summary>
+        bool HasSameFrameNameCollision(IReadOnlyList<object> shapes);
 
         // ── Hot Reload ────────────────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/ShapeFrameLookup.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/ShapeFrameLookup.cs
@@ -1,0 +1,44 @@
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.Utilities;
+
+/// <summary>
+/// Finds which <see cref="AnimationFrameSave"/> owns a given shape (AARectSave/CircleSave/
+/// PolygonSave), by reference, across every chain in a project.
+/// </summary>
+public static class ShapeFrameLookup
+{
+    public static AnimationFrameSave? FindFrameForShape(AnimationChainListSave? acls, object shape)
+    {
+        if (acls is null) return null;
+        foreach (var chain in acls.AnimationChains)
+        {
+            foreach (var frame in chain.Frames)
+            {
+                if (frame.ShapesSave?.Shapes.Contains(shape) == true)
+                    return frame;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// True when two or more of <paramref name="shapes"/> are owned by the same frame. Shape
+    /// names only need to be unique within a single frame, not across frames (see
+    /// <see cref="AARectSave.Name"/>), so batch-renaming shapes that share a frame to one literal
+    /// name would collide, while batch-renaming shapes spread across different frames is safe.
+    /// </summary>
+    public static bool HasSameFrameCollision(AnimationChainListSave? acls, IReadOnlyList<object> shapes)
+    {
+        if (shapes.Count < 2) return false;
+        var framesSeen = new HashSet<AnimationFrameSave>();
+        foreach (var shape in shapes)
+        {
+            var frame = FindFrameForShape(acls, shape);
+            if (frame != null && !framesSeen.Add(frame))
+                return true;
+        }
+        return false;
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShapeMultiSelectPropertyPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShapeMultiSelectPropertyPanelTests.cs
@@ -91,4 +91,106 @@ public class ShapeMultiSelectPropertyPanelTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// Regression test for issue #844: Name used to be disabled outright for any multi-selection.
+    /// Shape names only need to be unique within a frame, so renaming rects that live on different
+    /// frames to one literal name is safe and should apply to both.
+    /// </summary>
+    [AvaloniaFact]
+    public void ApplyRectProps_TwoRectsAcrossDifferentFrames_RenamingAppliesToBoth()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var rect0 = new AARectSave { Name = "Box0" };
+            var rect1 = new AARectSave { Name = "Box1" };
+            f0.ShapesSave!.Shapes.Add(rect0);
+            f1.ShapesSave!.Shapes.Add(rect1);
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+            var frame0Node = chainNode.Children[0];
+            var frame1Node = chainNode.Children[1];
+            frame0Node.IsExpanded = true;
+            frame1Node.IsExpanded = true;
+            FlushUi();
+            var rect0Node = frame0Node.Children.Single(n => ReferenceEquals(n.Data, rect0));
+            var rect1Node = frame1Node.Children.Single(n => ReferenceEquals(n.Data, rect1));
+
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rect0Node);
+            tree.SelectedItems.Add(rect1Node);
+            FlushUi();
+
+            var nameInput = window.FindControl<TextBox>("PropRectName")!;
+            var scaleXInput = window.FindControl<NumericUpDown>("PropRectScaleX")!;
+            Assert.True(nameInput.IsEnabled);
+
+            nameInput.Focus();
+            FlushUi();
+            nameInput.Text = "Hitbox";
+            scaleXInput.Focus(); // moves focus away, raising LostFocus on the name field
+            FlushUi();
+
+            Assert.Equal("Hitbox", rect0.Name);
+            Assert.Equal("Hitbox", rect1.Name);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Two selected rects on the SAME frame can't share one literal name — shape names only need
+    /// to be unique within a frame, so applying one name to both would collide. The field is
+    /// disabled instead of silently renaming.
+    /// </summary>
+    [AvaloniaFact]
+    public void RefreshPropertyPanel_TwoRectsSameFrame_NameFieldDisabled()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, ShapesSave = new ShapesSave() };
+            var rect0 = new AARectSave { Name = "Box0" };
+            var rect1 = new AARectSave { Name = "Box1" };
+            f0.ShapesSave!.Shapes.Add(rect0);
+            f0.ShapesSave!.Shapes.Add(rect1);
+            chain.Frames.Add(f0);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var chainNode = FirstChainNode(tree);
+            chainNode.IsExpanded = true;
+            FlushUi();
+            var frame0Node = chainNode.Children[0];
+            frame0Node.IsExpanded = true;
+            FlushUi();
+            var rect0Node = frame0Node.Children.Single(n => ReferenceEquals(n.Data, rect0));
+            var rect1Node = frame0Node.Children.Single(n => ReferenceEquals(n.Data, rect1));
+
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(rect0Node);
+            tree.SelectedItems.Add(rect1Node);
+            FlushUi();
+
+            var nameInput = window.FindControl<TextBox>("PropRectName")!;
+
+            Assert.False(nameInput.IsEnabled);
+            Assert.Equal("Box0", rect0.Name);
+            Assert.Equal("Box1", rect1.Name);
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
@@ -78,4 +78,64 @@ public class AppCommandsShapePropsBulkTests
         Assert.Equal(15f, circleA.Radius);
         Assert.Equal(15f, circleB.Radius);
     }
+
+    [Fact]
+    public void SetRectPropsBulk_NameGiven_AppliesToEveryRect()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(rectB);
+
+        ctx.AppCommands.SetRectPropsBulk(
+            new List<AARectSave> { rectA, rectB }, "Hitbox", null, null, null, null);
+
+        Assert.Equal("Hitbox", rectA.Name);
+        Assert.Equal("Hitbox", rectB.Name);
+    }
+
+    [Fact]
+    public void SetCirclePropsBulk_NameGiven_AppliesToEveryCircle()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Jump", 2);
+        var circleA = new CircleSave { Name = "A" };
+        var circleB = new CircleSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(circleA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(circleB);
+
+        ctx.AppCommands.SetCirclePropsBulk(
+            new List<CircleSave> { circleA, circleB }, "Hurtbox", null, null, null);
+
+        Assert.Equal("Hurtbox", circleA.Name);
+        Assert.Equal("Hurtbox", circleB.Name);
+    }
+
+    [Fact]
+    public void HasSameFrameNameCollision_RectsAcrossDifferentFrames_ReturnsFalse()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(rectB);
+
+        Assert.False(ctx.AppCommands.HasSameFrameNameCollision(new List<object> { rectA, rectB }));
+    }
+
+    [Fact]
+    public void HasSameFrameNameCollision_RectsOnSameFrame_ReturnsTrue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectB);
+
+        Assert.True(ctx.AppCommands.HasSameFrameNameCollision(new List<object> { rectA, rectB }));
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeFrameLookupTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ShapeFrameLookupTests.cs
@@ -1,0 +1,77 @@
+using AnimationEditor.Core.Utilities;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ShapeFrameLookupTests
+{
+    [Fact]
+    public void FindFrameForShape_ShapeInFrame_ReturnsOwningFrame()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 2);
+        var rect = new AARectSave { Name = "A" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rect);
+
+        var found = ShapeFrameLookup.FindFrameForShape(acls, rect);
+
+        Assert.Same(chain.Frames[0], found);
+    }
+
+    [Fact]
+    public void FindFrameForShape_ShapeNotInAnyFrame_ReturnsNull()
+    {
+        var acls = new AnimationChainListSave();
+        TestHelpers.MakeChain(acls, "Walk", 1);
+        var rect = new AARectSave { Name = "Orphan" };
+
+        var found = ShapeFrameLookup.FindFrameForShape(acls, rect);
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void HasSameFrameCollision_ShapesOnDifferentFrames_ReturnsFalse()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 2);
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[1].ShapesSave!.Shapes.Add(rectB);
+
+        var collision = ShapeFrameLookup.HasSameFrameCollision(acls, new List<object> { rectA, rectB });
+
+        Assert.False(collision);
+    }
+
+    [Fact]
+    public void HasSameFrameCollision_TwoShapesOnSameFrame_ReturnsTrue()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var rectA = new AARectSave { Name = "A" };
+        var rectB = new AARectSave { Name = "B" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectB);
+
+        var collision = ShapeFrameLookup.HasSameFrameCollision(acls, new List<object> { rectA, rectB });
+
+        Assert.True(collision);
+    }
+
+    [Fact]
+    public void HasSameFrameCollision_SingleShape_ReturnsFalse()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 1);
+        var rectA = new AARectSave { Name = "A" };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rectA);
+
+        var collision = ShapeFrameLookup.HasSameFrameCollision(acls, new List<object> { rectA });
+
+        Assert.False(collision);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -118,6 +118,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SetRectPropsBulk)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCirclePropsBulk)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.HasSameFrameNameCollision)]    = Category.NonMutating,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteRectangle)]               = Category.MutatingUndoable,


### PR DESCRIPTION
## Summary
- Name was disabled for any multi-selected rects/circles, on the assumption a shared literal name would clobber distinct names.
- Shape names only need to be unique within a frame (not across frames), so that assumption was wrong for the common case: multi-selecting shapes across different frames.
- Adds `ShapeFrameLookup` to find a shape's owning frame and detect when two selected shapes share a frame. Name field is now enabled unless the selection has a same-frame collision, in which case it's disabled (unchanged behavior for that case).

Closes #844

## Test plan
- [x] `ShapeFrameLookupTests` (Core) — frame lookup + collision detection
- [x] `AppCommandsShapePropsBulkTests` (Core) — `SetRectPropsBulk`/`SetCirclePropsBulk` apply name to every shape when given; `HasSameFrameNameCollision` true/false cases
- [x] `ShapeMultiSelectPropertyPanelTests` (App, headless Avalonia) — renaming two rects across different frames applies to both; two rects on the same frame keep the field disabled
- [x] Full `AnimationEditor.Core.Tests` (1783) and `AnimationEditor.App.Tests` (789) suites pass
- [x] Full solution builds clean (desktop + Browser/WASM)