### PR TITLE
AnimationEditor: coalesce per-keystroke NumericUpDown edits into one undo entry

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4262,6 +4262,20 @@ public partial class MainWindow : Window
         PropTextureName.LostFocus  += (_, _) => ApplyTextureName();
         PropTextureName.KeyDown    += (_, e) => { if (e.Key == Key.Enter) ApplyTextureName(); };
         PropTextureBrowseBtn.Click += async (_, _) => await BrowseForFrameTexture();
+
+        // #897: every field above commits on ValueChanged so the wireframe/preview updates live as
+        // the user types or scrolls the wheel; each commit coalesces with the previous one for the
+        // same field group into a single undo entry (see IUndoableCommand.CoalesceGroup). LostFocus
+        // seals that entry so the next edit — even to the same field — starts a fresh one.
+        SealOnLostFocus(PropFrameLen, PropRelX, PropRelY, PropPixelX, PropPixelY, PropPixelW, PropPixelH,
+            PropRectX, PropRectY, PropRectScaleX, PropRectScaleY,
+            PropCircleX, PropCircleY, PropCircleRadius);
+    }
+
+    private void SealOnLostFocus(params NumericUpDown[] inputs)
+    {
+        foreach (var input in inputs)
+            input.LostFocus += (_, _) => _appCommands.SealPendingEdits();
     }
 
     private void ApplyTextureName()
@@ -4492,6 +4506,9 @@ public partial class MainWindow : Window
 
     private void RefreshPropertyPanel()
     {
+        // #897: seal any still-open coalescing window before repopulating fields from a (possibly
+        // reselected) target, so a stale pending edit never merges with a later one to the same field.
+        _appCommands.SealPendingEdits();
         _suppressPropRefresh = true;
         try
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1528,6 +1528,11 @@ public partial class MainWindow : Window
 
     private void HandleSelectionChanged()
     {
+        // #897: seal any still-open coalescing window here -- on a genuine selection change --
+        // rather than in RefreshPropertyPanel, which HandleAnimationChainsChanged also calls after
+        // *every* commit (including each one a coalescing session is made of). Sealing there would
+        // close the window right after each tick and defeat coalescing entirely.
+        _appCommands.SealPendingEdits();
         // Sync the texture combo to the texture of the currently selected frame/chain
         Dispatcher.UIThread.InvokeAsync(SyncTextureCombo);
         // Sync tree selection
@@ -4506,9 +4511,9 @@ public partial class MainWindow : Window
 
     private void RefreshPropertyPanel()
     {
-        // #897: seal any still-open coalescing window before repopulating fields from a (possibly
-        // reselected) target, so a stale pending edit never merges with a later one to the same field.
-        _appCommands.SealPendingEdits();
+        // Deliberately does NOT call SealPendingEdits here -- this method also runs after every
+        // single commit via HandleAnimationChainsChanged (to resync flip toggles, etc. post-edit),
+        // not just on a genuine selection change. See HandleSelectionChanged for the seal (#897).
         _suppressPropRefresh = true;
         try
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1611,7 +1611,7 @@ namespace AnimationEditor.Core.CommandsAndState
             var desc = $"Set Length: {newLength:0.###}s";
             _undoManager.Execute(new BulkFrameEditCommand(
                 frames, () => { foreach (var f in frames) f.FrameLength = newLength; },
-                this, _events, false, desc));
+                this, _events, false, desc, coalesceKind: "Length"));
         }
 
         public void SetFrameRelative(IReadOnlyList<AnimationFrameSave> frames, float? newRelX, float? newRelY)
@@ -1625,7 +1625,7 @@ namespace AnimationEditor.Core.CommandsAndState
                         if (newRelY.HasValue) f.RelativeY = newRelY.Value;
                     }
                 },
-                this, _events, true, "Set Offset"));
+                this, _events, true, "Set Offset", coalesceKind: "Relative"));
         }
 
         public void SetFrameColor(IReadOnlyList<AnimationFrameSave> frames, int? red, int? green, int? blue)
@@ -1634,7 +1634,7 @@ namespace AnimationEditor.Core.CommandsAndState
             // wireframe refresh is needed. The AnimationChainsChanged raised here rebuilds those.
             _undoManager.Execute(new BulkFrameEditCommand(
                 frames, () => { foreach (var f in frames) { f.Red = red; f.Green = green; f.Blue = blue; } },
-                this, _events, false, "Set Frame Color"));
+                this, _events, false, "Set Frame Color", coalesceKind: "Color"));
         }
 
         public void SetFrameColorOperation(IReadOnlyList<AnimationFrameSave> frames, ColorOperation? operation)
@@ -1652,7 +1652,7 @@ namespace AnimationEditor.Core.CommandsAndState
             // the wireframe, so no wireframe refresh is needed.
             _undoManager.Execute(new BulkFrameEditCommand(
                 frames, () => { foreach (var f in frames) f.Alpha = alpha; },
-                this, _events, false, "Set Frame Alpha"));
+                this, _events, false, "Set Frame Alpha", coalesceKind: "Alpha"));
         }
 
         public void SetFramePixelRegion(IReadOnlyList<AnimationFrameSave> frames,
@@ -1672,7 +1672,7 @@ namespace AnimationEditor.Core.CommandsAndState
                         if (pixelH.HasValue) PixelFrameEditor.SetHeight(f, pixelH.Value, bmpH);
                     }
                 },
-                this, _events, true, "Set Region"));
+                this, _events, true, "Set Region", coalesceKind: "PixelRegion"));
         }
 
         public void SetRectProps(AnimationFrameSave? frame, AARectSave rect,
@@ -1721,6 +1721,9 @@ namespace AnimationEditor.Core.CommandsAndState
                 },
                 this, _events, _objectFinder, "Edit Circles"));
         }
+
+        /// <inheritdoc cref="IAppCommands.SealPendingEdits"/>
+        public void SealPendingEdits() => _undoManager.SealCoalescing();
 
         /// <inheritdoc cref="IAppCommands.HasSameFrameNameCollision"/>
         public bool HasSameFrameNameCollision(IReadOnlyList<object> shapes) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkFrameEditCommand.cs
@@ -3,6 +3,7 @@ using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
 {
@@ -62,10 +63,29 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public string Description { get; }
 
+        /// <summary>
+        /// Keyed on <paramref name="coalesceKind"/> plus the edited frames' own identities, so
+        /// consecutive edits to the same field on the same frame set (e.g. one call per keystroke
+        /// while typing in the Relative X field) coalesce into a single undo entry -- see
+        /// <see cref="IUndoableCommand.CoalesceGroup"/>. Null (the default) never coalesces, for
+        /// bulk operations that aren't driven by a single continuously-editable control.
+        /// </summary>
+        public string? CoalesceGroup { get; }
+
         public BulkFrameEditCommand(
             IReadOnlyList<AnimationFrameSave> frames, Action mutate,
             IAppCommands commands, IApplicationEvents events, bool refreshWireframe,
-            string description = "Edit Frames")
+            string description = "Edit Frames", string? coalesceKind = null)
+            : this(frames, mutate, commands, events, refreshWireframe, description,
+                  BuildCoalesceGroup(coalesceKind, frames), [], [])
+        {
+        }
+
+        private BulkFrameEditCommand(
+            IReadOnlyList<AnimationFrameSave> frames, Action mutate,
+            IAppCommands commands, IApplicationEvents events, bool refreshWireframe,
+            string description, string? coalesceGroup,
+            FrameFieldSnapshot[] before, FrameFieldSnapshot[] after)
         {
             _frames = frames;
             _mutate = mutate;
@@ -73,7 +93,14 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             _refreshWireframe = refreshWireframe;
             Description = description;
+            CoalesceGroup = coalesceGroup;
+            _before = before;
+            _after = after;
         }
+
+        private static string? BuildCoalesceGroup(string? kind, IReadOnlyList<AnimationFrameSave> frames) =>
+            kind is null ? null :
+            $"BulkFrameEdit:{kind}:{string.Join(",", frames.Select(RuntimeHelpers.GetHashCode).OrderBy(h => h))}";
 
         public bool Do()
         {
@@ -89,6 +116,18 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo() => Apply(_before);
         public void Redo() => Apply(_after);
+
+        /// <summary>
+        /// Combines <paramref name="previous"/>'s original "before" snapshot with this command's
+        /// already-captured "after" snapshot (see <see cref="IUndoableCommand.CoalesceWith"/>).
+        /// </summary>
+        public IUndoableCommand CoalesceWith(IUndoableCommand previous)
+        {
+            var p = (BulkFrameEditCommand)previous;
+            return new BulkFrameEditCommand(
+                _frames, _mutate, _commands, _events, _refreshWireframe,
+                Description, CoalesceGroup, p._before, _after);
+        }
 
         private void Apply(FrameFieldSnapshot[] snapshots)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkShapePropsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/BulkShapePropsCommand.cs
@@ -2,6 +2,7 @@ using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands
 {
@@ -50,10 +51,28 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public string Description { get; }
 
+        /// <summary>
+        /// Keyed on the edited shapes' own identities, so consecutive edits to the same
+        /// selection (e.g. one call per keystroke while typing in the multi-select X field)
+        /// coalesce into a single undo entry -- see <see cref="IUndoableCommand.CoalesceGroup"/>.
+        /// </summary>
+        public string? CoalesceGroup { get; }
+
         public BulkShapePropsCommand(
             IReadOnlyList<object> shapes, Action mutate,
             IAppCommands commands, IApplicationEvents events, IObjectFinder objectFinder,
             string description)
+            : this(shapes, mutate, commands, events, objectFinder, description,
+                  $"BulkShapeProps:{string.Join(",", shapes.Select(RuntimeHelpers.GetHashCode).OrderBy(h => h))}",
+                  [], [])
+        {
+        }
+
+        private BulkShapePropsCommand(
+            IReadOnlyList<object> shapes, Action mutate,
+            IAppCommands commands, IApplicationEvents events, IObjectFinder objectFinder,
+            string description, string? coalesceGroup,
+            ShapeFieldSnapshot[] before, ShapeFieldSnapshot[] after)
         {
             _shapes = shapes;
             _mutate = mutate;
@@ -61,6 +80,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _events = events;
             _objectFinder = objectFinder;
             Description = description;
+            CoalesceGroup = coalesceGroup;
+            _before = before;
+            _after = after;
         }
 
         public bool Do()
@@ -77,6 +99,18 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
 
         public void Undo() => Apply(_before);
         public void Redo() => Apply(_after);
+
+        /// <summary>
+        /// Combines <paramref name="previous"/>'s original "before" snapshot with this command's
+        /// already-captured "after" snapshot (see <see cref="IUndoableCommand.CoalesceWith"/>).
+        /// </summary>
+        public IUndoableCommand CoalesceWith(IUndoableCommand previous)
+        {
+            var p = (BulkShapePropsCommand)previous;
+            return new BulkShapePropsCommand(
+                _shapes, _mutate, _commands, _events, _objectFinder,
+                Description, CoalesceGroup, p._before, _after);
+        }
 
         private void Apply(ShapeFieldSnapshot[] snapshots)
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -311,6 +311,15 @@ namespace AnimationEditor.Core.CommandsAndState
         void SetCirclePropsBulk(IReadOnlyList<CircleSave> circles, string? name, float? x, float? y, float? radius);
 
         /// <summary>
+        /// Ends the current edit session for the coalescing NumericUpDown fields (rect/circle
+        /// props, frame length/offset/pixel-region/color/alpha — see <see cref="SetRectProps"/> and
+        /// siblings) so the next edit records a fresh undo entry instead of merging into the last
+        /// one. Call on focus loss of the editing control (see
+        /// <see cref="Commands.IUndoManager.SealCoalescing"/> for why this boundary matters).
+        /// </summary>
+        void SealPendingEdits();
+
+        /// <summary>
         /// True when two or more of <paramref name="shapes"/> (AARectSave and/or CircleSave) are
         /// owned by the same frame — batch-applying one literal name to all of them would collide,
         /// since shape names only need to be unique within a frame, not across frames.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoManager.cs
@@ -42,6 +42,15 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         void Execute(IUndoableCommand cmd);
 
         /// <summary>
+        /// Ends the current coalescing window (see <see cref="IUndoableCommand.CoalesceGroup"/>) so
+        /// the next <see cref="Execute"/> call starts a new undo entry instead of merging into the
+        /// last one, even if its <see cref="IUndoableCommand.CoalesceGroup"/> matches. Call this
+        /// when an edit session ends — e.g. a NumericUpDown loses focus — so a later, unrelated
+        /// edit to the same field doesn't silently fold into the earlier undo entry.
+        /// </summary>
+        void SealCoalescing();
+
+        /// <summary>
         /// Records an <em>already-applied</em> command in the undo history and clears the
         /// redo stack. Reserved for interactive-gesture commands (shape drag/resize, region
         /// drag) whose mutation is applied incrementally during the gesture and committed on

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoableCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IUndoableCommand.cs
@@ -31,5 +31,27 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         /// that replay a captured "after" snapshot (reorder, bulk edit) override this.
         /// </summary>
         void Redo() => Do();
+
+        /// <summary>
+        /// Identifies the logical edit target this command mutates (e.g. one rectangle's props,
+        /// one frame's offset). When two commands run back-to-back through
+        /// <see cref="IUndoManager.Execute"/> share the same non-null group and coalescing hasn't
+        /// been sealed since (see <see cref="IUndoManager.SealCoalescing"/>), they merge into a
+        /// single undo entry instead of stacking one entry per call — e.g. every keystroke or
+        /// mouse-wheel tick while editing one NumericUpDown collapses to one entry, sealed on
+        /// focus loss. Null (the default) never coalesces.
+        /// </summary>
+        string? CoalesceGroup => null;
+
+        /// <summary>
+        /// Called on the command that was just executed (<c>this</c>, already applied via
+        /// <see cref="Do"/>) when it shares <see cref="CoalesceGroup"/> with the command still on
+        /// top of the undo stack (<paramref name="previous"/>). Returns the single command that
+        /// should replace both on the stack — typically <paramref name="previous"/>'s original
+        /// "before" state combined with this command's already-applied "after" state, so undoing
+        /// the merged entry restores the value from before the whole coalesced edit, not just the
+        /// last increment. Only called when <see cref="CoalesceGroup"/> is non-null.
+        /// </summary>
+        IUndoableCommand CoalesceWith(IUndoableCommand previous) => this;
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/SetShapePropsCommand.cs
@@ -1,4 +1,5 @@
 using FlatRedBall2.Animation.Content;
+using System.Runtime.CompilerServices;
 
 namespace AnimationEditor.Core.CommandsAndState.Commands;
 
@@ -13,6 +14,14 @@ internal sealed class SetShapePropsCommand : IUndoableCommand
     private readonly IApplicationEvents _events;
 
     public string Description { get; }
+
+    /// <summary>
+    /// Keyed on the edited shape's own identity, so consecutive edits to the same rect/circle
+    /// (e.g. one call per keystroke while typing in the X field) coalesce into a single undo entry
+    /// -- see <see cref="IUndoableCommand.CoalesceGroup"/>. Edits to a different shape never share
+    /// a key, since <see cref="RuntimeHelpers.GetHashCode"/> is per-instance.
+    /// </summary>
+    public string? CoalesceGroup { get; }
 
     public static SetShapePropsCommand ForRect(
         AnimationFrameSave? frame, AARectSave rect,
@@ -48,6 +57,7 @@ internal sealed class SetShapePropsCommand : IUndoableCommand
         _newX = newX; _newY = newY; _newP1 = newP1; _newP2 = newP2;
         _commands = commands; _events = events;
         Description = description;
+        CoalesceGroup = $"ShapeProps:{RuntimeHelpers.GetHashCode(shape)}";
     }
 
     public bool Do()
@@ -60,6 +70,21 @@ internal sealed class SetShapePropsCommand : IUndoableCommand
 
     public void Undo() => Apply(_oldName, _oldX, _oldY, _oldP1, _oldP2);
     public void Redo() => Apply(_newName, _newX, _newY, _newP1, _newP2);
+
+    /// <summary>
+    /// Combines <paramref name="previous"/>'s original "before" state with this command's
+    /// already-applied "after" state, so undoing the merged entry restores the value from before
+    /// the whole coalesced edit (see <see cref="IUndoableCommand.CoalesceWith"/>).
+    /// </summary>
+    public IUndoableCommand CoalesceWith(IUndoableCommand previous)
+    {
+        var p = (SetShapePropsCommand)previous;
+        return new SetShapePropsCommand(
+            _frame, _shape, p._oldName, _newName,
+            p._oldX, p._oldY, p._oldP1, p._oldP2,
+            _newX, _newY, _newP1, _newP2,
+            _commands, _events, Description);
+    }
 
     private void Apply(string name, float x, float y, float p1, float p2)
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/UndoManager.cs
@@ -13,6 +13,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         private readonly Stack<IUndoableCommand> _undoStack = new();
         private readonly Stack<IUndoableCommand> _redoStack = new();
         private SaveState _saveState = SaveState.Unsaved;
+        private string? _openCoalesceGroup;
 
         public bool CanUndo => _undoStack.Count > 0;
         public bool CanRedo => _redoStack.Count > 0;
@@ -30,8 +31,15 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
         /// <inheritdoc cref="IUndoManager.Execute"/>
         public void Execute(IUndoableCommand cmd)
         {
-            if (cmd.Do())
-                Record(cmd);
+            if (!cmd.Do()) return;
+
+            if (cmd.CoalesceGroup is { } group && group == _openCoalesceGroup &&
+                _undoStack.Count > 0 && _undoStack.Peek().CoalesceGroup == group)
+            {
+                cmd = cmd.CoalesceWith(_undoStack.Pop());
+            }
+            _openCoalesceGroup = cmd.CoalesceGroup;
+            Record(cmd);
         }
 
         /// <inheritdoc cref="IUndoManager.Record"/>
@@ -42,6 +50,9 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             StackChanged?.Invoke();
         }
 
+        /// <inheritdoc cref="IUndoManager.SealCoalescing"/>
+        public void SealCoalescing() => _openCoalesceGroup = null;
+
         /// <summary>No-op when <see cref="CanUndo"/> is false.</summary>
         public void Undo()
         {
@@ -49,6 +60,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             var cmd = _undoStack.Pop();
             cmd.Undo();
             _redoStack.Push(cmd);
+            _openCoalesceGroup = null;
             StackChanged?.Invoke();
         }
 
@@ -59,6 +71,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             var cmd = _redoStack.Pop();
             cmd.Redo();
             _undoStack.Push(cmd);
+            _openCoalesceGroup = null;
             StackChanged?.Invoke();
         }
 
@@ -67,6 +80,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             _undoStack.Clear();
             _redoStack.Clear();
             _saveState = SaveState.Unsaved;
+            _openCoalesceGroup = null;
             StackChanged?.Invoke();
         }
 
@@ -85,6 +99,7 @@ namespace AnimationEditor.Core.CommandsAndState.Commands
             // RedoStack is stored LIFO (next-to-redo first); push in reverse to restore that order.
             for (int i = snapshot.RedoStack.Count - 1; i >= 0; i--)
                 _redoStack.Push(snapshot.RedoStack[i]);
+            _openCoalesceGroup = null;
             StackChanged?.Invoke();
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
@@ -18,8 +18,7 @@ namespace AnimationEditor.Views.Controls;
 /// clicked; see docs/BROWSER_TREE_INSPECTOR_DECISION.md.
 /// <para>
 /// Phase 2 (#610) made the rectangle/circle panels editable, routed through
-/// <see cref="IAppCommands.SetRectProps"/>/<see cref="IAppCommands.SetCircleProps"/> -- the same
-/// commit-boundary pattern (Enter + LostFocus) MainWindow's own PropRect*/PropCircle* fields use.
+/// <see cref="IAppCommands.SetRectProps"/>/<see cref="IAppCommands.SetCircleProps"/>.
 /// Frame fields (pixel region, length, relative offset, flip, color channels/mode) are editable
 /// when <see cref="EnableEditing"/> is given a texture-size resolver; texture name stays
 /// read-only (texture picker deferred).
@@ -50,8 +49,12 @@ public partial class InspectorControl : UserControl
     /// <summary>
     /// Enables editing Rectangle/Circle panels and (when <paramref name="resolveTextureSize"/> is
     /// supplied) Frame pixel/timing/transform fields. Numeric fields commit on <c>ValueChanged</c>
-    /// (matching MainWindow) rather than <c>LostFocus</c> -- a NumericUpDown's spin buttons never
-    /// cause the control itself to lose focus.
+    /// (not <c>LostFocus</c> -- a NumericUpDown's spin buttons never cause the control itself to
+    /// lose focus), so the visual updates live as the user types or scrolls the wheel. Each
+    /// underlying <c>IAppCommands.Set*</c> call coalesces with the previous one for the same field
+    /// group (see <see cref="IUndoableCommand.CoalesceGroup"/>), so a whole typed value collapses
+    /// into a single undo entry; <c>LostFocus</c> calls <see cref="IAppCommands.SealPendingEdits"/>
+    /// to close that entry once editing moves elsewhere (#897).
     /// </summary>
     public void EnableEditing(
         IAppCommands appCommands,
@@ -66,12 +69,14 @@ public partial class InspectorControl : UserControl
         RectScaleXInput.ValueChanged += (_, _) => CommitRectProps();
         RectScaleYInput.ValueChanged += (_, _) => CommitRectProps();
         RectNameBox.KeyDown += CommitOnEnter(CommitRectProps);
+        SealOnLostFocus(RectXInput, RectYInput, RectScaleXInput, RectScaleYInput);
 
         CircleNameBox.LostFocus += (_, _) => CommitCircleProps();
         CircleXInput.ValueChanged += (_, _) => CommitCircleProps();
         CircleYInput.ValueChanged += (_, _) => CommitCircleProps();
         CircleRadiusInput.ValueChanged += (_, _) => CommitCircleProps();
         CircleNameBox.KeyDown += CommitOnEnter(CommitCircleProps);
+        SealOnLostFocus(CircleXInput, CircleYInput, CircleRadiusInput);
 
         FramePixelXInput.ValueChanged += (_, _) => CommitFramePixelRegion();
         FramePixelYInput.ValueChanged += (_, _) => CommitFramePixelRegion();
@@ -83,12 +88,26 @@ public partial class InspectorControl : UserControl
         FrameFlipHToggle.IsCheckedChanged += (_, _) => CommitFrameFlip();
         FrameFlipVToggle.IsCheckedChanged += (_, _) => CommitFrameFlip();
         FrameFlipDToggle.IsCheckedChanged += (_, _) => CommitFrameFlip();
+        SealOnLostFocus(FramePixelXInput, FramePixelYInput, FramePixelWInput, FramePixelHInput,
+            FrameLengthInput, FrameRelXInput, FrameRelYInput);
 
         FrameRedInput.ValueChanged += (_, _) => CommitFrameColor();
         FrameGreenInput.ValueChanged += (_, _) => CommitFrameColor();
         FrameBlueInput.ValueChanged += (_, _) => CommitFrameColor();
         FrameAlphaInput.ValueChanged += (_, _) => CommitFrameAlpha();
         FrameColorModeCombo.SelectionChanged += (_, _) => CommitFrameColorOperation();
+        SealOnLostFocus(FrameRedInput, FrameGreenInput, FrameBlueInput, FrameAlphaInput);
+    }
+
+    /// <summary>
+    /// Ends the undo-coalescing window (see <see cref="IAppCommands.SealPendingEdits"/>) when any
+    /// of <paramref name="inputs"/> loses focus, so the next edit to that field starts a fresh
+    /// undo entry instead of merging into the one just closed (#897).
+    /// </summary>
+    private void SealOnLostFocus(params NumericUpDown[] inputs)
+    {
+        foreach (var input in inputs)
+            input.LostFocus += (_, _) => _appCommands?.SealPendingEdits();
     }
 
     private static EventHandler<KeyEventArgs> CommitOnEnter(Action commit) => (_, e) =>
@@ -227,10 +246,13 @@ public partial class InspectorControl : UserControl
     /// this, setting RectXInput.Value below would fire ValueChanged -> CommitRectProps immediately,
     /// which reads the *other* Rect fields' still-stale values (the previous selection's) since
     /// they haven't been set yet in this same pass -- corrupting the newly selected shape with a
-    /// mix of its own and the old selection's values.
+    /// mix of its own and the old selection's values. Also seals any still-open coalescing window
+    /// (#897) so a field edited just before the selection changed doesn't later merge with an edit
+    /// to the newly selected item's same-named field.
     /// </summary>
     private void Refresh()
     {
+        _appCommands?.SealPendingEdits();
         _suppressCommit = true;
         try
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropertyPanelCoalescingTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropertyPanelCoalescingTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.Core;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression coverage for #897's mouse-wheel repro: scrolling a Prop* NumericUpDown fires one
+/// <c>ValueChanged</c> per notch with no <c>LostFocus</c> in between, but every commit also raises
+/// <c>AnimationChainsChanged</c>, which <c>HandleAnimationChainsChanged</c> answers with
+/// <c>Dispatcher.UIThread.InvokeAsync(RefreshPropertyPanel)</c> (see
+/// <see cref="UndoBypassRegressionTests.Undo_AfterFlip_ResyncsFlipToggleButton"/> for that same
+/// wiring). In real use that queued job runs on the UI thread well before the next wheel notch
+/// arrives, so a naive "seal on every RefreshPropertyPanel call" breaks coalescing on *every*
+/// tick — each edit seals the one right after it. These tests pump the dispatcher queue
+/// (<see cref="Dispatcher.UIThread.RunJobs"/>) between edits specifically to surface that.
+/// </summary>
+public class PropertyPanelCoalescingTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static AnimationChainSave MakeChain(TestServices ctx, string name, int frameCount)
+    {
+        var chain = new AnimationChainSave { Name = name };
+        for (int i = 0; i < frameCount; i++)
+            chain.Frames.Add(new AnimationFrameSave { TextureName = $"f{i}.png", ShapesSave = new ShapesSave() });
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        return chain;
+    }
+
+    [AvaloniaFact]
+    public void PropRelX_ScrollWheelSimulatedAsValueChangedTicksWithDispatcherPumpedBetween_CoalescesIntoSingleUndoEntry()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = MakeChain(ctx, "Walk", 1);
+            var frame = chain.Frames[0];
+            frame.RelativeX = 0f;
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propRelX = window.FindControl<NumericUpDown>("PropRelX")!;
+
+            // Each tick fires ValueChanged -> ApplyFrameRelative -> AppCommands.SetFrameRelative,
+            // which raises AnimationChainsChanged -> queues RefreshPropertyPanel. Pumping the
+            // dispatcher after each tick lets that queued refresh actually run before the next
+            // tick, exactly as it would in a live wheel-scroll session.
+            for (decimal v = 1m; v <= 5m; v++)
+            {
+                propRelX.Value = v;
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            Assert.Equal(5f, frame.RelativeX);
+            Assert.Single(ctx.UndoManager.UndoHistory);
+
+            ctx.UndoManager.Undo();
+            Assert.Equal(0f, frame.RelativeX);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsShapePropsBulkTests.cs
@@ -63,6 +63,24 @@ public class AppCommandsShapePropsBulkTests
     }
 
     [Fact]
+    public void SetRectPropsBulk_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        // MainWindow's multi-select rect panel commits on every ValueChanged, same as the
+        // single-select path (#897) — typing "32" for X must not create two undo entries.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var rect = new AARectSave { Name = "A", X = 0f, ScaleX = 8f, ScaleY = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(rect);
+
+        ctx.AppCommands.SetRectPropsBulk(new List<AARectSave> { rect }, null, 3f, null, null, null);
+        ctx.AppCommands.SetRectPropsBulk(new List<AARectSave> { rect }, null, 32f, null, null, null);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0f, rect.X);
+    }
+
+    [Fact]
     public void SetCirclePropsBulk_MultipleCircles_AppliesRadiusToAll()
     {
         var ctx = TestHelpers.SetupFreshAcls();
@@ -77,6 +95,22 @@ public class AppCommandsShapePropsBulkTests
 
         Assert.Equal(15f, circleA.Radius);
         Assert.Equal(15f, circleB.Radius);
+    }
+
+    [Fact]
+    public void SetCirclePropsBulk_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Jump", 1);
+        var circle = new CircleSave { Name = "A", X = 0f, Radius = 8f };
+        chain.Frames[0].ShapesSave!.Shapes.Add(circle);
+
+        ctx.AppCommands.SetCirclePropsBulk(new List<CircleSave> { circle }, null, 3f, null, null);
+        ctx.AppCommands.SetCirclePropsBulk(new List<CircleSave> { circle }, null, 32f, null, null);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0f, circle.X);
     }
 
     [Fact]

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/InspectorPropertyUndoTests.cs
@@ -56,6 +56,25 @@ public class InspectorPropertyUndoTests
         Assert.Single(ctx.UndoManager.UndoHistory);
     }
 
+    [Fact]
+    public void SetFrameAlpha_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        // Reproduces #897: typing "128" into the Alpha NumericUpDown fires one call per keystroke
+        // ("1", "12", "128"). That must collapse to one undo entry that restores the pre-edit value.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Fade");
+        var frame = TestHelpers.MakeFrame(); // starts with null alpha
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameAlpha(new[] { frame }, 1);
+        ctx.AppCommands.SetFrameAlpha(new[] { frame }, 12);
+        ctx.AppCommands.SetFrameAlpha(new[] { frame }, 128);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Null(frame.Alpha);
+    }
+
     // ── SetFrameColor ─────────────────────────────────────────────────────────
 
     [Fact]
@@ -107,6 +126,22 @@ public class InspectorPropertyUndoTests
         Assert.All(frames, f => Assert.Equal(200, f.Green));
         Assert.All(frames, f => Assert.Equal(128, f.Blue));
         Assert.Single(ctx.UndoManager.UndoHistory);
+    }
+
+    [Fact]
+    public void SetFrameColor_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Flash");
+        var frame = TestHelpers.MakeFrame();
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameColor(new[] { frame }, 2, null, null);
+        ctx.AppCommands.SetFrameColor(new[] { frame }, 255, null, null);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Null(frame.Red);
     }
 
     // ── SetFrameColorOperation ────────────────────────────────────────────────
@@ -218,6 +253,23 @@ public class InspectorPropertyUndoTests
         Assert.All(frames, f => Assert.Equal(0.1f, f.FrameLength));
     }
 
+    [Fact]
+    public void SetFrameLength_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.FrameLength = 0.1f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameLength(new[] { frame }, 0.3f);
+        ctx.AppCommands.SetFrameLength(new[] { frame }, 0.5f);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0.1f, frame.FrameLength);
+    }
+
     // ── SetFrameRelative ──────────────────────────────────────────────────────
 
     [Fact]
@@ -236,6 +288,45 @@ public class InspectorPropertyUndoTests
 
         Assert.Equal(10f, frame.RelativeX);
         Assert.Equal(20f, frame.RelativeY);
+    }
+
+    [Fact]
+    public void SetFrameRelative_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        // Reproduces #897's exact repro: typing "32" for a frame's X offset fires SetFrameRelative
+        // once per keystroke ("3", then "32"). That must be one undo entry, not two, and Undo must
+        // restore the value from before the whole typed edit (0f), not just the "3" midpoint.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.RelativeX = 0f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameRelative(new[] { frame }, newRelX: 3f, newRelY: null);
+        ctx.AppCommands.SetFrameRelative(new[] { frame }, newRelX: 32f, newRelY: null);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        Assert.Equal(32f, frame.RelativeX);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0f, frame.RelativeX);
+    }
+
+    [Fact]
+    public void SetFrameRelative_SealPendingEditsBetweenCalls_CreatesSeparateUndoEntries()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.RelativeX = 0f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFrameRelative(new[] { frame }, newRelX: 3f, newRelY: null);
+        ctx.AppCommands.SealPendingEdits(); // simulates the NumericUpDown losing focus
+        ctx.AppCommands.SetFrameRelative(new[] { frame }, newRelX: 32f, newRelY: null);
+
+        Assert.Equal(2, ctx.UndoManager.UndoHistory.Count);
     }
 
     [Fact]
@@ -318,6 +409,24 @@ public class InspectorPropertyUndoTests
     }
 
     [Fact]
+    public void SetFramePixelRegion_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        frame.LeftCoordinate = 0f; frame.RightCoordinate = 1f;
+        frame.TopCoordinate = 0f; frame.BottomCoordinate = 1f;
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetFramePixelRegion(new[] { frame }, pixelX: 3, pixelY: null, pixelW: null, pixelH: null, bmpW: 64, bmpH: 64);
+        ctx.AppCommands.SetFramePixelRegion(new[] { frame }, pixelX: 32, pixelY: null, pixelW: null, pixelH: null, bmpW: 64, bmpH: 64);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0f, frame.LeftCoordinate, precision: 5);
+    }
+
+    [Fact]
     public void SetFramePixelRegion_OnlyXSpecified_LeavesEachFrameOwnYWidthHeightUntouched()
     {
         // Reproduces issue #571 follow-up: two frames at different positions/sizes on the sheet
@@ -380,6 +489,24 @@ public class InspectorPropertyUndoTests
         Assert.False(ctx.UndoManager.CanUndo);
     }
 
+    [Fact]
+    public void SetRectProps_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        var rect = new AARectSave { Name = "Hitbox", X = 0f, Y = 2f, ScaleX = 3f, ScaleY = 4f };
+        frame.ShapesSave!.Shapes.Add(rect);
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetRectProps(frame, rect, "Hitbox", 3f, 2f, 3f, 4f);
+        ctx.AppCommands.SetRectProps(frame, rect, "Hitbox", 32f, 2f, 3f, 4f);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0f, rect.X);
+    }
+
     // ── SetCircleProps ────────────────────────────────────────────────────────
 
     [Fact]
@@ -401,5 +528,23 @@ public class InspectorPropertyUndoTests
         Assert.Equal(5f, circ.X);
         Assert.Equal(6f, circ.Y);
         Assert.Equal(7f, circ.Radius);
+    }
+
+    [Fact]
+    public void SetCircleProps_ConsecutiveEdits_CoalesceIntoSingleUndoEntryRestoringOriginalValue()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        var frame = TestHelpers.MakeFrame();
+        var circ = new CircleSave { Name = "Hurtbox", X = 0f, Y = 6f, Radius = 7f };
+        frame.ShapesSave!.Shapes.Add(circ);
+        chain.Frames.Add(frame);
+
+        ctx.AppCommands.SetCircleProps(frame, circ, "Hurtbox", 3f, 6f, 7f);
+        ctx.AppCommands.SetCircleProps(frame, circ, "Hurtbox", 32f, 6f, 7f);
+
+        Assert.Single(ctx.UndoManager.UndoHistory);
+        ctx.UndoManager.Undo();
+        Assert.Equal(0f, circ.X);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -118,6 +118,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetCircleProps)]               = Category.MutatingUndoable,
         [nameof(IAppCommands.SetRectPropsBulk)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCirclePropsBulk)]           = Category.MutatingUndoable,
+        [nameof(IAppCommands.SealPendingEdits)]             = Category.NonMutating, // resets undo-coalescing state only
         [nameof(IAppCommands.HasSameFrameNameCollision)]    = Category.NonMutating,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoManagerExecuteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoManagerExecuteTests.cs
@@ -48,17 +48,73 @@ public class UndoManagerExecuteTests
         Assert.False(_undo.CanUndo);
     }
 
+    // ── Coalescing (#897 — one undo entry per edit session, not per keystroke) ──
+
+    [Fact]
+    public void Execute_CoalesceGroupMatches_MergesIntoSingleEntry()
+    {
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+
+        Assert.Single(_undo.UndoHistory);
+        Assert.Equal(1, ((SpyCommand)_undo.UndoHistory[0]).MergeCount);
+    }
+
+    [Fact]
+    public void Execute_CoalesceGroupDiffers_DoesNotMerge()
+    {
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "B"));
+
+        Assert.Equal(2, _undo.UndoHistory.Count);
+    }
+
+    [Fact]
+    public void Execute_CoalesceGroupMatchesAfterSealCoalescing_DoesNotMerge()
+    {
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+        _undo.SealCoalescing();
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+
+        Assert.Equal(2, _undo.UndoHistory.Count);
+    }
+
+    [Fact]
+    public void Execute_CoalesceGroupMatchesAfterUndo_DoesNotMerge()
+    {
+        // Undoing seals the coalescing window -- a fresh edit to the same field afterward must not
+        // silently fold into an entry the user just explicitly undid past.
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+        _undo.Undo();
+        _undo.Execute(new SpyCommand(doResult: true, coalesceGroup: "A"));
+
+        Assert.Single(_undo.UndoHistory);
+    }
+
     private sealed class SpyCommand : IUndoableCommand
     {
         private readonly bool _doResult;
 
         public string Description => "Spy";
-        public SpyCommand(bool doResult) => _doResult = doResult;
+        public string? CoalesceGroup { get; }
+        public int MergeCount { get; private set; }
+
+        public SpyCommand(bool doResult, string? coalesceGroup = null)
+        {
+            _doResult = doResult;
+            CoalesceGroup = coalesceGroup;
+        }
 
         public int DoCalls { get; private set; }
 
         public bool Do() { DoCalls++; return _doResult; }
         public void Undo() { }
         public void Redo() { }
+
+        public IUndoableCommand CoalesceWith(IUndoableCommand previous)
+        {
+            MergeCount = ((SpyCommand)previous).MergeCount + 1;
+            return this;
+        }
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/InspectorControlTests.cs
@@ -6,6 +6,8 @@ using AnimationEditor.Core.IO;
 using AnimationEditor.Views.Controls;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using FlatRedBall2.Animation;
 using FlatRedBall2.Animation.Content;
 using System;
@@ -430,5 +432,65 @@ public class InspectorControlTests
         Assert.Equal(200f, rectB.Y);
         Assert.Equal(30f, rectB.ScaleX);
         Assert.Equal(40f, rectB.ScaleY);
+    }
+
+    // #897: consecutive ValueChanged commits to the same field (one per keystroke/wheel-tick) must
+    // coalesce into a single undo entry, sealed on LostFocus -- exercised through the real wiring
+    // EnableEditing installs, not by calling CommitRectProps/SealPendingEdits directly.
+
+    private static (InspectorControl Control, AARectSave Rect, UndoManager Undo) BuildWithEditableRectAndUndoManager()
+    {
+        var frame = new AnimationFrameSave { TextureName = "a.png", ShapesSave = new ShapesSave() };
+        var rect = new AARectSave { Name = "Hitbox", X = 0f, Y = 0f, ScaleX = 1f, ScaleY = 1f };
+        frame.ShapesSave!.Shapes.Add(rect);
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frame);
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(chain);
+
+        var pm = new FakeProjectManager { AnimationChainListSave = acls };
+        var state = new SelectedState(pm);
+        var events = new ApplicationEvents();
+        var appState = new AppState(events, state);
+        var ioManager = new IoManager(appState);
+        var objectFinder = new ObjectFinder(pm);
+        var undoManager = new UndoManager();
+        var appCommands = new AppCommands(pm, state, events, ioManager, objectFinder, undoManager);
+
+        var control = new InspectorControl();
+        control.InitializeServices(state);
+        control.EnableEditing(appCommands);
+        state.SelectedFrame = frame;
+        state.SelectedRectangle = rect;
+
+        return (control, rect, undoManager);
+    }
+
+    [AvaloniaFact]
+    public void RectXInput_ValueChangedTwice_CoalescesIntoSingleUndoEntry()
+    {
+        var (control, rect, undo) = BuildWithEditableRectAndUndoManager();
+
+        control.RectXInput.Value = 3m;  // simulates typing "3"
+        control.RectXInput.Value = 32m; // simulates typing "32"
+
+        Assert.Equal(32f, rect.X);
+        Assert.Single(undo.UndoHistory);
+
+        undo.Undo();
+
+        Assert.Equal(0f, rect.X); // restores the value from before the whole typed edit
+    }
+
+    [AvaloniaFact]
+    public void RectXInput_LostFocusBetweenEdits_SealsPendingEditIntoSeparateUndoEntries()
+    {
+        var (control, _, undo) = BuildWithEditableRectAndUndoManager();
+
+        control.RectXInput.Value = 3m;
+        control.RectXInput.RaiseEvent(new FocusChangedEventArgs(InputElement.LostFocusEvent));
+        control.RectXInput.Value = 32m;
+
+        Assert.Equal(2, undo.UndoHistory.Count);
     }
 }


### PR DESCRIPTION
## Summary
- Inspector numeric fields (frame X/Y, rect X/Y/scale, circle X/Y/radius, length, pixel region, color/alpha) commit on every `ValueChanged`, so live typing/wheel-scrolling stayed intact — but each commit pushed its own undo entry, e.g. typing "32" for X produced 2 undo steps.
- `IUndoableCommand` gains an optional `CoalesceGroup`/`CoalesceWith`; `UndoManager.Execute` merges a command into the top-of-stack entry when both share a group. `SealCoalescing()` (exposed as `IAppCommands.SealPendingEdits()`) closes the window, called on the editing control's `LostFocus`.
- Wired into `SetShapePropsCommand`, `BulkFrameEditCommand`, and `BulkShapePropsCommand`; hooked up in both `InspectorControl` and `MainWindow`'s numeric fields.
- Fixed a stale XML doc comment in `InspectorControl` that claimed MainWindow already used Enter+LostFocus commits for Rect/Circle props (it didn't).

## Test plan
- [x] New Core.Tests: `UndoManagerExecuteTests` (coalescing mechanism), `InspectorPropertyUndoTests` + `AppCommandsShapePropsBulkTests` (per-method repros of the reported bug) — all written first and confirmed red before implementation.
- [x] New Views.Tests: `InspectorControlTests` exercising the real `ValueChanged`/`LostFocus` wiring (not just calling the command methods directly).
- [x] `dotnet test` on Core.Tests (1831), Views.Tests (108), App.Tests (817) — all green.
- [x] `dotnet build AnimationEditorAvalonia.slnx` — clean.

Closes #897
