### PR TITLE
AnimationEditor: drag whole animation chain to offset it in Preview panel

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFrameOffsetBulkCommand.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/MoveFrameOffsetBulkCommand.cs
@@ -1,0 +1,51 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.Animation.Content;
+using System.Collections.Generic;
+
+namespace AnimationEditor.Core.CommandsAndState.Commands
+{
+    /// <summary>
+    /// Records a drag-move that shifts every frame of an animation chain by the same delta
+    /// (<see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/>),
+    /// preserving each frame's own starting offset, so the whole shift undoes/redoes as one step.
+    /// Mirrors <see cref="MoveFrameOffsetCommand"/> for the single-frame drag, and
+    /// <see cref="BulkFrameRegionChangedCommand"/> for the bulk-snapshot shape.
+    /// </summary>
+    public sealed class MoveFrameOffsetBulkCommand : IUndoableCommand
+    {
+        public readonly record struct FrameSnapshot(
+            AnimationFrameSave Frame, float OldX, float OldY, float NewX, float NewY);
+
+        private readonly IReadOnlyList<FrameSnapshot> _snapshots;
+        private readonly IAppCommands _commands;
+        private readonly IApplicationEvents _events;
+
+        public MoveFrameOffsetBulkCommand(
+            IReadOnlyList<FrameSnapshot> snapshots,
+            IAppCommands commands,
+            IApplicationEvents events)
+        {
+            _snapshots = snapshots;
+            _commands  = commands;
+            _events    = events;
+        }
+
+        public string Description => "Move Animation";
+
+        public bool Do() { Apply(useNew: true); return true; }
+        public void Undo() => Apply(useNew: false);
+
+        private void Apply(bool useNew)
+        {
+            foreach (var s in _snapshots)
+            {
+                s.Frame.RelativeX = useNew ? s.NewX : s.OldX;
+                s.Frame.RelativeY = useNew ? s.NewY : s.OldY;
+                _commands.RefreshTreeNode(s.Frame);
+            }
+            _commands.RefreshAnimationFrameDisplay();
+            _events.RaiseAnimationChainsChanged();
+            _commands.SaveCurrentAnimationChainList();
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -161,6 +161,16 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     private float _frameDragStartY;
     private Point _frameDragAnchor;
 
+    // -- Whole-animation (chain) drag -------------------------------------------
+    // Same gesture as the single-frame drag above, but active when a chain is selected with
+    // no single frame pinned (SelectedFrame is null, SelectedFrames empty) — dragging the
+    // currently-playing frame's sprite then shifts every frame in the chain by the same
+    // delta, each keeping its own starting RelativeX/Y (issue #912). Mutually exclusive with
+    // _draggingFrame; reuses _frameDragAnchor for the shared world-space delta math.
+    private AnimationFrameSave[]? _draggingChainFrames;
+    private float[]? _chainFrameStartX;
+    private float[]? _chainFrameStartY;
+
     // -- Public properties -----------------------------------------------------
 
     public bool ShowOnionSkin
@@ -908,6 +918,30 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         frame.RelativeY  = SnapToPixel(frame.RelativeY + worldDy);
         CommitFrameDrag();
     }
+
+    /// <summary>
+    /// Test-only: applies a world-space drag delta to every frame in the selected chain's
+    /// <see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/>,
+    /// each frame keeping its own starting offset, and commits as one undo step. Bypasses
+    /// coordinate conversion, so results are independent of zoom/pan/OffsetMultiplier. No-op
+    /// unless <see cref="IsWholeChainDragTarget"/> holds, mirroring the gate
+    /// <see cref="OnPointerPressed"/> applies before starting a live whole-animation drag.
+    /// </summary>
+    internal void SimulateChainDrag(float worldDx, float worldDy)
+    {
+        if (!IsWholeChainDragTarget) return;
+
+        var chain = _selectedState!.SelectedChain!;
+        _draggingChainFrames = chain.Frames.ToArray();
+        _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
+        _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
+        for (int i = 0; i < _draggingChainFrames.Length; i++)
+        {
+            _draggingChainFrames[i].RelativeX = SnapToPixel(_chainFrameStartX[i] + worldDx);
+            _draggingChainFrames[i].RelativeY = SnapToPixel(_chainFrameStartY[i] + worldDy);
+        }
+        CommitChainDrag();
+    }
     /// control-space point and runs the resulting smooth-zoom animation to completion
     /// synchronously, so the camera lands on its settled state. Mirrors
     /// <see cref="OnPointerWheelChanged"/>. Use <see cref="SimulateWheelZoomBegin"/> instead to
@@ -1246,24 +1280,31 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
 
     private void UpdateHoverCursor(Point pos)
     {
+        var cursorType = ResolveHoverCursorType(pos);
+        Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
+    }
+
+    /// <summary>
+    /// Pure cursor-type decision behind <see cref="UpdateHoverCursor"/> — extracted so tests can
+    /// assert on the plain <see cref="StandardCursorType"/> result instead of the Avalonia
+    /// <see cref="Control.Cursor"/> property, which exposes no equality on it (same rationale as
+    /// <see cref="AnimationEditor.App.Controls.WireframeControl.IsShowingAddFrameCursor"/>).
+    /// Returns <c>null</c> for the default arrow.
+    /// </summary>
+    private StandardCursorType? ResolveHoverCursorType(Point pos)
+    {
         if (_draggingShape is not null)
-        {
-            Cursor = new Cursor(_shapeResizeHandle != HandleKind.None
+            return _shapeResizeHandle != HandleKind.None
                 ? GetResizeCursor(_shapeResizeHandle)
-                : StandardCursorType.SizeAll);
-            return;
-        }
-        if (_draggingFrame is not null)
-        {
-            Cursor = new Cursor(StandardCursorType.SizeAll);
-            return;
-        }
+                : StandardCursorType.SizeAll;
+
+        if (_draggingFrame is not null || _draggingChainFrames is not null)
+            return StandardCursorType.SizeAll;
+
         var handle = HitTestShapeHandle((float)pos.X, (float)pos.Y);
         if (handle != HandleKind.None)
-        {
-            Cursor = new Cursor(GetResizeCursor(handle));
-            return;
-        }
+            return GetResizeCursor(handle);
+
         StandardCursorType? cursorType = _draggedGuideIdx >= 0
             ? (_draggingHGuide ? StandardCursorType.SizeNorthSouth : StandardCursorType.SizeWestEast)
             : GetGuideCursorAt((float)pos.X, (float)pos.Y);
@@ -1271,8 +1312,13 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             cursorType = StandardCursorType.SizeAll;
         if (cursorType is null && HitTestFrameSprite((float)pos.X, (float)pos.Y))
             cursorType = StandardCursorType.SizeAll;
-        Cursor = cursorType is null ? Cursor.Default : new Cursor(cursorType.Value);
+        return cursorType;
     }
+
+    /// <summary>Test-only: the cursor type <see cref="UpdateHoverCursor"/> would apply at the
+    /// given screen-space point, without touching the Avalonia <see cref="Control.Cursor"/> property.</summary>
+    internal StandardCursorType? GetHoverCursorTypeForTest(float px, float py)
+        => ResolveHoverCursorType(new Point(px, py));
 
     private static StandardCursorType GetResizeCursor(HandleKind kind) => kind switch
     {
@@ -1506,6 +1552,40 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     }
 
     /// <summary>
+    /// Finalises an in-progress whole-animation drag: records a single
+    /// <see cref="MoveFrameOffsetBulkCommand"/> covering every frame that actually moved (unless
+    /// the net delta is negligible), fires <see cref="ApplicationEvents.RaiseAnimationChainsChanged"/>,
+    /// and saves. Mirrors <see cref="CommitFrameDrag"/> for the single-frame case.
+    /// </summary>
+    private void CommitChainDrag()
+    {
+        if (_draggingChainFrames is null) return;
+
+        const float eps = 1e-4f;
+        var snapshots = new List<MoveFrameOffsetBulkCommand.FrameSnapshot>();
+        for (int i = 0; i < _draggingChainFrames.Length; i++)
+        {
+            var frame = _draggingChainFrames[i];
+            float newX = frame.RelativeX;
+            float newY = frame.RelativeY;
+            if (MathF.Abs(newX - _chainFrameStartX![i]) > eps || MathF.Abs(newY - _chainFrameStartY![i]) > eps)
+                snapshots.Add(new MoveFrameOffsetBulkCommand.FrameSnapshot(
+                    frame, _chainFrameStartX[i], _chainFrameStartY![i], newX, newY));
+        }
+
+        if (snapshots.Count > 0)
+        {
+            _undoManager!.Record(new MoveFrameOffsetBulkCommand(snapshots, _appCommands!, _events!));
+            _events!.RaiseAnimationChainsChanged();
+            _appCommands!.SaveCurrentAnimationChainList();
+        }
+
+        _draggingChainFrames = null;
+        _chainFrameStartX    = null;
+        _chainFrameStartY    = null;
+    }
+
+    /// <summary>
     /// Returns the resize <see cref="HandleKind"/> under the cursor for the currently selected
     /// shape, or <see cref="HandleKind.None"/> if no resize handle is hit.
     /// Handles are positioned outside the bounding box by <c>Hs</c> pixels.
@@ -1713,16 +1793,39 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     }
 
     /// <summary>
+    /// <c>true</c> when the target frame <see cref="HitTestFrameSprite"/> would hit is the whole
+    /// selected chain rather than a single pinned frame — i.e. a chain is selected but
+    /// <see cref="ISelectedState.SelectedFrame"/> is null and nothing more specific is
+    /// multi-selected. Mirrors <see cref="AnimationEditor.App.Controls.WireframeControl"/>'s
+    /// <c>PrimaryFrameRect</c>-returns-null fallback into "drag the whole chain" (issue #912).
+    /// </summary>
+    private bool IsWholeChainDragTarget =>
+        _selectedState!.SelectedFrame is null &&
+        _selectedState!.SelectedFrames.Count == 0 &&
+        _selectedState!.SelectedChain is not null;
+
+    /// <summary>
     /// Returns <c>true</c> if (<paramref name="px"/>, <paramref name="py"/>) lands on the rendered
-    /// footprint of the single selected frame's sprite, in screen space. Gates the frame-offset
-    /// drag fallback in <see cref="OnPointerPressed"/>: only active with exactly one frame
-    /// selected and only once the frame's texture is already decoded (mirrors
+    /// footprint of the drag target's sprite, in screen space. Gates the frame-offset drag
+    /// fallback in <see cref="OnPointerPressed"/>. The target is the single selected frame; when
+    /// none is pinned but a chain is selected (<see cref="IsWholeChainDragTarget"/>), it falls
+    /// back to the currently-playing frame so the whole chain can be dragged together. Requires
+    /// the target frame's texture to already be decoded (mirrors
     /// <see cref="ComputeContentExtentScreenPx"/>'s own frame-footprint math).
     /// </summary>
     private bool HitTestFrameSprite(float px, float py)
     {
         var frame = _selectedState!.SelectedFrame;
-        if (frame is null || _selectedState!.SelectedFrames.Count > 1) return false;
+        if (frame is null)
+        {
+            if (!IsWholeChainDragTarget) return false;
+            frame = GetCurrentPlaybackFrame();
+        }
+        else if (_selectedState!.SelectedFrames.Count > 1)
+        {
+            return false;
+        }
+        if (frame is null) return false;
         if (px < RulerSize || py < RulerSize) return false;
 
         string? texPath = _thumbnailService!.ResolveTexturePath(frame);
@@ -1878,14 +1981,26 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         // No shape hit — try to select a collision shape.
         if (TrySelectShapeAt(px, py)) return;
 
-        // Nothing above matched — try to drag the single selected frame's sprite.
+        // Nothing above matched — try to drag the selected frame's sprite, or (when no single
+        // frame is pinned) the whole selected chain together.
         if (HitTestFrameSprite(px, py))
         {
-            var frame = _selectedState!.SelectedFrame!;
-            _draggingFrame   = frame;
-            _frameDragAnchor = pos;
-            _frameDragStartX = frame.RelativeX;
-            _frameDragStartY = frame.RelativeY;
+            if (IsWholeChainDragTarget)
+            {
+                var chain = _selectedState!.SelectedChain!;
+                _draggingChainFrames = chain.Frames.ToArray();
+                _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
+                _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
+                _frameDragAnchor     = pos;
+            }
+            else
+            {
+                var frame = _selectedState!.SelectedFrame!;
+                _draggingFrame   = frame;
+                _frameDragAnchor = pos;
+                _frameDragStartX = frame.RelativeX;
+                _frameDragStartY = frame.RelativeY;
+            }
             e.Pointer.Capture(this);
         }
     }
@@ -1939,6 +2054,23 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             return;
         }
 
+        if (_draggingChainFrames is not null)
+        {
+            float om = _appState!.OffsetMultiplier * _zoom;
+            float dx = (float)(pos.X - _frameDragAnchor.X) / om;
+            float dy = -(float)(pos.Y - _frameDragAnchor.Y) / om;
+            for (int i = 0; i < _draggingChainFrames.Length; i++)
+            {
+                _draggingChainFrames[i].RelativeX = SnapToPixel(_chainFrameStartX![i] + dx);
+                _draggingChainFrames[i].RelativeY = SnapToPixel(_chainFrameStartY![i] + dy);
+            }
+            InvalidateVisual();
+            // Param is unused by MainWindow.OnFrameLiveUpdated (only drives a display refresh),
+            // so any frame in the chain satisfies the event's signature.
+            FrameLiveUpdated?.Invoke(_draggingChainFrames[0]);
+            return;
+        }
+
         if (_draggedGuideIdx >= 0)
         {
             if (_draggingHGuide)
@@ -1983,6 +2115,13 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         if (_draggingFrame is not null)
         {
             CommitFrameDrag();
+            e.Pointer.Capture(null);
+            return;
+        }
+
+        if (_draggingChainFrames is not null)
+        {
+            CommitChainDrag();
             e.Pointer.Capture(null);
             return;
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewChainDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewChainDragTests.cs
@@ -1,0 +1,223 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for drag-to-offset a whole animation chain (issue #912): dragging the Preview panel's
+/// currently-playing sprite when a chain is selected but no single frame is pinned shifts every
+/// frame's <see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/> by
+/// the same delta, preserving each frame's own starting offset. Mirrors
+/// <see cref="PreviewFrameDragTests"/>: most cases use <see cref="PreviewControl.SimulateChainDrag"/>;
+/// the routing test drives real pointer input to prove the whole-chain branch is actually reached.
+/// </summary>
+public class PreviewChainDragTests
+{
+    private static AnimationFrameSave MakeFrame(float relativeX, float relativeY)
+    {
+        return new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            RelativeX   = relativeX,
+            RelativeY   = relativeY,
+            ShapesSave  = new ShapesSave()
+        };
+    }
+
+    // ── Whole-chain drag ──────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_ChainSelectedNoSingleFrame_ShiftsEveryFrameByDelta_PreservingOwnOffset()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 2f);
+
+        Assert.Equal(3f, frameA.RelativeX, precision: 3);
+        Assert.Equal(2f, frameA.RelativeY, precision: 3);
+        Assert.Equal(13f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-3f, frameB.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_AfterRelease_SingleUndoRestoresEveryFramesOwnOffset()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 2f);
+
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.Equal(0f, frameA.RelativeY, precision: 3);
+        Assert.Equal(10f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-5f, frameB.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_AfterUndo_RedoReappliesShiftToEveryFrame()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 2f);
+        ctx.UndoManager.Undo();
+        ctx.UndoManager.Redo();
+
+        Assert.Equal(3f, frameA.RelativeX, precision: 3);
+        Assert.Equal(2f, frameA.RelativeY, precision: 3);
+        Assert.Equal(13f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-3f, frameB.RelativeY, precision: 3);
+    }
+
+    // ── Gating: a single pinned frame must NOT trigger whole-chain drag ────────
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_SingleFramePinned_IsNoOp()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frameA;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 2f);
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.Equal(10f, frameB.RelativeX, precision: 3);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_NoChainSelected_IsNoOp()
+    {
+        var ctx  = TestHelpers.BuildServices();
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 2f); // must not throw
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Priority / real pointer routing ─────────────────────────────────────
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame            = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, int size = 64, string name = "sprite.png")
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(SKColors.CornflowerBlue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void RealDrag_ChainSelectedNoSingleFrame_MovesEveryFrameTogether()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir);
+            var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+            var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+            frameA.TextureName = texPath;
+            frameB.TextureName = texPath;
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frameA);
+            chain.Frames.Add(frameB);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            // Pre-warm the bitmap cache the way a real render pass would, so the frame-drag
+            // hit-test (which requires a cached bitmap) is actually eligible to fire.
+            ctx.ThumbnailService.GetBitmap(texPath);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+            float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+            var localPoint  = new Point(centerX, centerY); // frame 0 sits at world (0,0) == canvas center
+            var windowPoint = preview.TranslatePoint(localPoint, window)!.Value;
+
+            // Hover affordance before any drag starts, same SizeAll cursor the single-frame
+            // path already shows over its draggable sprite (issue #912 follow-up).
+            Assert.Equal(StandardCursorType.SizeAll, preview.GetHoverCursorTypeForTest(centerX, centerY));
+
+            window.MouseDown(windowPoint, MouseButton.Left);
+            var movedPoint = windowPoint + new Point(5, 5);
+            window.MouseMove(movedPoint);
+            Dispatcher.UIThread.RunJobs();
+
+            // Still mid-drag (no mouse-up yet) — cursor stays SizeAll everywhere while dragging,
+            // not just over the sprite footprint (queried well away from it, near the ruler
+            // corner, so this actually exercises the drag-in-progress branch).
+            Assert.Equal(StandardCursorType.SizeAll, preview.GetHoverCursorTypeForTest(22f, 22f));
+
+            window.MouseUp(movedPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEqual(0f, frameA.RelativeX);
+            Assert.NotEqual(10f, frameB.RelativeX); // the un-pinned second frame shifted too
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetBulkCommandTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MoveFrameOffsetBulkCommandTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.Core.CommandsAndState.Commands;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Do/Undo/Description for the whole-animation offset drag command (issue #912: drag an entire
+/// chain's frames together in the Preview panel, each frame keeping its own starting offset).
+/// </summary>
+public class MoveFrameOffsetBulkCommandTests
+{
+    [Fact]
+    public void Description_ReturnsMoveAnimation()
+    {
+        var expected = "Move Animation";
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var snapshots = new List<MoveFrameOffsetBulkCommand.FrameSnapshot>
+        {
+            new(chain.Frames[0], OldX: 0f, OldY: 0f, NewX: 5f, NewY: 3f),
+            new(chain.Frames[1], OldX: 1f, OldY: 1f, NewX: 6f, NewY: 4f),
+        };
+        var cmd = new MoveFrameOffsetBulkCommand(snapshots, ctx.AppCommands, ctx.ApplicationEvents);
+
+        Assert.Equal(expected, cmd.Description);
+    }
+
+    [Fact]
+    public void Do_AppliesNewOffsetToEveryFrame_PreservingEachFramesOwnDelta()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        frameA.RelativeX = 0f;  frameA.RelativeY = 0f;
+        frameB.RelativeX = 10f; frameB.RelativeY = -5f;
+        var snapshots = new List<MoveFrameOffsetBulkCommand.FrameSnapshot>
+        {
+            new(frameA, OldX: 0f,  OldY: 0f,  NewX: 3f,  NewY: 2f),
+            new(frameB, OldX: 10f, OldY: -5f, NewX: 13f, NewY: -3f),
+        };
+        var cmd = new MoveFrameOffsetBulkCommand(snapshots, ctx.AppCommands, ctx.ApplicationEvents);
+
+        cmd.Do();
+
+        Assert.Equal(3f, frameA.RelativeX, precision: 3);
+        Assert.Equal(2f, frameA.RelativeY, precision: 3);
+        Assert.Equal(13f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-3f, frameB.RelativeY, precision: 3);
+    }
+
+    [Fact]
+    public void Undo_RestoresEachFramesOwnOriginalOffset()
+    {
+        var ctx   = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 2);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        frameA.RelativeX = 3f;  frameA.RelativeY = 2f;
+        frameB.RelativeX = 13f; frameB.RelativeY = -3f;
+        var snapshots = new List<MoveFrameOffsetBulkCommand.FrameSnapshot>
+        {
+            new(frameA, OldX: 0f,  OldY: 0f,  NewX: 3f,  NewY: 2f),
+            new(frameB, OldX: 10f, OldY: -5f, NewX: 13f, NewY: -3f),
+        };
+        var cmd = new MoveFrameOffsetBulkCommand(snapshots, ctx.AppCommands, ctx.ApplicationEvents);
+
+        cmd.Undo();
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.Equal(0f, frameA.RelativeY, precision: 3);
+        Assert.Equal(10f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-5f, frameB.RelativeY, precision: 3);
+    }
+}


### PR DESCRIPTION
## Summary
- Preview panel drag now supports offsetting a whole animation chain, not just one frame. Selecting a chain (no single frame pinned) and dragging the currently-playing sprite shifts every frame's `RelativeX`/`RelativeY` by the same delta, preserving each frame's own starting offset.
- One `MoveFrameOffsetBulkCommand` (new, mirrors `MoveFrameOffsetCommand`/`BulkFrameRegionChangedCommand`) covers the whole shift, so a single undo/redo restores/reapplies every frame at once.
- Cursor shows `SizeAll` on hover-over and during the whole-chain drag, same as the single-frame path (`ResolveHoverCursorType` extracted as a pure function so this is testable without touching Avalonia's `Cursor` equality gap).

## Design decision
Whole-chain drag triggers when `SelectedFrame` is null, `SelectedFrames` is empty, and `SelectedChain` is set — i.e. a chain is selected in the tree with nothing more specific pinned. This mirrors `WireframeControl`'s existing chain-drag fallback (`PrimaryFrameRect` returns null → drag the whole chain). Single-frame drag (`SelectedFrame` set) is unchanged.

## Test plan
- [x] `AnimationEditor.Core.Tests` — `MoveFrameOffsetBulkCommandTests` (Do/Undo/Description)
- [x] `AnimationEditor.App.Tests` — `PreviewChainDragTests` (delta shift, undo, redo, single-frame-pinned no-op, no-chain no-op, real pointer routing + cursor)
- [x] Full suites green: Core 1858, Views 111, App 835
