### PR TITLE
Document AnimationChain.MonoGame draw origin and RelativeY

### DIFF
--- a/samples/AnimationChainSample/README.md
+++ b/samples/AnimationChainSample/README.md
@@ -1,6 +1,8 @@
 # AnimationChainSample
 
 Small sample showing `.achx` animation playback with `AnimationPlayer`.
+For draw origin, `RelativeY`, and grounded sprites, see the package README
+at `src/AnimationChain.MonoGame/README.md`.
 
 ## Run locally
 

--- a/src/AnimationChain.MonoGame/README.md
+++ b/src/AnimationChain.MonoGame/README.md
@@ -36,6 +36,58 @@ spriteBatch.DrawAnimation(_player, position, Color.White);
 _loader.Dispose();
 ```
 
+Copy the `.achx` and its PNGs next to each other (`CopyToOutputDirectory`).
+`AchxLoader` loads them with `Texture2D.FromStream`, not the MGCB pipeline.
+
+## Drawing
+
+`DrawAnimation` uses MonoGame `SpriteBatch` conventions:
+
+- `position` is the **top-left** of the current frame's source rectangle
+  (before per-frame offset), in screen pixels. Y increases downward.
+- `scale` multiplies the source rectangle. A 16×32 frame at `scale: 3` is
+  48×96 on screen.
+- `AnimationFrame.RelativeX` / `RelativeY` are **unscaled source pixels**
+  from the `.achx`. `DrawAnimation` applies them as `offset * scale`.
+  Positive `RelativeY` moves the sprite down.
+- If the `.achx` was authored in a Y-up world, negate `RelativeY` or flip Y
+  in your camera transform.
+
+To stand a character on a ground point `(x, y)` (feet on `y`):
+
+```csharp
+var frame = player.CurrentFrame;
+int srcW = frame?.SourceRectangle?.Width ?? 0;
+int srcH = frame?.SourceRectangle?.Height ?? 0;
+float width = srcW * scale;
+float height = srcH * scale;
+spriteBatch.DrawAnimation(
+    player,
+    new Vector2(x - width / 2f, y - height),
+    Color.White,
+    scale: scale);
+```
+
+Empty pixels at the bottom of a cell still count in `SourceRectangle.Height`.
+If idle-up/down hover while left/right look planted, set `RelativeY` on those
+frames in the Animation Editor (or crop the source rect) so the shoes sit on
+the last row of the cell.
+
+Use `SamplerState.PointClamp` for pixel art.
+
+## Playback notes
+
+- `Play(name)` is a no-op if that chain is already playing, so it is safe every
+  frame. Unknown names are ignored and the current animation continues.
+- One `AchxLoader` owns and caches textures. Many `AnimationPlayer`s can share
+  one `AnimationChainList`.
+- `DrawAnimation` applies authored multiply color, alpha, and `ColorOperation.Add`
+  (Add ends and restarts the `SpriteBatch` — see the method remarks).
+  Per-frame **shapes** are data only. **`FlipDiagonal`** is authored and not
+  applied (`SpriteEffects` has no diagonal option).
+- This package is not the FlatRedBall2 engine player. `Sprite.PlayAnimation`
+  uses a different origin and Y axis — do not mix the two type systems.
+
 ## Web / Blazor WASM (KNI)
 
 The filesystem is unavailable in browser environments. Pre-fetch bytes and pass streams instead:

--- a/src/AnimationChain.MonoGame/Runtime/AnimationFrame.cs
+++ b/src/AnimationChain.MonoGame/Runtime/AnimationFrame.cs
@@ -31,19 +31,22 @@ public class AnimationFrame
     /// <summary>When <c>true</c>, the source region is mirrored along the Y axis.</summary>
     public bool FlipVertical;
 
-    /// <summary>When <c>true</c>, the source region is transposed (flipped along the diagonal).</summary>
+    /// <summary>When <c>true</c>, the source region is transposed (flipped along the diagonal).
+    /// Authored and round-tripped by the Animation Editor; <see cref="SpriteBatchExtensions.DrawAnimation"/>
+    /// does <b>not</b> apply it — MonoGame's <see cref="SpriteEffects"/> has no diagonal option.</summary>
     public bool FlipDiagonal;
 
     /// <summary>
-    /// Per-frame X offset applied while this frame is displayed. In screen pixels; positive
-    /// shifts right. Applied by <see cref="SpriteBatchExtensions.DrawAnimation"/>.
+    /// Per-frame X offset applied while this frame is displayed. Unscaled source pixels from
+    /// the .achx; positive shifts right. <see cref="SpriteBatchExtensions.DrawAnimation"/>
+    /// applies this as <c>RelativeX * scale</c>.
     /// </summary>
     public float RelativeX;
 
     /// <summary>
-    /// Per-frame Y offset applied while this frame is displayed. In screen pixels; positive
-    /// shifts down (standard MonoGame screen-space convention).
-    /// Applied by <see cref="SpriteBatchExtensions.DrawAnimation"/>.
+    /// Per-frame Y offset applied while this frame is displayed. Unscaled source pixels from
+    /// the .achx; positive shifts down (standard MonoGame screen-space convention).
+    /// <see cref="SpriteBatchExtensions.DrawAnimation"/> applies this as <c>RelativeY * scale</c>.
     /// </summary>
     public float RelativeY;
 
@@ -73,8 +76,9 @@ public class AnimationFrame
     /// How <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/> combine with the texture,
     /// sticky-resolved. <c>null</c> means none. <see cref="FlatRedBall.AnimationChain.ColorOperation.Multiply"/>
     /// is applied automatically by <see cref="SpriteBatchExtensions.DrawAnimation"/>;
-    /// <see cref="FlatRedBall.AnimationChain.ColorOperation.Add"/> is authored data only for now — it needs a
-    /// custom shader, since <see cref="Microsoft.Xna.Framework.Graphics.SpriteBatch"/> can only multiply texture color, not offset it.
+    /// <see cref="FlatRedBall.AnimationChain.ColorOperation.Add"/> is also applied, via a pixel
+    /// shader that ends and restarts the <see cref="Microsoft.Xna.Framework.Graphics.SpriteBatch"/>
+    /// — see the remarks on <see cref="SpriteBatchExtensions.DrawAnimation"/>.
     /// </summary>
     public ColorOperation? ColorOperation;
 

--- a/src/AnimationChain.MonoGame/SpriteBatchExtensions.cs
+++ b/src/AnimationChain.MonoGame/SpriteBatchExtensions.cs
@@ -10,14 +10,18 @@ public static class SpriteBatchExtensions
 {
     /// <summary>
     /// Draws the current frame of <paramref name="player"/> at <paramref name="position"/>.
+    /// <paramref name="position"/> is the <b>top-left</b> of the frame's source rectangle
+    /// in screen pixels (Y down), before per-frame offset.
     /// Per-frame <see cref="AnimationFrame.RelativeX"/> and <see cref="AnimationFrame.RelativeY"/>
-    /// are added to <paramref name="position"/> automatically — these represent authoring-time
-    /// offsets baked into the .achx (e.g. a kick frame that shifts the character forward).
+    /// are unscaled source pixels from the .achx; they are added as <c>offset * scale</c>
+    /// (e.g. a kick frame that shifts the character forward).
     /// <para>
-    /// <b>Coordinate convention:</b> <c>RelativeY</c> is in screen-down space (positive = down),
+    /// <b>Coordinate convention:</b> positive <c>RelativeY</c> moves the sprite down,
     /// matching standard MonoGame <see cref="SpriteBatch"/> coordinates. If your .achx was
     /// authored in a Y-up world, negate <c>RelativeY</c> manually or flip the Y axis in your
-    /// camera transform.
+    /// camera transform. Empty pixels inside <see cref="AnimationFrame.SourceRectangle"/> still
+    /// count toward height — offset those frames in the editor if shoes do not sit on the
+    /// last row of the cell.
     /// </para>
     /// </summary>
     /// <param name="spriteBatch">Must be between <see cref="SpriteBatch.Begin"/> and <see cref="SpriteBatch.End"/>.</param>


### PR DESCRIPTION
## Summary
- Document `DrawAnimation` top-left origin, Y-down, and `RelativeX`/`RelativeY` as unscaled source pixels applied as `offset * scale`.
- Show how to plant feet on a ground point, including empty padding in the source cell.
- Align XML docs with that contract (and note `FlipDiagonal` is not applied; `ColorOperation.Add` is).
- Point the in-repo sample README at the package readme.

Closes #871

## Test plan
- [ ] Read the packed README in `src/AnimationChain.MonoGame/README.md` as a MonoGame consumer — can you stand a sprite on a ground line without guessing?
- [ ] Hover `DrawAnimation`, `RelativeX`, `RelativeY`, and `FlipDiagonal` in the IDE and confirm IntelliSense matches the README
- [ ] Confirm no runtime/API change (docs only)