### PR TITLE
Fix #853: bump Apos.Shapes 0.7.8 -> 0.8.1 (macOS DesktopGL shader crash)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,11 @@
     packages are pinned to the same version here since they track the same upstream release.
   -->
   <PropertyGroup>
-    <AposShapesVersion>0.7.8</AposShapesVersion>
+    <!-- 0.7.8 shipped ~10 hours before ShadowDusk fixed a trunc() lowering bug in its GLSL
+         rewriter (Apos.Shapes #34) that crashed any shape draw on macOS DesktopGL — see
+         AposShapesEmbeddedShaderPortabilityTests and issue #853. Keep at or above the first
+         fixed release (0.7.9). -->
+    <AposShapesVersion>0.8.1</AposShapesVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FlatRedBall2.Tests/Packaging/AposShapesEmbeddedShaderPortabilityTests.cs
+++ b/tests/FlatRedBall2.Tests/Packaging/AposShapesEmbeddedShaderPortabilityTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Apos.Shapes;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Packaging;
+
+// Issue #853. Apos.Shapes' OpenGL shader is built by ShadowDusk's DXC->SPIRV-Cross pipeline, which
+// (before ShadowDusk's "Rule 15" trunc() lowering, tracked as Apos.Shapes #34) emitted a bare
+// trunc() call for HLSL's truncating %/fmod operator. trunc() is a GLSL 1.30 / GLSL ES 3.00
+// builtin, absent from the legacy, versionless GLSL dialect MonoGame's OpenGL runtime requires --
+// it silently compiled on lenient desktop drivers but failed as an undeclared identifier on macOS
+// DesktopGL (Apple Silicon), crashing any Screen that drew a shape on its first frame.
+//
+// Apos.Shapes 0.7.8 (pinned when #853 was filed) was published ~10 hours before the ShadowDusk fix
+// landed; 0.7.9+ ships it (confirmed by extracting and diffing the embedded shader resource of both
+// versions' published NuGet packages). This guards the pin against ever regressing back to a build
+// with the bug, independent of which exact version is pinned.
+public class AposShapesEmbeddedShaderPortabilityTests
+{
+    private static readonly Regex BareTrunc = new(@"\btrunc\s*\(", RegexOptions.Compiled);
+
+    [Fact]
+    public void EmbeddedOpenGLShader_DoesNotCallBareTrunc()
+    {
+        var assembly = typeof(ShapeBatch).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Apos.Shapes.apos-shapes.ogl.mgfx")
+            ?? throw new InvalidOperationException(
+                "Apos.Shapes.dll no longer embeds a resource named 'apos-shapes.ogl.mgfx' -- " +
+                "update this test's resource name to match the current package.");
+        using var reader = new StreamReader(stream, Encoding.Latin1);
+        var glsl = reader.ReadToEnd();
+
+        BareTrunc.IsMatch(glsl).ShouldBeFalse(
+            "The embedded OpenGL shader calls trunc(), a GLSL 1.30/ES 3.00 builtin absent from the " +
+            "legacy dialect MonoGame's GL runtime requires. It compiles on lenient desktop drivers " +
+            "but fails as an undeclared identifier on macOS DesktopGL (issue #853). Bump " +
+            "AposShapesVersion in Directory.Packages.props to a release built after ShadowDusk's " +
+            "trunc() lowering fix.");
+    }
+}


### PR DESCRIPTION
## Summary
- Apos.Shapes' OpenGL shader is built by ShadowDusk's DXC→SPIRV-Cross pipeline, which emitted a bare `trunc()` call for HLSL's truncating `%`/fmod operator (used in the shader's `Mod()` helper). `trunc()` is a GLSL 1.30/ES 3.00 builtin, absent from the legacy dialect MonoGame's GL runtime requires — it compiled silently on lenient desktop drivers but failed as an undeclared identifier on macOS DesktopGL (Apple Silicon), crashing any `Screen` that draws a shape on its first `Draw()`.
- Proved this by extracting the embedded `apos-shapes.ogl.mgfx` resource directly from both published NuGet packages: 0.7.8 (pinned here, published ~10h before ShadowDusk's fix landed) contains the exact broken `trunc()` expression and identifier (`_3673`) quoted in the crash report; 0.8.1 has zero `trunc()` calls (lowered to `sign()/floor()/abs()`).
- Bumps `AposShapesVersion` 0.7.8 → 0.8.1 in `Directory.Packages.props`. No other call sites needed changes (checked for 0.8.0's FontStashSharp `DrawString` removal — FRB2 doesn't use it; text goes through Gum).
- Adds `AposShapesEmbeddedShaderPortabilityTests`: loads the actual resolved `Apos.Shapes` assembly and asserts its embedded OpenGL shader never calls bare `trunc()`. No GPU/macOS needed — runs on existing Ubuntu CI, guards the pin against ever regressing back to a broken build.

Closes #853

## Test plan
- [x] New test fails against 0.7.8 (`AposShapesEmbeddedShaderPortabilityTests`), passes against 0.8.1 — real red→green against live NuGet resolution, no mocking.
- [x] Full engine test suite green (1542/1542).
- [x] `dotnet build src/FlatRedBall2.csproj` succeeds with no new warnings.
- [ ] Manual: run a Screen that draws a shape on real macOS DesktopGL (Apple Silicon) to confirm the crash is gone — not reproducible from this Windows machine; the byte-level shader diff + regression test are the available proof.