### PR TITLE
Skip physics response between collidables sharing a top parent

### DIFF
--- a/src/Collision/CollisionRelationship.cs
+++ b/src/Collision/CollisionRelationship.cs
@@ -149,7 +149,7 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
     {
         var sep = ComputeSeparationVector(GetEffectiveA(a), GetEffectiveB(b), out var axisAligned);
 
-        if (sep == Vector2.Zero || !TryApplyOneWayGate(a, b, ref sep))
+        if (sep == Vector2.Zero || !TryApplyOneWayGate(a, b, ref sep) || SharesTopParent(a, b))
             return false;
 
         ApplyResponse(a, b, sep, axisAligned);
@@ -518,7 +518,7 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
         var sep = ComputeSeparationVector(effectiveA, effectiveB, out var axisAligned);
         if (sep == Vector2.Zero) return;
         if (!TryApplyOneWayGate(a, (B)(object)b, ref sep)) return;
-        if (ArePhysicsAppliedAutomatically)
+        if (ArePhysicsAppliedAutomatically && !SharesTopParent(a, (B)(object)b))
         {
             ApplyResponse(a, (B)(object)b, sep, axisAligned);
             TryTransferPlatformVelocity(a, (B)(object)b, sep);
@@ -548,7 +548,7 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
             TryOfferGroundSnap(a, b);
             return;
         }
-        if (ArePhysicsAppliedAutomatically)
+        if (ArePhysicsAppliedAutomatically && !SharesTopParent(a, b))
         {
             ApplyResponse(a, b, sep, axisAligned);
             TryTransferPlatformVelocity(a, b, sep);
@@ -605,8 +605,11 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
                     TryOfferGroundSnap(a, b);
                     continue;
                 }
-                ApplyResponse(a, b, sep, axisAligned);
-                TryTransferPlatformVelocity(a, b, sep);
+                if (!SharesTopParent(a, b))
+                {
+                    ApplyResponse(a, b, sep, axisAligned);
+                    TryTransferPlatformVelocity(a, b, sep);
+                }
                 RecordContact(a, b);
                 CollisionOccurred?.Invoke(a, b);
                 TryOfferGroundSnap(a, b);
@@ -696,6 +699,22 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
 
     private ICollidable GetEffectiveA(A a) => _firstShapeSelector != null ? _firstShapeSelector(a) : a;
     private ICollidable GetEffectiveB(B b) => _secondShapeSelector != null ? _secondShapeSelector(b) : b;
+
+    // Two objects attached (directly or via a shared ancestor, e.g. ObjectToGrab.Add(other) or
+    // both parented under the same rig) would otherwise have Move/Bounce reposition their shared
+    // ancestor, which does not change their relative offset — they'd still overlap next frame,
+    // causing endless repositioning. Objects with no attachable parent chain (e.g. TileShapes)
+    // always return themselves here, so this only ever matches genuinely attached pairs.
+    private static bool SharesTopParent(ICollidable a, ICollidable b) =>
+        ReferenceEquals(GetTopParent(a), GetTopParent(b));
+
+    private static object GetTopParent(ICollidable obj)
+    {
+        if (obj is not ISpatialAttachable attachable || attachable.Parent == null) return obj;
+        var top = attachable.Parent;
+        while (top.Parent != null) top = top.Parent;
+        return top;
+    }
 
     private static ICollidable? GetSingleLeafShape(ICollidable collidable)
     {

--- a/tests/FlatRedBall2.Tests/Collision/CollisionRelationshipSameTopParentTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/CollisionRelationshipSameTopParentTests.cs
@@ -1,0 +1,71 @@
+using FlatRedBall2.Collision;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Collision;
+
+// Pins the port of FRB1's #2122 fix: physics (Move/Bounce) must not reposition two entities that
+// share a top parent (e.g. one Add()'d as a child of the other). Applying physics between them
+// would reposition the shared ancestor, which does not change their relative offset, so they'd
+// still overlap next frame — an endless repositioning loop. Events must still fire.
+public class CollisionRelationshipSameTopParentTests
+{
+    static Entity CreateEntityWithCircle(float circleX)
+    {
+        var entity = new Entity();
+        entity.Add(new Circle { Radius = 10f, X = circleX });
+        return entity;
+    }
+
+    [Fact]
+    public void RunCollisions_BounceOnCollision_ObjectsShareTopParent_SkipsPhysicsButRaisesEvent()
+    {
+        var player = CreateEntityWithCircle(circleX: 0f);
+        var grabbed = CreateEntityWithCircle(circleX: 5f); // overlaps player's circle (10+10 > 5)
+        player.Add(grabbed);
+
+        var rel = new CollisionRelationship<Entity, Entity>(new[] { player }, new[] { grabbed });
+        rel.BounceBothOnCollision(1f, 1f, 1f);
+        int occurredCount = 0;
+        rel.CollisionOccurred += (_, _) => occurredCount++;
+
+        rel.RunCollisions();
+
+        occurredCount.ShouldBe(1);
+        player.Position.ShouldBe(System.Numerics.Vector2.Zero);
+        grabbed.Position.ShouldBe(System.Numerics.Vector2.Zero);
+    }
+
+    [Fact]
+    public void RunCollisions_MoveBothOnCollision_ObjectsDoNotShareTopParent_AppliesPhysics()
+    {
+        var first = CreateEntityWithCircle(circleX: 0f);
+        var second = CreateEntityWithCircle(circleX: 5f); // overlaps first's circle (10+10 > 5)
+
+        var rel = new CollisionRelationship<Entity, Entity>(new[] { first }, new[] { second });
+        rel.MoveBothOnCollision(1f, 1f);
+
+        rel.RunCollisions();
+
+        first.Position.ShouldNotBe(System.Numerics.Vector2.Zero);
+    }
+
+    [Fact]
+    public void RunCollisions_MoveBothOnCollision_ObjectsShareTopParent_SkipsPhysicsButRaisesEvent()
+    {
+        var player = CreateEntityWithCircle(circleX: 0f);
+        var grabbed = CreateEntityWithCircle(circleX: 5f); // overlaps player's circle (10+10 > 5)
+        player.Add(grabbed);
+
+        var rel = new CollisionRelationship<Entity, Entity>(new[] { player }, new[] { grabbed });
+        rel.MoveBothOnCollision(1f, 1f);
+        int occurredCount = 0;
+        rel.CollisionOccurred += (_, _) => occurredCount++;
+
+        rel.RunCollisions();
+
+        occurredCount.ShouldBe(1);
+        player.Position.ShouldBe(System.Numerics.Vector2.Zero);
+        grabbed.Position.ShouldBe(System.Numerics.Vector2.Zero);
+    }
+}


### PR DESCRIPTION
## Summary
Ports vchelaru/FlatRedBall#2123 to FRB2: two collidables that share a top parent (e.g. an object `Add()`'d as a child of another) would endlessly reposition each other on collision — Move/Bounce physics repositions the shared ancestor, which doesn't change their relative offset, so they still overlap next frame.

`CollisionRelationship<A,B>` now skips the physics response (Move/Bounce, and the manual `ApplyPhysics`) at every dispatch site whenever both sides resolve to the same top-level ancestor via `Entity.Parent`/`ISpatialAttachable`. `CollisionOccurred` still fires. `TileShapes` and other non-attachable collidables are unaffected since they have no parent chain.

MoveSoft has no FRB2 equivalent yet, so unlike FRB1's port there's nothing to exclude there.

## Test plan
- `CollisionRelationshipSameTopParentTests.cs`: Move/Bounce skip physics but still raise `CollisionOccurred` when two entities share a top parent; a control test confirms physics still applies when they don't.
- Confirmed both new shared-top-parent tests fail (repositioning still happens) with the source change reverted, and pass with it applied.
- Full suite: 1569/1569 passing.

Manual test: not needed — fully covered by the unit tests above plus compilation (headless `Entity`/`CollisionRelationship` construction, no `GraphicsDevice` needed).
