### PR TITLE
Sync KernSmith.MonoGameGum/KniGum to Gum.MonoGame's pinned version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,8 +47,8 @@
     <!-- KernSmith moved from a 0.x scheme to the same date-based versioning as Gum, tracking
          Gum's release cadence 1:1. 0.16.0 was its last 0.x release, so a floating "0.16.*" no
          longer matches anything published; pin exactly like the Gum.* packages above. -->
-    <PackageVersion Include="KernSmith.MonoGameGum" Version="2026.8.2.1" />
-    <PackageVersion Include="KernSmith.KniGum" Version="2026.8.2.1" />
+    <PackageVersion Include="KernSmith.MonoGameGum" Version="2026.8.5.2-preview.2" />
+    <PackageVersion Include="KernSmith.KniGum" Version="2026.8.5.2-preview.2" />
     <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
     <PackageVersion Include="MonoGame.Extended" Version="6.0.0" />

--- a/tests/FlatRedBall2.Tests/UI/DynamicFontGenerationTests.cs
+++ b/tests/FlatRedBall2.Tests/UI/DynamicFontGenerationTests.cs
@@ -1,0 +1,61 @@
+using System;
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.UI;
+
+/// <summary>
+/// Covers the KernSmith in-memory font generator that <see cref="FlatRedBallService.Initialize(Game, EngineInitSettings?)"/>
+/// wires up as Gum's <c>IInMemoryFontCreator</c>. Requires a real <see cref="GraphicsDevice"/> because
+/// KernSmith rasterizes fonts through it — see issue #855, where a version mismatch between
+/// <c>Gum.MonoGame</c> and <c>KernSmith.MonoGameGum</c> in <c>Directory.Packages.props</c> made in-memory
+/// font generation throw internally (caught and silently swallowed by Gum), leaving every
+/// <see cref="TextRuntime"/> sharing whatever font happened to be cached first regardless of its own
+/// <see cref="TextRuntime.FontSize"/>.
+/// </summary>
+[Collection(GraphicsDeviceCollection.Name)]
+public class DynamicFontGenerationTests
+{
+    private static bool GumIsOwnedElsewhere => SystemManagers.Default is not null;
+
+    private static Game? TryCreateGame()
+    {
+        try
+        {
+            var game = new Game();
+            _ = new GraphicsDeviceManager(game) { PreferredBackBufferWidth = 64, PreferredBackBufferHeight = 64 };
+            game.RunOneFrame();
+            return game;
+        }
+        catch (Exception e)
+        {
+            // No display, no driver, or a headless agent — same contract as GraphicsDeviceFixture.
+            System.Diagnostics.Debug.WriteLine($"[tests] No graphics device available: {e.Message}");
+            return null;
+        }
+    }
+
+    [Fact]
+    public void FontSize_TwoDistinctSizes_ProduceDistinctlyRasterizedFonts()
+    {
+        if (GumIsOwnedElsewhere)
+            return;
+
+        using var game = TryCreateGame();
+        if (game is null)
+            return;
+
+        var engine = new FlatRedBallService();
+        engine.Initialize(game);
+
+        var small = new TextRuntime { Font = "Arial", FontSize = 20 };
+        var large = new TextRuntime { Font = "Arial", FontSize = 90 };
+
+        small.Typeface.ShouldNotBeNull();
+        large.Typeface.ShouldNotBeNull();
+        large.Typeface.LineHeightInPixels.ShouldBeGreaterThan(small.Typeface.LineHeightInPixels);
+    }
+}


### PR DESCRIPTION
## Summary
- `Directory.Packages.props` pinned `Gum.MonoGame`/`Gum.KNI` at `2026.8.5.2-preview.2` but left `KernSmith.MonoGameGum`/`KniGum` at `2026.8.2.1` — the mismatch throws `MissingFieldException` inside KernSmith's in-memory font generator, which Gum silently swallows and falls back to whatever font is already cached.
- Bumped both KernSmith packages to `2026.8.5.2-preview.2` to match.

## Test plan
- [x] Added `DynamicFontGenerationTests.FontSize_TwoDistinctSizes_ProduceDistinctlyRasterizedFonts`, which boots a real engine (`FlatRedBallService.Initialize`) with a real `GraphicsDevice` and asserts two `TextRuntime`s with different `FontSize` rasterize to different `LineHeightInPixels`.
- [x] Confirmed red on the old pin (both sizes collapsed to the same cached `LineHeightInPixels`, matching the issue's reported symptom) and green after the bump.
- [x] Full suite: 1543/1543 passing.

Closes #855