### PR TITLE
AnimationEditor: right-click on empty Project tab space offers New Animation

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -88,7 +88,7 @@
                         <!-- InputGesture text for New/Load/Save is set in code from the hotkey
                              registry (MainWindow.ApplyHotkeyMenuGestureText, issue #638) so it
                              can never drift from what the KeyDown handler actually does. -->
-                        <MenuItem Header="_New"          x:Name="MenuNew" />
+                        <MenuItem Header="_New Animation" x:Name="MenuNew" />
                         <MenuItem Header="_Load..."       x:Name="MenuLoad" />
                         <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
                         <MenuItem Header="Open _Project Folder…" x:Name="MenuOpenProjectFolder" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -267,6 +267,9 @@ public partial class MainWindow : Window
         ProjectPanel.FolderRevealRequested += relativePath => RevealProjectFolderInExplorer(relativePath);
         ProjectPanel.FileRevealRequested += relativePath => RevealProjectFileInExplorer(relativePath);
         ProjectPanel.FileCopyPathRequested += relativePath => CopyProjectFilePathToClipboard(relativePath);
+        // Right-clicking blank space in the tree offers "New Animation" (#908) -- same flow as
+        // File > New.
+        ProjectPanel.NewAnimationRequested += () => OnNewClick(null, null!);
         // On scope toggle, re-supply the current referenced-texture set so "This File" reflects
         // the live .achx instead of the snapshot cached at the last refresh.
         FilesPanel.ScopeChanged += (_, _) => RefreshFilesPanel();
@@ -5447,7 +5450,7 @@ public partial class MainWindow : Window
             },
             new()
             {
-                Id = "new", Description = "New", Category = "File",
+                Id = "new", Description = "New Animation", Category = "File",
                 Gestures = new[] { new HotkeyGesture("N", Command) },
                 Action = () => OnNewClick(null, null!),
             },

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -1492,8 +1492,7 @@ public partial class App : Application
         // see docs/BROWSER_MENU_BAR_DECISION.md. No window controls (minimize/maximize/close) --
         // the browser tab already has real OS chrome for those.
         int untitledCounter = 0;
-        var menuNew = new MenuItem { Header = "_New" };
-        menuNew.Click += (_, _) =>
+        void NewAnimation()
         {
             var leaving = tabManager.ActiveTab;
             if (leaving != null)
@@ -1510,7 +1509,11 @@ public partial class App : Application
             animationTree.InitializeServices(selectedState, projectManager.AnimationChainListSave);
             textureListPanel.SetAnimationChainList(projectManager.AnimationChainListSave);
             RebuildTabStrip();
-        };
+        }
+        var menuNew = new MenuItem { Header = "_New Animation" };
+        menuNew.Click += (_, _) => NewAnimation();
+        // Right-clicking blank space in the Project tree offers "New Animation" too (#908).
+        projectPanel.NewAnimationRequested += NewAnimation;
         var menuLoad = new MenuItem { Header = "Open _Project Folder…" };
         menuLoad.Click += (_, _) => openButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
         var menuSave = new MenuItem { Header = "_Save" };

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -81,6 +81,13 @@ public partial class ProjectPanelControl : UserControl
     public event Action<string>? FileCopyPathRequested;
 
     /// <summary>
+    /// Raised when the user picks "New Animation" from the context menu shown on right-clicking
+    /// blank space in the tree, i.e. no node under the cursor (issue #908). The host resolves what
+    /// "new" means (desktop/browser both currently reuse their existing File → New flow).
+    /// </summary>
+    public event Action? NewAnimationRequested;
+
+    /// <summary>
     /// Completes once every thumbnail from the most recent <see cref="Rebuild"/> has finished
     /// loading (or been cancelled by a newer one). Test seam for awaiting the async thumbnail
     /// load -- production code never needs to await this.
@@ -294,6 +301,16 @@ public partial class ProjectPanelControl : UserControl
     {
         if (ProjectTree.ContextMenu is null) return;
         ProjectTree.ContextMenu.Items.Clear();
+
+        // No node under the cursor -- right-clicked blank space below/between rows (issue #908).
+        // Independent of SupportsRevealInExplorer: that flag only gates filesystem-reveal items.
+        if (_contextNode is null)
+        {
+            var newAnimationItem = new MenuItem { Header = "New Animation" };
+            newAnimationItem.Click += (_, _) => NewAnimationRequested?.Invoke();
+            ProjectTree.ContextMenu.Items.Add(newAnimationItem);
+            return;
+        }
 
         if (!SupportsRevealInExplorer) return;
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -329,6 +329,59 @@ public class ProjectPanelControlTests
         finally { window.Close(); }
     }
 
+    // Issue #908: right-clicking blank space below the tree rows (no node under the cursor) used
+    // to open a context menu with zero items. It should offer "New Animation" instead, regardless
+    // of SupportsRevealInExplorer (that flag only gates filesystem-reveal items, not this).
+    [AvaloniaFact]
+    public void RightClickingEmptySpace_ShowsNewAnimationItem()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClickEmptySpace(window, control);
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>().Single();
+            Assert.Equal("New Animation", item.Header);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ClickingNewAnimation_RaisesNewAnimationRequested()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClickEmptySpace(window, control);
+            var raised = false;
+            control.NewAnimationRequested += () => raised = true;
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>().Single();
+            item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+            Assert.True(raised);
+        }
+        finally { window.Close(); }
+    }
+
+    private static void RightClickEmptySpace(Window window, Controls.ProjectPanelControl control)
+    {
+        // Below the single "hero.achx" row (~24-28px tall) but still inside the tree's bounds.
+        var local = new Point(10, control.ProjectTree.Bounds.Height - 5);
+        var p = control.ProjectTree.TranslatePoint(local, window)!.Value;
+        window.MouseDown(p, MouseButton.Right);
+        window.MouseUp(p, MouseButton.Right);
+        Dispatcher.UIThread.RunJobs();
+    }
+
     // Issue #839: SetEntries kicks off async thumbnail generation via ProjectTreeThumbnailService.
     // ThumbnailLoadTask is the test seam for awaiting it deterministically.
     [AvaloniaFact]


### PR DESCRIPTION
## Summary
Right-clicking blank space in the Project tab tree (no file/folder under the cursor) opened a context menu with zero items. Now shows "New Animation", reusing the existing File > New flow (desktop and browser). File > New renamed to File > New Animation to match.

## Manual test
Not needed — covered by two new AvaloniaFact tests driving a real right-click through `ProjectPanelControl`, plus the full Core/Views/App suites passing.

Closes #908
