### PR TITLE
Animation Editor: tab context menu gets Open Containing Folder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -419,6 +419,18 @@ public partial class MainWindow : Window
                     Header = "Detach to New Window",
                     Command = new RelayCommand(() => DetachTab(captured)),
                 });
+            // Issue #881: same action as the title-bar "Open Containing Folder", but for the
+            // right-clicked tab (which may not be the active one).
+            tabMenu.Items.Add(new MenuItem
+            {
+                Header = "Open Containing Folder",
+                Command = new RelayCommand(() =>
+                {
+                    var error = Services.ShellExplorer.RevealFile(captured.Path.FullPath);
+                    if (error is not null)
+                        ShowStatusMessage($"⚠ {error}", isError: true);
+                }),
+            });
             // Issue #546: same action as the title-bar "Copy Full Path", but for the right-clicked
             // tab (which may not be the active one).
             tabMenu.Items.Add(new MenuItem

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabContextMenuTests.cs
@@ -64,6 +64,7 @@ public class TabContextMenuTests
                     .Select(m => (string?)m.Header)
                     .ToList();
                 Assert.Contains("Detach to New Window", headers);
+                Assert.Contains("Open Containing Folder", headers);
                 Assert.Contains("Copy Full Path", headers);
                 Assert.Contains("Close Tab", headers);
             }


### PR DESCRIPTION
Right-clicking an open document tab now offers "Open Containing Folder," matching the title-bar filename's context menu. Wires the same `Services.ShellExplorer.RevealFile` used there and by the Files panel.

Closes #881

## Test plan
- [x] `AnimationEditor.App.Tests.TabContextMenuTests` extended to assert the new item's presence; failed before the fix, passes after.
- [x] Full `AnimationEditor.App.Tests` suite green (814 passed).
- Manual test: not needed — headless test covers menu wiring; the click delegates to `ShellExplorer.RevealFile`/`ToWindowsSelectPath`, already covered by `ShellExplorerTests`.
