### PR TITLE
Fix opening .achj files failing with an XmlException toast

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -156,9 +156,16 @@ namespace AnimationEditor.Core.CommandsAndState
         /// <inheritdoc cref="IAppCommands.OpenAchxWorkflowAsync"/>
         public async Task OpenAchxWorkflowAsync(string path)
         {
-            // Quick-parse to read CoordinateType without committing to a full load.
+            // Quick-parse to read CoordinateType without committing to a full load. Must dispatch
+            // on extension the same way ProjectManager.LoadAnimationChain does (#878) -- a .achj
+            // (JSON) file hits the XML parser otherwise and fails with an XmlException.
             AnimationChainListSave preview;
-            try { preview = AnimationChainListSave.FromFile(path); }
+            try
+            {
+                preview = ProjectManager.IsJsonPath(path)
+                    ? AnimationChainListSave.FromJsonFile(path)
+                    : AnimationChainListSave.FromFile(path);
+            }
             catch (Exception ex) { LoadFailed?.Invoke(path, ex); return; }
 
             string achxDir = System.IO.Path.GetDirectoryName(path) ?? string.Empty;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ProjectManager.cs
@@ -201,7 +201,7 @@ namespace AnimationEditor.Core
         }
 
         /// <summary>True when <paramref name="path"/> has a .achj (JSON) extension; false for .achx or anything else.</summary>
-        private static bool IsJsonPath(string? path) =>
+        internal static bool IsJsonPath(string? path) =>
             !string.IsNullOrEmpty(path) && new FilePath(path).Extension == "achj";
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/OpenAchxWorkflowTests.cs
@@ -42,6 +42,16 @@ public class OpenAchxWorkflowTests : IDisposable
         return path;
     }
 
+    /// <summary>Same as <see cref="WriteMinimalAchx"/> but written as .achj (JSON).</summary>
+    private string WriteMinimalAchj(string chainName = "Idle")
+    {
+        var path = Path.Combine(_dir.Path, "test.achj");
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        acls.AnimationChains.Add(new AnimationChainSave { Name = chainName });
+        acls.SaveJson(path);
+        return path;
+    }
+
     // ── Data loading ──────────────────────────────────────────────────────────
 
     [Fact]
@@ -64,6 +74,33 @@ public class OpenAchxWorkflowTests : IDisposable
         await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
 
         Assert.Equal(new FilePath(path), new FilePath(_ctx.ProjectManager.FileName!));
+    }
+
+    // #878: the preview-parse step that reads CoordinateType before committing to a full load
+    // must dispatch on extension the same way ProjectManager.LoadAnimationChain does -- otherwise
+    // a .achj (JSON) file hits the XML parser and the open fails with an XmlException toast.
+    [Fact]
+    public async Task OpenAchxWorkflow_WithValidAchjFile_LoadsChainIntoProjectManager()
+    {
+        var path = WriteMinimalAchj("Walk");
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
+
+        Assert.NotNull(_ctx.ProjectManager.AnimationChainListSave);
+        Assert.Single(_ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        Assert.Equal("Walk", _ctx.ProjectManager.AnimationChainListSave.AnimationChains[0].Name);
+    }
+
+    [Fact]
+    public async Task OpenAchxWorkflow_WithValidAchjFile_DoesNotRaiseLoadFailed()
+    {
+        var path = WriteMinimalAchj();
+        Exception? failure = null;
+        _ctx.AppCommands.LoadFailed += (_, ex) => failure = ex;
+
+        await _ctx.AppCommands.OpenAchxWorkflowAsync(path);
+
+        Assert.Null(failure);
     }
 
     // ── Event ordering ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`AppCommands.OpenAchxWorkflowAsync`'s preview-parse step (reads `CoordinateType` before committing to a full load, to decide whether a UV-conversion prompt is needed) always called the XML parser, regardless of extension -- unlike `ProjectManager.LoadAnimationChain` underneath it, which already dispatches correctly. Opening a `.achj` (JSON) file hit the XML parser and failed with an `XmlException` ("Data at the root level is invalid"), shown as a load-failed toast.

Fix: made `ProjectManager.IsJsonPath` `internal` and reused it in the preview-parse branch, same dispatch `LoadAnimationChain` already does.

Both the Project tab's double-click-to-open and File -> Open route through this same method, so both were affected.

## Manual-test verdict
Not needed. Pure parse-dispatch logic, fully covered by the new `OpenAchxWorkflowTests.cs` cases (headless, no Avalonia dependency).

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` -- 1817 passed
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` -- 0 errors

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
