### PR TITLE
AnimationEditor: New Animation reachable via right-click on empty project

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -146,8 +146,9 @@ public partial class ProjectPanelControl : UserControl
             : _allEntries.ToList();
         files = AchxSearchFilter.Filter(files, _searchQuery).ToList();
 
+        // ProjectTree stays visible even with zero rows (issue #916): hiding it also hid its
+        // right-click "New Animation" context menu, which is exactly what an empty project needs.
         EmptyMessage.IsVisible = files.Count == 0;
-        ProjectTree.IsVisible = files.Count > 0;
         EmptyMessage.Text = _allEntries.Count == 0
             ? "File → Open Project Folder… to browse its .achx files."
             : string.IsNullOrWhiteSpace(_searchQuery)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -372,6 +372,30 @@ public class ProjectPanelControlTests
         finally { window.Close(); }
     }
 
+    // Issue #916: the tree used to be hidden entirely (ProjectTree.IsVisible = false) whenever the
+    // project had zero .achx files, so right-clicking anywhere in the panel hit nothing with a
+    // context menu -- "New Animation" was reachable only after a file already existed.
+    [AvaloniaFact]
+    public void RightClickingEmptyTree_WithNoEntries_ShowsNewAnimationItem()
+    {
+        var control = new Controls.ProjectPanelControl();
+        control.SetEntries(Array.Empty<AchxFileEntry>());
+
+        var window = ShowInWindow(control);
+        try
+        {
+            var local = new Point(10, 10);
+            var p = control.ProjectTree.TranslatePoint(local, window)!.Value;
+            window.MouseDown(p, MouseButton.Right);
+            window.MouseUp(p, MouseButton.Right);
+            Dispatcher.UIThread.RunJobs();
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>().Single();
+            Assert.Equal("New Animation", item.Header);
+        }
+        finally { window.Close(); }
+    }
+
     private static void RightClickEmptySpace(Window window, Controls.ProjectPanelControl control)
     {
         // Below the single "hero.achx" row (~24-28px tall) but still inside the tree's bounds.


### PR DESCRIPTION
## Summary
- `ProjectPanelControl.Rebuild()` hid `ProjectTree` entirely when the project had zero `.achx` files, but the right-click "New Animation" context menu (#908) is attached only to `ProjectTree` — so an empty project had no context menu reachable at all.
- Fix: stop hiding `ProjectTree` when empty; it renders with zero rows (the Grid's `*` row still reserves its space) and stays hit-testable, so right-click reaches the existing "no node under cursor" branch and shows "New Animation". `EmptyMessage` guidance text is unaffected — it's a separate Grid row below the tree.

## Test plan
- [x] New failing-first `[AvaloniaFact]`: `RightClickingEmptyTree_WithNoEntries_ShowsNewAnimationItem` (red before the fix, green after)
- [x] `dotnet test tests/AnimationEditor.Views.Tests/` — 18/18 pass
- [x] `dotnet test tests/AnimationEditor.App.Tests/ --filter Project` — 20/20 pass
- [x] `dotnet build AnimationEditorAvalonia.slnx` — clean

Closes #916
