### PR TITLE
AnimationEditor: open a tab when Add Animation runs with zero tabs

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -127,7 +127,6 @@ public partial class MainWindow : Window
     private List<object>? _chainDragSelectionSnapshot;
     private AnimationChainSave? _pendingSingleSelectChain;
     private bool _chainDragInProgress;
-    private int _untitledCounter;
     private bool _suppressPropRefresh;
     private bool _suppressTextureComboChanged;
 
@@ -227,7 +226,7 @@ public partial class MainWindow : Window
         // Desktop renders the tree with its own _treeRoots collection, so the controller
         // reads expand state from there (browser reads its AnimationTreeControl instead).
         _tabController = new TabController(_undoManager, _appCommands,
-            () => TreeBuilder.CaptureExpandState(_treeRoots));
+            () => TreeBuilder.CaptureExpandState(_treeRoots), _tabManager);
 
         InitializeComponent();
 
@@ -817,7 +816,7 @@ public partial class MainWindow : Window
     {
         // Exclude unsaved (sentinel) Untitled tabs — they have no on-disk path to restore.
         _appSettings.OpenTabPaths = _tabManager.OpenTabPaths
-            .Where(p => !IsUntitledSentinel(p))
+            .Where(p => !TabManager.IsUntitledSentinel(p))
             .ToList();
         _appSettings.ActiveTabPath = IsUntitledTab(_tabManager.ActiveTab)
             ? null
@@ -2078,7 +2077,7 @@ public partial class MainWindow : Window
         // Open a new numbered Untitled tab and activate it.
         var displayName = TabManager.ComputeUntitledDisplayName(
             _tabManager.Tabs.Select(t => t.DisplayName).ToList());
-        var sentinelPath = new FilePath(NewUntitledSentinelPath());
+        var sentinelPath = new FilePath(_tabManager.NewUntitledSentinelPath());
         _tabManager.OpenOrFocus(sentinelPath, displayName);
         RebuildTabStrip();
     }
@@ -2622,12 +2621,7 @@ public partial class MainWindow : Window
             RoutingStrategies.Bubble);
 
         // "Add Animation" button under the tree
-        AddChainBtn.Click += (_, _) =>
-        {
-            if (_projectManager.AnimationChainListSave is null)
-                _projectManager.AnimationChainListSave = new AnimationChainListSave();
-            AddAnimationChainAndBeginInlineRename();
-        };
+        AddChainBtn.Click += (_, _) => AddAnimationChainAndBeginInlineRename();
 
         // Expand/Collapse toolbar buttons
         ExpandAllBtn.Click  += (_, _) => SetAllExpanded(true);
@@ -2766,6 +2760,11 @@ public partial class MainWindow : Window
 
         var chain = _appCommands.AddNewAnimationChain();
         if (chain is null) return;
+
+        // #898: a project with zero open tabs (empty Open Project Folder, or the last tab was
+        // just closed) would otherwise add this chain with no tab visible for it.
+        _tabController.EnsureCurrentDocumentHasTab(_projectManager, TabActivation.Activate);
+        RebuildTabStrip();
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -4941,25 +4940,8 @@ public partial class MainWindow : Window
     /// content but no saved path) as a background tab so it appears before the next file that
     /// is about to be opened.
     /// </summary>
-    private void EnsureCurrentEditorContentHasTab()
-    {
-        var currentPath = _projectManager.FileName;
-        if (!string.IsNullOrEmpty(currentPath))
-        {
-            // Saved file — add its tab if not already tracked.
-            var fp = new FilePath(currentPath);
-            if (_tabManager.Tabs.All(t => t.Path != fp))
-                _tabManager.RegisterBackground(fp);
-        }
-        else if (_tabManager.Tabs.Count == 0 &&
-                 _projectManager.AnimationChainListSave?.AnimationChains.Count > 0)
-        {
-            // Unsaved new file with content — register a numbered Untitled placeholder tab.
-            var displayName = TabManager.ComputeUntitledDisplayName(
-                _tabManager.Tabs.Select(t => t.DisplayName).ToList());
-            _tabManager.RegisterBackground(new FilePath(NewUntitledSentinelPath()), displayName);
-        }
-    }
+    private void EnsureCurrentEditorContentHasTab() =>
+        _tabController.EnsureCurrentDocumentHasTab(_projectManager, TabActivation.Background);
 
     /// <summary>
     /// Shows (or moves) a thin vertical line in <see cref="DragOverlayCanvas"/> marking where
@@ -5029,19 +5011,9 @@ public partial class MainWindow : Window
         return Math.Max(0, children.Count - 1);
     }
 
-    // Sentinel paths use the prefix "__untitled__:" so they are distinguishable from real
-    // on-disk paths and are unique per new-file action within this window session.
-    private const string UntitledSentinelPrefix = "__untitled__:";
-
-    private static bool IsUntitledSentinel(string? path) =>
-        path?.StartsWith(UntitledSentinelPrefix, StringComparison.Ordinal) == true;
-
     private static bool IsUntitledTab(TabEntry? tab) =>
         tab != null &&
-        (string.IsNullOrEmpty(tab.Path.Original) || IsUntitledSentinel(tab.Path.Original));
-
-    private string NewUntitledSentinelPath() =>
-        $"{UntitledSentinelPrefix}{++_untitledCounter}";
+        (string.IsNullOrEmpty(tab.Path.Original) || TabManager.IsUntitledSentinel(tab.Path.Original));
 
     /// <summary>
     /// Closes <paramref name="tab"/> in this window and opens it in a brand-new,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -256,7 +256,7 @@ public partial class App : Application
         // Browser renders the tree with AnimationTreeControl, so the controller reads expand
         // state from there (desktop reads its own _treeRoots collection instead).
         var tabController = new TabController(undoManager, appCommands,
-            () => animationTree.CaptureExpandState());
+            () => animationTree.CaptureExpandState(), tabManager);
         var inspector = new InspectorControl();
         inspector.InitializeServices(selectedState);
         inspector.EnableEditing(appCommands, textureName =>
@@ -716,7 +716,20 @@ public partial class App : Application
         // tab switch (e.g. Add Frame on a chain that borrows a different texture).
         applicationEvents.AnimationChainsChanged += () => textureListPanel.SetAnimationChainList(projectManager.AnimationChainListSave);
 
-        addAnimationButton.Click += (_, _) => appCommands.AddNewAnimationChain();
+        // #898: the tree's own "Add Animation" context-menu action needs a tab opened when
+        // zero tabs are open. Wired here (rather than beside EnableContextMenu above) because
+        // RebuildTabStrip's closure isn't definitely-assigned until after its first call above.
+        animationTree.EnableAddAnimationTab(tabController, RebuildTabStrip);
+
+        addAnimationButton.Click += (_, _) =>
+        {
+            var chain = appCommands.AddNewAnimationChain();
+            if (chain is null) return;
+            // #898: a project with zero open tabs (e.g. just closed its last tab) would
+            // otherwise add this chain with no tab visible for it.
+            tabController.EnsureCurrentDocumentHasTab(projectManager, TabActivation.Activate);
+            RebuildTabStrip();
+        };
 
         addFrameButton.Click += (_, _) =>
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabController.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabController.cs
@@ -1,20 +1,37 @@
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Paths;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AnimationEditor.Core.Models
 {
     /// <summary>
+    /// Whether <see cref="TabController.EnsureCurrentDocumentHasTab"/> should make the new/found
+    /// tab active or merely register it. Use <see cref="Background"/> when switching away to a
+    /// different tab that is about to become active (the outgoing tab must not steal focus);
+    /// use <see cref="Activate"/> when nothing else is being switched to (e.g. Add Animation on
+    /// a document with zero open tabs, #898).
+    /// </summary>
+    public enum TabActivation
+    {
+        Background,
+        Activate,
+    }
+
+    /// <summary>
     /// Host-agnostic orchestration of the Animation Editor's open tabs, shared by the desktop
-    /// and browser hosts. Currently owns the "leaving tab" capture couplet; broader
-    /// tab-switch/close sequencing migrates here incrementally (issue #714).
+    /// and browser hosts. Owns the "leaving tab" capture couplet and "ensure a tab exists for
+    /// the current document" logic; broader tab-switch/close sequencing migrates here
+    /// incrementally (issue #714).
     /// </summary>
     public sealed class TabController
     {
         private readonly IUndoManager _undoManager;
         private readonly IAppCommands _appCommands;
         private readonly Func<Dictionary<object, bool>> _captureTreeExpandState;
+        private readonly TabManager _tabManager;
 
         /// <param name="captureTreeExpandState">
         /// Host callback returning the live tree's current expand state. Kept as a callback
@@ -24,11 +41,13 @@ namespace AnimationEditor.Core.Models
         public TabController(
             IUndoManager undoManager,
             IAppCommands appCommands,
-            Func<Dictionary<object, bool>> captureTreeExpandState)
+            Func<Dictionary<object, bool>> captureTreeExpandState,
+            TabManager tabManager)
         {
             _undoManager = undoManager;
             _appCommands = appCommands;
             _captureTreeExpandState = captureTreeExpandState;
+            _tabManager = tabManager;
         }
 
         /// <summary>
@@ -42,6 +61,44 @@ namespace AnimationEditor.Core.Models
             leaving.UndoSnapshot = _undoManager.TakeSnapshot();
             _appCommands.CaptureTabEditorState(leaving);
             leaving.CachedTreeExpandState = _captureTreeExpandState();
+        }
+
+        /// <summary>
+        /// Ensures the currently-loaded document — on disk or unsaved — has a tab. No-op when
+        /// the document is unsaved and empty (nothing worth a tab yet), or when it already has
+        /// a tracked tab. Built from the same primitives <c>OpenAsNewUnsavedDocument</c> and the
+        /// old per-site <c>EnsureCurrentEditorContentHasTab</c> duplicated (#898): a project with
+        /// zero open tabs — e.g. after Open Project Folder on a folder with no files, or after
+        /// closing the last tab — otherwise leaves any content added next (like Add Animation)
+        /// with no visible tab.
+        /// </summary>
+        public void EnsureCurrentDocumentHasTab(IProjectManager projectManager, TabActivation activation)
+        {
+            var currentPath = projectManager.FileName;
+            if (!string.IsNullOrEmpty(currentPath))
+            {
+                var fp = new FilePath(currentPath);
+                if (_tabManager.Tabs.All(t => t.Path != fp))
+                {
+                    if (activation == TabActivation.Activate)
+                        _tabManager.OpenOrFocus(fp);
+                    else
+                        _tabManager.RegisterBackground(fp);
+                }
+                return;
+            }
+
+            if (_tabManager.Tabs.Count != 0 ||
+                projectManager.AnimationChainListSave is not { AnimationChains.Count: > 0 })
+                return;
+
+            var displayName = TabManager.ComputeUntitledDisplayName(
+                _tabManager.Tabs.Select(t => t.DisplayName).ToList());
+            var sentinelPath = new FilePath(_tabManager.NewUntitledSentinelPath());
+            if (activation == TabActivation.Activate)
+                _tabManager.OpenOrFocus(sentinelPath, displayName);
+            else
+                _tabManager.RegisterBackground(sentinelPath, displayName);
         }
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -14,6 +14,12 @@ namespace AnimationEditor.Core.Models
     public class TabManager
     {
         private readonly List<TabEntry> _tabs = new();
+        private int _untitledCounter;
+
+        // Sentinel paths use this prefix so they are distinguishable from real on-disk paths.
+        // Moved here from MainWindow (#898) so both hosts, and TabController, can generate
+        // "no on-disk file yet" tab paths without duplicating the counter.
+        private const string UntitledSentinelPrefix = "__untitled__:";
 
         /// <summary>All open tabs, in the order they were opened.</summary>
         public IReadOnlyList<TabEntry> Tabs => _tabs;
@@ -115,6 +121,17 @@ namespace AnimationEditor.Core.Models
         tab.IsPreview = false;
         RaiseTabsChanged();
     }
+
+    /// <summary>
+    /// Generates a new, unique "no on-disk file yet" sentinel path for an Untitled tab.
+    /// Unique per <see cref="TabManager"/> instance (each host owns one instance, so a
+    /// counter local to this class is enough to avoid collisions within that host's session).
+    /// </summary>
+    public string NewUntitledSentinelPath() => $"{UntitledSentinelPrefix}{++_untitledCounter}";
+
+    /// <summary>True when <paramref name="path"/> was produced by <see cref="NewUntitledSentinelPath"/>.</summary>
+    public static bool IsUntitledSentinel(string? path) =>
+        path?.StartsWith(UntitledSentinelPrefix, StringComparison.Ordinal) == true;
 
     /// <summary>
     /// Computes the next unique "Untitled" display name given the set of names already in

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
 using AnimationEditor.Core.ViewModels;
 using AnimationEditor.Views.Dialogs;
 using Avalonia.Controls;
@@ -41,6 +42,8 @@ public partial class AnimationTreeControl : UserControl
     private IEditorDialogHost? _dialogHost;
     private Func<AnimationFrameSave, float?>? _getTextureHeight;
     private Action<string>? _showStatus;
+    private TabController? _tabController;
+    private Action? _onTabsChanged;
     private bool _suppressTreeSelectionHandling;
 
     public AnimationTreeControl()
@@ -56,6 +59,18 @@ public partial class AnimationTreeControl : UserControl
     /// via <c>SetRectProps</c>/<c>SetCircleProps</c>).
     /// </summary>
     public void EnableRename(IAppCommands appCommands) => _appCommands = appCommands;
+
+    /// <summary>
+    /// Wires <see cref="TabController.EnsureCurrentDocumentHasTab"/> into the "Add Animation"
+    /// tree-menu action so a chain added while zero tabs are open (e.g. after loading an empty
+    /// project folder) still gets a visible tab (#898). <paramref name="onTabsChanged"/> is the
+    /// host's tab-strip rebuild -- this control has no tab-strip UI of its own to refresh.
+    /// </summary>
+    public void EnableAddAnimationTab(TabController tabController, Action onTabsChanged)
+    {
+        _tabController = tabController;
+        _onTabsChanged = onTabsChanged;
+    }
 
     /// <summary>
     /// Wires a right-click context menu built from <see cref="TreeMenuPlanBuilder"/> -- the same
@@ -634,6 +649,15 @@ public partial class AnimationTreeControl : UserControl
 
         var chain = _appCommands.AddNewAnimationChain();
         if (chain is null || _roots is null) return;
+
+        // #898: a project with zero open tabs would otherwise add this chain with no tab
+        // visible for it.
+        if (_tabController is not null)
+        {
+            _tabController.EnsureCurrentDocumentHasTab(_projectManager, TabActivation.Activate);
+            _onTabsChanged?.Invoke();
+        }
+
         TreeBuilder.FindNodeForData(_roots, chain)?.BeginEdit();
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -111,6 +111,11 @@ public class HeadlessTreeViewTests
             .ToList();
     }
 
+    private static AnimationEditor.Core.Models.TabManager GetTabManager(MainWindow window) =>
+        (AnimationEditor.Core.Models.TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
     // ── TV05: Multi-select ────────────────────────────────────────────────────
 
     [AvaloniaFact]
@@ -229,6 +234,29 @@ public class HeadlessTreeViewTests
             Assert.Single(roots);
             Assert.True(roots[0].IsEditing);
             Assert.Equal(roots[0].Header, roots[0].EditingText);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void AddChainButton_Click_ZeroTabsOpen_OpensAndActivatesTab()
+    {
+        // #898: CreateWindow's default startup state (no CLI file, no saved tabs, no recovery
+        // file) is exactly the zero-tabs bug scenario -- clicking Add Animation there previously
+        // added the chain to the model but left no tab visible for it.
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var tabManager = GetTabManager(window);
+            Assert.Empty(tabManager.Tabs); // sanity: reproduces the zero-tabs starting state
+
+            var addChainBtn = window.FindControl<Button>("AddChainBtn")
+                ?? throw new InvalidOperationException("AddChainBtn not found");
+            addChainBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(tabManager.Tabs);
+            Assert.Same(tabManager.Tabs[0], tabManager.ActiveTab);
         }
         finally { window.Close(); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabControllerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabControllerTests.cs
@@ -28,7 +28,7 @@ public class TabControllerTests
         ctx.UndoManager.Execute(new StubCommand());
 
         var expandState = new Dictionary<object, bool> { [new object()] = true };
-        var controller = new TabController(ctx.UndoManager, ctx.AppCommands, () => expandState);
+        var controller = new TabController(ctx.UndoManager, ctx.AppCommands, () => expandState, new TabManager());
         var tab = new TabEntry(new FilePath(""));
 
         controller.CaptureLeavingTab(tab);
@@ -36,5 +36,97 @@ public class TabControllerTests
         Assert.Single(tab.UndoSnapshot!.UndoStack);           // undo history captured
         Assert.NotNull(tab.CachedEditorModel);                // in-memory editor model captured
         Assert.Same(expandState, tab.CachedTreeExpandState);  // #687 tree expand state captured
+    }
+
+    // ── EnsureCurrentDocumentHasTab (#898) ──────────────────────────────────────
+    // Add Animation (and any other "start editing with zero tabs open" site) needs the new
+    // tab to become the active one; the pre-existing "leaving tab" background-registration
+    // need (EnsureCurrentEditorContentHasTab) must keep not activating. One method,
+    // parameterized by TabActivation, so a third site can't duplicate this logic again.
+
+    private static TabController MakeController(TestServices ctx, TabManager tabManager) =>
+        new(ctx.UndoManager, ctx.AppCommands, () => new Dictionary<object, bool>(), tabManager);
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_ZeroTabsUnsavedContentActivate_OpensAndActivatesTab()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        TestHelpers.MakeChain(ctx.Acls, "Idle");
+        var tabManager = new TabManager();
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Activate);
+
+        Assert.Single(tabManager.Tabs);
+        Assert.NotNull(tabManager.ActiveTab);
+        Assert.Equal("Untitled", tabManager.ActiveTab!.DisplayName);
+    }
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_ZeroTabsUnsavedContentBackground_RegistersWithoutActivating()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        TestHelpers.MakeChain(ctx.Acls, "Idle");
+        var tabManager = new TabManager();
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Background);
+
+        Assert.Single(tabManager.Tabs);
+        Assert.Null(tabManager.ActiveTab);
+    }
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_NoChainsYet_NoOp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls(); // empty ACLS, no chains
+        var tabManager = new TabManager();
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Activate);
+
+        Assert.Empty(tabManager.Tabs);
+    }
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_TabsAlreadyOpen_NoOp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        TestHelpers.MakeChain(ctx.Acls, "Idle");
+        var tabManager = new TabManager();
+        tabManager.OpenOrFocus(new FilePath(tabManager.NewUntitledSentinelPath()), "Untitled");
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Activate);
+
+        Assert.Single(tabManager.Tabs); // no second tab opened
+    }
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_SavedFileActivate_OpensAndActivatesItsTab()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.ProjectManager.FileName = @"C:\Games\hero.achx";
+        var tabManager = new TabManager();
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Activate);
+
+        Assert.Single(tabManager.Tabs);
+        Assert.Equal(new FilePath(@"C:\Games\hero.achx"), tabManager.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void EnsureCurrentDocumentHasTab_SavedFileAlreadyTracked_NoDuplicate()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        ctx.ProjectManager.FileName = @"C:\Games\hero.achx";
+        var tabManager = new TabManager();
+        tabManager.OpenOrFocus(new FilePath(@"C:\Games\hero.achx"));
+        var controller = MakeController(ctx, tabManager);
+
+        controller.EnsureCurrentDocumentHasTab(ctx.ProjectManager, TabActivation.Activate);
+
+        Assert.Single(tabManager.Tabs);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -119,6 +119,46 @@ public class TabManagerTests
         Assert.Equal("Untitled (1)", result);
     }
 
+    // ── NewUntitledSentinelPath / IsUntitledSentinel ───────────────────────────
+    // Moved here from MainWindow (#898) so TabController can generate sentinel paths for
+    // both hosts without duplicating the counter/prefix.
+
+    [Fact]
+    public void NewUntitledSentinelPath_FirstCall_ReturnsSentinelWithCounter1()
+    {
+        var tm = new TabManager();
+
+        var result = tm.NewUntitledSentinelPath();
+
+        Assert.Equal("__untitled__:1", result);
+    }
+
+    [Fact]
+    public void NewUntitledSentinelPath_SecondCall_IncrementsCounter()
+    {
+        var tm = new TabManager();
+        tm.NewUntitledSentinelPath();
+
+        var result = tm.NewUntitledSentinelPath();
+
+        Assert.Equal("__untitled__:2", result);
+    }
+
+    [Fact]
+    public void IsUntitledSentinel_SentinelPath_ReturnsTrue()
+    {
+        Assert.True(TabManager.IsUntitledSentinel("__untitled__:1"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(@"C:\Games\hero.achx")]
+    public void IsUntitledSentinel_NonSentinelPath_ReturnsFalse(string? path)
+    {
+        Assert.False(TabManager.IsUntitledSentinel(path));
+    }
+
 
     [Fact]
     public void OpenOrFocus_SecondFile_SetsSecondAsActive()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlContextMenuTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AnimationTreeControlContextMenuTests.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Data;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
 using AnimationEditor.Core.ViewModels;
 using AnimationEditor.Views.Controls;
 using AnimationEditor.Views.Dialogs;
@@ -81,11 +82,13 @@ public class AnimationTreeControlContextMenuTests
         public required IAppCommands AppCommands;
         public required AnimationChainListSave Acls;
         public required IPendingCutState PendingCutState;
+        public TabManager? TabManager;
     }
 
     private static Harness Build(
         AnimationChainListSave? acls = null,
-        IEditorDialogHost? dialogHost = null)
+        IEditorDialogHost? dialogHost = null,
+        bool wireTabController = false)
     {
         acls ??= new AnimationChainListSave();
         var pm = new FakeProjectManager { AnimationChainListSave = acls };
@@ -106,6 +109,15 @@ public class AnimationTreeControlContextMenuTests
             getTextureHeight: _ => 64);
         events.AnimationChainsChanged += control.Refresh;
 
+        TabManager? tabManager = null;
+        if (wireTabController)
+        {
+            tabManager = new TabManager();
+            var tabController = new TabController(undoManager, appCommands,
+                () => control.CaptureExpandState(), tabManager);
+            control.EnableAddAnimationTab(tabController, onTabsChanged: () => { });
+        }
+
         var window = new Window { Content = control, Width = 400, Height = 400 };
         window.Show();
         Dispatcher.UIThread.RunJobs();
@@ -118,6 +130,7 @@ public class AnimationTreeControlContextMenuTests
             AppCommands = appCommands,
             Acls = acls,
             PendingCutState = pendingCutState,
+            TabManager = tabManager,
         };
     }
 
@@ -626,6 +639,29 @@ public class AnimationTreeControlContextMenuTests
             Assert.All(
                 acls.AnimationChains.Where(c => c != walk && c != run),
                 copy => Assert.True(copy.Frames[0].FlipHorizontal));
+        }
+        finally { h.Window.Close(); }
+    }
+
+    // ── Add Animation opens a tab (#898) ────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void AddAnimationMenuItem_ZeroTabsOpen_OpensAndActivatesTab()
+    {
+        // Reproduces the browser-host "empty project, zero open tabs" state (e.g. after Open
+        // Project Folder on a folder with no .achx files) -- an empty ACLS with nothing selected,
+        // which routes through TreeMenuPlanBuilder's default case.
+        var h = Build(new AnimationChainListSave(), wireTabController: true);
+        try
+        {
+            var items = OpenMenuFor(h, null!);
+            Assert.True(IndexOfItem(items, "Add Animation") >= 0);
+
+            Assert.Empty(h.TabManager!.Tabs); // sanity: reproduces the zero-tabs starting state
+            ClickMenuItem(h, "Add Animation");
+
+            Assert.Single(h.TabManager.Tabs);
+            Assert.Same(h.TabManager.Tabs[0], h.TabManager.ActiveTab);
         }
         finally { h.Window.Close(); }
     }


### PR DESCRIPTION
## Summary
- Add Animation (toolbar button, tree context menu) added the chain to the model but never opened a tab for it when zero tabs were open (empty Open Project Folder, or last tab just closed). Same bug class as #892/#893.
- Adds `TabController.EnsureCurrentDocumentHasTab(IProjectManager, TabActivation)` — a single, parameterized method (`Background` vs `Activate`) that both the pre-existing "leaving tab" registration and Add Animation's "activate the new tab" need now share, instead of duplicating the logic per site.
- Moves sentinel-path generation (`__untitled__:N`) from `MainWindow` private fields into `TabManager` so `TabController` can generate one for either host.
- Wires all three Add Animation call sites: desktop toolbar/context-menu (`MainWindow`), the shared `AnimationTreeControl` (browser's tree — new `EnableAddAnimationTab`), and the browser toolbar button.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1829 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — 107 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 818 passed
- [x] New tests drive real UI: `HeadlessTreeViewTests.AddChainButton_Click_ZeroTabsOpen_OpensAndActivatesTab` (desktop button click) and `AnimationTreeControlContextMenuTests.AddAnimationMenuItem_ZeroTabsOpen_OpensAndActivatesTab` (tree context-menu click) — both verified to fail without the fix.

Closes #898