### PR TITLE
Add screen-level texture filter mode (Point/Linear)

### DIFF
--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -841,6 +841,7 @@ public class FlatRedBallService
         DisplaySettings.ResolutionHeight = source.ResolutionHeight;
         DisplaySettings.LetterboxColor = source.LetterboxColor;
         DisplaySettings.WindowMode = source.WindowMode;
+        DisplaySettings.TextureFilterMode = source.TextureFilterMode;
     }
 
     /// <summary>

--- a/src/Glue/GlueDisplayMapper.cs
+++ b/src/Glue/GlueDisplayMapper.cs
@@ -56,12 +56,20 @@ public static class GlueDisplayMapper
                               "so it was loaded as 2D anyway.");
         }
 
-        // FRB2 hardcodes point sampling. 1 is Point in XNA's enum, which is what nearly every real
-        // project uses, so anything else is a genuine difference worth naming.
-        if (source.TextureFilter != 1)
+        // XNA's TextureFilter enum: 0 is Linear, 1 is Point. Those are the only two FRB2 supports;
+        // anything else (Anisotropic, the filtered-mip modes) is left unmapped and reported.
+        switch (source.TextureFilter)
         {
-            Warn(diagnostics, $"Texture filter {source.TextureFilter} was authored, but FRB2 samples " +
-                              "with point filtering and exposes no setting for it.");
+            case 0:
+                target.TextureFilterMode = Frb.TextureFilterMode.Linear;
+                break;
+            case 1:
+                target.TextureFilterMode = Frb.TextureFilterMode.Point;
+                break;
+            default:
+                Warn(diagnostics, $"Texture filter {source.TextureFilter} was authored, but FRB2 only " +
+                                  "supports Point and Linear sampling.");
+                break;
         }
 
         if (source.ScaleGum != 100)

--- a/src/Rendering/Batches/ScreenSpaceAddColorBatch.cs
+++ b/src/Rendering/Batches/ScreenSpaceAddColorBatch.cs
@@ -1,3 +1,4 @@
+using FlatRedBall2;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace FlatRedBall2.Rendering.Batches;
@@ -19,7 +20,7 @@ public class ScreenSpaceAddColorBatch : IRenderBatch
     public void Begin(SpriteBatch spriteBatch, Camera camera)
         => spriteBatch.Begin(
             sortMode: SpriteSortMode.Immediate,
-            samplerState: SamplerState.PointClamp,
+            samplerState: FlatRedBallService.Default.DisplaySettings.GetSamplerState(),
             effect: AddColorEffect.Get(spriteBatch.GraphicsDevice));
 
     /// <inheritdoc/>

--- a/src/Rendering/Batches/ScreenSpaceBatch.cs
+++ b/src/Rendering/Batches/ScreenSpaceBatch.cs
@@ -1,3 +1,4 @@
+using FlatRedBall2;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace FlatRedBall2.Rendering.Batches;
@@ -15,7 +16,7 @@ public class ScreenSpaceBatch : IRenderBatch
 
     /// <inheritdoc/>
     public void Begin(SpriteBatch spriteBatch, Camera camera)
-        => spriteBatch.Begin(samplerState: SamplerState.PointClamp);
+        => spriteBatch.Begin(samplerState: FlatRedBallService.Default.DisplaySettings.GetSamplerState());
 
     /// <inheritdoc/>
     public void End(SpriteBatch spriteBatch) => spriteBatch.End();

--- a/src/Rendering/Batches/WorldSpaceAddColorBatch.cs
+++ b/src/Rendering/Batches/WorldSpaceAddColorBatch.cs
@@ -1,3 +1,4 @@
+using FlatRedBall2;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace FlatRedBall2.Rendering.Batches;
@@ -27,7 +28,7 @@ public class WorldSpaceAddColorBatch : IRenderBatch
         => spriteBatch.Begin(
             sortMode: SpriteSortMode.Immediate,
             transformMatrix: camera.GetTransformMatrix(),
-            samplerState: SamplerState.PointClamp,
+            samplerState: FlatRedBallService.Default.DisplaySettings.GetSamplerState(),
             rasterizerState: RasterizerState.CullNone,
             effect: AddColorEffect.Get(spriteBatch.GraphicsDevice));
 

--- a/src/Rendering/Batches/WorldSpaceBatch.cs
+++ b/src/Rendering/Batches/WorldSpaceBatch.cs
@@ -1,3 +1,4 @@
+using FlatRedBall2;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace FlatRedBall2.Rendering.Batches;
@@ -17,7 +18,7 @@ public class WorldSpaceBatch : IRenderBatch
     public void Begin(SpriteBatch spriteBatch, Camera camera)
         => spriteBatch.Begin(
             transformMatrix: camera.GetTransformMatrix(),
-            samplerState: SamplerState.PointClamp,
+            samplerState: FlatRedBallService.Default.DisplaySettings.GetSamplerState(),
             rasterizerState: RasterizerState.CullNone);
 
     /// <inheritdoc/>

--- a/src/Rendering/DisplaySettings.cs
+++ b/src/Rendering/DisplaySettings.cs
@@ -77,6 +77,20 @@ public enum DominantAxis
 }
 
 /// <summary>
+/// How textures are sampled when scaled. Applies to every sprite drawn by the engine — there is no
+/// per-sprite override (FlatRedBall 1 had one; FRB2 does not, to avoid flushing/splitting sprite
+/// batches mid-draw).
+/// </summary>
+public enum TextureFilterMode
+{
+    /// <summary>Nearest-neighbor sampling. Crisp, blocky edges — the right choice for pixel art.</summary>
+    Point,
+
+    /// <summary>Bilinear sampling. Smooths scaled edges — the right choice for hand-drawn/high-res art.</summary>
+    Linear,
+}
+
+/// <summary>
 /// Display configuration that controls both camera behavior and (optionally) window properties.
 /// <para>
 /// The engine owns a default instance (<see cref="FlatRedBallService.DisplaySettings"/>) that is set once
@@ -176,6 +190,17 @@ public class DisplaySettings
 
     /// <summary>Color of letterbox/pillarbox bars. Only painted when <see cref="AspectPolicy"/> is <see cref="AspectPolicy.Locked"/>.</summary>
     public Color LetterboxColor { get; set; } = Color.Black;
+
+    /// <summary>
+    /// How textures are sampled when scaled. Defaults to <see cref="TextureFilterMode.Point"/> —
+    /// the engine's original hardcoded behavior, correct for pixel art. Set to
+    /// <see cref="TextureFilterMode.Linear"/> for smoother scaling of hand-drawn/high-res art.
+    /// </summary>
+    public TextureFilterMode TextureFilterMode { get; set; } = TextureFilterMode.Point;
+
+    /// <summary>Maps <see cref="TextureFilterMode"/> onto the matching clamped <see cref="SamplerState"/>.</summary>
+    internal SamplerState GetSamplerState() =>
+        TextureFilterMode == TextureFilterMode.Linear ? SamplerState.LinearClamp : SamplerState.PointClamp;
 
     /// <summary>
     /// Effective target aspect ratio: <see cref="FixedAspectRatio"/> if set, else

--- a/tests/FlatRedBall2.Tests/Glue/GlueDisplayTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueDisplayTests.cs
@@ -159,6 +159,13 @@ public class GlueDisplayTests
         diagnostics.ShouldContain(d => d.Message.Contains(expected));
     }
 
+    // XNA's TextureFilter enum: 0 is Linear, 1 is Point (see Glue.Model.DisplaySettings.TextureFilter).
+    [Theory]
+    [InlineData(1, TextureFilterMode.Point)]
+    [InlineData(0, TextureFilterMode.Linear)]
+    public void Apply_ATextureFilterFrb2CanHonor_MapsOntoTextureFilterMode(int filter, TextureFilterMode expected) =>
+        Applied(s => s.TextureFilter = filter).TextureFilterMode.ShouldBe(expected);
+
     [Fact]
     public void Apply_AGumScaleFrb2CannotHonor_IsReported()
     {

--- a/tests/FlatRedBall2.Tests/Rendering/CameraTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/CameraTests.cs
@@ -230,4 +230,28 @@ public class DisplaySettingsTests
         vp.Width.ShouldBe(1920);
         vp.Height.ShouldBe(1080);
     }
+
+    [Fact]
+    public void GetSamplerState_Point_ReturnsPointClamp()
+    {
+        var settings = new DisplaySettings { TextureFilterMode = FlatRedBall2.Rendering.TextureFilterMode.Point };
+
+        settings.GetSamplerState().ShouldBeSameAs(SamplerState.PointClamp);
+    }
+
+    [Fact]
+    public void GetSamplerState_Linear_ReturnsLinearClamp()
+    {
+        var settings = new DisplaySettings { TextureFilterMode = FlatRedBall2.Rendering.TextureFilterMode.Linear };
+
+        settings.GetSamplerState().ShouldBeSameAs(SamplerState.LinearClamp);
+    }
+
+    [Fact]
+    public void TextureFilterMode_Default_IsPoint()
+    {
+        var settings = new DisplaySettings();
+
+        settings.TextureFilterMode.ShouldBe(FlatRedBall2.Rendering.TextureFilterMode.Point);
+    }
 }

--- a/tests/FlatRedBall2.Tests/ScreenTests.cs
+++ b/tests/FlatRedBall2.Tests/ScreenTests.cs
@@ -492,6 +492,22 @@ public class ScreenTests
         ((ConfigurableTestScreen)engine.CurrentScreen).X.ShouldBe(99);
     }
 
+    private class LinearFilterScreen : Screen
+    {
+        public override FlatRedBall2.Rendering.DisplaySettings PreferredDisplaySettings { get; }
+            = new() { TextureFilterMode = FlatRedBall2.Rendering.TextureFilterMode.Linear };
+    }
+
+    [Fact]
+    public void Start_ScreenWithPreferredDisplaySettings_AppliesTextureFilterModeToEngineDisplaySettings()
+    {
+        var engine = new FlatRedBallService();
+
+        engine.Start<LinearFilterScreen>();
+
+        engine.DisplaySettings.TextureFilterMode.ShouldBe(FlatRedBall2.Rendering.TextureFilterMode.Linear);
+    }
+
     // ---------- Increment 2: Hot-reload restart ----------
 
     private class HotReloadTrackingScreen : Screen


### PR DESCRIPTION
Adds a `TextureFilterMode` (Point/Linear) setting to `DisplaySettings`, replacing the four sprite batches' hardcoded `SamplerState.PointClamp`. Default stays `Point`, so existing games render unchanged.

- `DisplaySettings.TextureFilterMode` (default `Point`) + `GetSamplerState()` mapping to `SamplerState.PointClamp`/`LinearClamp`.
- The four render batches (`WorldSpaceBatch`, `ScreenSpaceBatch`, `WorldSpaceAddColorBatch`, `ScreenSpaceAddColorBatch`) now read the mapped sampler state instead of hardcoding point sampling.
- `Screen.PreferredDisplaySettings` can override it per screen, same mechanism as the other display properties.
- `GlueDisplayMapper` now applies an authored Glue texture filter (0=Linear, 1=Point) instead of only warning about it; other filter modes (anisotropic, etc.) still warn since FRB2 doesn't support them.

Scope note: this is screen-level only, matching the issue. FRB1's per-sprite override is deferred — it'd require splitting/flushing sprite batches mid-draw, which compounds the render-state-thrashing item already tracked in `design/TODOS.md`.

Build clean, all 1549 tests pass (new coverage: sampler-state mapping, Glue filter mapping, screen-activation propagation).

Closes #864