### PR TITLE
Add string forcing to automation mode's set command

### DIFF
--- a/frb-skills/automation-mode/SKILL.md
+++ b/frb-skills/automation-mode/SKILL.md
@@ -87,9 +87,9 @@ A property the agent expects but doesn't see in the snapshot is almost always ei
 
 ## Setting Values (Zero Config)
 
-`set entity:"Player" prop:"X" value:50.0` looks up the factory for `Player`, takes the first live instance, and assigns via reflection. `value` is always parsed as `double` and converted to the target property's type (including `int`, `float`, enums by ordinal). Errors are specific: missing factory, no live instances, non-existent property, non-writable property.
+`set entity:"Player" prop:"X" value:50.0` looks up the factory for `Player`, takes the first live instance, and assigns via reflection. Errors are specific: missing factory, no live instances, non-existent property, non-writable property.
 
-Boolean/string forcing isn't supported — `value` is numeric only. Register a custom setter if you need that.
+`value` can be a JSON number or a JSON string. A number converts to the target property's type via `Convert.ChangeType` — this covers `int`, `float`, `bool` (nonzero → `true`), and enums (by ordinal). A string also converts via `Convert.ChangeType` — `value:"true"` sets a `bool`, `value:"7"` sets an `int`, and `value:"boss"` sets a `string` directly. Enums only accept a numeric ordinal, not a name string. Registered custom setters (below) only ever receive a `double`, so send a numeric `value` when targeting one.
 
 ## Custom Providers and Setters (Optional)
 

--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading;
 using FlatRedBall2.Input;
@@ -347,12 +348,19 @@ internal class AutomationMode
     {
         var entity = cmd.TryGetProperty("entity", out var e) ? e.GetString() : null;
         var prop   = cmd.TryGetProperty("prop",   out var p) ? p.GetString() : null;
-        var value  = cmd.TryGetProperty("value",  out var v) ? v.GetDouble() : 0.0;
+        cmd.TryGetProperty("value", out var v);
+
+        // "value" is either a JSON number (the common case — also covers bool/enum targets via
+        // Convert.ChangeType) or a JSON string (for string-typed properties, or any property
+        // whose type has a string-parsing IConvertible path, e.g. "true" -> bool).
+        object value = v.ValueKind == JsonValueKind.String ? (v.GetString() ?? "")
+                     : v.ValueKind == JsonValueKind.Number ? v.GetDouble()
+                     : 0.0;
 
         var key = $"{entity}.{prop}";
-        if (_valueSetters.TryGetValue(key, out var setter))
+        if (value is double d && _valueSetters.TryGetValue(key, out var setter))
         {
-            setter(value);
+            setter(d);
             WriteResponse(new { ok = true, frame });
             return;
         }
@@ -369,7 +377,7 @@ internal class AutomationMode
         }
     }
 
-    private bool TryReflectSet(string entityName, string propName, double value, out string? error)
+    private bool TryReflectSet(string entityName, string propName, object value, out string? error)
     {
         if (!TryFindFactoryByTypeName(entityName, out var factory))
         {
@@ -394,9 +402,18 @@ internal class AutomationMode
         var target = Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType;
         try
         {
-            object? converted = target.IsEnum
-                ? Enum.ToObject(target, (long)value)
-                : Convert.ChangeType(value, target);
+            object? converted;
+            if (target.IsEnum)
+            {
+                if (value is double dv)
+                    converted = Enum.ToObject(target, (long)dv);
+                else
+                    throw new InvalidCastException($"enum property requires a numeric ordinal, got string \"{value}\"");
+            }
+            else
+            {
+                converted = Convert.ChangeType(value, target, CultureInfo.InvariantCulture);
+            }
             p.SetValue(inst, converted);
             error = null;
             return true;

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
@@ -374,6 +374,8 @@ public class AutomationModeReflectionTests
     private class AutoTestEntity : Entity
     {
         public int Health { get; set; } = 5;
+        public bool IsActive { get; set; } = false;
+        public string Label { get; set; } = "";
     }
     private class AutoTestScreen : Screen { }
 
@@ -427,6 +429,69 @@ public class AutomationModeReflectionTests
         mode.TryAdvanceFrame(1);
 
         e.Health.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SetByEntityTypeName_BoolProperty_NonzeroValueConvertsToTrue()
+    {
+        var (_, mode, output) = MakeWithFactory(out var factory);
+        var e = factory.Create();
+
+        mode.ProcessLine("{\"cmd\":\"set\",\"entity\":\"AutoTestEntity\",\"prop\":\"IsActive\",\"value\":1.0}");
+        mode.TryAdvanceFrame(1);
+
+        e.IsActive.ShouldBeTrue();
+        output.ToString().Trim().ShouldContain("\"ok\":true");
+    }
+
+    [Fact]
+    public void SetByEntityTypeName_BoolProperty_ZeroValueConvertsToFalse()
+    {
+        var (_, mode, output) = MakeWithFactory(out var factory);
+        var e = factory.Create();
+        e.IsActive = true;
+
+        mode.ProcessLine("{\"cmd\":\"set\",\"entity\":\"AutoTestEntity\",\"prop\":\"IsActive\",\"value\":0.0}");
+        mode.TryAdvanceFrame(1);
+
+        e.IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetByEntityTypeName_StringProperty_JsonStringAssignsDirectly()
+    {
+        var (_, mode, output) = MakeWithFactory(out var factory);
+        var e = factory.Create();
+
+        mode.ProcessLine("{\"cmd\":\"set\",\"entity\":\"AutoTestEntity\",\"prop\":\"Label\",\"value\":\"boss\"}");
+        mode.TryAdvanceFrame(1);
+
+        e.Label.ShouldBe("boss");
+        output.ToString().Trim().ShouldContain("\"ok\":true");
+    }
+
+    [Fact]
+    public void SetByEntityTypeName_IntProperty_JsonStringValueConvertsNumerically()
+    {
+        var (_, mode, output) = MakeWithFactory(out var factory);
+        var e = factory.Create();
+
+        mode.ProcessLine("{\"cmd\":\"set\",\"entity\":\"AutoTestEntity\",\"prop\":\"Health\",\"value\":\"7\"}");
+        mode.TryAdvanceFrame(1);
+
+        e.Health.ShouldBe(7);
+    }
+
+    [Fact]
+    public void SetByEntityTypeName_BoolProperty_JsonStringTrueConvertsToTrue()
+    {
+        var (_, mode, output) = MakeWithFactory(out var factory);
+        var e = factory.Create();
+
+        mode.ProcessLine("{\"cmd\":\"set\",\"entity\":\"AutoTestEntity\",\"prop\":\"IsActive\",\"value\":\"true\"}");
+        mode.TryAdvanceFrame(1);
+
+        e.IsActive.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `set`'s reflection fallback previously parsed `value` as `double` only, so bool worked (via `Convert.ChangeType`) but string-typed properties had no path.
- `TryReflectSet` now accepts a JSON string or number `value` and routes both through `Convert.ChangeType`; enums still require a numeric ordinal (explicit error on string).
- Corrected the `automation-mode` SKILL.md claim that boolean/string forcing isn't supported.

## Test plan
- [x] New tests: bool forcing (0/1 numeric), string-property forcing (direct JSON string), int-via-JSON-string, bool-via-JSON-string `"true"`.
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1554 passed.

Closes #863
