### PR TITLE
AnimationEditor: persist preview pane height across restarts

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using AnimationEditor.Core.DragDrop;
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.Hotkeys;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Layout;
 using AnimationEditor.Core.Models;
 using AnimationEditor.Core.Rendering;
 using AnimationEditor.Core.Update;
@@ -239,6 +240,7 @@ public partial class MainWindow : Window
         LoadSettingsFile();
         ApplyPersistedTheme();
         ApplyPersistedCanvasColors();
+        ApplyPersistedPreviewPaneHeight();
         WireMenuEvents();
         WireWireframeToolbar();
         WireWireframeControl();
@@ -306,6 +308,8 @@ public partial class MainWindow : Window
         Opened += OnOpened;
         Closed += (_, _) =>
         {
+            // Piggyback on SaveTabsToSettings' write rather than a separate SaveSettingsFile call.
+            _appSettings.PreviewPaneHeight = AchxEditorPane.RowDefinitions[3].Height.Value;
             SaveTabsToSettings();
             _appCommands.HotReloadWatcher.Dispose();
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
@@ -5120,6 +5124,22 @@ public partial class MainWindow : Window
         _appSettings.GuideLineArgb = argb;
         PreviewCtrl.GuideLineOverride = argb;
         SaveSettingsFile();
+    }
+
+    // ── Preview pane height ──────────────────────────────────────────────────
+    // The AchxEditorPane's row 3 (bottom preview panel) is resized by dragging the
+    // GridSplitter at row 2. See PreviewPaneHeightValidator for the bounds a stored value
+    // is checked against (#904).
+    private const double MinPreviewPaneHeight = 80;
+    private const double MaxPreviewPaneHeight = 2000;
+    private const double DefaultPreviewPaneHeight = 250;
+
+    /// <summary>Applies the persisted (or default, if missing/invalid) preview-pane row height.</summary>
+    private void ApplyPersistedPreviewPaneHeight()
+    {
+        var resolved = PreviewPaneHeightValidator.Resolve(
+            _appSettings.PreviewPaneHeight, MinPreviewPaneHeight, MaxPreviewPaneHeight, DefaultPreviewPaneHeight);
+        AchxEditorPane.RowDefinitions[3].Height = new GridLength(resolved, GridUnitType.Pixel);
     }
 
     private static uint ToArgb(SKColor color) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Layout/PreviewPaneHeightValidator.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Layout/PreviewPaneHeightValidator.cs
@@ -1,0 +1,21 @@
+namespace AnimationEditor.Core.Layout;
+
+/// <summary>
+/// Resolves the persisted preview-pane row height (issue #904) against sane bounds so a
+/// missing, corrupt, or otherwise nonsensical stored value can never produce a broken window
+/// layout — a valid-JSON-but-bad-number case the whole-file settings load's try/catch doesn't
+/// catch on its own.
+/// </summary>
+public static class PreviewPaneHeightValidator
+{
+    public static double Resolve(double? stored, double min, double max, double fallback)
+    {
+        if (stored is not { } value)
+            return fallback;
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            return fallback;
+        if (value < min || value > max)
+            return fallback;
+        return value;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -72,6 +72,14 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public string? LastProjectFolderPath { get; set; }
 
+        /// <summary>
+        /// The bottom preview panel's row height in pixels, as last dragged via the horizontal
+        /// GridSplitter (#904). <c>null</c> falls back to the editor's default height —
+        /// see <see cref="Layout.PreviewPaneHeightValidator"/> for the bounds a stored value
+        /// is checked against before use.
+        /// </summary>
+        public double? PreviewPaneHeight { get; set; }
+
         public void AddFile(FilePath filePath)
         {
             RecentFiles.RemoveAll(item => new FilePath(item) == filePath);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPaneHeightPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewPaneHeightPersistenceTests.cs
@@ -1,0 +1,55 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using System;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #904: the preview pane's dragged height must survive a restart instead of always
+/// resetting to the fixed 250px default.
+/// </summary>
+public class PreviewPaneHeightPersistenceTests
+{
+    [AvaloniaFact]
+    public void Startup_PersistedPreviewPaneHeight_AppliesToAchxEditorPaneRow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        Directory.CreateDirectory(settingsFile.GetDirectoryContainingThis().FullPath);
+        File.WriteAllText(settingsFile.FullPath,
+            JsonSerializer.Serialize(new AppSettingsModel { PreviewPaneHeight = 420.0 }));
+
+        var window = ctx.CreateMainWindow();
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(420.0, window.AchxEditorPane.RowDefinitions[3].Height.Value);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Closing_AfterResizingPreviewPane_PersistsRowHeight()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // Stand in for a real GridSplitter drag, which just changes the row's Height.
+        window.AchxEditorPane.RowDefinitions[3].Height = new GridLength(410.0, GridUnitType.Pixel);
+        window.Close();
+
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        var settings = JsonSerializer.Deserialize<AppSettingsModel>(File.ReadAllText(settingsFile.FullPath))!;
+        Assert.Equal(410.0, settings.PreviewPaneHeight);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PreviewPaneHeightValidatorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PreviewPaneHeightValidatorTests.cs
@@ -1,0 +1,33 @@
+using AnimationEditor.Core.Layout;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreviewPaneHeightValidator"/> — the safeguard that keeps a corrupt or
+/// stale settings value from producing a broken window layout (issue #904).
+/// </summary>
+public class PreviewPaneHeightValidatorTests
+{
+    [Fact]
+    public void Resolve_StoredWithinBounds_ReturnsStoredValue()
+    {
+        var resolved = PreviewPaneHeightValidator.Resolve(320.0, min: 80, max: 2000, fallback: 250);
+
+        Assert.Equal(320.0, resolved);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0.0)]
+    [InlineData(-10.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(5000.0)]
+    public void Resolve_InvalidStoredValue_ReturnsFallback(double? stored)
+    {
+        var resolved = PreviewPaneHeightValidator.Resolve(stored, min: 80, max: 2000, fallback: 250);
+
+        Assert.Equal(250.0, resolved);
+    }
+}


### PR DESCRIPTION
Closes #904

Dragging the horizontal GridSplitter to resize the bottom preview panel never persisted — restarting the editor always reset it to the fixed 250px default. `AppSettingsModel` gained a nullable `PreviewPaneHeight`, and a pure `PreviewPaneHeightValidator` (Core, unit-tested) resolves a stored value against bounds (80–2000px), falling back to 250 for null/NaN/Infinity/out-of-range — guarding against a valid-JSON-but-nonsensical stored number, not just a corrupt file. Wired into `MainWindow`'s existing load/save settings lifecycle (`ApplyPersistedPreviewPaneHeight` alongside `ApplyPersistedCanvasColors`; written into `_appSettings` in the `Closed` handler before the existing `SaveTabsToSettings` write).

Manual test: not needed — fully covered by the headless `[AvaloniaFact]` integration tests (`PreviewPaneHeightPersistenceTests`) plus the Core validator tests; no pixel/rendering behavior is involved, only a `RowDefinition.Height` value.