### PR TITLE
Animation Editor: Project tree file rows get Copy Full Path / Open Containing Folder

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -266,6 +266,8 @@ public partial class MainWindow : Window
         // shows a "View in Explorer" item it couldn't act on (#654's reasoning, applied here).
         ProjectPanel.SupportsRevealInExplorer = true;
         ProjectPanel.FolderRevealRequested += relativePath => RevealProjectFolderInExplorer(relativePath);
+        ProjectPanel.FileRevealRequested += relativePath => RevealProjectFileInExplorer(relativePath);
+        ProjectPanel.FileCopyPathRequested += relativePath => CopyProjectFilePathToClipboard(relativePath);
         // On scope toggle, re-supply the current referenced-texture set so "This File" reflects
         // the live .achx instead of the snapshot cached at the last refresh.
         FilesPanel.ScopeChanged += (_, _) => RefreshFilesPanel();
@@ -1851,9 +1853,10 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Resolves a Project-tree folder row's <see cref="AchxTreeNodeVm.RelativePath"/> to an
-    /// absolute path against <see cref="ProjectManager.ProjectFolderPath"/> (issue #841 follow-up:
-    /// "View in Explorer" on a folder row). Split out from <see cref="RevealProjectFolderInExplorer"/>
+    /// Resolves a Project-tree row's <see cref="AchxTreeNodeVm.RelativePath"/> (folder or file) to
+    /// an absolute path against <see cref="ProjectManager.ProjectFolderPath"/> (issue #841
+    /// follow-up: "View in Explorer" on a folder row; issue #886: "Copy Full Path" / "Open
+    /// Containing Folder" on a file row). Split out from <see cref="RevealProjectFolderInExplorer"/>
     /// so this pure resolution is unit-testable without going through <c>Process.Start</c>.
     /// </summary>
     internal string? ResolveProjectFolderAbsolutePath(string relativePath) =>
@@ -1879,6 +1882,26 @@ public partial class MainWindow : Window
         }
 
         Process.Start(new ProcessStartInfo { FileName = absolutePath, UseShellExecute = true });
+    }
+
+    // Issue #886: same two actions as the document tab strip's context menu (#881/#884), for a
+    // Project-tree file row instead of an open tab.
+    private void RevealProjectFileInExplorer(string relativePath)
+    {
+        var absolutePath = ResolveProjectFolderAbsolutePath(relativePath);
+        if (absolutePath is null) return;
+
+        var error = Services.ShellExplorer.RevealFile(absolutePath);
+        if (error is not null)
+            ShowStatusMessage($"⚠ {error}", isError: true);
+    }
+
+    private void CopyProjectFilePathToClipboard(string relativePath)
+    {
+        var absolutePath = ResolveProjectFolderAbsolutePath(relativePath);
+        if (absolutePath is null) return;
+
+        _ = TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(absolutePath);
     }
 
     private void OnTitleFileCopyPathClick(object? sender, RoutedEventArgs e)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -67,6 +67,20 @@ public partial class ProjectPanelControl : UserControl
     public event Action<string>? FolderRevealRequested;
 
     /// <summary>
+    /// Raised when the user picks "Open Containing Folder" for a file row (issue #886). Carries
+    /// the file's <see cref="AchxTreeNodeVm.RelativePath"/> for the host to resolve, same as
+    /// <see cref="FolderRevealRequested"/>.
+    /// </summary>
+    public event Action<string>? FileRevealRequested;
+
+    /// <summary>
+    /// Raised when the user picks "Copy Full Path" for a file row (issue #886). Carries the
+    /// file's <see cref="AchxTreeNodeVm.RelativePath"/> for the host to resolve, same as
+    /// <see cref="FolderRevealRequested"/>.
+    /// </summary>
+    public event Action<string>? FileCopyPathRequested;
+
+    /// <summary>
     /// Completes once every thumbnail from the most recent <see cref="Rebuild"/> has finished
     /// loading (or been cancelled by a newer one). Test seam for awaiting the async thumbnail
     /// load -- production code never needs to await this.
@@ -282,11 +296,27 @@ public partial class ProjectPanelControl : UserControl
         ProjectTree.ContextMenu.Items.Clear();
 
         if (!SupportsRevealInExplorer) return;
-        if (_contextNode is not { IsFolder: true } node) return;
 
-        var revealItem = new MenuItem { Header = "View in Explorer" };
-        revealItem.Click += (_, _) => FolderRevealRequested?.Invoke(node.RelativePath);
-        ProjectTree.ContextMenu.Items.Add(revealItem);
+        if (_contextNode is { IsFolder: true } folderNode)
+        {
+            var revealItem = new MenuItem { Header = "View in Explorer" };
+            revealItem.Click += (_, _) => FolderRevealRequested?.Invoke(folderNode.RelativePath);
+            ProjectTree.ContextMenu.Items.Add(revealItem);
+            return;
+        }
+
+        if (_contextNode is { IsFile: true } fileNode)
+        {
+            // Same two items and headers as the document tab strip's context menu
+            // (MainWindow.axaml.cs, #881/#884) for the equivalent open file.
+            var openFolderItem = new MenuItem { Header = "Open Containing Folder" };
+            openFolderItem.Click += (_, _) => FileRevealRequested?.Invoke(fileNode.RelativePath);
+            ProjectTree.ContextMenu.Items.Add(openFolderItem);
+
+            var copyPathItem = new MenuItem { Header = "Copy Full Path" };
+            copyPathItem.Click += (_, _) => FileCopyPathRequested?.Invoke(fileNode.RelativePath);
+            ProjectTree.ContextMenu.Items.Add(copyPathItem);
+        }
     }
 
     private void OnFolderExpanderToggled(object? sender, EventArgs e)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -228,10 +228,77 @@ public class ProjectPanelControlTests
         finally { window.Close(); }
     }
 
+    // Issue #886: right-click a file row -> "Open Containing Folder" + "Copy Full Path", same
+    // headers as the document tab strip's context menu (#881/#884) for the equivalent open file.
     [AvaloniaFact]
-    public void RightClickingFileRow_DoesNotShowViewInExplorerItem()
+    public void RightClickingFileRow_WithRevealSupported_ShowsOpenFolderAndCopyPathItems()
     {
         var control = new Controls.ProjectPanelControl { SupportsRevealInExplorer = true };
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClick(window, control, control.TreeRoots[0]); // "hero.achx" file
+
+            var headers = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Select(i => i.Header).ToArray();
+            Assert.Equal(new object?[] { "Open Containing Folder", "Copy Full Path" }, headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ClickingOpenContainingFolder_RaisesFileRevealRequestedWithRelativePath()
+    {
+        var control = new Controls.ProjectPanelControl { SupportsRevealInExplorer = true };
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClick(window, control, control.TreeRoots[0].Children[0]); // "hero.achx" under "Sprites"
+            string? requested = null;
+            control.FileRevealRequested += path => requested = path;
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Single(i => (string)i.Header! == "Open Containing Folder");
+            item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+            Assert.Equal("Sprites/hero.achx", requested);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ClickingCopyFullPath_RaisesFileCopyPathRequestedWithRelativePath()
+    {
+        var control = new Controls.ProjectPanelControl { SupportsRevealInExplorer = true };
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClick(window, control, control.TreeRoots[0].Children[0]); // "hero.achx" under "Sprites"
+            string? requested = null;
+            control.FileCopyPathRequested += path => requested = path;
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Single(i => (string)i.Header! == "Copy Full Path");
+            item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+            Assert.Equal("Sprites/hero.achx", requested);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RightClickingFileRow_WithRevealNotSupported_ShowsNoItems()
+    {
+        var control = new Controls.ProjectPanelControl(); // SupportsRevealInExplorer defaults false
         var root = new FakeFolder("Content");
         control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "hero.achx") });
 


### PR DESCRIPTION
## Summary
- Right-clicking a `.achx` file row in the Project tree now shows "Open Containing Folder" and "Copy Full Path" (same headers as the document tab strip's context menu, #881/#884).
- Absolute path resolution reuses `MainWindow.ResolveProjectFolderAbsolutePath`, the same seam folder rows already use (#841 follow-up); doc comment updated to reflect it now serves file rows too.

## Test plan
- `AnimationEditor.Views.Tests` (`ProjectPanelControlTests`): new tests cover the two menu items appearing/not appearing, and each raising its event with the row's relative path — 15/15 pass.
- `AnimationEditor.App.Tests`: full suite, 814/814 pass (no regressions; `ResolveProjectFolderAbsolutePath` coverage already generic across folder/file paths).
- Manual test: not needed — headless Avalonia coverage exercises the full right-click → menu → event → resolve path.

Closes #886
