### PR TITLE
AnimationEditor: stop padding whole-pixel inspector values with trailing zeros

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -883,14 +883,14 @@
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRelX" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Relative Y" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRelY" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <StackPanel Orientation="Horizontal" Spacing="4">
                                                     <ToggleButton x:Name="PropFlipH"
@@ -1036,28 +1036,28 @@
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRectX" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Y" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRectY" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Scale X" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRectScaleX" Grid.Column="1"
                                                                    Minimum="0.001" Maximum="10000"
-                                                                   Increment="0.5" FormatString="0.000" />
+                                                                   Increment="0.5" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Scale Y" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropRectScaleY" Grid.Column="1"
                                                                    Minimum="0.001" Maximum="10000"
-                                                                   Increment="0.5" FormatString="0.000" />
+                                                                   Increment="0.5" FormatString="0.###" />
                                                 </Grid>
                                             </StackPanel>
                                         </Border>
@@ -1083,21 +1083,21 @@
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropCircleX" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Y" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropCircleY" Grid.Column="1"
                                                                    Minimum="-10000" Maximum="10000"
-                                                                   Increment="1" FormatString="0.000" />
+                                                                   Increment="1" FormatString="0.###" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="78,*">
                                                     <TextBlock Text="Radius" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
                                                     <NumericUpDown x:Name="PropCircleRadius" Grid.Column="1"
                                                                    Minimum="0.001" Maximum="10000"
-                                                                   Increment="0.5" FormatString="0.000" />
+                                                                   Increment="0.5" FormatString="0.###" />
                                                 </Grid>
                                             </StackPanel>
                                         </Border>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropertyPanelFormatStringTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropertyPanelFormatStringTests.cs
@@ -1,0 +1,67 @@
+using AnimationEditor.Core;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression coverage for #902: whole-pixel Relative X/Y values were displayed with three
+/// padded decimal places ("5.000") because of FormatString="0.000" on the Prop* NumericUpDowns.
+/// </summary>
+public class PropertyPanelFormatStringTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    [AvaloniaFact]
+    public void PropRelX_WholeNumberValue_DisplaysWithoutTrailingZeros()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave(), RelativeX = 5f };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propRelX = window.FindControl<NumericUpDown>("PropRelX")!;
+
+            Assert.Equal("5", propRelX.Text);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void PropRelY_FractionalValue_StillDisplaysDecimals()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave(), RelativeY = 2.5f };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propRelY = window.FindControl<NumericUpDown>("PropRelY")!;
+
+            Assert.Equal("2.5", propRelY.Text);
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
## Summary
- `FormatString="0.000"` on the Relative/Rect/Circle X/Y/Scale/Radius `NumericUpDown`s in `MainWindow.axaml` padded whole-pixel values (`5` -> `5.000`). Switched to `"0.###"` so integers display bare and fractional values still show decimals.
- Left `PropFrameLen` and the RGBA fields (`FormatString="0"`) alone — out of scope per the issue.

## Test plan
- [x] `PropertyPanelFormatStringTests.cs` (new): asserts `PropRelX.Text == "5"` for a whole value and `PropRelY.Text == "2.5"` for a fractional one — failed against `"0.000"` before the fix, passes after.
- [x] Full `AnimationEditor.App.Tests` suite (826 tests) green.

Closes #902