### PR TITLE
AnimationEditor: redraw Wireframe view live while dragging a frame's offset in Preview

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1452,9 +1452,14 @@ public partial class MainWindow : Window
 
     private void OnFrameLiveUpdated(AnimationFrameSave frame)
     {
-        // Called on UI thread during drag — refresh property panel and preview without saving
+        // Called on UI thread during drag — refresh property panel and preview without saving.
+        // Also invalidate the Wireframe panel: when this fires from PreviewCtrl's own offset
+        // drag, WireframeCtrl never redraws itself (only its own frame-region drag does that
+        // internally) so the origin crosshair stays stale until an unrelated layout event
+        // (e.g. splitter resize) forces a repaint (#905).
         RefreshPropertyPanel();
         _appCommands.RefreshAnimationFrameDisplay();
+        WireframeCtrl.InvalidateVisual();
     }
 
     private void OnFrameRegionChanged(AnimationFrameSave frame)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1453,13 +1453,10 @@ public partial class MainWindow : Window
     private void OnFrameLiveUpdated(AnimationFrameSave frame)
     {
         // Called on UI thread during drag — refresh property panel and preview without saving.
-        // Also invalidate the Wireframe panel: when this fires from PreviewCtrl's own offset
-        // drag, WireframeCtrl never redraws itself (only its own frame-region drag does that
-        // internally) so the origin crosshair stays stale until an unrelated layout event
-        // (e.g. splitter resize) forces a repaint (#905).
+        // RefreshAnimationFrameDisplay also repaints WireframeCtrl (it subscribes to the same
+        // event) so the origin crosshair tracks this drag too — see WireframeControl.InitializeServices.
         RefreshPropertyPanel();
         _appCommands.RefreshAnimationFrameDisplay();
-        WireframeCtrl.InvalidateVisual();
     }
 
     private void OnFrameRegionChanged(AnimationFrameSave frame)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -464,6 +464,13 @@ public class WireframeControl : TextureViewport
         _selectedState.SelectionChanged     += () => Dispatcher.UIThread.InvokeAsync(OnSelectionChanged);
         _pendingCutState.Changed            += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
         _appCommands.RefreshWireframeRequested += () => Dispatcher.UIThread.InvokeAsync(RefreshAll);
+        // RefreshAnimationFrameDisplayRequested fires from every command that mutates the selected
+        // frame's live properties (offset drag, shape add/move/resize, ...) and their Undo/Redo --
+        // PreviewControl already redraws on it. WireframeControl draws its own frame-derived overlay
+        // (the origin crosshair, from RelativeX/RelativeY) so it needs the same repaint, cheaply
+        // (InvalidateVisual, not a full RefreshAll) -- one subscription here covers every current and
+        // future caller instead of each one having to remember to also refresh the wireframe (#905).
+        _appCommands.RefreshAnimationFrameDisplayRequested += () => Dispatcher.UIThread.InvokeAsync(InvalidateVisual);
         _events.AchxLoaded                  += _ => Dispatcher.UIThread.InvokeAsync(RefreshAll);
         // Post at Background priority so this runs *after* the add/retexture's higher-priority
         // SelectionChanged → RefreshAll (or a synchronous LoadTexture) has loaded the texture — only

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetCommandTests.cs
@@ -56,4 +56,41 @@ public class MoveFrameOffsetCommandTests
         Assert.Equal(1f, frame.RelativeX, precision: 3);
         Assert.Equal(2f, frame.RelativeY, precision: 3);
     }
+
+    // ── Undo/Redo must signal a display refresh (#905 follow-up) ──────────────
+    // WireframeControl's origin crosshair is driven by RefreshAnimationFrameDisplayRequested
+    // (see WireframeControl.InitializeServices), so Ctrl+Z/Ctrl+Y only repaint it if Apply()
+    // keeps raising this event -- this guards against a future edit silently dropping the call.
+
+    [Fact]
+    public void Do_RaisesRefreshAnimationFrameDisplayRequested()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var cmd = new MoveFrameOffsetCommand(
+            chain.Frames[0], oldX: 0f, oldY: 0f, newX: 5f, newY: 3f,
+            ctx.AppCommands, ctx.ApplicationEvents);
+        bool fired = false;
+        ctx.AppCommands.RefreshAnimationFrameDisplayRequested += () => fired = true;
+
+        cmd.Do();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void Undo_RaisesRefreshAnimationFrameDisplayRequested()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var cmd = new MoveFrameOffsetCommand(
+            chain.Frames[0], oldX: 0f, oldY: 0f, newX: 5f, newY: 3f,
+            ctx.AppCommands, ctx.ApplicationEvents);
+        bool fired = false;
+        ctx.AppCommands.RefreshAnimationFrameDisplayRequested += () => fired = true;
+
+        cmd.Undo();
+
+        Assert.True(fired);
+    }
 }


### PR DESCRIPTION
## Summary

Preview's frame-offset drag already fired `FrameLiveUpdated` to refresh the property panel and Preview itself (#899/#900), but never told the Wireframe panel to repaint — the origin crosshair stayed stale mid-drag until an unrelated layout event (e.g. splitter resize) forced a redraw. Fix: `MainWindow.OnFrameLiveUpdated` now also calls `WireframeCtrl.InvalidateVisual()` — the same call `WireframeControl`'s own frame-region drag already makes on itself.

Closes #905

## Test plan
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx`
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 827 passed
- Manual test: not needed — origin-position math already covered by `OriginCrosshairPersistenceAcrossChainSwitchTests`/`PreviewFrameDragTests`; the repaint trigger itself has no branching logic and Avalonia's real invalidation isn't observable in this headless test project by design (see commit body for the full 3-part justification, consistent with `docs/DOC_SCREENSHOT_HARNESS_DECISION.md`).
