### PR TITLE
AnimationEditor: drag sprite in Preview panel to reposition frame offset

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2508,6 +2508,9 @@ public partial class MainWindow : Window
         PreviewCtrl.Playback.PlaybackTicked += OnPlaybackTicked;
         PreviewCtrl.GroupTracksChanged += RefreshGroupTimelineTracks;
         PreviewCtrl.GroupPlaybackTicked += RefreshGroupTimelineScrubbers;
+        // Same "no save, just a live refresh" handler the WireframeControl frame-region drag uses,
+        // so dragging a frame's offset in the Preview panel tracks in the property panel too (#900 follow-up).
+        PreviewCtrl.FrameLiveUpdated += OnFrameLiveUpdated;
 
         // ── Preview scrollbars (#415) ──
         // Persist on scroll-end only (not per tick), matching the pan-drag save semantics.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFrameOffsetCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFrameOffsetCommand.cs
@@ -1,0 +1,49 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Records a drag-move of a single frame's display offset
+    /// (<see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/>)
+    /// so the operation can be undone and redone.
+    /// </summary>
+    public sealed class MoveFrameOffsetCommand : IUndoableCommand
+    {
+        private readonly AnimationFrameSave _frame;
+        private readonly float _oldX, _oldY;
+        private readonly float _newX, _newY;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public MoveFrameOffsetCommand(
+            AnimationFrameSave frame,
+            float oldX, float oldY,
+            float newX, float newY,
+            IAppCommands commands,
+            IApplicationEvents events)
+        {
+            _frame    = frame;
+            _oldX     = oldX;  _oldY  = oldY;
+            _newX     = newX;  _newY  = newY;
+            _commands = commands;
+            _events   = events;
+        }
+
+        public string Description => "Move Frame";
+
+        public bool Do() { Apply(_newX, _newY); return true; }
+        public void Undo() => Apply(_oldX, _oldY);
+
+        private void Apply(float x, float y)
+        {
+            _frame.RelativeX = x;
+            _frame.RelativeY = y;
+
+            _commands.RefreshTreeNode(_frame);
+            _commands.RefreshAnimationFrameDisplay();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -196,6 +196,13 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         set { _showBoundingBox = value; InvalidateVisual(); }
     }
 
+    /// <summary>
+    /// Fires on every pointer-move frame during a frame-offset drag (see <see cref="HitTestFrameSprite"/>) —
+    /// no save, just a live refresh — mirroring <see cref="AnimationEditor.App.Controls.WireframeControl.FrameLiveUpdated"/>
+    /// so the property panel tracks the drag instead of only updating on release.
+    /// </summary>
+    public event Action<AnimationFrameSave>? FrameLiveUpdated;
+
     /// <summary>Fires whenever a guide is added, removed, or bulk-replaced via <see cref="SetGuides"/>.</summary>
     public event Action? GuidesChanged;
 
@@ -1928,6 +1935,7 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             _draggingFrame.RelativeX = SnapToPixel(_frameDragStartX + dx);
             _draggingFrame.RelativeY = SnapToPixel(_frameDragStartY + dy);
             InvalidateVisual();
+            FrameLiveUpdated?.Invoke(_draggingFrame);
             return;
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -150,6 +150,17 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     private float      _shapeDragStartScaleX;  // rect ScaleX or circle Radius at drag start
     private float      _shapeDragStartScaleY;  // rect ScaleY at drag start (0 for circle)
 
+    // -- Frame (sprite position) drag -------------------------------------------
+    // Repositions AnimationFrameSave.RelativeX/Y by dragging the rendered sprite. Only
+    // active when exactly one frame is selected (SelectedFrame set, SelectedFrames.Count
+    // <= 1) and the pointer-down lands on that frame's rendered sprite footprint — checked
+    // last in OnPointerPressed's fallback chain, after guides and shapes, so it never
+    // steals a click meant for shape selection/drag.
+    private AnimationFrameSave? _draggingFrame;
+    private float _frameDragStartX;
+    private float _frameDragStartY;
+    private Point _frameDragAnchor;
+
     // -- Public properties -----------------------------------------------------
 
     public bool ShowOnionSkin
@@ -870,6 +881,26 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
 
         CommitShapeResize();
     }
+
+    /// <summary>
+    /// Test-only: applies a world-space drag delta to the currently selected frame's
+    /// <see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/> and
+    /// commits. Bypasses coordinate conversion, so results are independent of zoom/pan/
+    /// OffsetMultiplier. No-op unless exactly one frame is selected, mirroring the gate
+    /// <see cref="OnPointerPressed"/> applies before starting a live frame drag.
+    /// </summary>
+    internal void SimulateFrameDrag(float worldDx, float worldDy)
+    {
+        var frame = _selectedState!.SelectedFrame;
+        if (frame is null || _selectedState!.SelectedFrames.Count > 1) return;
+
+        _draggingFrame   = frame;
+        _frameDragStartX = frame.RelativeX;
+        _frameDragStartY = frame.RelativeY;
+        frame.RelativeX  = SnapToPixel(frame.RelativeX + worldDx);
+        frame.RelativeY  = SnapToPixel(frame.RelativeY + worldDy);
+        CommitFrameDrag();
+    }
     /// control-space point and runs the resulting smooth-zoom animation to completion
     /// synchronously, so the camera lands on its settled state. Mirrors
     /// <see cref="OnPointerWheelChanged"/>. Use <see cref="SimulateWheelZoomBegin"/> instead to
@@ -1437,6 +1468,30 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     }
 
     /// <summary>
+    /// Finalises an in-progress frame-offset drag: records an undo command (unless the delta is
+    /// negligible), fires <see cref="ApplicationEvents.RaiseAnimationChainsChanged"/>, and saves.
+    /// </summary>
+    private void CommitFrameDrag()
+    {
+        if (_draggingFrame is null) return;
+
+        float newX = _draggingFrame.RelativeX;
+        float newY = _draggingFrame.RelativeY;
+
+        const float eps = 1e-4f;
+        if (MathF.Abs(newX - _frameDragStartX) > eps || MathF.Abs(newY - _frameDragStartY) > eps)
+        {
+            _undoManager!.Record(new MoveFrameOffsetCommand(
+                _draggingFrame, _frameDragStartX, _frameDragStartY, newX, newY,
+                _appCommands!, _events!));
+            _events!.RaiseAnimationChainsChanged();
+            _appCommands!.SaveCurrentAnimationChainList();
+        }
+
+        _draggingFrame = null;
+    }
+
+    /// <summary>
     /// Returns the resize <see cref="HandleKind"/> under the cursor for the currently selected
     /// shape, or <see cref="HandleKind.None"/> if no resize handle is hit.
     /// Handles are positioned outside the bounding box by <c>Hs</c> pixels.
@@ -1643,6 +1698,34 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         return false;
     }
 
+    /// <summary>
+    /// Returns <c>true</c> if (<paramref name="px"/>, <paramref name="py"/>) lands on the rendered
+    /// footprint of the single selected frame's sprite, in screen space. Gates the frame-offset
+    /// drag fallback in <see cref="OnPointerPressed"/>: only active with exactly one frame
+    /// selected and only once the frame's texture is already decoded (mirrors
+    /// <see cref="ComputeContentExtentScreenPx"/>'s own frame-footprint math).
+    /// </summary>
+    private bool HitTestFrameSprite(float px, float py)
+    {
+        var frame = _selectedState!.SelectedFrame;
+        if (frame is null || _selectedState!.SelectedFrames.Count > 1) return false;
+        if (px < RulerSize || py < RulerSize) return false;
+
+        string? texPath = _thumbnailService!.ResolveTexturePath(frame);
+        if (texPath is null ||
+            !_thumbnailService.BitmapCache.TryGetValue(texPath, out var bm) || bm is null)
+            return false;
+
+        var (_, _, sw, sh) = ComputeSourceRect(frame, bm.Width, bm.Height);
+        float om = _appState!.OffsetMultiplier * _zoom;
+        float sx = GetCenterX() + frame.RelativeX * om;
+        float sy = GetCenterY() - frame.RelativeY * om;
+        float halfW = sw * _zoom / 2f;
+        float halfH = sh * _zoom / 2f;
+
+        return px >= sx - halfW && px <= sx + halfW && py >= sy - halfH && py <= sy + halfH;
+    }
+
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
@@ -1779,7 +1862,18 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         }
 
         // No shape hit — try to select a collision shape.
-        TrySelectShapeAt(px, py);
+        if (TrySelectShapeAt(px, py)) return;
+
+        // Nothing above matched — try to drag the single selected frame's sprite.
+        if (HitTestFrameSprite(px, py))
+        {
+            var frame = _selectedState!.SelectedFrame!;
+            _draggingFrame   = frame;
+            _frameDragAnchor = pos;
+            _frameDragStartX = frame.RelativeX;
+            _frameDragStartY = frame.RelativeY;
+            e.Pointer.Capture(this);
+        }
     }
 
     protected override void OnPointerMoved(PointerEventArgs e)
@@ -1815,6 +1909,17 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             float newY = _shapeDragStartY + dy;
             if (_draggingShape is AARectSave r) { r.X = newX; r.Y = newY; }
             else if (_draggingShape is CircleSave c)          { c.X = newX; c.Y = newY; }
+            InvalidateVisual();
+            return;
+        }
+
+        if (_draggingFrame is not null)
+        {
+            float om = _appState!.OffsetMultiplier * _zoom;
+            float dx = (float)(pos.X - _frameDragAnchor.X) / om;
+            float dy = -(float)(pos.Y - _frameDragAnchor.Y) / om;
+            _draggingFrame.RelativeX = SnapToPixel(_frameDragStartX + dx);
+            _draggingFrame.RelativeY = SnapToPixel(_frameDragStartY + dy);
             InvalidateVisual();
             return;
         }
@@ -1856,6 +1961,13 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         if (_draggingShape is not null)
         {
             CommitShapeDrag();
+            e.Pointer.Capture(null);
+            return;
+        }
+
+        if (_draggingFrame is not null)
+        {
+            CommitFrameDrag();
             e.Pointer.Capture(null);
             return;
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -1246,6 +1246,11 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
                 : StandardCursorType.SizeAll);
             return;
         }
+        if (_draggingFrame is not null)
+        {
+            Cursor = new Cursor(StandardCursorType.SizeAll);
+            return;
+        }
         var handle = HitTestShapeHandle((float)pos.X, (float)pos.Y);
         if (handle != HandleKind.None)
         {
@@ -1256,6 +1261,8 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             ? (_draggingHGuide ? StandardCursorType.SizeNorthSouth : StandardCursorType.SizeWestEast)
             : GetGuideCursorAt((float)pos.X, (float)pos.Y);
         if (cursorType is null && HitTestShape((float)pos.X, (float)pos.Y) is not null)
+            cursorType = StandardCursorType.SizeAll;
+        if (cursorType is null && HitTestFrameSprite((float)pos.X, (float)pos.Y))
             cursorType = StandardCursorType.SizeAll;
         Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewFrameDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewFrameDragTests.cs
@@ -1,0 +1,181 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for drag-to-reposition the previewed sprite (writes
+/// <see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/>) in the
+/// PreviewControl. Mirrors <see cref="PreviewShapeDragTests"/>: most cases use
+/// <see cref="PreviewControl.SimulateFrameDrag"/>, which applies a world-space delta and commits
+/// exactly as the live pointer path does. The priority test drives real pointer input through a
+/// full window, since it verifies OnPointerPressed's branch order, not just the drag math.
+/// </summary>
+public class PreviewFrameDragTests
+{
+    private static AnimationFrameSave MakeFrame(float relativeX = 0f, float relativeY = 0f)
+    {
+        return new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            RelativeX   = relativeX,
+            RelativeY   = relativeY,
+            ShapesSave  = new ShapesSave()
+        };
+    }
+
+    // ── Single-frame drag ─────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_SingleFrameSelected_UpdatesAndSnapsRelativeXY()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var frame = MakeFrame();
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(10.6f, -4.2f);
+
+        Assert.Equal(11f, frame.RelativeX, precision: 3);
+        Assert.Equal(-4f, frame.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_AfterRelease_UndoRestoresPosition()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var frame = MakeFrame(relativeX: 2f, relativeY: 3f);
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(5f, 5f);
+
+        Assert.Equal(7f, frame.RelativeX, precision: 3);
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(2f, frame.RelativeX, precision: 3);
+        Assert.Equal(3f, frame.RelativeY, precision: 3);
+    }
+
+    // ── Multi-select gating ────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_MultipleFramesSelected_IsNoOp()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frame  = MakeFrame();
+        var other  = MakeFrame();
+        ctx.SelectedState.SelectedFrame = frame;
+        ctx.SelectedState.SelectedNodes = new List<object> { frame, other };
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(10f, 10f);
+
+        Assert.Equal(0f, frame.RelativeX, precision: 3);
+        Assert.Equal(0f, frame.RelativeY, precision: 3);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── No-op when no frame ───────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_NoFrameSelected_IsNoOp()
+    {
+        var ctx  = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(10f, 10f); // must not throw
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Priority: an existing shape must still win over frame-drag ─────────────
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, int size = 64, string name = "sprite.png")
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(SKColors.CornflowerBlue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void RealDrag_OnExistingShape_MovesShapeNotFrame()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir);
+            var circle  = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+            var frame   = MakeFrame();
+            frame.TextureName = texPath;
+            frame.ShapesSave!.Shapes.Add(circle);
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain  = chain;
+            ctx.SelectedState.SelectedFrame  = frame;
+            ctx.SelectedState.SelectedCircle = circle;
+            // Pre-warm the bitmap cache the way a real render pass would, so the frame-drag
+            // hit-test (which requires a cached bitmap) is actually eligible to fire.
+            ctx.ThumbnailService.GetBitmap(texPath);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+            float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+            var localPoint  = new Point(centerX, centerY); // circle sits at world (0,0) == canvas center
+            var windowPoint = preview.TranslatePoint(localPoint, window)!.Value;
+
+            window.MouseDown(windowPoint, MouseButton.Left);
+            var movedPoint = windowPoint + new Point(5, 5);
+            window.MouseMove(movedPoint);
+            window.MouseUp(movedPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEqual(0f, circle.X);
+            Assert.Equal(0f, frame.RelativeX, precision: 3);
+            Assert.Equal(0f, frame.RelativeY, precision: 3);
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewFrameDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewFrameDragTests.cs
@@ -178,4 +178,60 @@ public class PreviewFrameDragTests
         }
         finally { Directory.Delete(dir, true); }
     }
+
+    // ── Live update while dragging (not just on release) ───────────────────────
+
+    [AvaloniaFact]
+    public void RealDrag_OnFrameSprite_FiresFrameLiveUpdatedBeforeRelease()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir);
+            var frame   = MakeFrame();
+            frame.TextureName = texPath;
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+            // Pre-warm the bitmap cache the way a real render pass would, so the frame-drag
+            // hit-test (which requires a cached bitmap) is actually eligible to fire.
+            ctx.ThumbnailService.GetBitmap(texPath);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+            float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+            var localPoint  = new Point(centerX, centerY); // frame sits at world (0,0) == canvas center
+            var windowPoint = preview.TranslatePoint(localPoint, window)!.Value;
+
+            AnimationFrameSave? liveUpdatedFrame = null;
+            preview.FrameLiveUpdated += f => liveUpdatedFrame = f;
+
+            window.MouseDown(windowPoint, MouseButton.Left);
+            var movedPoint = windowPoint + new Point(5, 5);
+            window.MouseMove(movedPoint);
+            Dispatcher.UIThread.RunJobs();
+
+            // Still mid-drag (no mouse-up yet) — the live event, and the property-panel field it
+            // drives, must already reflect the move; not just after release (#900 follow-up).
+            Assert.Same(frame, liveUpdatedFrame);
+            Assert.NotEqual(0f, frame.RelativeX);
+
+            var propRelX = window.FindControl<NumericUpDown>("PropRelX")!;
+            Assert.Equal((decimal)frame.RelativeX, propRelX.Value);
+
+            window.MouseUp(movedPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetCommandTests.cs
@@ -1,0 +1,59 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Do/Undo/Description for the frame-offset drag command (issue: drag sprite in Preview panel).
+/// </summary>
+public class MoveFrameOffsetCommandTests
+{
+    [Fact]
+    public void Description_ReturnsMoveFrame()
+    {
+        var expected = "Move Frame";
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var cmd = new MoveFrameOffsetCommand(
+            chain.Frames[0], oldX: 0f, oldY: 0f, newX: 5f, newY: 3f,
+            ctx.AppCommands, ctx.ApplicationEvents);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void Do_AppliesNewOffset()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        frame.RelativeX = 1f;
+        frame.RelativeY = 2f;
+        var cmd = new MoveFrameOffsetCommand(
+            frame, oldX: 1f, oldY: 2f, newX: 7f, newY: -4f,
+            ctx.AppCommands, ctx.ApplicationEvents);
+
+        cmd.Do();
+
+        Assert.Equal(7f, frame.RelativeX, precision: 3);
+        Assert.Equal(-4f, frame.RelativeY, precision: 3);
+    }
+
+    [Fact]
+    public void Undo_RestoresOldOffset()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var frame = chain.Frames[0];
+        frame.RelativeX = 7f;
+        frame.RelativeY = -4f;
+        var cmd = new MoveFrameOffsetCommand(
+            frame, oldX: 1f, oldY: 2f, newX: 7f, newY: -4f,
+            ctx.AppCommands, ctx.ApplicationEvents);
+
+        cmd.Undo();
+
+        Assert.Equal(1f, frame.RelativeX, precision: 3);
+        Assert.Equal(2f, frame.RelativeY, precision: 3);
+    }
+}


### PR DESCRIPTION
## Summary
- Drag the previewed sprite in the bottom Preview panel to set `AnimationFrameSave.RelativeX/RelativeY`, snapped to the pixel live during drag.
- Gated to exactly one selected frame (multi-frame selection is a no-op); only engages when the click lands on the sprite, so shape selection/drag keeps priority.
- New `MoveFrameOffsetCommand` (undoable) mirrors the existing `MoveShapeCommand` pattern.

## Test plan
- [x] `MoveFrameOffsetCommandTests` (Core) — Do/Undo/Description
- [x] `PreviewFrameDragTests` (App) — single-frame drag+snap+undo, multi-select gating no-op, no-selection no-op, real-pointer regression proving shape-drag still wins priority over frame-drag
- [x] Full solution build + `AnimationEditor.Core.Tests`/`AnimationEditor.App.Tests` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)