### PR TITLE
Add .achj (JSON) animation chain format alongside .achx (XML)

### DIFF
--- a/src/Animation.Content/AnimationChainListSave.cs
+++ b/src/Animation.Content/AnimationChainListSave.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -35,8 +37,9 @@ public enum TextureCoordinateType
 }
 
 /// <summary>
-/// Deserialized representation of a .achx animation file.
-/// Load with <see cref="FromFile(string)"/> and convert to runtime types with
+/// Deserialized representation of a .achx (XML) or .achj (JSON) animation file — the two
+/// on-disk dialects of the same data model. Load with <see cref="FromFile(string)"/> /
+/// <see cref="FromJsonFile(string)"/> and convert to runtime types with
 /// <c>ToAnimationChainList</c> (an extension method in the main FlatRedBall2 engine
 /// assembly — this type itself has no MonoGame dependency so tooling, like the
 /// Animation Editor, can reference it without pulling MonoGame in at all).
@@ -114,6 +117,34 @@ public class AnimationChainListSave
         using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
         return FromStream(stream);
     }
+
+    /// <summary>
+    /// Loads a .achj file directly from disk via <see cref="File.OpenRead(string)"/>. JSON
+    /// counterpart of <see cref="FromFile(string)"/>.
+    /// </summary>
+    public static AnimationChainListSave FromJsonFile(string path)
+        => FromJsonFile(path, File.OpenRead!);
+
+    /// <summary>
+    /// Loads a .achj file via manual JSON parsing (AOT-safe). JSON counterpart of
+    /// <see cref="FromFile(string, Func{string, Stream})"/> — see that overload for why
+    /// <paramref name="streamProvider"/> has no default.
+    /// </summary>
+    public static AnimationChainListSave FromJsonFile(string filePath, Func<string, Stream> streamProvider)
+    {
+        using var stream = streamProvider(filePath);
+        var result = ParseJson(JsonNode.Parse(stream)!.AsObject());
+        result.FileName = filePath;
+        return result;
+    }
+
+    /// <summary>Parses .achj JSON from an already-open <paramref name="stream"/>, same contract as <see cref="FromStream(Stream)"/>.</summary>
+    public static AnimationChainListSave FromJsonStream(Stream stream)
+        => ParseJson(JsonNode.Parse(stream)!.AsObject());
+
+    /// <summary>Parses .achj JSON from an in-memory string, same contract as <see cref="FromString(string)"/>.</summary>
+    public static AnimationChainListSave FromJsonString(string json)
+        => ParseJson(JsonNode.Parse(json)!.AsObject());
 
     private static AnimationChainListSave ParseXml(XDocument doc)
     {
@@ -228,6 +259,136 @@ public class AnimationChainListSave
     /// with <see cref="FromString"/> to read it back.
     /// </summary>
     public string ToXmlString() => ToXDocument().ToString();
+
+    /// <summary>
+    /// Writes this save as a .achj file. JSON counterpart of <see cref="Save(string)"/>. Unlike
+    /// the XML dialect, .achj has no legacy byte-format to match, so property names are camelCase
+    /// and optional/default fields are omitted the same way the XML writer omits them (small diffs).
+    /// </summary>
+    public void SaveJson(string path)
+    {
+        using var stream = File.Create(path);
+        SaveJson(stream);
+    }
+
+    /// <summary>
+    /// Writes this save as indented .achj JSON to an already-open stream. JSON counterpart of
+    /// <see cref="Save(Stream)"/> — the caller owns <paramref name="stream"/> and is responsible
+    /// for disposing it; this method does not close it.
+    /// </summary>
+    public void SaveJson(Stream stream)
+    {
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        ToJsonNode().WriteTo(writer);
+    }
+
+    /// <summary>Async-safe counterpart to <see cref="SaveJson(Stream)"/>, same contract as <see cref="SaveAsync(Stream, CancellationToken)"/>.</summary>
+    public async Task SaveJsonAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+        using var buffer = new MemoryStream();
+        SaveJson(buffer);
+        await stream.WriteAsync(buffer.GetBuffer().AsMemory(0, (int)buffer.Length), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Serializes this save to a .achj JSON string. JSON counterpart of <see cref="ToXmlString"/>.</summary>
+    public string ToJsonString() => ToJsonNode().ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+
+    private JsonObject ToJsonNode()
+    {
+        var root = new JsonObject
+        {
+            ["fileRelativeTextures"] = FileRelativeTextures,
+            ["timeMeasurementUnit"] = TimeMeasurementUnit.ToString(),
+            ["coordinateType"] = CoordinateType.ToString(),
+        };
+
+        var chainsArray = new JsonArray();
+        foreach (var chain in AnimationChains)
+        {
+            var framesArray = new JsonArray();
+            foreach (var frame in chain.Frames)
+                framesArray.Add((JsonNode)WriteFrameJson(frame));
+
+            chainsArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = chain.Name,
+                ["frames"] = framesArray,
+            });
+        }
+        root["animationChains"] = chainsArray;
+
+        if (ProjectFile != null)
+            root["projectFile"] = ProjectFile;
+
+        return root;
+    }
+
+    private static JsonObject WriteFrameJson(AnimationFrameSave frame)
+    {
+        var obj = new JsonObject
+        {
+            ["textureName"] = frame.TextureName,
+            ["frameLength"] = frame.FrameLength,
+            ["leftCoordinate"] = frame.LeftCoordinate,
+            ["rightCoordinate"] = frame.RightCoordinate,
+            ["topCoordinate"] = frame.TopCoordinate,
+            ["bottomCoordinate"] = frame.BottomCoordinate,
+        };
+        if (frame.FlipHorizontal) obj["flipHorizontal"] = true;
+        if (frame.FlipVertical) obj["flipVertical"] = true;
+        if (frame.FlipDiagonal) obj["flipDiagonal"] = true;
+        if (frame.RelativeX != 0f) obj["relativeX"] = frame.RelativeX;
+        if (frame.RelativeY != 0f) obj["relativeY"] = frame.RelativeY;
+        if (frame.Red.HasValue) obj["red"] = frame.Red.Value;
+        if (frame.Green.HasValue) obj["green"] = frame.Green.Value;
+        if (frame.Blue.HasValue) obj["blue"] = frame.Blue.Value;
+        if (frame.Alpha.HasValue) obj["alpha"] = frame.Alpha.Value;
+        if (frame.ColorOperation.HasValue) obj["colorOperation"] = frame.ColorOperation.Value.ToString();
+        if (frame.ShapesSave is { } shapes) obj["shapes"] = WriteShapesJson(shapes);
+        return obj;
+    }
+
+    private static JsonObject WriteShapesJson(ShapesSave shapes)
+    {
+        var rectsArray = new JsonArray();
+        foreach (var r in shapes.AARectSaves)
+            rectsArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = r.Name, ["x"] = r.X, ["y"] = r.Y, ["scaleX"] = r.ScaleX, ["scaleY"] = r.ScaleY,
+                ["z"] = r.Z, ["alpha"] = r.Alpha, ["red"] = r.Red, ["green"] = r.Green, ["blue"] = r.Blue,
+            });
+
+        var circlesArray = new JsonArray();
+        foreach (var c in shapes.CircleSaves)
+            circlesArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = c.Name, ["x"] = c.X, ["y"] = c.Y, ["radius"] = c.Radius,
+                ["z"] = c.Z, ["alpha"] = c.Alpha, ["red"] = c.Red, ["green"] = c.Green, ["blue"] = c.Blue,
+            });
+
+        var polysArray = new JsonArray();
+        foreach (var p in shapes.PolygonSaves)
+        {
+            var pointsArray = new JsonArray();
+            foreach (var v in p.Points)
+                pointsArray.Add((JsonNode)new JsonObject { ["x"] = v.X, ["y"] = v.Y });
+
+            polysArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = p.Name, ["x"] = p.X, ["y"] = p.Y,
+                ["z"] = p.Z, ["alpha"] = p.Alpha, ["red"] = p.Red, ["green"] = p.Green, ["blue"] = p.Blue,
+                ["points"] = pointsArray,
+            });
+        }
+
+        return new JsonObject
+        {
+            ["rectangles"] = rectsArray,
+            ["circles"] = circlesArray,
+            ["polygons"] = polysArray,
+        };
+    }
 
     private XDocument ToXDocument()
     {
@@ -550,4 +711,156 @@ public class AnimationChainListSave
         var el = parent.Element(name);
         return el != null ? Enum.Parse<ColorOperation>(el.Value) : null;
     }
+
+    private static AnimationChainListSave ParseJson(JsonObject root)
+    {
+        var result = new AnimationChainListSave();
+
+        if (root["fileRelativeTextures"] is JsonValue frt)
+            result.FileRelativeTextures = frt.GetValue<bool>();
+
+        if (root["timeMeasurementUnit"] is JsonValue tmu)
+            result.TimeMeasurementUnit = Enum.Parse<TimeMeasurementUnit>(tmu.GetValue<string>()!);
+
+        if (root["coordinateType"] is JsonValue ct)
+            result.CoordinateType = Enum.Parse<TextureCoordinateType>(ct.GetValue<string>()!);
+
+        if (root["animationChains"] is JsonArray chainsArray)
+        {
+            foreach (var chainNode in chainsArray)
+            {
+                var chainObj = chainNode!.AsObject();
+                var chain = new AnimationChainSave
+                {
+                    Name = chainObj["name"]?.GetValue<string>() ?? string.Empty
+                };
+
+                if (chainObj["frames"] is JsonArray framesArray)
+                    foreach (var frameNode in framesArray)
+                        chain.Frames.Add(ParseFrameJson(frameNode!.AsObject()));
+
+                result.AnimationChains.Add(chain);
+            }
+        }
+
+        if (root["projectFile"] is JsonValue pf)
+            result.ProjectFile = pf.GetValue<string>();
+
+        return result;
+    }
+
+    private static AnimationFrameSave ParseFrameJson(JsonObject el)
+    {
+        var frame = new AnimationFrameSave
+        {
+            TextureName = el["textureName"]?.GetValue<string>() ?? string.Empty,
+            FrameLength = FloatProp(el, "frameLength"),
+            LeftCoordinate = FloatProp(el, "leftCoordinate"),
+            RightCoordinate = FloatProp(el, "rightCoordinate", 1f),
+            TopCoordinate = FloatProp(el, "topCoordinate"),
+            BottomCoordinate = FloatProp(el, "bottomCoordinate", 1f),
+            FlipHorizontal = BoolProp(el, "flipHorizontal"),
+            FlipVertical = BoolProp(el, "flipVertical"),
+            FlipDiagonal = BoolProp(el, "flipDiagonal"),
+            RelativeX = FloatProp(el, "relativeX"),
+            RelativeY = FloatProp(el, "relativeY"),
+            Red = IntPropNullable(el, "red"),
+            Green = IntPropNullable(el, "green"),
+            Blue = IntPropNullable(el, "blue"),
+            Alpha = IntPropNullable(el, "alpha"),
+            ColorOperation = ColorOperationProp(el, "colorOperation"),
+        };
+
+        if (el["shapes"] is JsonObject shapesObj)
+            frame.ShapesSave = ParseShapesJson(shapesObj);
+
+        return frame;
+    }
+
+    private static ShapesSave ParseShapesJson(JsonObject el)
+    {
+        var shapes = new ShapesSave();
+
+        if (el["rectangles"] is JsonArray rectsArray)
+        {
+            foreach (var node in rectsArray)
+            {
+                var r = node!.AsObject();
+                var rect = new AARectSave
+                {
+                    Name = r["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(r, "x"),
+                    Y = FloatProp(r, "y"),
+                    ScaleX = FloatProp(r, "scaleX", 16f),
+                    ScaleY = FloatProp(r, "scaleY", 16f),
+                };
+                ReadColorJson(r, rect);
+                shapes.Shapes.Add(rect);
+            }
+        }
+
+        if (el["circles"] is JsonArray circlesArray)
+        {
+            foreach (var node in circlesArray)
+            {
+                var c = node!.AsObject();
+                var circle = new CircleSave
+                {
+                    Name = c["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(c, "x"),
+                    Y = FloatProp(c, "y"),
+                    Radius = FloatProp(c, "radius", 16f),
+                };
+                ReadColorJson(c, circle);
+                shapes.Shapes.Add(circle);
+            }
+        }
+
+        if (el["polygons"] is JsonArray polysArray)
+        {
+            foreach (var node in polysArray)
+            {
+                var p = node!.AsObject();
+                var poly = new PolygonSave
+                {
+                    Name = p["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(p, "x"),
+                    Y = FloatProp(p, "y"),
+                };
+                if (p["points"] is JsonArray pointsArray)
+                    foreach (var ptNode in pointsArray)
+                    {
+                        var pt = ptNode!.AsObject();
+                        poly.Points.Add(new Vector2Save { X = FloatProp(pt, "x"), Y = FloatProp(pt, "y") });
+                    }
+                ReadColorJson(p, poly);
+                shapes.Shapes.Add(poly);
+            }
+        }
+
+        return shapes;
+    }
+
+    // JSON counterpart of ReadColor: reads per-shape Z/Alpha/Red/Green/Blue, falling back to
+    // FRB1 defaults when absent.
+    private static void ReadColorJson(JsonObject el, Frb1ShapeData target)
+    {
+        target.Z = FloatProp(el, "z");
+        target.Alpha = FloatProp(el, "alpha", 1f);
+        target.Red = FloatProp(el, "red", 1f);
+        target.Green = FloatProp(el, "green", 1f);
+        target.Blue = FloatProp(el, "blue", 1f);
+    }
+
+    private static float FloatProp(JsonObject parent, string name, float defaultValue = 0f) =>
+        parent[name] is JsonValue v ? v.GetValue<float>() : defaultValue;
+
+    private static bool BoolProp(JsonObject parent, string name, bool defaultValue = false) =>
+        parent[name] is JsonValue v ? v.GetValue<bool>() : defaultValue;
+
+    private static int? IntPropNullable(JsonObject parent, string name) =>
+        parent[name] is JsonValue v ? v.GetValue<int>() : null;
+
+    private static ColorOperation? ColorOperationProp(JsonObject parent, string name) =>
+        parent[name] is JsonValue v ? Enum.Parse<ColorOperation>(v.GetValue<string>()!) : null;
 }

--- a/src/Animation/AnimationChainList.cs
+++ b/src/Animation/AnimationChainList.cs
@@ -55,7 +55,7 @@ public class AnimationChainList : List<AnimationChain>
     }
 
     /// <summary>
-    /// Re-parses the .achx at <paramref name="path"/> and applies the result in place so any
+    /// Re-parses the .achx/.achj at <paramref name="path"/> and applies the result in place so any
     /// live <see cref="FlatRedBall2.Rendering.Sprite.CurrentAnimation"/> reference keeps working.
     /// For each chain in the reloaded file, matches by <see cref="AnimationChain.Name"/>: if the
     /// name exists in this list the existing chain's frames are replaced (instance identity
@@ -63,9 +63,10 @@ public class AnimationChainList : List<AnimationChain>
     /// the file) are left alone — sprites still playing them keep rendering their old art until
     /// the caller switches them.
     /// <para>
-    /// Returns <c>false</c> on I/O or XML parse failure (e.g. file mid-write). Callers should
-    /// fall back to <c>RestartScreen(RestartMode.HotReload)</c> in that case, or retry after
-    /// the next debounce window.
+    /// Returns <c>false</c> on I/O or parse failure (e.g. file mid-write) — XML or JSON, depending
+    /// on <paramref name="path"/>'s extension. Callers should fall back to
+    /// <c>RestartScreen(RestartMode.HotReload)</c> in that case, or retry after the next debounce
+    /// window.
     /// </para>
     /// </summary>
     public bool TryReloadFrom(string path, ContentLoader content)
@@ -77,6 +78,7 @@ public class AnimationChainList : List<AnimationChain>
         }
         catch (IOException) { return false; }
         catch (XmlException) { return false; }
+        catch (System.Text.Json.JsonException) { return false; }
 
         foreach (var freshChain in fresh)
         {

--- a/src/Animation/Content/ContentLoaderAnimationExtensions.cs
+++ b/src/Animation/Content/ContentLoaderAnimationExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace FlatRedBall2.Animation.Content;
 
 /// <summary>
@@ -10,12 +12,22 @@ namespace FlatRedBall2.Animation.Content;
 public static class ContentLoaderAnimationExtensions
 {
     /// <summary>
-    /// Loads a .achx file and converts it to a runtime <see cref="AnimationChainList"/>. The .achx
-    /// XML is read through the service's stream seam; referenced textures are loaded through
+    /// Loads a .achx (XML) or .achj (JSON) file — dialect chosen by <paramref name="path"/>'s
+    /// extension — and converts it to a runtime <see cref="AnimationChainList"/>. The file is read
+    /// through the service's stream seam; referenced textures are loaded through
     /// <see cref="ContentLoader.Load{T}"/> (so PNG hot-reload still applies).
     /// </summary>
     public static AnimationChainList LoadAnimationChainList(this ContentLoader content, string path)
-        => AnimationChainListSave.FromFile(path, content.StreamProvider).ToAnimationChainList(content);
+    {
+        var save = IsJsonPath(path)
+            ? AnimationChainListSave.FromJsonFile(path, content.StreamProvider)
+            : AnimationChainListSave.FromFile(path, content.StreamProvider);
+        return save.ToAnimationChainList(content);
+    }
+
+    /// <summary>True when <paramref name="path"/> has a .achj (JSON) extension; false for .achx or anything else.</summary>
+    internal static bool IsJsonPath(string path) =>
+        path.EndsWith(".achj", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Loads an Adobe Animate TextureAtlas XML and converts it to a runtime

--- a/src/AnimationChain.MonoGame/AchxLoader.cs
+++ b/src/AnimationChain.MonoGame/AchxLoader.cs
@@ -43,22 +43,24 @@ public sealed class AchxLoader : IDisposable
     }
 
     /// <summary>
-    /// Loads the .achx at <paramref name="achxPath"/> from the local filesystem and returns a
-    /// ready-to-play <see cref="AnimationChainList"/>. Textures referenced by the file are loaded
-    /// relative to the .achx location and cached for reuse.
+    /// Loads the .achx (XML) or .achj (JSON) at <paramref name="achxPath"/> — dialect chosen by
+    /// its extension — from the local filesystem and returns a ready-to-play
+    /// <see cref="AnimationChainList"/>. Textures referenced by the file are loaded relative to
+    /// the file's location and cached for reuse.
     /// </summary>
-    /// <param name="achxPath">Absolute or working-directory-relative path to the .achx file.</param>
+    /// <param name="achxPath">Absolute or working-directory-relative path to the .achx/.achj file.</param>
     public AnimationChainList Load(string achxPath)
         => Load(achxPath, File.OpenRead!);
 
     /// <summary>
-    /// Loads the .achx using a custom stream provider. Use this for non-filesystem environments
+    /// Loads the .achx/.achj using a custom stream provider — dialect chosen by
+    /// <paramref name="achxPath"/>'s extension. Use this for non-filesystem environments
     /// (Blazor WASM, embedded resources, unit tests) where <see cref="File.OpenRead"/> is
     /// unavailable. The <paramref name="textureStreamProvider"/> is called with the resolved
     /// texture path; return <c>null</c> from the stream provider to skip a texture.
     /// </summary>
     /// <param name="achxPath">Path passed to <paramref name="achxStreamProvider"/>.</param>
-    /// <param name="achxStreamProvider">Returns a readable stream for the .achx XML.</param>
+    /// <param name="achxStreamProvider">Returns a readable stream for the .achx/.achj file.</param>
     /// <param name="textureStreamProvider">
     /// Optional override for texture loading. When <c>null</c>, falls back to
     /// <see cref="File.OpenRead"/>. Return <c>null</c> to produce a frame with no texture.
@@ -69,7 +71,9 @@ public sealed class AchxLoader : IDisposable
         Func<string, Stream?>? textureStreamProvider = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        var save = AnimationChainListSave.FromFile(achxPath, achxStreamProvider);
+        var save = achxPath.EndsWith(".achj", StringComparison.OrdinalIgnoreCase)
+            ? AnimationChainListSave.FromJsonFile(achxPath, achxStreamProvider)
+            : AnimationChainListSave.FromFile(achxPath, achxStreamProvider);
         string achxDir = Path.GetDirectoryName(Path.GetFullPath(achxPath)) ?? "";
 
         return save.ToAnimationChainList(texPath =>
@@ -82,13 +86,15 @@ public sealed class AchxLoader : IDisposable
     }
 
     /// <summary>
-    /// Loads animation data from an already-open .achx XML <paramref name="achxStream"/>.
+    /// Loads animation data from an already-open <paramref name="achxStream"/> containing either
+    /// .achx (XML) or .achj (JSON) -- the dialect is auto-detected from the content, since no file
+    /// path is available to inspect an extension (see <see cref="AnimationChainListSave.FromDetectedStream"/>).
     /// Because no file path is available, <see cref="AnimationChainListSave.FileRelativeTextures"/>
     /// resolution is skipped — texture paths stored in the file are passed directly to
     /// <paramref name="textureStreamProvider"/>. Supply a <paramref name="textureStreamProvider"/>
-    /// that handles those paths as written in the .achx XML.
+    /// that handles those paths as written in the file.
     /// </summary>
-    /// <param name="achxStream">A readable stream containing the .achx XML. The caller retains ownership.</param>
+    /// <param name="achxStream">A readable stream containing .achx or .achj data. The caller retains ownership.</param>
     /// <param name="textureStreamProvider">
     /// Optional override for texture loading. When <c>null</c>, falls back to
     /// <see cref="File.OpenRead"/>. Return <c>null</c> to produce a frame with no texture.
@@ -96,12 +102,12 @@ public sealed class AchxLoader : IDisposable
     public AnimationChainList Load(Stream achxStream, Func<string, Stream?>? textureStreamProvider = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        var save = AnimationChainListSave.FromStream(achxStream);
+        var save = AnimationChainListSave.FromDetectedStream(achxStream);
         return save.ToAnimationChainList(texPath => GetOrLoadTexture(texPath, textureStreamProvider));
     }
 
     /// <summary>
-    /// Reloads an existing <see cref="AnimationChainList"/> in place from the .achx at
+    /// Reloads an existing <see cref="AnimationChainList"/> in place from the .achx/.achj at
     /// <paramref name="achxPath"/>. Chains with matching names have their frames replaced
     /// (live <see cref="AnimationPlayer"/> references keep working); new chains are appended.
     /// Returns <c>false</c> if the file could not be read (e.g. mid-write) — callers should

--- a/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
+++ b/src/AnimationChain.MonoGame/AnimationChain.KNI.csproj
@@ -9,9 +9,9 @@
     <PackageId>FlatRedBall.AnimationChain.KNI</PackageId>
     <Authors>Victor Chelaru</Authors>
     <Description>
-      A standalone KNI (nkast) library for loading and playing .achx animation files created
-      by the FlatRedBall Animation Editor. Targets Blazor WASM and other KNI platforms.
-      No FlatRedBall2 engine dependency required.
+      A standalone KNI (nkast) library for loading and playing .achx (XML) or .achj (JSON)
+      animation files created by the FlatRedBall Animation Editor. Targets Blazor WASM and other
+      KNI platforms. No FlatRedBall2 engine dependency required.
       For MonoGame DesktopGL targets, use FlatRedBall.AnimationChain.MonoGame instead.
     </Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
+++ b/src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj
@@ -9,9 +9,9 @@
     <PackageId>FlatRedBall.AnimationChain.MonoGame</PackageId>
     <Authors>Victor Chelaru</Authors>
     <Description>
-      A standalone MonoGame (DesktopGL) library for loading and playing .achx animation files
-      created by the FlatRedBall Animation Editor. No FlatRedBall2 engine dependency required.
-      For KNI / Blazor WASM targets, use FlatRedBall.AnimationChain.KNI instead.
+      A standalone MonoGame (DesktopGL) library for loading and playing .achx (XML) or .achj
+      (JSON) animation files created by the FlatRedBall Animation Editor. No FlatRedBall2 engine
+      dependency required. For KNI / Blazor WASM targets, use FlatRedBall.AnimationChain.KNI instead.
     </Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
+++ b/src/AnimationChain.MonoGame/Content/AnimationChainListSave.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -104,6 +106,54 @@ public class AnimationChainListSave
         return FromStream(stream);
     }
 
+    /// <summary>
+    /// Loads a .achj (JSON) file from disk. JSON counterpart of <see cref="FromFile(string)"/>.
+    /// </summary>
+    public static AnimationChainListSave FromJsonFile(string path)
+        => FromJsonFile(path, File.OpenRead!);
+
+    /// <summary>
+    /// Loads a .achj file via a custom stream provider. JSON counterpart of
+    /// <see cref="FromFile(string, Func{string, Stream})"/>.
+    /// </summary>
+    public static AnimationChainListSave FromJsonFile(string filePath, Func<string, Stream> streamProvider)
+    {
+        using var stream = streamProvider(filePath);
+        var result = ParseJson(JsonNode.Parse(stream)!.AsObject());
+        result.FileName = Path.GetFullPath(filePath);
+        return result;
+    }
+
+    /// <summary>Parses .achj JSON from an already-open <paramref name="stream"/>, same contract as <see cref="FromStream(Stream)"/>.</summary>
+    public static AnimationChainListSave FromJsonStream(Stream stream)
+        => ParseJson(JsonNode.Parse(stream)!.AsObject());
+
+    /// <summary>Parses .achj JSON from an in-memory string, same contract as <see cref="FromString(string)"/>.</summary>
+    public static AnimationChainListSave FromJsonString(string json)
+        => ParseJson(JsonNode.Parse(json)!.AsObject());
+
+    /// <summary>
+    /// Parses .achx (XML) or .achj (JSON) from <paramref name="stream"/>, detecting the dialect
+    /// from its content rather than a file extension -- for callers (e.g. <see cref="AchxLoader"/>'s
+    /// stream overload) that only have a stream and no path to inspect. Reads the stream fully
+    /// into memory first, so this works even on a non-seekable stream (network fetch, WASM).
+    /// The caller retains ownership of <paramref name="stream"/> and is responsible for disposing it.
+    /// </summary>
+    public static AnimationChainListSave FromDetectedStream(Stream stream)
+    {
+        string text;
+        using (var reader = new StreamReader(stream, leaveOpen: true))
+            text = reader.ReadToEnd();
+
+        return LooksLikeJson(text) ? FromJsonString(text) : FromString(text);
+    }
+
+    private static bool LooksLikeJson(string text)
+    {
+        var trimmed = text.AsSpan().TrimStart();
+        return trimmed.Length > 0 && trimmed[0] == '{';
+    }
+
     private static AnimationChainListSave ParseXml(XDocument doc)
     {
         var root = doc.Root!;
@@ -163,6 +213,248 @@ public class AnimationChainListSave
         using var stream = File.Create(path);
         doc.Save(stream);
     }
+
+    /// <summary>
+    /// Writes this save as a .achj (JSON) file. JSON counterpart of <see cref="Save(string)"/>.
+    /// </summary>
+    public void SaveJson(string path)
+    {
+        using var stream = File.Create(path);
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        ToJsonNode().WriteTo(writer);
+    }
+
+    /// <summary>Serializes this save to a .achj JSON string.</summary>
+    public string ToJsonString() => ToJsonNode().ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+
+    private JsonObject ToJsonNode()
+    {
+        var root = new JsonObject
+        {
+            ["fileRelativeTextures"] = FileRelativeTextures,
+            ["timeMeasurementUnit"] = TimeMeasurementUnit.ToString(),
+            ["coordinateType"] = CoordinateType.ToString(),
+        };
+
+        var chainsArray = new JsonArray();
+        foreach (var chain in AnimationChains)
+        {
+            var framesArray = new JsonArray();
+            foreach (var frame in chain.Frames)
+                framesArray.Add((JsonNode)WriteFrameJson(frame));
+
+            chainsArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = chain.Name,
+                ["frames"] = framesArray,
+            });
+        }
+        root["animationChains"] = chainsArray;
+
+        if (ProjectFile != null)
+            root["projectFile"] = ProjectFile;
+
+        return root;
+    }
+
+    private static JsonObject WriteFrameJson(AnimationFrameSave frame)
+    {
+        var obj = new JsonObject
+        {
+            ["textureName"] = frame.TextureName,
+            ["frameLength"] = frame.FrameLength,
+            ["leftCoordinate"] = frame.LeftCoordinate,
+            ["rightCoordinate"] = frame.RightCoordinate,
+            ["topCoordinate"] = frame.TopCoordinate,
+            ["bottomCoordinate"] = frame.BottomCoordinate,
+        };
+        if (frame.FlipHorizontal) obj["flipHorizontal"] = true;
+        if (frame.FlipVertical) obj["flipVertical"] = true;
+        if (frame.FlipDiagonal) obj["flipDiagonal"] = true;
+        if (frame.RelativeX != 0f) obj["relativeX"] = frame.RelativeX;
+        if (frame.RelativeY != 0f) obj["relativeY"] = frame.RelativeY;
+        if (frame.Red.HasValue) obj["red"] = frame.Red.Value;
+        if (frame.Green.HasValue) obj["green"] = frame.Green.Value;
+        if (frame.Blue.HasValue) obj["blue"] = frame.Blue.Value;
+        if (frame.Alpha.HasValue) obj["alpha"] = frame.Alpha.Value;
+        if (frame.ColorOperation.HasValue) obj["colorOperation"] = frame.ColorOperation.Value.ToString();
+        if (frame.ShapesSave is { } shapes) obj["shapes"] = WriteShapesJson(shapes);
+        return obj;
+    }
+
+    private static JsonObject WriteShapesJson(ShapesSave shapes)
+    {
+        var rectsArray = new JsonArray();
+        foreach (var r in shapes.AARectSaves)
+            rectsArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = r.Name, ["x"] = r.X, ["y"] = r.Y, ["scaleX"] = r.ScaleX, ["scaleY"] = r.ScaleY,
+            });
+
+        var circlesArray = new JsonArray();
+        foreach (var c in shapes.CircleSaves)
+            circlesArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = c.Name, ["x"] = c.X, ["y"] = c.Y, ["radius"] = c.Radius,
+            });
+
+        var polysArray = new JsonArray();
+        foreach (var p in shapes.PolygonSaves)
+        {
+            var pointsArray = new JsonArray();
+            foreach (var v in p.Points)
+                pointsArray.Add((JsonNode)new JsonObject { ["x"] = v.X, ["y"] = v.Y });
+
+            polysArray.Add((JsonNode)new JsonObject
+            {
+                ["name"] = p.Name, ["x"] = p.X, ["y"] = p.Y,
+                ["points"] = pointsArray,
+            });
+        }
+
+        return new JsonObject
+        {
+            ["rectangles"] = rectsArray,
+            ["circles"] = circlesArray,
+            ["polygons"] = polysArray,
+        };
+    }
+
+    private static AnimationChainListSave ParseJson(JsonObject root)
+    {
+        var result = new AnimationChainListSave();
+
+        if (root["fileRelativeTextures"] is JsonValue frt)
+            result.FileRelativeTextures = frt.GetValue<bool>();
+
+        if (root["timeMeasurementUnit"] is JsonValue tmu)
+            result.TimeMeasurementUnit = Enum.Parse<TimeMeasurementUnit>(tmu.GetValue<string>()!);
+
+        if (root["coordinateType"] is JsonValue ct)
+            result.CoordinateType = Enum.Parse<TextureCoordinateType>(ct.GetValue<string>()!);
+
+        if (root["animationChains"] is JsonArray chainsArray)
+        {
+            foreach (var chainNode in chainsArray)
+            {
+                var chainObj = chainNode!.AsObject();
+                var chain = new AnimationChainSave
+                {
+                    Name = chainObj["name"]?.GetValue<string>() ?? string.Empty
+                };
+
+                if (chainObj["frames"] is JsonArray framesArray)
+                    foreach (var frameNode in framesArray)
+                        chain.Frames.Add(ParseFrameJson(frameNode!.AsObject()));
+
+                result.AnimationChains.Add(chain);
+            }
+        }
+
+        if (root["projectFile"] is JsonValue pf)
+            result.ProjectFile = pf.GetValue<string>();
+
+        return result;
+    }
+
+    private static AnimationFrameSave ParseFrameJson(JsonObject el)
+    {
+        var frame = new AnimationFrameSave
+        {
+            TextureName = el["textureName"]?.GetValue<string>() ?? string.Empty,
+            FrameLength = FloatProp(el, "frameLength"),
+            LeftCoordinate = FloatProp(el, "leftCoordinate"),
+            RightCoordinate = FloatProp(el, "rightCoordinate", 1f),
+            TopCoordinate = FloatProp(el, "topCoordinate"),
+            BottomCoordinate = FloatProp(el, "bottomCoordinate", 1f),
+            FlipHorizontal = BoolProp(el, "flipHorizontal"),
+            FlipVertical = BoolProp(el, "flipVertical"),
+            FlipDiagonal = BoolProp(el, "flipDiagonal"),
+            RelativeX = FloatProp(el, "relativeX"),
+            RelativeY = FloatProp(el, "relativeY"),
+            Red = IntPropNullable(el, "red"),
+            Green = IntPropNullable(el, "green"),
+            Blue = IntPropNullable(el, "blue"),
+            Alpha = IntPropNullable(el, "alpha"),
+            ColorOperation = ColorOperationProp(el, "colorOperation"),
+        };
+
+        if (el["shapes"] is JsonObject shapesObj)
+            frame.ShapesSave = ParseShapesJson(shapesObj);
+
+        return frame;
+    }
+
+    private static ShapesSave ParseShapesJson(JsonObject el)
+    {
+        var shapes = new ShapesSave();
+
+        if (el["rectangles"] is JsonArray rectsArray)
+        {
+            foreach (var node in rectsArray)
+            {
+                var r = node!.AsObject();
+                shapes.Shapes.Add(new AARectSave
+                {
+                    Name = r["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(r, "x"),
+                    Y = FloatProp(r, "y"),
+                    ScaleX = FloatProp(r, "scaleX", 16f),
+                    ScaleY = FloatProp(r, "scaleY", 16f),
+                });
+            }
+        }
+
+        if (el["circles"] is JsonArray circlesArray)
+        {
+            foreach (var node in circlesArray)
+            {
+                var c = node!.AsObject();
+                shapes.Shapes.Add(new CircleSave
+                {
+                    Name = c["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(c, "x"),
+                    Y = FloatProp(c, "y"),
+                    Radius = FloatProp(c, "radius", 16f),
+                });
+            }
+        }
+
+        if (el["polygons"] is JsonArray polysArray)
+        {
+            foreach (var node in polysArray)
+            {
+                var p = node!.AsObject();
+                var poly = new PolygonSave
+                {
+                    Name = p["name"]?.GetValue<string>() ?? string.Empty,
+                    X = FloatProp(p, "x"),
+                    Y = FloatProp(p, "y"),
+                };
+                if (p["points"] is JsonArray pointsArray)
+                    foreach (var ptNode in pointsArray)
+                    {
+                        var pt = ptNode!.AsObject();
+                        poly.Points.Add(new Vector2Save { X = FloatProp(pt, "x"), Y = FloatProp(pt, "y") });
+                    }
+                shapes.Shapes.Add(poly);
+            }
+        }
+
+        return shapes;
+    }
+
+    private static float FloatProp(JsonObject parent, string name, float defaultValue = 0f) =>
+        parent[name] is JsonValue v ? v.GetValue<float>() : defaultValue;
+
+    private static bool BoolProp(JsonObject parent, string name, bool defaultValue = false) =>
+        parent[name] is JsonValue v ? v.GetValue<bool>() : defaultValue;
+
+    private static int? IntPropNullable(JsonObject parent, string name) =>
+        parent[name] is JsonValue v ? v.GetValue<int>() : null;
+
+    private static ColorOperation? ColorOperationProp(JsonObject parent, string name) =>
+        parent[name] is JsonValue v ? Enum.Parse<ColorOperation>(v.GetValue<string>()!) : null;
 
     /// <summary>
     /// Converts this save to a runtime <see cref="AnimationChainList"/>. Texture paths are

--- a/src/AnimationChain.MonoGame/README.md
+++ b/src/AnimationChain.MonoGame/README.md
@@ -1,7 +1,8 @@
 # FlatRedBall.AnimationChain
 
-A standalone library for loading and playing `.achx` sprite animation files created by the
-[FlatRedBall Animation Editor](https://github.com/vchelaru/FlatRedBall2).
+A standalone library for loading and playing `.achx` (XML) or `.achj` (JSON) sprite animation
+files created by the [FlatRedBall Animation Editor](https://github.com/vchelaru/FlatRedBall2) —
+`AchxLoader` picks the dialect from the file extension automatically.
 No FlatRedBall2 engine dependency required — drop it into any MonoGame or KNI project.
 
 ## Choose a variant

--- a/src/AnimationChain.MonoGame/Runtime/AnimationChainList.cs
+++ b/src/AnimationChain.MonoGame/Runtime/AnimationChainList.cs
@@ -27,16 +27,17 @@ public class AnimationChainList : List<AnimationChain>
     }
 
     /// <summary>
-    /// Re-parses the .achx at <paramref name="achxPath"/> and applies changes in place so any
+    /// Re-parses the .achx/.achj at <paramref name="achxPath"/> and applies changes in place so any
     /// live <see cref="AnimationPlayer"/> reference keeps working. For each chain in the reloaded
     /// file, matches by <see cref="AnimationChain.Name"/>: existing chains have their frames
     /// replaced in place (instance identity preserved); new chains are appended.
     /// <para>
-    /// Returns <c>false</c> on I/O or XML parse failure (e.g. file mid-write). Callers should
-    /// retry after the next file-system debounce window.
+    /// Returns <c>false</c> on I/O or parse failure (e.g. file mid-write) — XML or JSON, depending
+    /// on <paramref name="achxPath"/>'s extension. Callers should retry after the next
+    /// file-system debounce window.
     /// </para>
     /// </summary>
-    /// <param name="achxPath">Absolute path to the .achx file to reload from.</param>
+    /// <param name="achxPath">Absolute path to the .achx/.achj file to reload from.</param>
     /// <param name="textureLoader">
     /// Called with the resolved absolute path of each texture file. May return <c>null</c>
     /// if the texture is unavailable — affected frames keep their existing texture.
@@ -48,27 +49,32 @@ public class AnimationChainList : List<AnimationChain>
         AnimationChainList fresh;
         try
         {
-            var save = Content.AnimationChainListSave.FromFile(achxPath);
+            var save = achxPath.EndsWith(".achj", StringComparison.OrdinalIgnoreCase)
+                ? Content.AnimationChainListSave.FromJsonFile(achxPath)
+                : Content.AnimationChainListSave.FromFile(achxPath);
             fresh = save.ToAnimationChainList(textureLoader);
         }
         catch (IOException) { return false; }
         catch (System.Xml.XmlException) { return false; }
+        catch (System.Text.Json.JsonException) { return false; }
 
         ApplyReloadedChains(fresh);
         return true;
     }
 
     /// <summary>
-    /// Re-parses .achx XML from an already-open <paramref name="achxStream"/> and applies
-    /// changes in place so live <see cref="AnimationPlayer"/> references keep working.
+    /// Re-parses .achx (XML) or .achj (JSON) from an already-open <paramref name="achxStream"/> --
+    /// dialect auto-detected from the content, since no file path is available to inspect an
+    /// extension (see <see cref="Content.AnimationChainListSave.FromDetectedStream"/>) -- and
+    /// applies changes in place so live <see cref="AnimationPlayer"/> references keep working.
     /// For each chain in the reloaded data, matches by <see cref="AnimationChain.Name"/>:
     /// existing chains have their frames replaced in place (instance identity preserved);
     /// new chains are appended.
     /// <para>
-    /// Returns <c>false</c> on I/O or XML parse failure.
+    /// Returns <c>false</c> on I/O or parse failure (XML or JSON).
     /// </para>
     /// </summary>
-    /// <param name="achxStream">Readable stream containing .achx XML. Caller retains ownership.</param>
+    /// <param name="achxStream">Readable stream containing .achx or .achj data. Caller retains ownership.</param>
     /// <param name="textureLoader">
     /// Called with each texture path stored in the .achx data. May return <c>null</c> if
     /// a texture is unavailable — affected frames keep a <c>null</c> texture.
@@ -78,11 +84,12 @@ public class AnimationChainList : List<AnimationChain>
         AnimationChainList fresh;
         try
         {
-            var save = Content.AnimationChainListSave.FromStream(achxStream);
+            var save = Content.AnimationChainListSave.FromDetectedStream(achxStream);
             fresh = save.ToAnimationChainList(textureLoader);
         }
         catch (IOException) { return false; }
         catch (System.Xml.XmlException) { return false; }
+        catch (System.Text.Json.JsonException) { return false; }
 
         ApplyReloadedChains(fresh);
         return true;

--- a/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
+++ b/tests/AnimationChain.KNI.Tests/AnimationChain.KNI.Tests.csproj
@@ -29,5 +29,6 @@
     <Compile Include="..\AnimationChain.MonoGame.Tests\AchxLoaderTests.cs" Link="AchxLoaderTests.cs" />
     <Compile Include="..\AnimationChain.MonoGame.Tests\AnimationPlayerTests.cs" Link="AnimationPlayerTests.cs" />
     <Compile Include="..\AnimationChain.MonoGame.Tests\AnimationChainListSaveRoundTripTests.cs" Link="AnimationChainListSaveRoundTripTests.cs" />
+    <Compile Include="..\AnimationChain.MonoGame.Tests\AnimationChainListSaveJsonTests.cs" Link="AnimationChainListSaveJsonTests.cs" />
   </ItemGroup>
 </Project>

--- a/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AchxLoaderTests.cs
@@ -294,6 +294,92 @@ public class AchxLoaderTests
         Assert.Null(list["Slide"]);
     }
 
+    [Fact]
+    public void TryReloadFrom_Stream_JsonContent_AutoDetectsAndReplacesFrames()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+
+        var reloadSave = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "tex.png", FrameLength = 0.25f });
+        reloadSave.AnimationChains.Add(chain);
+
+        using var reloadStream = new MemoryStream(Encoding.UTF8.GetBytes(reloadSave.ToJsonString()));
+        var ok = list.TryReloadFrom(reloadStream, _ => null);
+
+        Assert.True(ok);
+        Assert.Single(list["Run"]!);
+        Assert.Equal(TimeSpan.FromSeconds(0.25), list["Run"]![0].FrameLength);
+    }
+
+    [Fact]
+    public void TryReloadFrom_Stream_InvalidJsonContent_ReturnsFalseAndLeavesListUntouched()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+        var beforeRunFrames = list["Run"]!.Count;
+
+        using var reloadStream = new MemoryStream(Encoding.UTF8.GetBytes("{not valid json"));
+        var ok = list.TryReloadFrom(reloadStream, _ => null);
+
+        Assert.False(ok);
+        Assert.Equal(beforeRunFrames, list["Run"]!.Count);
+    }
+
+    // ─── AnimationChainList.TryReloadFrom(path) — .achj (JSON) dispatch by extension ─────────
+
+    [Fact]
+    public void TryReloadFrom_Path_AchjExtension_ParsesJsonAndReplacesFrames()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Run" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "tex.png", FrameLength = 0.25f });
+        save.AnimationChains.Add(chain);
+
+        var tempPath = Path.GetTempFileName() + ".achj";
+        try
+        {
+            save.SaveJson(tempPath);
+
+            var ok = list.TryReloadFrom(tempPath, _ => null);
+
+            Assert.True(ok);
+            Assert.Single(list["Run"]!);
+            Assert.Equal(TimeSpan.FromSeconds(0.25), list["Run"]![0].FrameLength);
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void TryReloadFrom_Path_InvalidJson_ReturnsFalseAndLeavesListUntouched()
+    {
+        var list = AnimationChainListSave.FromFile("dummy.achx", XmlStream(SimpleAchx))
+            .ToAnimationChainList(_ => null);
+        var beforeRunFrames = list["Run"]!.Count;
+
+        var tempPath = Path.GetTempFileName() + ".achj";
+        try
+        {
+            File.WriteAllText(tempPath, "not valid json at all");
+
+            var ok = list.TryReloadFrom(tempPath, _ => null);
+
+            Assert.False(ok);
+            Assert.Equal(beforeRunFrames, list["Run"]!.Count);
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+
     // ─── FromStream ──────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/AnimationChain.MonoGame.Tests/AnimationChainListSaveJsonTests.cs
+++ b/tests/AnimationChain.MonoGame.Tests/AnimationChainListSaveJsonTests.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using System.Text;
+using FlatRedBall.AnimationChain;
+using FlatRedBall.AnimationChain.Content;
+using Xunit;
+
+namespace AnimationChain.MonoGame.Tests;
+
+// .achj (JSON) dialect added alongside .achx (XML), mirroring FlatRedBall2.Animation.Content's
+// support (#872 follow-up) -- this package has no dependency on that assembly, so the JSON
+// read/write is a separate implementation over this package's own Content types.
+public class AnimationChainListSaveJsonTests
+{
+    private static Func<string, Stream> JsonStream(string json) =>
+        _ => new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+    [Fact]
+    public void FromJsonFile_StreamProvider_ReceivesProvidedPathAndProducesSave()
+    {
+        string requestedPath = "Content/Animations/Player.achj";
+        string? observedPath = null;
+        string json = "{\"animationChains\":[{\"name\":\"Walk\",\"frames\":[" +
+            "{\"textureName\":\"walk.png\",\"frameLength\":0.1}]}]}";
+
+        var save = AnimationChainListSave.FromJsonFile(requestedPath, path =>
+        {
+            observedPath = path;
+            return JsonStream(json)(path);
+        });
+
+        Assert.Equal(Path.GetFullPath(requestedPath), save.FileName);
+        Assert.Equal("Walk", save.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public void ToJsonString_FromJsonString_RoundTripsFrameFields()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "walk.png",
+            FrameLength = 0.25f,
+            LeftCoordinate = 0.1f,
+            RightCoordinate = 0.9f,
+            FlipDiagonal = true,
+            RelativeX = 3.5f,
+            Red = 200,
+            ColorOperation = ColorOperation.Add,
+        });
+        save.AnimationChains.Add(chain);
+
+        var roundTripped = AnimationChainListSave.FromJsonString(save.ToJsonString());
+
+        var frame = roundTripped.AnimationChains[0].Frames[0];
+        Assert.Equal("walk.png", frame.TextureName);
+        Assert.Equal(0.25f, frame.FrameLength, precision: 5);
+        Assert.True(frame.FlipDiagonal);
+        Assert.Equal(3.5f, frame.RelativeX, precision: 5);
+        Assert.Equal(200, frame.Red);
+        Assert.Null(frame.Green);
+        Assert.Equal(ColorOperation.Add, frame.ColorOperation);
+    }
+
+    [Fact]
+    public void ToJsonString_FrameWithRectangleShape_RoundTripsShapeData()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Attack" };
+        var frame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
+        frame.ShapesSave = new ShapesSave();
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Sword", X = 5, Y = 1, ScaleX = 15, ScaleY = 5 });
+        chain.Frames.Add(frame);
+        save.AnimationChains.Add(chain);
+
+        var roundTripped = AnimationChainListSave.FromJsonString(save.ToJsonString());
+
+        var rect = roundTripped.AnimationChains[0].Frames[0].ShapesSave!.AARectSaves.Single();
+        Assert.Equal("Sword", rect.Name);
+        Assert.Equal(5f, rect.X, precision: 5);
+        Assert.Equal(15f, rect.ScaleX, precision: 5);
+    }
+
+    // ─── FromDetectedStream (auto-detect XML vs JSON from content) ────────────────
+
+    [Fact]
+    public void FromDetectedStream_JsonContent_ParsesAsJson()
+    {
+        var save = new AnimationChainListSave();
+        save.AnimationChains.Add(new AnimationChainSave { Name = "Walk" });
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(save.ToJsonString()));
+
+        var loaded = AnimationChainListSave.FromDetectedStream(stream);
+
+        Assert.Equal("Walk", loaded.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public void FromDetectedStream_XmlContent_ParsesAsXml()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AnimationChainArraySave>
+              <AnimationChain><Name>Run</Name></AnimationChain>
+            </AnimationChainArraySave>
+            """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        var loaded = AnimationChainListSave.FromDetectedStream(stream);
+
+        Assert.Equal("Run", loaded.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public void FromDetectedStream_JsonContentWithLeadingWhitespace_StillDetectsJson()
+    {
+        var save = new AnimationChainListSave();
+        save.AnimationChains.Add(new AnimationChainSave { Name = "Idle" });
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("   \n" + save.ToJsonString()));
+
+        var loaded = AnimationChainListSave.FromDetectedStream(stream);
+
+        Assert.Equal("Idle", loaded.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public void SaveJson_FromJsonFile_RoundTripsThroughDisk()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Idle" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "idle.png", FrameLength = 0.5f });
+        save.AnimationChains.Add(chain);
+
+        var tempPath = Path.GetTempFileName() + ".achj";
+        try
+        {
+            save.SaveJson(tempPath);
+            var loaded = AnimationChainListSave.FromJsonFile(tempPath);
+
+            Assert.Equal("Idle", loaded.AnimationChains[0].Name);
+            Assert.Equal("idle.png", loaded.AnimationChains[0].Frames[0].TextureName);
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}

--- a/tests/FlatRedBall2.Tests/Animation/AnimationChainListReloadTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationChainListReloadTests.cs
@@ -93,6 +93,57 @@ public class AnimationChainListReloadTests
     }
 
     [Fact]
+    public void TryReloadFrom_InvalidJson_ReturnsFalse()
+    {
+        var content = MakeContent();
+        var list = LoadFresh(WriteAchx("base.achx", ("Walk", 2)), content);
+        WriteRaw("bad.achj", "not valid json at all");
+
+        var result = list.TryReloadFrom("bad.achj", content);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryReloadFrom_AchjFile_SameChain_PreservesChainInstanceIdentity()
+    {
+        var content = MakeContent();
+        var path = "anim.achj";
+        WriteRaw(path, MakeAchjJson(("Walk", 2)));
+        var list = LoadFresh(path, content);
+        var walkBefore = list["Walk"];
+
+        // Author edits the file — same chain name, grown frame count.
+        WriteRaw(path, MakeAchjJson(("Walk", 4)));
+
+        list.TryReloadFrom(path, content).ShouldBeTrue();
+
+        list["Walk"].ShouldBeSameAs(walkBefore); // identity preserved — live Sprite refs still valid
+        list["Walk"]!.Count.ShouldBe(4);
+    }
+
+    private static string MakeAchjJson(params (string ChainName, int FrameCount)[] chains)
+    {
+        var save = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        foreach (var (name, count) in chains)
+        {
+            var chain = new AnimationChainSave { Name = name };
+            for (int i = 0; i < count; i++)
+                chain.Frames.Add(new AnimationFrameSave
+                {
+                    TextureName = $"{name}.png",
+                    FrameLength = 0.1f,
+                    LeftCoordinate = i * 16,
+                    RightCoordinate = i * 16 + 16,
+                    TopCoordinate = 0,
+                    BottomCoordinate = 16,
+                });
+            save.AnimationChains.Add(chain);
+        }
+        return save.ToJsonString();
+    }
+
+    [Fact]
     public void TryReloadFrom_NonParseInvalidOperationException_Propagates()
     {
         // A genuine bug (not file mid-write / bad XML) should surface rather than be swallowed as

--- a/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveJsonTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/AnimationChainListSaveJsonTests.cs
@@ -1,0 +1,112 @@
+using System.IO;
+using System.Linq;
+using FlatRedBall2.Animation;
+using FlatRedBall2.Animation.Content;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Animation;
+
+// Verifies the .achj (JSON) dialect added alongside .achx (XML): AnimationChainListSave can
+// round-trip chains, frames, and shapes through ToJsonString/FromJsonString and SaveJson/FromJsonFile.
+public class AnimationChainListSaveJsonTests
+{
+    [Fact]
+    public void FromJsonFile_StreamProvider_ReceivesProvidedPathAndProducesSave()
+    {
+        string requestedPath = "Content/Animations/ShmupSpace.achj";
+        string? observedPath = null;
+        string json = "{\"animationChains\":[{\"name\":\"Walk\",\"frames\":[" +
+            "{\"textureName\":\"walk.png\",\"frameLength\":0.1}]}]}";
+
+        var save = AnimationChainListSave.FromJsonFile(requestedPath, path =>
+        {
+            observedPath = path;
+            return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        });
+
+        observedPath.ShouldBe(requestedPath);
+        save.AnimationChains.Count.ShouldBe(1);
+        save.AnimationChains[0].Name.ShouldBe("Walk");
+    }
+
+    [Fact]
+    public void ToJsonString_FromJsonString_RoundTripsFrameFields()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = "walk.png",
+            FrameLength = 0.25f,
+            LeftCoordinate = 0.1f,
+            RightCoordinate = 0.9f,
+            TopCoordinate = 0.2f,
+            BottomCoordinate = 0.8f,
+            FlipHorizontal = true,
+            RelativeX = 3.5f,
+            Red = 200,
+            Alpha = 128,
+            ColorOperation = ColorOperation.Add,
+        });
+        save.AnimationChains.Add(chain);
+
+        var roundTripped = AnimationChainListSave.FromJsonString(save.ToJsonString());
+
+        var frame = roundTripped.AnimationChains.Single().Frames.Single();
+        frame.TextureName.ShouldBe("walk.png");
+        frame.FrameLength.ShouldBe(0.25f);
+        frame.LeftCoordinate.ShouldBe(0.1f);
+        frame.RightCoordinate.ShouldBe(0.9f);
+        frame.FlipHorizontal.ShouldBeTrue();
+        frame.FlipVertical.ShouldBeFalse();
+        frame.RelativeX.ShouldBe(3.5f);
+        frame.Red.ShouldBe(200);
+        frame.Green.ShouldBeNull();
+        frame.Alpha.ShouldBe(128);
+        frame.ColorOperation.ShouldBe(ColorOperation.Add);
+    }
+
+    [Fact]
+    public void ToJsonString_FrameWithRectangleShape_RoundTripsShapeData()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Attack" };
+        var frame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
+        frame.ShapesSave = new ShapesSave();
+        frame.ShapesSave.Shapes.Add(new AARectSave { Name = "Sword", X = 5, Y = 1, ScaleX = 15, ScaleY = 5 });
+        chain.Frames.Add(frame);
+        save.AnimationChains.Add(chain);
+
+        var roundTripped = AnimationChainListSave.FromJsonString(save.ToJsonString());
+
+        var rect = roundTripped.AnimationChains.Single().Frames.Single().ShapesSave!.AARectSaves.Single();
+        rect.Name.ShouldBe("Sword");
+        rect.X.ShouldBe(5f);
+        rect.ScaleX.ShouldBe(15f);
+        rect.ScaleY.ShouldBe(5f);
+    }
+
+    [Fact]
+    public void SaveJson_FromJsonFile_RoundTripsThroughDisk()
+    {
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Idle" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "idle.png", FrameLength = 0.5f });
+        save.AnimationChains.Add(chain);
+
+        var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".achj");
+        try
+        {
+            save.SaveJson(tempPath);
+            var loaded = AnimationChainListSave.FromJsonFile(tempPath);
+
+            loaded.AnimationChains.Single().Name.ShouldBe("Idle");
+            loaded.AnimationChains.Single().Frames.Single().TextureName.ShouldBe("idle.png");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}

--- a/tests/FlatRedBall2.Tests/Animation/ContentLoaderAnimationExtensionsJsonTests.cs
+++ b/tests/FlatRedBall2.Tests/Animation/ContentLoaderAnimationExtensionsJsonTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FlatRedBall2.Animation.Content;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Animation;
+
+// ContentLoader.LoadAnimationChainList (the game-code entry point) must dispatch to the JSON
+// parser for .achj paths, same as AnimationEditor.Core.ProjectManager already does (#872 follow-up).
+public class ContentLoaderAnimationExtensionsJsonTests
+{
+    [Fact]
+    public void LoadAnimationChainList_AchjPath_ParsesJsonIntoRuntimeChainList()
+    {
+        var svc = new ContentLoader();
+        svc.TextureLoader = _ => null!;
+        var virtualFiles = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        svc.StreamProvider = path =>
+        {
+            if (!virtualFiles.TryGetValue(path, out var bytes))
+                throw new FileNotFoundException(path);
+            return new MemoryStream(bytes);
+        };
+
+        var save = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "walk.png", FrameLength = 0.1f });
+        save.AnimationChains.Add(chain);
+        virtualFiles["anim.achj"] = Encoding.UTF8.GetBytes(save.ToJsonString());
+
+        var list = svc.LoadAnimationChainList("anim.achj");
+
+        list["Walk"].ShouldNotBeNull();
+        list["Walk"]!.Count.ShouldBe(1);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2067,7 +2067,7 @@ public partial class MainWindow : Window
             AllowMultiple = false,
             FileTypeFilter = new[]
             {
-                new FilePickerFileType("Animation Chain") { Patterns = new[] { "*.achx" } }
+                new FilePickerFileType("Animation Chain") { Patterns = new[] { "*.achx", "*.achj" } }
             }
         });
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/WindowsFileAssociationService.cs
@@ -21,8 +21,15 @@ namespace AnimationEditor.App.Services;
 /// </summary>
 internal sealed class WindowsFileAssociationService : IFileAssociationService
 {
-    /// <summary>The file extension this editor handles, including the leading dot.</summary>
+    /// <summary>The primary file extension this editor handles, including the leading dot.
+    /// Default-handler status (<see cref="GetStatus"/>/<see cref="IsDefault"/>) is tracked for
+    /// this extension only; <see cref="SecondaryExtension"/> is registered to the same ProgId
+    /// alongside it but doesn't affect that status.</summary>
     internal const string Extension = ".achx";
+
+    /// <summary>The .achj (JSON) extension, registered to the same ProgId as <see cref="Extension"/>
+    /// so double-clicking either format opens this editor.</summary>
+    internal const string SecondaryExtension = ".achj";
 
     /// <summary>
     /// The per-user ProgId the editor registers under <c>HKCU\Software\Classes</c>. Namespaced
@@ -107,10 +114,11 @@ internal sealed class WindowsFileAssociationService : IFileAssociationService
             Registry.SetValue($@"{progIdKey}\DefaultIcon", null, $"\"{exe}\",0");
             Registry.SetValue($@"{progIdKey}\shell\open\command", null, BuildOpenCommand(exe));
 
-            // Point the extension at our ProgId. On modern Windows this is only a fallback —
+            // Point both extensions at our ProgId. On modern Windows this is only a fallback —
             // an existing hash-protected UserChoice still wins, which is why we open the
             // default-apps settings below for the user to confirm.
             Registry.SetValue($@"{ClassesRoot}\{Extension}", null, ProgId);
+            Registry.SetValue($@"{ClassesRoot}\{SecondaryExtension}", null, ProgId);
         }
         catch (Exception e)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserProjectLoader.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/BrowserProjectLoader.cs
@@ -47,7 +47,8 @@ internal static class BrowserProjectLoader
         ISelectedState selectedState)
     {
         var achxFile = files.FirstOrDefault(
-            f => f.Name.EndsWith(".achx", StringComparison.OrdinalIgnoreCase));
+            f => f.Name.EndsWith(".achx", StringComparison.OrdinalIgnoreCase) ||
+                 f.Name.EndsWith(".achj", StringComparison.OrdinalIgnoreCase));
         if (achxFile is null) return null;
 
         string achxText;
@@ -55,7 +56,9 @@ internal static class BrowserProjectLoader
         using (var reader = new StreamReader(achxStream))
             achxText = await reader.ReadToEndAsync();
 
-        var acls = AnimationChainListSave.FromString(achxText);
+        var acls = achxFile.Name.EndsWith(".achj", StringComparison.OrdinalIgnoreCase)
+            ? AnimationChainListSave.FromJsonString(achxText)
+            : AnimationChainListSave.FromString(achxText);
         var achxDirectory = RootRelativePath.DirectoryOf(achxFile.Name);
 
         var pngsByPath = new Dictionary<string, IEditorFile>(StringComparer.OrdinalIgnoreCase);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
 using StringFunctions = AnimationEditor.Core.Utilities.StringFunctions;
 
 namespace AnimationEditor.Core.CommandsAndState
@@ -400,10 +401,22 @@ namespace AnimationEditor.Core.CommandsAndState
         /// and <see cref="IApplicationEvents.CurrentFileChanged"/>.
         /// Does nothing if the user cancels the dialog.
         /// </summary>
+        /// <remarks>
+        /// The dialog's default extension follows the currently-loaded file: <c>achj</c> (JSON)
+        /// for a brand-new, never-saved file (#872 -- .achj is the default going forward), or
+        /// whatever extension the loaded file already has (typically <c>achx</c>, preserving the
+        /// on-disk format of an opened legacy file). The user can still pick the other format
+        /// from the dialog's file-type filter.
+        /// </remarks>
         public async Task SaveCurrentAnimationChainListAsync()
         {
+            var currentExtension = string.IsNullOrEmpty(_pm.FileName)
+                ? null
+                : new FilePath(_pm.FileName).Extension;
+            var defaultExtension = string.IsNullOrEmpty(currentExtension) ? "achj" : currentExtension;
+
             var path = await FileDialogService.PickSaveFileAsync(
-                "Save Animation Chain", "achx", "Animation Chain (*.achx)");
+                "Save Animation Chain", defaultExtension, $"Animation Chain (*.{defaultExtension})");
 
             if (string.IsNullOrEmpty(path)) return;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/AchxDropProcessor.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/DragDrop/AchxDropProcessor.cs
@@ -12,19 +12,20 @@ namespace AnimationEditor.Core.DragDrop;
 public static class AchxDropProcessor
 {
     /// <summary>
-    /// Returns the dropped paths that are <c>.achx</c> files (case-insensitive), preserving
-    /// their original order and skipping null/blank entries. Non-.achx paths (e.g. PNG
-    /// textures) are filtered out so a mixed drop opens the .achx files and ignores the rest.
+    /// Returns the dropped paths that are <c>.achx</c> or <c>.achj</c> files (case-insensitive),
+    /// preserving their original order and skipping null/blank entries. Other paths (e.g. PNG
+    /// textures) are filtered out so a mixed drop opens the animation chain files and ignores the rest.
     /// </summary>
     public static IReadOnlyList<string> SelectAchxFiles(IEnumerable<string?>? droppedFilePaths) =>
         droppedFilePaths is null
             ? new List<string>()
             : droppedFilePaths
-                .Where(p => !string.IsNullOrWhiteSpace(p) && new FilePath(p).Extension == "achx")
+                .Where(p => !string.IsNullOrWhiteSpace(p) &&
+                    (new FilePath(p).Extension == "achx" || new FilePath(p).Extension == "achj"))
                 .Select(p => p!)
                 .ToList();
 
-    /// <summary>True when at least one dropped path is an <c>.achx</c> file.</summary>
+    /// <summary>True when at least one dropped path is an <c>.achx</c> or <c>.achj</c> file.</summary>
     public static bool ContainsAchx(IEnumerable<string?>? droppedFilePaths) =>
         SelectAchxFiles(droppedFilePaths).Count > 0;
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFolderScanner.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxFolderScanner.cs
@@ -24,12 +24,16 @@ public static class AchxFolderScanner
 
     /// <summary>
     /// True when <paramref name="path"/> — an absolute path, a relative path, or a bare file
-    /// name — has a <c>.achx</c> extension. Shared by the recursive scan above and by
-    /// <see cref="FolderWatcher"/>'s live Project-tree watch (#843), so both agree on what
-    /// counts as an achx.
+    /// name — has a <c>.achx</c> (XML) or <c>.achj</c> (JSON) extension. Shared by the recursive
+    /// scan above and by <see cref="FolderWatcher"/>'s live Project-tree watch (#843), so both
+    /// agree on what counts as an animation chain file.
     /// </summary>
-    public static bool IsAchxPath(string path) =>
-        Path.GetExtension(path).Equals(".achx", StringComparison.OrdinalIgnoreCase);
+    public static bool IsAchxPath(string path)
+    {
+        var ext = Path.GetExtension(path);
+        return ext.Equals(".achx", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".achj", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static async Task ScanAsync(
         IEditorFolder folder, string relativePrefix, List<AchxFileEntry> results)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/CommandLineArgParser.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/CommandLineArgParser.cs
@@ -8,7 +8,7 @@ namespace AnimationEditor.Core.IO;
 public static class CommandLineArgParser
 {
     /// <summary>
-    /// Returns the first argument that ends with <c>.achx</c> (case-insensitive),
+    /// Returns the first argument that ends with <c>.achx</c> or <c>.achj</c> (case-insensitive),
     /// or <c>null</c> if no such argument is found.
     /// </summary>
     /// <param name="args">The application command-line arguments, as received in <c>Main(string[] args)</c>.</param>
@@ -19,6 +19,7 @@ public static class CommandLineArgParser
 
         return Array.Find(args, a =>
             !string.IsNullOrEmpty(a) &&
-            a.EndsWith(".achx", StringComparison.OrdinalIgnoreCase));
+            (a.EndsWith(".achx", StringComparison.OrdinalIgnoreCase) ||
+             a.EndsWith(".achj", StringComparison.OrdinalIgnoreCase)));
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -75,7 +75,9 @@ namespace AnimationEditor.Core
                     throw new System.IO.InvalidDataException(
                         $"{IO.AchxConflictMarkerDetector.ConflictMarkerMessage} ({fileName.FullPath})");
 
-                acls = AnimationChainListSave.FromFile(fileName.FullPath);
+                acls = IsJsonPath(fileName.FullPath)
+                    ? AnimationChainListSave.FromJsonFile(fileName.FullPath)
+                    : AnimationChainListSave.FromFile(fileName.FullPath);
             }
 
             AddShapeCollectionsToFrames(acls);
@@ -116,8 +118,9 @@ namespace AnimationEditor.Core
         }
 
         /// <summary>
-        /// Save the current animation chain list to <paramref name="targetPath"/> in the
-        /// format specified by <see cref="OnDiskCoordinateType"/>. The editor stores
+        /// Save the current animation chain list to <paramref name="targetPath"/>, as .achj
+        /// (JSON) or .achx (XML) depending on <paramref name="targetPath"/>'s extension, in the
+        /// coordinate format specified by <see cref="OnDiskCoordinateType"/>. The editor stores
         /// frame coordinates as UV internally (so the rendering pipeline can render at
         /// any texture size); when writing as Pixel, this method converts just for the
         /// on-disk write and then converts back so the in-memory model stays UV.
@@ -129,18 +132,19 @@ namespace AnimationEditor.Core
 
             var achxDirectory = System.IO.Path.GetDirectoryName(targetPath) ?? string.Empty;
             var diskFormat = OnDiskCoordinateType;
+            void Write() { if (IsJsonPath(targetPath)) acls.SaveJson(targetPath); else acls.Save(targetPath); }
 
             // No conversion needed when on-disk format matches the in-memory format (UV).
             if (diskFormat == TextureCoordinateType.UV)
             {
-                acls.Save(targetPath);
+                Write();
                 return;
             }
 
             var sizes = ConvertCoordinates(acls, achxDirectory, diskFormat);
             try
             {
-                acls.Save(targetPath);
+                Write();
             }
             finally
             {
@@ -150,11 +154,12 @@ namespace AnimationEditor.Core
         }
 
         /// <summary>
-        /// Save the current animation chain list to <paramref name="stream"/> in the format
-        /// specified by <see cref="OnDiskCoordinateType"/> -- the seam the browser-wasm build
-        /// needs, since it has no filesystem to write a path to. When converting UV back to
-        /// Pixel, texture sizes come from the <c>knownTextureSizes</c> supplied to the most
-        /// recent <see cref="LoadAnimationChain"/> call rather than a disk read: there is no
+        /// Save the current animation chain list to <paramref name="stream"/> -- the seam the
+        /// browser-wasm build needs, since it has no filesystem to write a path to. Written as
+        /// .achj (JSON) when <see cref="FileName"/> ends in .achj, otherwise .achx (XML), in the
+        /// coordinate format specified by <see cref="OnDiskCoordinateType"/>. When converting UV
+        /// back to Pixel, texture sizes come from the <c>knownTextureSizes</c> supplied to the
+        /// most recent <see cref="LoadAnimationChain"/> call rather than a disk read: there is no
         /// directory to resolve a relative <see cref="AnimationFrameSave.TextureName"/> against
         /// on this overload. A texture missing from that dictionary is left in UV coordinates,
         /// same as the path-based overload's behavior when a PNG can't be read.
@@ -164,7 +169,10 @@ namespace AnimationEditor.Core
             var acls = AnimationChainListSave;
             if (acls == null) return;
 
-            RunWithDiskCoordinateConversion(acls, () => acls.Save(stream));
+            RunWithDiskCoordinateConversion(acls, () =>
+            {
+                if (IsJsonPath(FileName)) acls.SaveJson(stream); else acls.Save(stream);
+            });
         }
 
         /// <summary>
@@ -179,8 +187,13 @@ namespace AnimationEditor.Core
             var acls = AnimationChainListSave;
             if (acls == null) return;
 
-            await RunWithDiskCoordinateConversionAsync(acls, () => acls.SaveAsync(stream));
+            await RunWithDiskCoordinateConversionAsync(acls,
+                () => IsJsonPath(FileName) ? acls.SaveJsonAsync(stream) : acls.SaveAsync(stream));
         }
+
+        /// <summary>True when <paramref name="path"/> has a .achj (JSON) extension; false for .achx or anything else.</summary>
+        private static bool IsJsonPath(string? path) =>
+            !string.IsNullOrEmpty(path) && new FilePath(path).Extension == "achj";
 
         /// <summary>
         /// Converts <paramref name="acls"/> to <see cref="OnDiskCoordinateType"/> (using

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxDropProcessorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxDropProcessorTests.cs
@@ -22,6 +22,14 @@ public class AchxDropProcessorTests
     }
 
     [Fact]
+    public void ContainsAchx_AchjOnly_ReturnsTrue()
+    {
+        var paths = new[] { @"C:\anims\hero.achj" };
+
+        Assert.True(AchxDropProcessor.ContainsAchx(paths));
+    }
+
+    [Fact]
     public void SelectAchxFiles_IsCaseInsensitive()
     {
         // OS file managers preserve on-disk casing; an uppercase extension must still match.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFolderScannerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxFolderScannerTests.cs
@@ -32,6 +32,18 @@ public class AchxFolderScannerTests
     }
 
     [Fact]
+    public async Task ScanAsync_AchjFile_IsIncluded()
+    {
+        var root = new FakeEditorFolder("Content");
+        root.Files.Add(new FakeEditorFile("hero.achj"));
+        root.Files.Add(new FakeEditorFile("notes.txt"));
+
+        var entries = await AchxFolderScanner.ScanAsync(root);
+
+        Assert.Equal(["hero.achj"], entries.Select(e => e.FileName).ToArray());
+    }
+
+    [Fact]
     public async Task ScanAsync_NestedSubfolders_ReturnsRelativePathsAndParentFolder()
     {
         var root = new FakeEditorFolder("Content");

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
@@ -131,6 +131,46 @@ public class AppCommandsSaveAsTests : IDisposable
         Assert.False(fired);
     }
 
+    // ── Default extension (#872: .achj is the default for new files, .achx is preserved) ──────
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_NewFile_RequestsAchjDefaultExtension()
+    {
+        var dialog = new CapturingFileDialogService(Path.Combine(_dir.Path, "out.achj"));
+        ctx.AppCommands.FileDialogService = dialog;
+        ctx.ProjectManager.FileName = null;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal("achj", dialog.RequestedDefaultExtension);
+    }
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_AchxFileAlreadyLoaded_RequestsAchxDefaultExtension()
+    {
+        var loadedPath = Path.Combine(_dir.Path, "loaded.achx");
+        var dialog = new CapturingFileDialogService(Path.Combine(_dir.Path, "out.achx"));
+        ctx.AppCommands.FileDialogService = dialog;
+        ctx.ProjectManager.FileName = loadedPath;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal("achx", dialog.RequestedDefaultExtension);
+    }
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_AchjFileAlreadyLoaded_RequestsAchjDefaultExtension()
+    {
+        var loadedPath = Path.Combine(_dir.Path, "loaded.achj");
+        var dialog = new CapturingFileDialogService(Path.Combine(_dir.Path, "out.achj"));
+        ctx.AppCommands.FileDialogService = dialog;
+        ctx.ProjectManager.FileName = loadedPath;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal("achj", dialog.RequestedDefaultExtension);
+    }
+
     [Fact]
     public async Task SaveCurrentAnimationChainListAsync_SavedFile_ContainsChainData()
     {
@@ -158,6 +198,25 @@ internal sealed class StubFileDialogService : IFileDialogService
 
     public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
         => Task.FromResult(_path);
+
+    public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription)
+        => Task.FromResult(_path);
+}
+
+/// <summary>Test double that records the requested default extension and returns a fixed path.</summary>
+internal sealed class CapturingFileDialogService : IFileDialogService
+{
+    private readonly string? _path;
+
+    public CapturingFileDialogService(string? path) => _path = path;
+
+    public string? RequestedDefaultExtension { get; private set; }
+
+    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    {
+        RequestedDefaultExtension = defaultExtension;
+        return Task.FromResult(_path);
+    }
 
     public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription)
         => Task.FromResult(_path);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandLineArgParserTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CommandLineArgParserTests.cs
@@ -42,6 +42,14 @@ public class CommandLineArgParserTests
     }
 
     [Fact]
+    public void AchjArg_ReturnsPath()
+    {
+        var path = TestPaths.Abs("projects", "anim.achj");
+        string? result = CommandLineArgParser.ParseFileArgument([path]);
+        Assert.Equal(path, result);
+    }
+
+    [Fact]
     public void MultipleArgs_ReturnsFirstAchx()
     {
         var first  = TestPaths.Abs("first.achx");

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerAchjFormatTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ProjectManagerAchjFormatTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.Core;
+using FlatRedBall2.Animation.Content;
+using System.Linq;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// ProjectManager dispatches between the .achx (XML) and .achj (JSON) dialects purely from the
+// file extension -- no separate "on disk format" flag. Loading a .achj file, then saving back to
+// the same FileName, round-trips as JSON; loading a .achx file keeps saving as XML (#872 follow-up).
+public class ProjectManagerAchjFormatTests
+{
+    [Fact]
+    public void LoadAnimationChain_AchjFile_ParsesJsonContent()
+    {
+        var pm = new ProjectManager();
+        using var dir = new TestHelpers.TempDir();
+        var path = dir.Path + "/test.achj";
+        System.IO.File.WriteAllText(path,
+            "{\"animationChains\":[{\"name\":\"Walk\",\"frames\":[{\"textureName\":\"walk.png\",\"frameLength\":0.1}]}]}");
+
+        pm.LoadAnimationChain(new FilePath(path));
+
+        Assert.Equal("Walk", pm.AnimationChainListSave!.AnimationChains.Single().Name);
+    }
+
+    [Fact]
+    public void SaveAnimationChainList_AchjPath_WritesJsonThatReloadsThroughFromJsonFile()
+    {
+        var pm = new ProjectManager();
+        using var dir = new TestHelpers.TempDir();
+        var path = dir.Path + "/test.achj";
+        pm.AnimationChainListSave = new AnimationChainListSave();
+        pm.AnimationChainListSave.AnimationChains.Add(new AnimationChainSave { Name = "Idle" });
+
+        pm.SaveAnimationChainList(path);
+        var reloaded = AnimationChainListSave.FromJsonFile(path);
+
+        Assert.Equal("Idle", reloaded.AnimationChains.Single().Name);
+    }
+
+    [Fact]
+    public void SaveAnimationChainList_AchxPath_StillWritesXml()
+    {
+        var pm = new ProjectManager();
+        using var dir = new TestHelpers.TempDir();
+        var path = dir.Path + "/test.achx";
+        pm.AnimationChainListSave = new AnimationChainListSave();
+        pm.AnimationChainListSave.AnimationChains.Add(new AnimationChainSave { Name = "Run" });
+
+        pm.SaveAnimationChainList(path);
+        var reloaded = AnimationChainListSave.FromFile(path);
+
+        Assert.Equal("Run", reloaded.AnimationChains.Single().Name);
+    }
+
+    [Fact]
+    public void LoadAnimationChain_AchjFile_ThenSaveWithSameFileName_RoundTripsAsJson()
+    {
+        var pm = new ProjectManager();
+        using var dir = new TestHelpers.TempDir();
+        var path = dir.Path + "/loaded.achj";
+        var original = new AnimationChainListSave();
+        original.AnimationChains.Add(new AnimationChainSave { Name = "Attack" });
+        original.SaveJson(path);
+
+        pm.LoadAnimationChain(new FilePath(path));
+        pm.SaveAnimationChainList(pm.FileName!);
+
+        // Would throw a JSON parse exception if the extension-preserving Save had instead
+        // written XML to the .achj path.
+        var reloaded = AnimationChainListSave.FromJsonFile(path);
+        Assert.Equal("Attack", reloaded.AnimationChains.Single().Name);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a JSON dialect (`.achj`) of the animation chain format alongside the existing XML `.achx`, dispatched by file extension (or content-sniffed where no filename is available)
- Covers the Animation Editor (load/save/new-file-default/Open dialog/drag-drop/folder scan/Windows file association), FRB2's engine runtime (`ContentLoader.LoadAnimationChainList`, hot-reload), and the standalone `AnimationChain.MonoGame`/`AnimationChain.KNI` packages (same source, both build clean)
- New files in the editor default to `.achj`; a loaded `.achx` keeps saving as `.achx`
- `AchxLoader.Load(Stream, ...)` / `AnimationChainList.TryReloadFrom(Stream, ...)` (no filename to inspect) auto-detect XML vs JSON from content instead of extension
- Verified JSON round-trip against all 102 real `.achx` files in an external KidDefense project — zero semantic mismatches

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1566/1566
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1815/1815
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 807/807
- [x] `dotnet test tests/AnimationChain.MonoGame.Tests/` — 71/71
- [x] `dotnet test tests/AnimationChain.KNI.Tests/` — 63/63
- [x] Clean build across `src/FlatRedBall2.csproj`, `tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx`, both `AnimationChain.MonoGame`/`AnimationChain.KNI` csprojs — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)