### PR TITLE
AnimationEditor: grid-mode double-click resizes frame to the cell

### DIFF
--- a/.claude/skills/animation-editor/SKILL.md
+++ b/.claude/skills/animation-editor/SKILL.md
@@ -100,3 +100,13 @@ Tests that exercise path logic **must** use Windows-style backslash literals (e.
 ## Tree reorder — chains and frames; shape order is fixed
 
 Drag-and-drop tree reorder covers **chains and frames** (pure resolvers `ChainDropResolver` / `FrameDropResolver`, wired in `MainWindow`). **Do not add shape DnD reorder:** collision shapes in `.achx` keep a **fixed list order** for FRB1 runtime compatibility — order is meaningful to legacy consumers, not a cosmetic tree sort. Menu/Alt+Arrow shape reorder exists in `AppCommands.MoveShape` today; treat new reorder UX as chain/frame-only unless an issue explicitly revisits shape ordering across runtimes.
+
+## Grid mode: double-click resizes; click/drag only repositions
+
+Grid-mode click-to-place and handle-drag preserve the frame's existing size — only
+double-click resizes it to the full grid cell (`GridPlacementCalculator.SnapToCell`,
+called only from `WireframeControl.SnapSelectedFrameToGridCell`). This is deliberate:
+a fresh PNG drop creates one frame sized to the whole sheet, and double-click-to-carve-
+a-cell is how that gets sized down without dragging edge handles by hand. Don't collapse
+the two gestures onto one shared size-preserving helper again — see
+`GridPlacementCalculator`'s doc comment for why that was tried and reverted.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/GridPlacementCalculator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/GridPlacementCalculator.cs
@@ -1,24 +1,41 @@
 namespace AnimationEditor.Core.Rendering;
 
 /// <summary>
-/// Computes the pixel region for placing an <em>existing</em> frame onto a grid cell.
-/// Grid placement snaps the frame's origin (top-left) to the grid but preserves its
-/// current size — clicking a cell must never resize a frame (issue #538). Contrast
-/// with new-frame creation, which is free to use a full grid cell as the frame size.
+/// Computes the pixel region for the grid double-click placement gesture: snaps the
+/// clicked point down to the grid and returns the full cell as the frame's new bounds.
+///
+/// <para>
+/// <b>History (read before "simplifying" this away — #895):</b> this double-click gesture
+/// has flip-flopped once already. #363 originally wanted double-click to resize the
+/// selected frame to fill the clicked cell. #538 (a real bug about grid-enabled DISPLAY
+/// snapping ballooning small frames on every refresh, and property-panel edits jumping to
+/// the grid — nothing to do with double-click specifically) swept this double-click call
+/// site into the same fix as a collateral side effect, making it preserve size instead.
+/// That silently reverted #363 with no discussion in the #538 issue/PR of the behavior it
+/// was overwriting. #895 restores #363's resize-to-cell behavior deliberately, because it
+/// matches the actual workflow: dropping a PNG onto an animation creates one frame sized to
+/// the entire sheet, and double-click-to-carve-out-a-cell is how users size it down — a
+/// preserve-size double-click can't do that; only a full edge-handle drag can, which is
+/// exactly the friction #895 was filed to remove.
+/// </para>
+/// <para>
+/// If a genuine future need for a size-preserving reposition-only gesture shows up, add it
+/// back as its own method (and its own explicit gesture, e.g. a modifier key) — don't
+/// collapse it into this one and repeat the #538/#363 flip-flop a third time.
+/// </para>
 /// </summary>
 public static class GridPlacementCalculator
 {
     /// <summary>
-    /// Snaps (<paramref name="worldX"/>, <paramref name="worldY"/>) down to the grid
-    /// via <see cref="GridSnapper.Snap"/> and returns the region
-    /// (minX, minY, maxX, maxY) whose size equals the passed
-    /// <paramref name="frameWidth"/> × <paramref name="frameHeight"/> in pixels.
+    /// Snaps (<paramref name="worldX"/>, <paramref name="worldY"/>) down to the grid via
+    /// <see cref="GridSnapper.Snap"/> and returns the full cell region (minX, minY,
+    /// maxX, maxY) — the frame is resized to exactly one <paramref name="gridSize"/> cell.
     /// </summary>
-    public static (int minX, int minY, int maxX, int maxY) SnapOriginPreserveSize(
-        float worldX, float worldY, int gridSize, int frameWidth, int frameHeight)
+    public static (int minX, int minY, int maxX, int maxY) SnapToCell(
+        float worldX, float worldY, int gridSize)
     {
         int gx = GridSnapper.Snap(worldX, gridSize);
         int gy = GridSnapper.Snap(worldY, gridSize);
-        return (gx, gy, gx + frameWidth, gy + frameHeight);
+        return (gx, gy, gx + gridSize, gy + gridSize);
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -1285,9 +1285,9 @@ public class WireframeControl : TextureViewport
         }
 
         // 3. Grid mode: Ctrl+click → create a new cell-sized frame; plain click →
-        //    select the frame under the cursor, same as plain mode. Repositioning
-        //    the selected frame to a grid cell is an explicit gesture (double-click,
-        //    issue #363) — a plain click must never silently move it.
+        //    select the frame under the cursor, same as plain mode. Resizing/repositioning
+        //    the selected frame onto a grid cell is an explicit gesture (double-click,
+        //    issue #363/#895) — a plain click must never silently move or resize it.
         if (_showGrid && _gridSize > 0)
         {
             if (isCtrl)
@@ -1761,20 +1761,18 @@ public class WireframeControl : TextureViewport
     }
 
     /// <summary>
-    /// Grid click-to-place: snaps the selected frame's origin to the grid cell
-    /// containing (<paramref name="worldX"/>, <paramref name="worldY"/>) while
-    /// preserving its current pixel size. Grid must never resize an existing
-    /// frame — only reposition it (issue #538).
+    /// Grid double-click: resizes the selected frame to exactly fill the grid cell
+    /// containing (<paramref name="worldX"/>, <paramref name="worldY"/>) — issue #895.
+    /// This is the explicit resize gesture for grid mode (a plain click never resizes
+    /// or repositions — see the call site's comment). It matters most right after
+    /// dropping a PNG onto an animation, which creates one frame sized to the entire
+    /// sheet; double-clicking a cell is how that gets carved down to size without
+    /// dragging edge handles by hand.
     /// </summary>
     private void SnapSelectedFrameToGridCell(float worldX, float worldY)
     {
         if (_selectedState!.SelectedFrame is null || _bitmap is null) return;
-        var frame = _selectedState!.SelectedFrame;
-        float w = _bitmap.Width, h = _bitmap.Height;
-        int frameW = (int)MathF.Round(frame.RightCoordinate  * w) - (int)MathF.Round(frame.LeftCoordinate * w);
-        int frameH = (int)MathF.Round(frame.BottomCoordinate * h) - (int)MathF.Round(frame.TopCoordinate  * h);
-        var (minX, minY, maxX, maxY) = GridPlacementCalculator.SnapOriginPreserveSize(
-            worldX, worldY, _gridSize, frameW, frameH);
+        var (minX, minY, maxX, maxY) = GridPlacementCalculator.SnapToCell(worldX, worldY, _gridSize);
         ApplyRegionToSelectedFrame(minX, minY, maxX, maxY);
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/GridRenderTests.cs
@@ -900,13 +900,15 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// Issue #538: grid double-click relocates the frame's origin to the clicked
-    /// grid cell but must preserve its existing size. A 4×4 frame double-clicked at
-    /// screen (20,20) with cellSize=16 snaps its origin to (16,16) and stays 4×4 →
-    /// bounds (16,16,20,20), never (16,16,32,32).
+    /// Issue #895: grid double-click resizes the selected frame to fill the clicked
+    /// grid cell, not just reposition it. A 4×4 frame double-clicked at screen
+    /// (20,20) with cellSize=16 snaps to the cell (16,16,32,32), not (16,16,20,20).
+    /// (This restores #363's original intent; #538's PR briefly made double-click
+    /// preserve size too, but that was a collateral side effect of fixing an
+    /// unrelated display-snap-on-refresh bug, not a deliberate call — see #895.)
     /// </summary>
     [AvaloniaFact]
-    public void GridSnapDoubleClick_SmallFrame_SnapsOriginAndPreservesSize()
+    public void GridSnapDoubleClick_SmallFrame_ResizesToGridCell()
     {
         var ctx = ResetSingletons();
         // 4×4 frame at pixel (5,5).
@@ -917,21 +919,21 @@ public class GridRenderTests
 
             ctrl.SimulateGridSnapDoubleClick(20f, 20f);
 
-            // Origin snaps to (16,16); size stays 4×4 → (16,16,20,20) on 64×64.
+            // Frame becomes the full clicked cell (16,16,32,32) on 64×64.
             Assert.Equal(16f / 64f, frame.LeftCoordinate,   precision: 5);
             Assert.Equal(16f / 64f, frame.TopCoordinate,    precision: 5);
-            Assert.Equal(20f / 64f, frame.RightCoordinate,  precision: 5);
-            Assert.Equal(20f / 64f, frame.BottomCoordinate, precision: 5);
+            Assert.Equal(32f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(32f / 64f, frame.BottomCoordinate, precision: 5);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
 
     /// <summary>
-    /// Verifies the grid-snap math preserves size at the top-left cell: a 4×4 frame
-    /// double-clicked at (5,5) snaps its origin to (0,0) and stays 4×4 → (0,0,4,4).
+    /// Verifies the grid-snap math at the top-left cell: a 4×4 frame double-clicked
+    /// at (5,5) with cellSize=16 becomes the full cell (0,0,16,16).
     /// </summary>
     [AvaloniaFact]
-    public void GridSnapDoubleClick_SnapsOriginToGridCell_PreservesSize()
+    public void GridSnapDoubleClick_SnapsToGridCell_ResizesToCell()
     {
         var ctx = ResetSingletons();
         // 4×4 frame at pixel (13,23) — deliberately off-grid.
@@ -942,11 +944,37 @@ public class GridRenderTests
 
             ctrl.SimulateGridSnapDoubleClick(5f, 5f);
 
-            // (5,5) snaps origin to (0,0); size stays 4×4 → (0,0,4,4) on 64×64.
-            Assert.Equal(0f,       frame.LeftCoordinate,   precision: 5);
-            Assert.Equal(0f,       frame.TopCoordinate,    precision: 5);
-            Assert.Equal(4f / 64f, frame.RightCoordinate,  precision: 5);
-            Assert.Equal(4f / 64f, frame.BottomCoordinate, precision: 5);
+            // (5,5) snaps to the top-left cell (0,0,16,16) on 64×64.
+            Assert.Equal(0f,        frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(0f,        frame.TopCoordinate,    precision: 5);
+            Assert.Equal(16f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(16f / 64f, frame.BottomCoordinate, precision: 5);
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Issue #895's motivating case: dragging a PNG onto an animation creates a new
+    /// frame sized to the *entire* image (see <c>FrameCreatedFromRegion</c> at full
+    /// texture bounds). Double-clicking a grid cell must shrink that oversized frame
+    /// down to the cell — not just relocate its origin and leave it full-sheet-sized.
+    /// </summary>
+    [AvaloniaFact]
+    public void GridSnapDoubleClick_FullSheetFrame_ShrinksToClickedCell()
+    {
+        var ctx = ResetSingletons();
+        // Frame covers the entire 64×64 sheet, as a fresh PNG drop would produce.
+        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 0, frameY: 0, frameW: 64, frameH: 64);
+        try
+        {
+            ctrl.SetGrid(true, 16);
+
+            ctrl.SimulateGridSnapDoubleClick(20f, 20f);
+
+            Assert.Equal(16f / 64f, frame.LeftCoordinate,   precision: 5);
+            Assert.Equal(16f / 64f, frame.TopCoordinate,    precision: 5);
+            Assert.Equal(32f / 64f, frame.RightCoordinate,  precision: 5);
+            Assert.Equal(32f / 64f, frame.BottomCoordinate, precision: 5);
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }
@@ -995,9 +1023,9 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// Grid click-to-place (single click or double-click, both routed through
-    /// <c>SnapSelectedFrameToGridCell</c> / <c>ApplyRegionToSelectedFrame</c>) must
-    /// push an undo entry when it actually repositions the selected frame — just
+    /// Grid double-click (routed through <c>SnapSelectedFrameToGridCell</c> /
+    /// <c>ApplyRegionToSelectedFrame</c>) must push an undo entry when it actually
+    /// changes the selected frame's bounds — just
     /// like a handle drag does via <c>FrameRegionChangedCommand</c>. Silently
     /// repositioning a frame with no way to undo it is the reported bug.
     /// </summary>
@@ -1049,23 +1077,25 @@ public class GridRenderTests
     }
 
     /// <summary>
-    /// Grid click-to-place at a position that does not actually move the frame
-    /// (already aligned) must not record a no-op undo entry.
+    /// Grid click-to-place at a position that does not actually change the frame
+    /// (already exactly the clicked cell — both position and size) must not record
+    /// a no-op undo entry. A frame smaller than the cell is NOT a no-op even at the
+    /// same origin, since it still gets resized up to fill the cell (#895).
     /// </summary>
     [AvaloniaFact]
-    public void GridSnapDoubleClick_NoActualMovement_DoesNotRecordUndo()
+    public void GridSnapDoubleClick_NoActualChange_DoesNotRecordUndo()
     {
         var ctx = ResetSingletons();
-        // Frame already at the grid-aligned origin (0,0) with cellSize=16.
-        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 0, frameY: 0, frameW: 4, frameH: 4);
+        // Frame already exactly the top-left cell (0,0,16,16) with cellSize=16.
+        var (ctrl, frame, dir) = BuildCtrlWithFrame(ctx, frameX: 0, frameY: 0, frameW: 16, frameH: 16);
         try
         {
             ctrl.SetGrid(true, 16);
 
-            ctrl.SimulateGridSnapDoubleClick(5f, 5f);   // snaps to (0,0) — same as current origin
+            ctrl.SimulateGridSnapDoubleClick(5f, 5f);   // snaps to (0,0,16,16) — already there
 
             Assert.False(ctx.UndoManager.CanUndo,
-                "Clicking a cell that doesn't change the frame's position must not record undo.");
+                "Clicking a cell that doesn't change the frame's bounds must not record undo.");
         }
         finally { System.IO.Directory.Delete(dir, true); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GridPlacementCalculatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/GridPlacementCalculatorTests.cs
@@ -6,26 +6,25 @@ namespace AnimationEditor.Core.Tests;
 public class GridPlacementCalculatorTests
 {
     [Fact]
-    public void SnapOriginPreserveSize_ClickInsideCell_SnapsOriginKeepsSize()
+    public void SnapToCell_ClickInsideCell_ReturnsFullCell()
     {
-        // Click at (20,20) with a 16px grid snaps origin to (16,16); a 4×4 frame
-        // stays 4×4 → (16,16,20,20).
-        var region = GridPlacementCalculator.SnapOriginPreserveSize(20f, 20f, 16, 4, 4);
-        Assert.Equal((16, 16, 20, 20), region);
+        // Click at (20,20) with a 16px grid snaps to the cell (16,16,32,32).
+        var region = GridPlacementCalculator.SnapToCell(20f, 20f, 16);
+        Assert.Equal((16, 16, 32, 32), region);
     }
 
     [Fact]
-    public void SnapOriginPreserveSize_ClickAtCellBoundary_ReturnsCellOrigin()
+    public void SnapToCell_ClickAtCellBoundary_ReturnsThatCell()
     {
-        var region = GridPlacementCalculator.SnapOriginPreserveSize(16f, 16f, 16, 4, 4);
-        Assert.Equal((16, 16, 20, 20), region);
+        var region = GridPlacementCalculator.SnapToCell(16f, 16f, 16);
+        Assert.Equal((16, 16, 32, 32), region);
     }
 
     [Fact]
-    public void SnapOriginPreserveSize_NonSquareFrame_PreservesBothDimensions()
+    public void SnapToCell_NonSquareGrid_ReturnsFullCell()
     {
-        // 8px grid: 33→32, 5→0. A 10×3 frame keeps 10 wide, 3 tall → (32,0,42,3).
-        var region = GridPlacementCalculator.SnapOriginPreserveSize(33f, 5f, 8, 10, 3);
-        Assert.Equal((32, 0, 42, 3), region);
+        // 8px grid: 33→32, 5→0 → cell (32,0,40,8).
+        var region = GridPlacementCalculator.SnapToCell(33f, 5f, 8);
+        Assert.Equal((32, 0, 40, 8), region);
     }
 }


### PR DESCRIPTION
## Summary
- Grid-mode double-click on a frame snapped its origin to the grid but preserved its old size — repositioning only, never resizing (#895).
- Traced #538's PR: its actual bug reports were about grid-toggle display-snap ballooning frames and property-panel edits jumping to grid, nothing about double-click. Its fix collaterally swept the double-click path into "preserve size" alongside the plain click-to-place path, silently reverting #363's original resize-to-cell intent (confirmed via the pre-#538 test asserting exactly that behavior). Full trail in the issue comments.
- Motivating case: dropping a PNG onto an animation creates one frame sized to the entire sheet; double-click-to-carve-a-cell is how that gets sized down without dragging edge handles by hand.
- `GridPlacementCalculator.SnapToCell` (returns the full grid cell) replaces `SnapOriginPreserveSize`; `WireframeControl.SnapSelectedFrameToGridCell` now resizes instead of preserving size. Click-to-place and handle-drag are untouched — they never routed through this method.
- Logged the reasoning in `GridPlacementCalculator`'s class doc comment and the `animation-editor` skill so a future pass doesn't flip this a third time.

## Test plan
- [x] `GridSnapDoubleClick_SmallFrame_ResizesToGridCell`, `GridSnapDoubleClick_SnapsToGridCell_ResizesToCell`, `GridSnapDoubleClick_FullSheetFrame_ShrinksToClickedCell` (new/rewritten) — failed before the fix, pass after.
- [x] `GridSnapDoubleClick_NoActualChange_DoesNotRecordUndo` updated (a same-position-but-undersized frame is no longer a no-op under resize-to-cell semantics).
- [x] `GridPlacementCalculatorTests` rewritten for `SnapToCell`.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 817 passed.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1817 passed.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — 106 passed.

Manual test: not needed — fully covered by the headless `[AvaloniaFact]`/`[Fact]` suites above.

Closes #895