### PR TITLE
Animation Editor: batch-edit TextureName across multi-selected frames

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4162,29 +4162,27 @@ public partial class MainWindow : Window
     private void ApplyTextureName()
     {
         if (_suppressPropRefresh) return;
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
 
         var inputText = PropTextureName.Text?.Trim() ?? string.Empty;
 
-        // Clearing the field clears the frame's texture and blanks the wireframe, rather than being
-        // ignored (which left the old texture showing). Only act when there's a texture to clear, so
-        // re-committing an already-empty field adds no spurious undo entry. SetFrameTextureName doesn't
-        // refresh the wireframe on its own, so blank it explicitly (DetermineTexturePath now resolves
-        // to no texture for the selected frame).
+        // Clearing the field clears every selected frame's texture and blanks the wireframe, rather
+        // than being ignored (which left the old texture showing). Only touch frames that actually
+        // have a texture to clear, so re-committing an already-empty field adds no spurious undo
+        // entry. SetFrameTextureName doesn't refresh the wireframe on its own, so blank it explicitly
+        // (DetermineTexturePath now resolves to no texture for the selected frame).
         if (string.IsNullOrEmpty(inputText))
         {
-            if (!string.IsNullOrEmpty(frame.TextureName))
+            var toClear = frames.Where(f => !string.IsNullOrEmpty(f.TextureName)).ToList();
+            if (toClear.Count > 0)
             {
-                _appCommands.SetFrameTextureName(frame, string.Empty);
+                _appCommands.SetFrameTextureName(toClear, string.Empty);
                 WireframeCtrl.RefreshAll();
                 RefreshPropertyPanel();
             }
             return;
         }
-
-        var currentDisplay = TexturePathHelper.ComputeDisplayPath(frame.TextureName, _projectManager.FileName);
-        if (inputText == currentDisplay) return;
 
         string achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
             ? string.Empty
@@ -4193,17 +4191,25 @@ public partial class MainWindow : Window
         string absolutePath = TexturePathHelper.ResolveDisplayPath(inputText, achxFolder);
         string storePath    = TexturePathHelper.ComputeStorePath(absolutePath, achxFolder);
 
-        CommitFrameTexture(frame, storePath, absolutePath);
+        // Only frames whose displayed path actually differs get touched, so committing an
+        // unedited (or already-shared) value adds no spurious undo entry.
+        var toChange = frames
+            .Where(f => TexturePathHelper.ComputeDisplayPath(f.TextureName, _projectManager.FileName) != inputText)
+            .ToList();
+        if (toChange.Count == 0) return;
+
+        CommitFrameTexture(toChange, storePath, absolutePath);
     }
 
     /// <summary>
     /// Displays <paramref name="absolutePath"/> and, only if it decodes, commits
-    /// <paramref name="storePath"/> as the frame's texture name. If the image can't be loaded
-    /// (corrupt/undecodable/missing — see issue #479), the name is left untouched so no broken
-    /// reference reaches the undo stack or the saved .achx, the wireframe is restored to the
-    /// frame's current texture, and a non-fatal status message is shown.
+    /// <paramref name="storePath"/> as the texture name for every frame in <paramref name="frames"/>
+    /// as one undo step. If the image can't be loaded (corrupt/undecodable/missing — see issue
+    /// #479), every frame's name is left untouched so no broken reference reaches the undo stack or
+    /// the saved .achx, the wireframe is restored to the current texture, and a non-fatal status
+    /// message is shown.
     /// </summary>
-    private void CommitFrameTexture(AnimationFrameSave frame, string storePath, string absolutePath)
+    private void CommitFrameTexture(IReadOnlyList<AnimationFrameSave> frames, string storePath, string absolutePath)
     {
         if (!WireframeCtrl.LoadTexture(absolutePath))
         {
@@ -4212,7 +4218,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        _appCommands.SetFrameTextureName(frame, storePath);
+        _appCommands.SetFrameTextureName(frames, storePath);
         RefreshPropertyPanel();
     }
 
@@ -4266,7 +4272,7 @@ public partial class MainWindow : Window
                             try
                             {
                                 File.Copy(capturedSource, capturedDest, overwrite: true);
-                                CommitFrameTexture(frame, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
+                                CommitFrameTexture(new[] { frame }, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
                             }
                             catch (Exception retryEx)
                             {
@@ -4284,7 +4290,7 @@ public partial class MainWindow : Window
             ? resolvedAbsPath
             : TexturePathHelper.ComputeStorePath(resolvedAbsPath, achxFolder);
 
-        CommitFrameTexture(frame, storePath, resolvedAbsPath);
+        CommitFrameTexture(new[] { frame }, storePath, resolvedAbsPath);
     }
 
     private enum TextureCopyChoice { Copy, Keep, Cancel }
@@ -4467,8 +4473,9 @@ public partial class MainWindow : Window
                 {
                     PropColorMode.SelectedIndex = 0; // None
                 }
-                PropTextureName.Text = TexturePathHelper.ComputeDisplayPath(
-                    frame.TextureName, _projectManager.FileName);
+                SetNameOrMixed(PropTextureName,
+                    frames.Select(f => TexturePathHelper.ComputeDisplayPath(f.TextureName, _projectManager.FileName)).ToList(),
+                    disableForCollision: false);
 
                 var (bmpW, bmpH) = WireframeCtrl.BitmapSize;
                 if (bmpW > 0 && bmpH > 0)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1568,6 +1568,15 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new SetFrameTextureNameCommand(frame, frame.TextureName, textureName, this, _events));
         }
 
+        public void SetFrameTextureName(IReadOnlyList<AnimationFrameSave> frames, string? textureName)
+        {
+            if (frames.Count == 0) return;
+            var cmds = frames
+                .Select(f => (IUndoableCommand)new SetFrameTextureNameCommand(f, f.TextureName, textureName, this, _events))
+                .ToArray();
+            _undoManager.Execute(new CompositeCommand(cmds, "Set Frame Texture"));
+        }
+
         public void SetAllFramesTextureName(AnimationChainSave chain, string? textureName)
         {
             if (chain.Frames.Count == 0) return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -252,6 +252,14 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetFrameTextureName(AnimationFrameSave frame, string? textureName);
 
         /// <summary>
+        /// Assigns <paramref name="textureName"/> to every frame in <paramref name="frames"/>
+        /// as a single undoable operation — the multi-select counterpart to the single-frame
+        /// overload, mirroring <see cref="SetFrameLength"/> and friends. No-op when
+        /// <paramref name="frames"/> is empty.
+        /// </summary>
+        void SetFrameTextureName(IReadOnlyList<AnimationFrameSave> frames, string? textureName);
+
+        /// <summary>
         /// Assigns <paramref name="textureName"/> to every frame in <paramref name="chain"/>
         /// as a single undoable operation. No-op when the chain has no frames.
         /// </summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FramePixelCoordsMultiSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FramePixelCoordsMultiSelectTests.cs
@@ -1,0 +1,142 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #860: unlike every other frame property, the PIXEL COORD fields (X/Y/W/H) were never
+/// pinned by an App-layer test that drives the real property-panel Apply path — only
+/// <c>InspectorPropertyUndoTests</c> exercises <c>IAppCommands.SetFramePixelRegion</c> directly,
+/// bypassing <c>ApplyFramePixelCoords</c>'s dependency on <c>WireframeControl.BitmapSize</c>
+/// (zero until a real bitmap is loaded). These tests drive the fields through
+/// <see cref="MainWindow"/> exactly as a user would, with a real PNG on disk so the wireframe
+/// actually loads a bitmap.
+/// </summary>
+public class FramePixelCoordsMultiSelectTests
+{
+    private static (MainWindow Window, TestServices Ctx, string Dir) CreateWindowWithTexture()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+        var pngPath = Path.Combine(dir, "sprite.png");
+        using (var bm = new SKBitmap(64, 64))
+        {
+            bm.Erase(SKColors.Gray);
+            using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+            File.WriteAllBytes(pngPath, data.ToArray());
+        }
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx, dir);
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ApplyFramePixelCoords_MultipleFramesSelected_AppliesPixelXToBothPreservingEachWidth()
+    {
+        var (window, ctx, dir) = CreateWindowWithTexture();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave
+            {
+                TextureName = "sprite.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, RightCoordinate = 16f / 64f,
+                TopCoordinate = 0f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            var f1 = new AnimationFrameSave
+            {
+                TextureName = "sprite.png", FrameLength = 0.1f,
+                LeftCoordinate = 32f / 64f, RightCoordinate = 48f / 64f,
+                TopCoordinate = 0f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            Assert.Equal((64, 64), wireframe.BitmapSize); // sanity: bitmap must be loaded for this section to work at all
+
+            var propPixelX = window.FindControl<NumericUpDown>("PropPixelX")!;
+            propPixelX.Value = 8m;
+            FlushUi();
+
+            // SetX preserves each frame's own width (16px for both here).
+            Assert.Equal(8f / 64f, f0.LeftCoordinate, 3);
+            Assert.Equal(24f / 64f, f0.RightCoordinate, 3);
+            Assert.Equal(8f / 64f, f1.LeftCoordinate, 3);
+            Assert.Equal(24f / 64f, f1.RightCoordinate, 3);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void ApplyFramePixelCoords_MultipleFramesSelected_AppliesPixelWToBoth()
+    {
+        var (window, ctx, dir) = CreateWindowWithTexture();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave
+            {
+                TextureName = "sprite.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, RightCoordinate = 16f / 64f,
+                TopCoordinate = 0f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            var f1 = new AnimationFrameSave
+            {
+                TextureName = "sprite.png", FrameLength = 0.1f,
+                LeftCoordinate = 32f / 64f, RightCoordinate = 48f / 64f,
+                TopCoordinate = 0f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")!;
+            Assert.Equal((64, 64), wireframe.BitmapSize);
+
+            var propPixelW = window.FindControl<NumericUpDown>("PropPixelW")!;
+            propPixelW.Value = 24m;
+            FlushUi();
+
+            // SetWidth keeps each frame's own Left fixed, only Right moves.
+            Assert.Equal(0f, f0.LeftCoordinate, 3);
+            Assert.Equal(24f / 64f, f0.RightCoordinate, 3);
+            Assert.Equal(32f / 64f, f1.LeftCoordinate, 3);
+            Assert.Equal(56f / 64f, f1.RightCoordinate, 3);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameTextureNameMultiSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameTextureNameMultiSelectTests.cs
@@ -1,0 +1,93 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #860: TextureName was the one frame property without multi-select batch-edit parity
+/// (see #571 for every other field). <c>ApplyTextureName</c> only ever read/wrote
+/// <c>_selectedState.SelectedFrame</c> (the primary frame), so committing a new texture path
+/// with multiple frames selected silently left every other selected frame untouched.
+/// </summary>
+public class FrameTextureNameMultiSelectTests
+{
+    private static (MainWindow Window, TestServices Ctx, string Dir) CreateWindowWithTextures()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+        WriteSolidPng(dir, "a.png", SKColors.Red);
+        WriteSolidPng(dir, "b.png", SKColors.Blue);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx, dir);
+    }
+
+    private static void WriteSolidPng(string dir, string name, SKColor color, int size = 16)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ApplyTextureName_MultipleFramesSelected_AppliesToAll()
+    {
+        var (window, ctx, dir) = CreateWindowWithTextures();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave
+            {
+                TextureName = "a.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            var f1 = new AnimationFrameSave
+            {
+                TextureName = "a.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var propTextureName = window.FindControl<TextBox>("PropTextureName")!;
+            propTextureName.Focus();
+            FlushUi();
+            propTextureName.Text = "b.png";
+            // Move focus away to raise LostFocus, which ApplyTextureName is wired to.
+            window.FindControl<NumericUpDown>("PropFrameLen")!.Focus();
+            FlushUi();
+
+            Assert.Equal("b.png", f0.TextureName);
+            Assert.Equal("b.png", f1.TextureName);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
@@ -79,4 +79,40 @@ public class MultiSelectPropertyPanelTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// Issue #860: the Core-level bulk command (<c>SetFrameRelative_MultipleFrames_AppliesToAllAsOneUndoStep</c>
+    /// in InspectorPropertyUndoTests) proves <c>IAppCommands.SetFrameRelative</c> itself works, but nothing
+    /// previously drove the real property-panel Apply path (<c>ApplyFrameRelative</c>, wired to
+    /// <c>PropRelX</c>/<c>PropRelY</c>'s <c>ValueChanged</c>) the way a user actually would.
+    /// </summary>
+    [AvaloniaFact]
+    public void ApplyFrameRelative_MultipleFramesSelected_AppliesXAndYToBoth()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f, RelativeX = 1f, RelativeY = 2f };
+            var f1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f, RelativeX = 3f, RelativeY = 4f };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            FlushUi();
+
+            var propRelX = window.FindControl<NumericUpDown>("PropRelX")!;
+            var propRelY = window.FindControl<NumericUpDown>("PropRelY")!;
+            propRelX.Value = 10m;
+            propRelY.Value = 20m;
+            FlushUi();
+
+            Assert.Equal(10f, f0.RelativeX);
+            Assert.Equal(20f, f0.RelativeY);
+            Assert.Equal(10f, f1.RelativeX);
+            Assert.Equal(20f, f1.RelativeY);
+        }
+        finally { window.Close(); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSetFrameTextureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSetFrameTextureTests.cs
@@ -60,7 +60,7 @@ public class AppCommandsSetFrameTextureTests
     {
         var ctx = TestHelpers.SetupFreshAcls();
         // Should be a silent no-op
-        ctx.AppCommands.SetFrameTextureName(null!, "hero.png");
+        ctx.AppCommands.SetFrameTextureName((AnimationFrameSave)null!, "hero.png");
     }
 
     // ── Event firing ──────────────────────────────────────────────────────────
@@ -113,7 +113,7 @@ public class AppCommandsSetFrameTextureTests
         bool changed = false;
         ctx.ApplicationEvents.AnimationChainsChanged += () => changed = true;
 
-        ctx.AppCommands.SetFrameTextureName(null!, "hero.png");
+        ctx.AppCommands.SetFrameTextureName((AnimationFrameSave)null!, "hero.png");
 
         Assert.False(changed);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SetFrameTextureNameUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/SetFrameTextureNameUndoTests.cs
@@ -1,5 +1,6 @@
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -42,5 +43,30 @@ public class SetFrameTextureNameUndoTests
         ctx.UndoManager.Redo();
 
         Assert.Equal("updated.png", frame.TextureName);
+    }
+
+    // ── SetFrameTextureName (bulk) — multi-select ─────────────────────────────
+
+    /// <summary>
+    /// Issue #860: unlike every other frame property (FrameLength, RelativeX/Y, RGBA,
+    /// ColorOperation, pixel region, Flip — all via #571), TextureName had no bulk overload,
+    /// so editing it with multiple frames selected only ever touched the primary frame.
+    /// </summary>
+    [Fact]
+    public void SetFrameTextureName_MultipleFrames_AppliesToAllAsOneUndoStep()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 2);
+        var frames = chain.Frames.ToList();
+
+        ctx.AppCommands.SetFrameTextureName(frames, "shared.png");
+
+        Assert.All(frames, f => Assert.Equal("shared.png", f.TextureName));
+        Assert.Single(ctx.UndoManager.UndoHistory);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal("frame0.png", frames[0].TextureName);
+        Assert.Equal("frame1.png", frames[1].TextureName);
     }
 }


### PR DESCRIPTION
## Summary
- TextureName was the one frame property without #571-style multi-select parity — `ApplyTextureName` only ever touched the primary selected frame; the panel never showed "(mixed)" for it.
- Adds `IAppCommands.SetFrameTextureName(IReadOnlyList<AnimationFrameSave>, string?)` and routes `ApplyTextureName`/`CommitFrameTexture` through the full selection as one undo step.
- Adds App-layer pinning tests (through the real `MainWindow` Apply path, not just the Core bulk-command level) for PixelX/PixelW and RelativeX/Y multi-select — both already worked correctly, but only had Core-level coverage of the underlying command, not the UI wiring.

Closes #860

## Test plan
- [x] New Core.Tests: `SetFrameTextureName_MultipleFrames_AppliesToAllAsOneUndoStep` (red before fix, green after)
- [x] New App.Tests: `ApplyTextureName_MultipleFramesSelected_AppliesToAll` (red before fix, green after)
- [x] New App.Tests: `FramePixelCoordsMultiSelectTests`, `ApplyFrameRelative_MultipleFramesSelected_AppliesXAndYToBoth` (both passed pre-fix; added as pinning coverage)
- [x] Full `AnimationEditor.Core.Tests` (1794) and `AnimationEditor.App.Tests` (803) pass
- [x] Full solution build (including Browser/WASM target) succeeds