### PR TITLE
Animation Editor: explicit project-folder concept for Files panel

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
@@ -102,7 +102,10 @@ public partial class FilesPanelControl : UserControl
         _openPng = openPng;
     }
 
-    /// <param name="filesRoot">Root folder to browse (from <c>ProjectManager.ResolveFilesPanelRoot</c>).</param>
+    /// <param name="filesRoot">
+    /// Root folder to browse: <c>ProjectManager.ProjectFolderPath</c> when set, otherwise the
+    /// achx-inferred <c>ProjectManager.ResolveFilesPanelRoot()</c> fallback.
+    /// </param>
     /// <param name="referencedTextureNames">
     /// Texture names referenced by the open .achx (from <c>TextureListBuilder.GetAvailableTextures</c>),
     /// used only in <see cref="FilesPanelScope.ThisFile"/> scope. Pass fresh values on every call so
@@ -130,9 +133,15 @@ public partial class FilesPanelControl : UserControl
         var allFiles = PngFolderScanner.ListFiles(_filesRoot);
         if (allFiles.Count == 0)
         {
+            // No root to scan at all (issue #875): Project scope has nothing to browse until a
+            // project folder is opened -- blaming an unsaved .achx (the old message) is wrong once
+            // ProjectFolderPath exists as a separate concept from the achx-inferred fallback.
+            // ThisFile scope's root still comes from the open .achx, so that message still fits there.
             SetEmptyMessage(
                 string.IsNullOrEmpty(_filesRoot)
-                    ? "Save the .achx to browse folder PNGs."
+                    ? Scope == FilesPanelScope.Project
+                        ? "Open a project folder to browse its images."
+                        : "Save the .achx to browse folder PNGs."
                     : "No PNG files in this folder.",
                 visible: true);
             return;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -377,10 +377,14 @@
             <Grid x:Name="LeftPanelGrid" Grid.Column="0" RowDefinitions="2*,4,3*"
                   Background="{DynamicResource BgCanvas}">
 
-                <!-- Animations block: header + tree + add button stay grouped.
-                     Collapsed for PNG-preview tabs (issue #604) — a read-only image has no
-                     animations to list; see SetSidebarForPng in the code-behind. -->
-                <Grid x:Name="AnimationsBlock" Grid.Row="0" RowDefinitions="Auto,*,Auto">
+                <!-- Top pane (#877): whichever "main" view is active — the ANIMATIONS tree by
+                     default, or the Diff/blame pane while a .png tab is open (issue #604). Both
+                     children fill this single cell and toggle IsVisible in SetSidebarForPng; the
+                     row's size never changes, only which one shows. The bottom tab strip
+                     (SidebarTabs, below the splitter) is a separate, independent region. -->
+                <Grid x:Name="TopPane" Grid.Row="0">
+
+                <Grid x:Name="AnimationsBlock" RowDefinitions="Auto,*,Auto">
 
                 <!-- ── Tree pane header ── -->
                 <Border Grid.Row="0"
@@ -709,16 +713,48 @@
 
                 </Grid>
 
-                <!-- Splitter between the ANIMATIONS tree and the tabbed tool panel -->
+                <!-- Diff/blame pane (PNG git history, #606) — fills TopPane while a .png tab is
+                     active, instead of taking over the bottom tab strip. Selecting a revision shows
+                     that revision's image with boxes outlining what changed vs. the previous one. -->
+                <Grid x:Name="DiffBlamePane" RowDefinitions="Auto,*"
+                      Background="{DynamicResource BgPanel}" IsVisible="False">
+                    <!-- Empty / fallback state (not a repo, untracked, LFS, git missing). -->
+                    <TextBlock x:Name="DiffBlameStatus" Grid.Row="0"
+                               Margin="8,4" FontSize="11" TextWrapping="Wrap"
+                               IsVisible="False"
+                               Foreground="{DynamicResource InkMid}" />
+
+                    <!-- Revision rail: newest first; selecting a row overlays that revision's changes. -->
+                    <ListBox x:Name="RevisionList" Grid.Row="1"
+                             Background="Transparent" BorderThickness="0"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="appModels:RevisionEntryVm">
+                                <StackPanel Margin="2,2">
+                                    <TextBlock Text="{Binding Subject}" FontSize="11"
+                                               FontWeight="SemiBold"
+                                               TextTrimming="CharacterEllipsis"
+                                               Foreground="{DynamicResource Ink}" />
+                                    <TextBlock Text="{Binding Meta}" FontSize="10"
+                                               Foreground="{DynamicResource InkMid}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Grid>
+
+                </Grid>
+
+                <!-- Splitter between the top pane and the tabbed tool panel -->
                 <GridSplitter x:Name="SidebarSplitter" Grid.Row="1"
                               ResizeDirection="Rows"
                               Background="{DynamicResource LineStrong}"
                               HorizontalAlignment="Stretch" />
 
                 <!-- ── Tool panel: Inspector / Files / History tabs (#544) ──
-                     A single tab strip below the always-visible ANIMATIONS tree. Inspector is the
-                     default tab (it's referenced constantly while clicking through frames/chains);
-                     Files and History sit behind it. The tree above is never covered by a tab. -->
+                     A single tab strip below TopPane (#877), which is never covered by a tab.
+                     Inspector is the default tab (it's referenced constantly while clicking through
+                     frames/chains); Files and History sit behind it. -->
                     <TabControl x:Name="SidebarTabs" Grid.Row="2"
                                 AutomationProperties.Name="Sidebar"
                                 AutomationProperties.AutomationId="sidebar-tabs"
@@ -1142,38 +1178,6 @@
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
                             </ScrollViewer>
-                        </Grid>
-                    </TabItem>
-
-                    <!-- Diff (PNG git history — shown only while a .png tab is active, #606).
-                         Selecting a revision shows that revision's image with boxes outlining what
-                         changed vs. the previous one. The one tunable (region grouping) lives in a bar
-                         above the PNG, since it affects the image display, not this list. -->
-                    <TabItem x:Name="DiffBlameTab" Header="Diff" IsVisible="False">
-                        <Grid RowDefinitions="Auto,*" Background="{DynamicResource BgPanel}">
-                            <!-- Empty / fallback state (not a repo, untracked, LFS, git missing). -->
-                            <TextBlock x:Name="DiffBlameStatus" Grid.Row="0"
-                                       Margin="8,4" FontSize="11" TextWrapping="Wrap"
-                                       IsVisible="False"
-                                       Foreground="{DynamicResource InkMid}" />
-
-                            <!-- Revision rail: newest first; selecting a row overlays that revision's changes. -->
-                            <ListBox x:Name="RevisionList" Grid.Row="1"
-                                     Background="Transparent" BorderThickness="0"
-                                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="appModels:RevisionEntryVm">
-                                        <StackPanel Margin="2,2">
-                                            <TextBlock Text="{Binding Subject}" FontSize="11"
-                                                       FontWeight="SemiBold"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       Foreground="{DynamicResource Ink}" />
-                                            <TextBlock Text="{Binding Meta}" FontSize="10"
-                                                       Foreground="{DynamicResource InkMid}" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
                         </Grid>
                     </TabItem>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -641,9 +641,11 @@ public partial class MainWindow : Window
     /// <summary>
     /// Collapses the animation-editing sidebar surfaces for a read-only PNG-preview tab (issue #604)
     /// and restores them for the achx editor. A PNG has no animations, no editable frame/shape
-    /// properties, and no undo history — and for now we don't offer file navigation from a PNG either
-    /// — so the ANIMATIONS tree and the Inspector, History, and Files tabs are all hidden; only the
-    /// Diff tab (#606) remains, and it becomes the selected tab.
+    /// properties, and no undo history, so the ANIMATIONS tree and the Inspector and History tabs
+    /// are hidden. Files/Textures stays visible (#875 follow-up): its Project scope browses PNGs
+    /// under the open project folder independent of any open tab, so it's still useful during a
+    /// PNG preview — hiding it made "double-click a PNG while on the Textures tab" appear to break
+    /// PNG browsing entirely. Diff (#606) becomes the selected tab unless Files was already selected.
     /// </summary>
     private void SetSidebarForPng(bool png)
     {
@@ -659,13 +661,14 @@ public partial class MainWindow : Window
             SidebarSplitter.IsVisible = false;
             InspectorTab.IsVisible = false;
             HistoryTab.IsVisible = false;
-            FilesTab.IsVisible = false;
             // Remember the achx tool tab so returning from Diff restores Files/History/etc. (#686).
-            _sidebarTabBeforePng = SidebarTabs.SelectedItem as TabItem;
-            // Diff is the only PNG surface; select it before hiding Files so the strip never shows
-            // a hidden selected tab (blank content).
+            var previouslySelected = SidebarTabs.SelectedItem as TabItem;
+            _sidebarTabBeforePng = previouslySelected;
             DiffBlameTab.IsVisible = true;
-            SidebarTabs.SelectedItem = DiffBlameTab;
+            // Files stays visible throughout, so only force the switch when it wasn't already the
+            // selected tab -- otherwise leave the user right where they were.
+            if (!ReferenceEquals(previouslySelected, FilesTab))
+                SidebarTabs.SelectedItem = DiffBlameTab;
         }
         else
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -91,11 +91,6 @@ public partial class MainWindow : Window
     // self-promote before the user did anything.
     private bool _suppressPreviewPromotion;
 
-    // Set by LoadProjectFolderAsync -- the root ProjectPanel's folder-relative paths resolve
-    // against, for "View in Explorer" on a folder row (#841 follow-up). Null until the user has
-    // opened (or a prior session restored) a project folder.
-    private string? _projectFolderRootPath;
-
     // ── Tab drag state ────────────────────────────────────────────────────────
     private TabEntry? _dragTab;
     private double _dragStartX;
@@ -1858,20 +1853,20 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Resolves a Project-tree folder row's <see cref="AchxTreeNodeVm.RelativePath"/> to an
-    /// absolute path against <see cref="_projectFolderRootPath"/> (issue #841 follow-up: "View in
-    /// Explorer" on a folder row). Split out from <see cref="RevealProjectFolderInExplorer"/> so
-    /// this pure resolution is unit-testable without going through <c>Process.Start</c>.
+    /// absolute path against <see cref="ProjectManager.ProjectFolderPath"/> (issue #841 follow-up:
+    /// "View in Explorer" on a folder row). Split out from <see cref="RevealProjectFolderInExplorer"/>
+    /// so this pure resolution is unit-testable without going through <c>Process.Start</c>.
     /// </summary>
     internal string? ResolveProjectFolderAbsolutePath(string relativePath) =>
-        _projectFolderRootPath is null
+        _projectManager.ProjectFolderPath is not { } root
             ? null
             : relativePath.Length == 0
-                ? _projectFolderRootPath
+                ? root
                 // AchxTreeNodeVm.RelativePath is always forward-slash separated (see
                 // AchxFolderTreeBuilder) -- Path.Combine only joins its two arguments, it doesn't
                 // normalize separators *inside* either one, so an un-normalized "/" here would
                 // survive straight into the path handed to Process.Start.
-                : Path.Combine(_projectFolderRootPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                : Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
 
     private void RevealProjectFolderInExplorer(string relativePath)
     {
@@ -2113,10 +2108,13 @@ public partial class MainWindow : Window
     /// <see cref="AchxFolderScanner"/> and populates the Project tab instead of guessing which one
     /// to load -- the folder can have more than one .achx (a normal Content-folder layout). Shared
     /// by the interactive Open Project Folder flow and by startup's last-folder restore (#772).
+    /// Also sets <see cref="ProjectManager.ProjectFolderPath"/> and refreshes the Files/Textures
+    /// panel (#875) so its Project scope reflects the newly-opened folder even with zero .achx
+    /// tabs open.
     /// </summary>
     private async Task LoadProjectFolderAsync(string path)
     {
-        _projectFolderRootPath = path;
+        _projectManager.ProjectFolderPath = path;
         _projectFolderWatcher.Watch(path);
         var rootFolder = new DiskEditorFolder(path);
         var entries = await AchxFolderScanner.ScanAsync(rootFolder);
@@ -2124,6 +2122,7 @@ public partial class MainWindow : Window
         ShowStatusMessage(entries.Count == 0
             ? $"No .achx files found under \"{rootFolder.Name}\"."
             : $"Found {entries.Count} .achx file(s) under \"{rootFolder.Name}\".", isError: false);
+        RefreshFilesPanel();
     }
 
     /// <summary>
@@ -2156,7 +2155,7 @@ public partial class MainWindow : Window
     private async Task HandleProjectFolderChangesAsync(
         IReadOnlyList<(string Path, WatcherChangeType Type)>? changes)
     {
-        if (_projectFolderRootPath is null) return;
+        if (_projectManager.ProjectFolderPath is null) return;
 
         // A create or delete changes tree *structure*, not just a thumbnail -- and a full rescan
         // is exactly what LoadProjectFolderAsync already does on every Open Project Folder, so
@@ -2171,7 +2170,7 @@ public partial class MainWindow : Window
             !File.Exists(c.Path) || FindProjectPanelEntry(ProjectPanel.TreeRoots, c.Path) is null);
         if (structureChanged)
         {
-            await LoadProjectFolderAsync(_projectFolderRootPath);
+            await LoadProjectFolderAsync(_projectManager.ProjectFolderPath);
             return;
         }
 
@@ -3416,7 +3415,9 @@ public partial class MainWindow : Window
 
     private void RefreshFilesPanel()
     {
-        string? filesRoot = _projectManager.ResolveFilesPanelRoot();
+        // ProjectFolderPath (#875) is the explicit "open project folder" -- it wins over the
+        // achx-inferred ResolveFilesPanelRoot() fallback, and works with zero .achx tabs open.
+        string? filesRoot = _projectManager.ProjectFolderPath ?? _projectManager.ResolveFilesPanelRoot();
         var referenced = TextureListBuilder.GetAvailableTextures(_projectManager.AnimationChainListSave);
         string? achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
             ? null

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2094,8 +2094,12 @@ public partial class MainWindow : Window
 
     private async Task LoadAndPersistProjectFolderAsync(string path)
     {
-        await LoadProjectFolderAsync(path);
-        SidebarTabs.SelectedItem = ProjectTab;
+        var achxCount = await LoadProjectFolderAsync(path);
+
+        // #875 follow-up: an empty Project tab is a dead end. The Textures tab is immediately
+        // useful in that case -- its Project scope (#875) lists the folder's PNGs without needing
+        // any .achx open.
+        SidebarTabs.SelectedItem = achxCount == 0 ? FilesTab : ProjectTab;
 
         // Immediate, not deferred to window Closed -- a debugger Stop or crash skips Closed
         // entirely (see TabSessionPersistenceTests / issue #439), so this must be safe there too.
@@ -2110,9 +2114,10 @@ public partial class MainWindow : Window
     /// by the interactive Open Project Folder flow and by startup's last-folder restore (#772).
     /// Also sets <see cref="ProjectManager.ProjectFolderPath"/> and refreshes the Files/Textures
     /// panel (#875) so its Project scope reflects the newly-opened folder even with zero .achx
-    /// tabs open.
+    /// tabs open. Returns the number of .achx files found, so callers can react to an empty
+    /// result (e.g. auto-selecting a more useful tab).
     /// </summary>
-    private async Task LoadProjectFolderAsync(string path)
+    private async Task<int> LoadProjectFolderAsync(string path)
     {
         _projectManager.ProjectFolderPath = path;
         _projectFolderWatcher.Watch(path);
@@ -2123,6 +2128,7 @@ public partial class MainWindow : Window
             ? $"No .achx files found under \"{rootFolder.Name}\"."
             : $"Found {entries.Count} .achx file(s) under \"{rootFolder.Name}\".", isError: false);
         RefreshFilesPanel();
+        return entries.Count;
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -630,64 +630,48 @@ public partial class MainWindow : Window
         AchxEditorPane.IsVisible = true;
     }
 
-    // Sidebar state saved when collapsing for a PNG tab, so restoring preserves the user's splitter
-    // position rather than snapping back to the XAML default ("2*,4,3*").
     private bool _sidebarCollapsedForPng;
-    private GridLength _savedTreeRowHeight = new(2, GridUnitType.Star);
-    private GridLength _savedSplitterRowHeight = new(4, GridUnitType.Pixel);
-    // Tool tab selected before Diff was forced for a PNG preview (#686) — restored when returning to achx.
+    // Bottom tab strip's selection just before it was forced away from a now-hidden tab
+    // (Inspector/History) during a PNG preview (#686) — restored when returning to the achx editor.
+    // Null whenever the bottom strip was never touched (the common case, #877).
     private TabItem? _sidebarTabBeforePng;
 
     /// <summary>
-    /// Collapses the animation-editing sidebar surfaces for a read-only PNG-preview tab (issue #604)
-    /// and restores them for the achx editor. A PNG has no animations, no editable frame/shape
-    /// properties, and no undo history, so the ANIMATIONS tree and the Inspector and History tabs
-    /// are hidden. Files/Textures stays visible (#875 follow-up): its Project scope browses PNGs
-    /// under the open project folder independent of any open tab, so it's still useful during a
-    /// PNG preview — hiding it made "double-click a PNG while on the Textures tab" appear to break
-    /// PNG browsing entirely. Diff (#606) becomes the selected tab unless Files was already selected.
+    /// Swaps <c>TopPane</c>'s content between the ANIMATIONS tree and the Diff/blame pane for a
+    /// read-only PNG-preview tab (issue #604), and restores it for the achx editor. Both panes fill
+    /// the same cell (#877) — the row's size never changes, only which one is visible — so resizing
+    /// the sidebar splitter behaves identically in either mode. A PNG has no editable frame/shape
+    /// properties or undo history, so Inspector and History hide too; Files/Textures stays visible (#875 follow-up)
+    /// since its Project scope browses PNGs independent of any open tab. The bottom tab strip's
+    /// selection is otherwise left alone — Diff no longer lives down there, so there's nothing to
+    /// force it to unless the previously-selected tab was Inspector or History and just got hidden.
     /// </summary>
     private void SetSidebarForPng(bool png)
     {
         if (png == _sidebarCollapsedForPng) return;
-        var rows = LeftPanelGrid.RowDefinitions;
         if (png)
         {
-            _savedTreeRowHeight = rows[0].Height;
-            _savedSplitterRowHeight = rows[1].Height;
-            rows[0].Height = new GridLength(0);
-            rows[1].Height = new GridLength(0);
             AnimationsBlock.IsVisible = false;
-            SidebarSplitter.IsVisible = false;
+            DiffBlamePane.IsVisible = true;
             InspectorTab.IsVisible = false;
             HistoryTab.IsVisible = false;
-            // Remember the achx tool tab so returning from Diff restores Files/History/etc. (#686).
-            var previouslySelected = SidebarTabs.SelectedItem as TabItem;
-            _sidebarTabBeforePng = previouslySelected;
-            DiffBlameTab.IsVisible = true;
-            // Files stays visible throughout, so only force the switch when it wasn't already the
-            // selected tab -- otherwise leave the user right where they were.
-            if (!ReferenceEquals(previouslySelected, FilesTab))
-                SidebarTabs.SelectedItem = DiffBlameTab;
+            if (SidebarTabs.SelectedItem is TabItem { IsVisible: false } hidden)
+            {
+                _sidebarTabBeforePng = hidden;
+                SidebarTabs.SelectedItem = FilesTab;
+            }
         }
         else
         {
-            rows[0].Height = _savedTreeRowHeight;
-            rows[1].Height = _savedSplitterRowHeight;
             AnimationsBlock.IsVisible = true;
-            SidebarSplitter.IsVisible = true;
+            DiffBlamePane.IsVisible = false;
             InspectorTab.IsVisible = true;
             HistoryTab.IsVisible = true;
-            FilesTab.IsVisible = true;
-            // Diff must not stay selected once hidden (#604). Prefer the tab that was active before
-            // the PNG forced Diff (#686); fall back to Inspector when that tab is gone or invalid.
-            var restore = _sidebarTabBeforePng;
-            SidebarTabs.SelectedItem =
-                restore is { IsVisible: true } && !ReferenceEquals(restore, DiffBlameTab)
-                    ? restore
-                    : InspectorTab;
-            DiffBlameTab.IsVisible = false;
-            _sidebarTabBeforePng = null;
+            if (_sidebarTabBeforePng is { } restore)
+            {
+                SidebarTabs.SelectedItem = restore;
+                _sidebarTabBeforePng = null;
+            }
         }
         _sidebarCollapsedForPng = png;
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IProjectManager.cs
@@ -11,6 +11,13 @@ namespace AnimationEditor.Core
         TileMapInformationList TileMapInformationList { get; set; }
         FilePath[] ReferencedPngs { get; }
         string? FileName { get; set; }
+
+        /// <summary>
+        /// The folder explicitly picked via File → Open Project Folder (or restored at startup).
+        /// Never inferred from the open .achx -- see <see cref="ProjectManager.ProjectFolderPath"/>.
+        /// </summary>
+        string? ProjectFolderPath { get; set; }
+
         TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -28,6 +28,15 @@ namespace AnimationEditor.Core
         public string? FileName { get; set; }
 
         /// <summary>
+        /// The folder explicitly picked via File → Open Project Folder (or restored from
+        /// <c>LastProjectFolderPath</c> at startup). Unlike <see cref="ResolveFilesPanelRoot"/>,
+        /// this is never inferred from the open .achx -- it stays set (and the Files panel's
+        /// Project scope keeps working) even with zero tabs open. Null until a project folder has
+        /// ever been opened this session.
+        /// </summary>
+        public string? ProjectFolderPath { get; set; }
+
+        /// <summary>
         /// The coordinate format the .achx should be written with. Set from the loaded
         /// file so a UV-format file round-trips as UV; defaults to <see cref="TextureCoordinateType.Pixel"/>
         /// for new files, since that is the preferred format going forward. Independent

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
@@ -115,13 +115,13 @@ public class PngTabTests
     }
 
     [AvaloniaFact]
-    public async Task OpenPngAsTab_HidesEditingTabsButKeepsFiles_SelectsDiff()
+    public async Task OpenPngAsTab_ShowsDiffPaneInTopPane_KeepsFilesTabVisible()
     {
         // A read-only PNG has no animations, no editable properties, and no undo history, so the
-        // ANIMATIONS tree, Inspector, and History are hidden. Files/Textures stays visible (#875
-        // follow-up): its Project scope browses PNGs under the open project folder independent of
-        // any open tab, so it's still useful during a PNG preview. Diff becomes the default
-        // selected tab since nothing was selected on Files beforehand in this test.
+        // ANIMATIONS tree, Inspector, and History are hidden. Diff (#877) takes over TopPane -- the
+        // same top-half cell the ANIMATIONS tree normally fills -- instead of taking over the
+        // bottom tab strip. Files/Textures stays visible down there (#875 follow-up): its Project
+        // scope browses PNGs under the open project folder independent of any open tab.
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         var ctx = TestHelpers.BuildServices();
@@ -134,17 +134,15 @@ public class PngTabTests
             await window.WhenPngTabLoaded();   // drain the off-thread git + decode before cleanup deletes dir
 
             Assert.False(window.FindControl<Grid>("AnimationsBlock")!.IsVisible);
+            Assert.True(window.FindControl<Grid>("DiffBlamePane")!.IsVisible);
             Assert.False(window.FindControl<TabItem>("InspectorTab")!.IsVisible);
             Assert.False(window.FindControl<TabItem>("HistoryTab")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("FilesTab")!.IsVisible);
-            Assert.True(window.FindControl<TabItem>("DiffBlameTab")!.IsVisible);
 
+            // Inspector was the default-selected bottom tab and just got hidden, so the bottom strip
+            // falls back to Files rather than showing a hidden selected tab.
             var tabs = window.FindControl<TabControl>("SidebarTabs")!;
-            Assert.Same(window.FindControl<TabItem>("DiffBlameTab"), tabs.SelectedItem);
-
-            // The Animations block's row must collapse to zero so the Diff tab fills the column
-            // rather than floating below an empty gap.
-            Assert.Equal(0, window.FindControl<Grid>("LeftPanelGrid")!.RowDefinitions[0].Height.Value);
+            Assert.Same(window.FindControl<TabItem>("FilesTab"), tabs.SelectedItem);
         }
         finally
         {
@@ -270,10 +268,50 @@ public class PngTabTests
             Dispatcher.UIThread.RunJobs();
 
             Assert.True(window.FindControl<Grid>("AnimationsBlock")!.IsVisible);
+            Assert.False(window.FindControl<Grid>("DiffBlamePane")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("InspectorTab")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("HistoryTab")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("FilesTab")!.IsVisible);   // Files comes back for the achx editor
-            Assert.True(window.FindControl<Grid>("LeftPanelGrid")!.RowDefinitions[0].Height.Value > 0);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task OpenAchxAfterPng_InspectorWasSelected_RestoresInspectorTab()
+    {
+        // #877: Inspector (the default-selected tab) gets hidden and the bottom strip falls back to
+        // Files while a PNG is open (see OpenPngAsTab_ShowsDiffPaneInTopPane_KeepsFilesTabVisible).
+        // Returning to the achx tab must restore Inspector, not leave the fallback selected.
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var achxPath = WriteAchx(dir, "hero.achx");
+            await window.OpenFileAsTab(achxPath);
+            Dispatcher.UIThread.RunJobs();
+
+            var inspectorTab = window.FindControl<TabItem>("InspectorTab")!;
+            var sidebar = window.FindControl<TabControl>("SidebarTabs")!;
+            Assert.Same(inspectorTab, sidebar.SelectedItem);   // Inspector is the default
+
+            window.OpenPngAsTab(WritePng(dir, "sheet.png"));
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+            Assert.NotSame(inspectorTab, sidebar.SelectedItem);   // fell back to Files while hidden
+
+            await window.OpenFileAsTab(achxPath);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Same(inspectorTab, sidebar.SelectedItem);
         }
         finally
         {
@@ -285,9 +323,8 @@ public class PngTabTests
     [AvaloniaFact]
     public async Task OpenAchxAfterPng_RestoresPriorSidebarTab()
     {
-        // #686: opening a PNG forces the Diff sidebar tab; returning to the achx tab must restore
-        // whichever tool tab (Files/Textures, History, …) was selected beforehand — not hard-reset
-        // to Inspector.
+        // Files/Textures stays visible and selected throughout a PNG preview (#877), so returning
+        // to the achx tab leaves it exactly where the user left it -- not hard-reset to Inspector.
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         var ctx = TestHelpers.BuildServices();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngTabTests.cs
@@ -115,11 +115,13 @@ public class PngTabTests
     }
 
     [AvaloniaFact]
-    public async Task OpenPngAsTab_HidesEditingTabsAndFiles_SelectsDiff()
+    public async Task OpenPngAsTab_HidesEditingTabsButKeepsFiles_SelectsDiff()
     {
-        // A read-only PNG has no animations, no editable properties, and no undo history — and for now
-        // we don't offer file navigation from a PNG either. Hide the ANIMATIONS tree, Inspector,
-        // History, and Files tabs; show only the Diff tab and select it.
+        // A read-only PNG has no animations, no editable properties, and no undo history, so the
+        // ANIMATIONS tree, Inspector, and History are hidden. Files/Textures stays visible (#875
+        // follow-up): its Project scope browses PNGs under the open project folder independent of
+        // any open tab, so it's still useful during a PNG preview. Diff becomes the default
+        // selected tab since nothing was selected on Files beforehand in this test.
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         var ctx = TestHelpers.BuildServices();
@@ -134,7 +136,7 @@ public class PngTabTests
             Assert.False(window.FindControl<Grid>("AnimationsBlock")!.IsVisible);
             Assert.False(window.FindControl<TabItem>("InspectorTab")!.IsVisible);
             Assert.False(window.FindControl<TabItem>("HistoryTab")!.IsVisible);
-            Assert.False(window.FindControl<TabItem>("FilesTab")!.IsVisible);
+            Assert.True(window.FindControl<TabItem>("FilesTab")!.IsVisible);
             Assert.True(window.FindControl<TabItem>("DiffBlameTab")!.IsVisible);
 
             var tabs = window.FindControl<TabControl>("SidebarTabs")!;
@@ -143,6 +145,37 @@ public class PngTabTests
             // The Animations block's row must collapse to zero so the Diff tab fills the column
             // rather than floating below an empty gap.
             Assert.Equal(0, window.FindControl<Grid>("LeftPanelGrid")!.RowDefinitions[0].Height.Value);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task OpenPngAsTab_FilesTabWasSelected_StaysOnFilesTab()
+    {
+        // The bug this guards: double-clicking a PNG while looking at Files/Textures used to hide
+        // that very tab and force-switch to Diff, so "the project no longer shows PNGs." Files was
+        // already visible and selected, so opening the PNG must leave it selected.
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var filesTab = window.FindControl<TabItem>("FilesTab")!;
+            var sidebar = window.FindControl<TabControl>("SidebarTabs")!;
+            sidebar.SelectedItem = filesTab;
+
+            window.OpenPngAsTab(WritePng(dir, "sheet.png"));
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();   // drain the off-thread git + decode before cleanup deletes dir
+
+            Assert.True(filesTab.IsVisible);
+            Assert.Same(filesTab, sidebar.SelectedItem);
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderFilesPanelScopeTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderFilesPanelScopeTests.cs
@@ -1,0 +1,87 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using SkiaSharp;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #875: <c>ProjectManager.ProjectFolderPath</c> is the explicit "open project folder" the
+/// Files/Textures panel's Project scope should browse -- not the achx-inferred
+/// <c>ResolveFilesPanelRoot()</c>, which returns null with zero .achx tabs open.
+/// </summary>
+public class ProjectFolderFilesPanelScopeTests
+{
+    private static void WritePng(string dir, string fileName, SKColor color)
+    {
+        using var bm = new SKBitmap(8, 8);
+        bm.Erase(color);
+        using var img = SKImage.FromBitmap(bm);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(Path.Combine(dir, fileName), data.ToArray());
+    }
+
+    [AvaloniaFact]
+    public async Task OpeningProjectFolder_WithNoAchxTabOpen_ListsFolderPngsInFilesPanel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        WritePng(dir, "hero.png", SKColors.Red);
+
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(window.FilesPanel.TreeRoots);
+            Assert.Equal("hero.png", window.FilesPanel.TreeRoots[0].Name);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Startup_NothingOpen_ProjectScopeFilesPanelShowsOpenProjectFolderMessage()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(FilesPanelScope.Project, window.FilesPanel.Scope);
+            Assert.True(window.FilesPanel.EmptyMessage.IsVisible);
+            Assert.Equal("Open a project folder to browse its images.", window.FilesPanel.EmptyMessage.Text);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Startup_NothingOpen_ThisFileScopeStillShowsSaveAchxMessage()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            window.FilesPanel.ScopeThisFileRadio.IsChecked = true;
+
+            Assert.True(window.FilesPanel.EmptyMessage.IsVisible);
+            Assert.Equal("Save the .achx to browse folder PNGs.", window.FilesPanel.EmptyMessage.Text);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderTabAutoSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFolderTabAutoSelectTests.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Small QoL follow-up to #875: when File → Open Project Folder finds no .achx files, landing on
+/// the (now-empty) Project tab is a dead end. The Textures tab is useful immediately in that case
+/// since its Project scope (#875) lists PNGs under the folder with zero .achx files needed.
+/// </summary>
+public class ProjectFolderTabAutoSelectTests
+{
+    private static void WriteAchx(string dir, string fileName)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new FlatRedBall2.Animation.Content.AnimationChainListSave();
+        acls.Save(path);
+    }
+
+    [AvaloniaFact]
+    public async Task OpeningProjectFolder_NoAchxFiles_SelectsTexturesTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs");
+            Assert.NotNull(tabs);
+            Assert.Equal("Textures", ((TabItem)tabs!.SelectedItem!).Header);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task OpeningProjectFolder_HasAchxFiles_SelectsProjectTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        WriteAchx(dir, "hero.achx");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+
+            var tabs = window.FindControl<TabControl>("SidebarTabs");
+            Assert.NotNull(tabs);
+            Assert.Equal("Project", ((TabItem)tabs!.SelectedItem!).Header);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveFailTests.cs
@@ -67,6 +67,7 @@ public class AppCommandsSaveFailTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabSwitchCacheTests.cs
@@ -148,6 +148,7 @@ public class TabSwitchCacheTests : IDisposable
 
         public FilePath[] ReferencedPngs => _inner.ReferencedPngs;
         public string? FileName { get => _inner.FileName; set => _inner.FileName = value; }
+        public string? ProjectFolderPath { get => _inner.ProjectFolderPath; set => _inner.ProjectFolderPath = value; }
         public TextureCoordinateType OnDiskCoordinateType
         {
             get => _inner.OnDiskCoordinateType;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlContextMenuTests.cs
@@ -56,6 +56,7 @@ public class AnimationTreeControlContextMenuTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlTests.cs
@@ -31,6 +31,7 @@ public class AnimationTreeControlTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
@@ -26,6 +26,7 @@ public class InspectorControlTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/TextureListPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/TextureListPanelTests.cs
@@ -25,6 +25,7 @@ public class TextureListPanelTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/TimelineStripControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/TimelineStripControlTests.cs
@@ -21,6 +21,7 @@ public class TimelineStripControlTests
         public TileMapInformationList TileMapInformationList { get; set; } = new();
         public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
         public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
         public TextureCoordinateType OnDiskCoordinateType { get; set; }
 
         public void LoadAnimationChain(


### PR DESCRIPTION
## Summary
- Adds `ProjectManager.ProjectFolderPath`, a real settable property for the folder picked via File -> Open Project Folder (or restored at startup), replacing `MainWindow`'s private `_projectFolderRootPath` field as the single source of truth.
- `RefreshFilesPanel()` now prefers `ProjectFolderPath` over the achx-inferred `ResolveFilesPanelRoot()` fallback, so the Files/Textures panel's Project scope works with zero `.achx` tabs open. `LoadProjectFolderAsync` now also calls `RefreshFilesPanel()`, which it never did before -- opening a project folder previously left the panel stale until some other action refreshed it.
- Empty state: Project scope with no root at all now says "Open a project folder to browse its images." instead of blaming an unsaved `.achx`. This-File scope with nothing open keeps the old "Save the .achx..." message.
- `ResolveFilesPanelRoot()` itself is untouched -- still the fallback for the single-file workflow (a lone `.achx` opened, no project folder ever picked).
- Auto-selects the Textures tab (instead of the empty Project tab) when Open Project Folder finds zero `.achx` files.
- Opening a PNG as a tab no longer hides the Textures tab -- it stays visible and selected if it already was.
- Diff (PNG git history, #606) now shows in TopPane -- the same top-half cell the ANIMATIONS tree fills -- instead of hijacking the bottom tab strip. Closes #877.

## Deviation from the issue text
The issue's design step 3 ("Textures tab gains the same scope toggle Files panel has") describes `TextureListPanel`/`TextureListBuilder`, but those are Browser-only (`AnimationEditor.Browser`'s Textures tab). On desktop, the tab labeled "Textures" is `FilesPanelControl` itself -- it already has the Project/This-File toggle from #615. There's no second, distinct desktop panel to add a toggle to; fixing `ProjectFolderPath` + `RefreshFilesPanel()` wiring on `FilesPanelControl` is the complete fix for the desktop "Textures" tab. Left `TextureListPanel`/`AnimationEditor.Browser` untouched per the issue's own "desktop-only, don't touch the browser build" instruction.

## Manual-test verdict
Not needed. Startup/open-folder wiring, sidebar visibility, and layout swaps, fully covered by the existing headless `[AvaloniaFact]` + `TestServices`/`CreateMainWindow` pattern (`ProjectFolderFilesPanelScopeTests.cs`, `ProjectFolderTabAutoSelectTests.cs`, `PngTabTests.cs`) -- no rendering or pixel output is involved.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` -- 1815 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` -- 93 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` -- 814 passed
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` -- 0 errors

Closes #875
Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
