### PR TITLE
AnimationEditor: closing a tab reactivates the previously-active tab (MRU)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -186,6 +186,7 @@ namespace AnimationEditor.Core.Models
 
             int idx = _tabs.IndexOf(tab);
             _tabs.RemoveAt(idx);
+            PurgeFromHistory(tab);
 
             // Re-pick the active tab only when the one closed was active. A background-tab
             // close leaves ActiveTab as-is but still changes the open-tab set, so TabsChanged
@@ -219,6 +220,26 @@ namespace AnimationEditor.Core.Models
                     return candidate;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Removes every occurrence of <paramref name="tab"/> from <see cref="_activationHistory"/>.
+        /// Closing a tab already makes it unreachable via <see cref="PopValidHistoryEntry"/> (it is
+        /// no longer in <see cref="_tabs"/>), but without this it would still sit in the stack --
+        /// pinning its <see cref="TabEntry.CachedEditorModel"/> and undo state alive -- until some
+        /// later close happened to pop deep enough to discard it. Called for every close, not just
+        /// active-tab closes, so a background-tab close can't leave that behind either.
+        /// </summary>
+        private void PurgeFromHistory(TabEntry tab)
+        {
+            if (!_activationHistory.Contains(tab)) return;
+
+            // Stack<T> enumerates top-to-bottom; reverse before re-pushing so the surviving
+            // entries land back in their original order (and the original top stays on top).
+            var remaining = _activationHistory.Where(t => t != tab).Reverse().ToArray();
+            _activationHistory.Clear();
+            foreach (var t in remaining)
+                _activationHistory.Push(t);
         }
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/TabManager.cs
@@ -16,6 +16,12 @@ namespace AnimationEditor.Core.Models
         private readonly List<TabEntry> _tabs = new();
         private int _untitledCounter;
 
+        // MRU back-stack (#911): the tab activated before the current one, most-recent on top.
+        // Only ever holds tabs that were genuinely switched away from, never a tab being closed --
+        // see the Contains guard in SetActive. Entries for tabs closed in the background go stale
+        // and are skipped (not removed) lazily by PopValidHistoryEntry.
+        private readonly Stack<TabEntry> _activationHistory = new();
+
         // Sentinel paths use this prefix so they are distinguishable from real on-disk paths.
         // Moved here from MainWindow (#898) so both hosts, and TabController, can generate
         // "no on-disk file yet" tab paths without duplicating the counter.
@@ -167,8 +173,11 @@ namespace AnimationEditor.Core.Models
 
         /// <summary>
         /// Closes the tab for <paramref name="path"/>. No-op if the path is not open.
-        /// When the active tab is closed, the next tab is activated; if none follows,
-        /// the previous tab is activated; if none remain, <see cref="ActiveTab"/> becomes <c>null</c>.
+        /// When the active tab is closed, the tab that was active immediately before it
+        /// (issue #911's MRU back-stack) is reactivated, skipping any entries that were
+        /// themselves closed in the meantime. If no such entry remains, falls back to the
+        /// next tab, or the previous tab if none follows; if no tabs remain, <see cref="ActiveTab"/>
+        /// becomes <c>null</c>.
         /// </summary>
         public void Close(FilePath path)
         {
@@ -183,7 +192,10 @@ namespace AnimationEditor.Core.Models
             // fires regardless (ActiveChanged would not).
             if (tab == ActiveTab)
             {
-                if (_tabs.Count == 0)
+                var previous = PopValidHistoryEntry();
+                if (previous != null)
+                    SetActive(previous);
+                else if (_tabs.Count == 0)
                     SetActive(null);
                 else
                     // Prefer the tab that moved into this slot; fall back to the one before.
@@ -191,6 +203,22 @@ namespace AnimationEditor.Core.Models
             }
 
             RaiseTabsChanged();
+        }
+
+        /// <summary>
+        /// Pops <see cref="_activationHistory"/> until it finds an entry still present in
+        /// <see cref="_tabs"/>, discarding stale entries for tabs closed in the background
+        /// along the way. Returns <c>null</c> if the history holds no still-open tab.
+        /// </summary>
+        private TabEntry? PopValidHistoryEntry()
+        {
+            while (_activationHistory.Count > 0)
+            {
+                var candidate = _activationHistory.Pop();
+                if (_tabs.Contains(candidate))
+                    return candidate;
+            }
+            return null;
         }
 
         /// <summary>
@@ -202,6 +230,10 @@ namespace AnimationEditor.Core.Models
         public void RestoreFrom(IReadOnlyList<string> paths, string? activePath)
         {
             _tabs.Clear();
+            // A restored session starts fresh -- old TabEntry references would never be found by
+            // PopValidHistoryEntry anyway (new entries are distinct instances), but drop them here
+            // rather than let them sit in the stack until popped.
+            _activationHistory.Clear();
             foreach (var p in paths)
                 _tabs.Add(new TabEntry(new FilePath(p)));
 
@@ -285,6 +317,12 @@ namespace AnimationEditor.Core.Models
 
         private void SetActive(TabEntry? tab)
         {
+            // Only push a genuine switch-away, and only while the outgoing tab is still open --
+            // this guard is what keeps a tab being closed (already removed from _tabs by the
+            // time Close calls SetActive) from being pushed onto its own back-stack.
+            if (ActiveTab != null && tab != ActiveTab && _tabs.Contains(ActiveTab))
+                _activationHistory.Push(ActiveTab);
+
             ActiveTab = tab;
             ActiveChanged?.Invoke(tab);
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TabManagerTests.cs
@@ -282,6 +282,58 @@ public class TabManagerTests
         Assert.Equal(before, tm.Tabs.Count);
     }
 
+    // ── Close: MRU reactivation (#911) ──────────────────────────────────────────
+    // Closing the active tab should return to whichever tab was active immediately
+    // before it, not just the tab-strip neighbor -- matching Chrome/VS Code rather
+    // than a purely positional fallback.
+
+    [Fact]
+    public void Close_ActiveTab_ReactivatesPreviouslyActiveTab_EvenWhenNotAdjacent()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\anim1.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\anim2.achx"));
+        tm.Activate(P(@"C:\Games\anim1.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\sprite.png")); // opens at the end, active
+
+        tm.Close(P(@"C:\Games\sprite.png"));
+
+        // Positional fallback would land on anim2 (sprite.png's tab-strip neighbor);
+        // MRU should return to anim1, the tab that was active before sprite.png opened.
+        Assert.Equal(P(@"C:\Games\anim1.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Close_ActiveTab_PreviouslyActiveTabAlreadyClosed_SkipsToOlderHistoryEntry()
+    {
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\c.achx")); // active; history is [a, b]
+        tm.Close(P(@"C:\Games\b.achx")); // background close; stale history entry for b remains
+
+        tm.Close(P(@"C:\Games\c.achx"));
+
+        Assert.Equal(P(@"C:\Games\a.achx"), tm.ActiveTab!.Path);
+    }
+
+    [Fact]
+    public void Close_ActiveTab_NoHistory_FallsBackToPositional()
+    {
+        // Same scenario as Close_ActiveTabWithNext_ActivatesNextTab: b became active by
+        // being opened (not by switching from elsewhere), so its history entry is the
+        // tab it replaced -- consistent with a plain positional fallback either way.
+        var tm = new TabManager();
+        tm.OpenOrFocus(P(@"C:\Games\a.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\b.achx"));
+        tm.OpenOrFocus(P(@"C:\Games\c.achx"));
+        tm.Activate(P(@"C:\Games\b.achx"));
+
+        tm.Close(P(@"C:\Games\b.achx"));
+
+        Assert.Equal(P(@"C:\Games\c.achx"), tm.ActiveTab!.Path);
+    }
+
     // ── Activate ─────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #911.

`TabManager.Close` fell back purely positionally (next tab, else previous), which
diverges from what most editors do: closing a newly-opened tab landed on its
tab-strip neighbor instead of the tab you were on before it opened.

Adds an activation history stack in `TabManager` — closing the active tab now
reactivates whichever tab was active immediately before it, skipping stale
entries for tabs closed in the background, falling back to the old positional
logic only when no history remains.

Manual test: not needed — covered by the headless `TabManager` unit tests plus
the existing App-level tab tests (`PngTabTests`, `TabSwitchUndoTests`, etc.),
all green with no changes needed on their side.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 2804 tests, 0 failures
