### PR TITLE
AnimationEditor: open a tab when restoring a crash-recovery file

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -925,12 +925,7 @@ public partial class MainWindow : Window
         }
 
         _ioManager.DeleteRecoveryFile();
-        _projectManager.AnimationChainListSave = recovered;
-        _projectManager.FileName = null;
-        _selectedState.Reset();
-        _selectedState.SelectedChain = recovered.AnimationChains.FirstOrDefault();
-        _undoManager.Clear();
-        RefreshTreeView();
+        OpenAsNewUnsavedDocument(recovered, recovered.AnimationChains.FirstOrDefault());
         return true;
     }
 
@@ -2058,9 +2053,25 @@ public partial class MainWindow : Window
         // Register the currently-open file (if any) as a tab before we clear it.
         EnsureCurrentEditorContentHasTab();
 
-        _projectManager.AnimationChainListSave = new AnimationChainListSave();
+        OpenAsNewUnsavedDocument(new AnimationChainListSave());
+
+        _ = _appCommands.SaveCurrentAnimationChainListAsync();
+    }
+
+    /// <summary>
+    /// Replaces the in-memory document with <paramref name="content"/> as a new, unsaved
+    /// (Untitled) document, resets selection/undo/tree state, and opens/activates a tab for it.
+    /// Shared by <see cref="OnNewClick"/> and <see cref="TryRestoreRecoveryFileAsync"/> so both
+    /// "start editing from a fresh in-memory document" paths can't drift apart again — #892 was
+    /// exactly that: the recovery path duplicated everything except the tab-opening step.
+    /// </summary>
+    private void OpenAsNewUnsavedDocument(AnimationChainListSave content, AnimationChainSave? selectedChain = null)
+    {
+        _projectManager.AnimationChainListSave = content;
         _projectManager.FileName = null;
         _selectedState.Reset();
+        if (selectedChain is not null)
+            _selectedState.SelectedChain = selectedChain;
         _undoManager.Clear();
         RefreshTreeView();
 
@@ -2070,8 +2081,6 @@ public partial class MainWindow : Window
         var sentinelPath = new FilePath(NewUntitledSentinelPath());
         _tabManager.OpenOrFocus(sentinelPath, displayName);
         RebuildTabStrip();
-
-        _ = _appCommands.SaveCurrentAnimationChainListAsync();
     }
 
     private void OnLoadClick(object? sender, RoutedEventArgs e) => _ = LoadAsync();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
@@ -1,6 +1,8 @@
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using FlatRedBall2.Animation.Content;
@@ -17,6 +19,11 @@ namespace AnimationEditor.App.Tests;
 /// </summary>
 public class StartupRecoveryTests
 {
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
     [AvaloniaFact]
     public void NoRecoveryFile_StartsNormally_NeverPrompts()
     {
@@ -56,6 +63,30 @@ public class StartupRecoveryTests
         {
             Assert.Contains(ctx.ProjectManager.AnimationChainListSave!.AnimationChains, c => c.Name == "Recovered");
             Assert.Null(ctx.ProjectManager.FileName);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_UserConfirms_OpensRestoredContentInATab()
+    {
+        // Issue #892: restoring loaded the content into the model/tree but never registered a
+        // tab for it, so the restored document was invisible/unreachable once you switched away.
+        var ctx = TestHelpers.BuildServices();
+        var seed = new AnimationChainListSave();
+        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
+        ctx.IoManager.WriteRecoveryFile(seed);
+
+        var window = ctx.CreateMainWindow();
+        window.ShowTwoButtonDialogAsync = (_, _, _, _) => Task.FromResult(true);
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            var tabManager = GetTabManager(window);
+            Assert.Single(tabManager.Tabs);
+            Assert.Same(tabManager.Tabs[0], tabManager.ActiveTab);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
## Summary
- `TryRestoreRecoveryFileAsync` loaded the recovered document but never opened a tab for it — restored content was invisible/unreachable once you switched tabs (#892).
- Extracted `OnNewClick`'s "reset to a fresh in-memory document + open/activate an Untitled tab" steps into a shared `OpenAsNewUnsavedDocument` helper, used by both `OnNewClick` and `TryRestoreRecoveryFileAsync`, so the two paths can't silently diverge again.

## Test plan
- [x] New `[AvaloniaFact]` `RecoveryFilePresent_UserConfirms_OpensRestoredContentInATab` (`StartupRecoveryTests.cs`) — failed before the fix, passes after.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 816 passed.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1817 passed.

Closes #892