### PR TITLE
Animation Editor: stop auto-showing default-handler banner

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -823,7 +823,11 @@ public partial class MainWindow : Window
             await LoadProjectFolderAsync(lastProjectFolder);
 
         RefreshFilesPanel();
-        ShowDefaultHandlerBannerIfAppropriate();
+        // Not auto-shown (issue #849): RegisterAsDefault() doesn't work for the current
+        // dev/portable distribution — no installer yet (#493) — so the banner would just
+        // offer a "Make default" button that does nothing useful. The manual "Set as
+        // default" / "Don't show again" controls in Settings still work for anyone who
+        // wants to try it.
         _ = RunStartupUpdateCheckAsync();
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DefaultHandlerBannerStartupTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DefaultHandlerBannerStartupTests.cs
@@ -1,0 +1,45 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Fake <see cref="IFileAssociationService"/> reporting "supported, not yet default" — the
+/// state that used to trigger <see cref="DefaultHandlerPromptDecider.ShouldPrompt"/>.
+/// </summary>
+internal sealed class FakeNotDefaultFileAssociationService : IFileAssociationService
+{
+    public bool IsSupported => true;
+
+    public bool IsDefault() => false;
+
+    public AchxFileAssociationStatus GetStatus() => AchxFileAssociationStatus.NotAssociated;
+
+    public void RegisterAsDefault() { }
+}
+
+/// <summary>
+/// Issue #849: <c>RegisterAsDefault()</c> doesn't work for the current dev/portable
+/// distribution (no installer — see #493), so the startup banner offering it should never
+/// auto-show, even when <see cref="DefaultHandlerPromptDecider.ShouldPrompt"/>'s inputs
+/// would otherwise say to.
+/// </summary>
+public class DefaultHandlerBannerStartupTests
+{
+    [AvaloniaFact]
+    public void Startup_NeverAutoShowsDefaultHandlerBanner()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.FileAssociationService = new FakeNotDefaultFileAssociationService();
+        var window = ctx.CreateMainWindow();
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var banner = window.FindControl<Border>("DefaultHandlerBanner");
+        Assert.False(banner!.IsVisible);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -46,7 +46,7 @@ internal sealed class TestServices
     // null diskCacheDirectory: tests never need thumbnails backed by a real per-user cache dir
     // (same rationale as SettingsRoot's isolation -- see class doc).
     public ProjectTreeThumbnailService ProjectTreeThumbnailService { get; } = new(diskCacheDirectory: null);
-    public IFileAssociationService FileAssociationService { get; } = new NullFileAssociationService();
+    public IFileAssociationService FileAssociationService { get; set; } = new NullFileAssociationService();
     public IUpdateChecker UpdateChecker { get; set; } = new FakeUpdateChecker();
 
     /// <summary>


### PR DESCRIPTION
## Summary
- `RegisterAsDefault()` doesn't work for the current dev/portable build (no installer — #493), so the startup banner just offered a "Make default" button that does nothing useful.
- Removed the auto-show call in `HandleStartupAsync`. Settings still exposes the manual "Set as default" / "Don't show again" controls.

## Test plan
- [x] New test `DefaultHandlerBannerStartupTests.Startup_NeverAutoShowsDefaultHandlerBanner` — red before the fix, green after.
- [x] Full `AnimationEditor.App.Tests` suite (792 tests) passes.
- [x] `AnimationEditor.Core.Tests` `DefaultHandlerPromptDecider` tests still pass (pure logic unchanged).

Closes #849