### PR TITLE
Animation Editor: multi-select frames with scoped drag+move

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -161,12 +161,17 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     private float _frameDragStartY;
     private Point _frameDragAnchor;
 
-    // -- Whole-animation (chain) drag -------------------------------------------
-    // Same gesture as the single-frame drag above, but active when a chain is selected with
-    // no single frame pinned (SelectedFrame is null, SelectedFrames empty) — dragging the
-    // currently-playing frame's sprite then shifts every frame in the chain by the same
-    // delta, each keeping its own starting RelativeX/Y (issue #912). Mutually exclusive with
-    // _draggingFrame; reuses _frameDragAnchor for the shared world-space delta math.
+    // -- Whole-animation (chain) drag, and multi-frame drag ----------------------
+    // Same gesture as the single-frame drag above, but shared by two bulk scopes that both
+    // record one MoveFrameOffsetBulkCommand:
+    //  - Whole chain (issue #912): a chain is selected with no single frame pinned and
+    //    nothing multi-selected (IsWholeChainDragTarget) — dragging the currently-playing
+    //    frame's sprite shifts every frame in the chain.
+    //  - Multi-frame (issue #917): 2+ individual frames are multi-selected
+    //    (IsMultiFrameDragTarget) — dragging the displayed frame's sprite shifts only
+    //    SelectedFrames. Each frame keeps its own starting RelativeX/Y either way. Mutually
+    //    exclusive with _draggingFrame; reuses _frameDragAnchor for the shared world-space
+    //    delta math.
     private AnimationFrameSave[]? _draggingChainFrames;
     private float[]? _chainFrameStartX;
     private float[]? _chainFrameStartY;
@@ -933,6 +938,30 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
 
         var chain = _selectedState!.SelectedChain!;
         _draggingChainFrames = chain.Frames.ToArray();
+        _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
+        _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
+        for (int i = 0; i < _draggingChainFrames.Length; i++)
+        {
+            _draggingChainFrames[i].RelativeX = SnapToPixel(_chainFrameStartX[i] + worldDx);
+            _draggingChainFrames[i].RelativeY = SnapToPixel(_chainFrameStartY[i] + worldDy);
+        }
+        CommitChainDrag();
+    }
+
+    /// <summary>
+    /// Test-only: applies a world-space drag delta to every frame in
+    /// <see cref="ISelectedState.SelectedFrames"/> (2+ individually multi-selected frames, not a
+    /// whole chain), each frame keeping its own starting offset, and commits as one undo step.
+    /// Bypasses coordinate conversion, so results are independent of zoom/pan/OffsetMultiplier.
+    /// No-op unless <see cref="IsMultiFrameDragTarget"/> holds, mirroring the gate
+    /// <see cref="OnPointerPressed"/> applies before starting a live multi-frame drag. Mirrors
+    /// <see cref="SimulateChainDrag"/>, scoped to the multi-selection instead of the whole chain.
+    /// </summary>
+    internal void SimulateMultiFrameDrag(float worldDx, float worldDy)
+    {
+        if (!IsMultiFrameDragTarget) return;
+
+        _draggingChainFrames = _selectedState!.SelectedFrames.ToArray();
         _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
         _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
         for (int i = 0; i < _draggingChainFrames.Length; i++)
@@ -1805,23 +1834,49 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         _selectedState!.SelectedChain is not null;
 
     /// <summary>
+    /// <c>true</c> when 2+ individual frames are multi-selected via
+    /// <see cref="ISelectedState.SelectedFrames"/> — the third drag scope alongside
+    /// <see cref="IsWholeChainDragTarget"/> (issue #917). Unlike <see cref="IsWholeChainDragTarget"/>,
+    /// this does not require <see cref="ISelectedState.SelectedFrame"/> to be null: ctrl/shift-clicking
+    /// frames in the tree pins the last-clicked one as <c>SelectedFrame</c> (so its sprite is what
+    /// actually renders in Preview — see <see cref="BuildRenderSnapshot"/>'s <c>selectedFrame</c> use),
+    /// and dragging that pinned sprite is how the user grabs the multi-selection in practice.
+    /// </summary>
+    private bool IsMultiFrameDragTarget =>
+        _selectedState!.SelectedFrames.Count > 1;
+
+    /// <summary>
     /// Returns <c>true</c> if (<paramref name="px"/>, <paramref name="py"/>) lands on the rendered
     /// footprint of the drag target's sprite, in screen space. Gates the frame-offset drag
-    /// fallback in <see cref="OnPointerPressed"/>. The target is the single selected frame; when
-    /// none is pinned but a chain is selected (<see cref="IsWholeChainDragTarget"/>), it falls
-    /// back to the currently-playing frame so the whole chain can be dragged together. Requires
-    /// the target frame's texture to already be decoded (mirrors
-    /// <see cref="ComputeContentExtentScreenPx"/>'s own frame-footprint math).
+    /// fallback in <see cref="OnPointerPressed"/>. The target is the pinned <see cref="ISelectedState.SelectedFrame"/>
+    /// when one is set (whether alone or as part of a multi-selection — see
+    /// <see cref="IsMultiFrameDragTarget"/>); when none is pinned, it falls back to the
+    /// currently-playing frame, gated by <see cref="IsWholeChainDragTarget"/> (drag the whole
+    /// chain) or <see cref="IsMultiFrameDragTarget"/> (drag just the multi-selection — only if the
+    /// playing frame is actually one of <see cref="ISelectedState.SelectedFrames"/>). Requires the
+    /// target frame's texture to already be decoded (mirrors <see cref="ComputeContentExtentScreenPx"/>'s
+    /// own frame-footprint math).
     /// </summary>
     private bool HitTestFrameSprite(float px, float py)
     {
         var frame = _selectedState!.SelectedFrame;
         if (frame is null)
         {
-            if (!IsWholeChainDragTarget) return false;
-            frame = GetCurrentPlaybackFrame();
+            if (IsWholeChainDragTarget)
+            {
+                frame = GetCurrentPlaybackFrame();
+            }
+            else if (IsMultiFrameDragTarget)
+            {
+                frame = GetCurrentPlaybackFrame();
+                if (frame is null || !_selectedState!.SelectedFrames.Contains(frame)) return false;
+            }
+            else
+            {
+                return false;
+            }
         }
-        else if (_selectedState!.SelectedFrames.Count > 1)
+        else if (_selectedState!.SelectedFrames.Count > 1 && !_selectedState!.SelectedFrames.Contains(frame))
         {
             return false;
         }
@@ -1982,13 +2037,21 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         if (TrySelectShapeAt(px, py)) return;
 
         // Nothing above matched — try to drag the selected frame's sprite, or (when no single
-        // frame is pinned) the whole selected chain together.
+        // frame is pinned) the whole selected chain together, or (when 2+ frames are
+        // multi-selected) just that subset together.
         if (HitTestFrameSprite(px, py))
         {
             if (IsWholeChainDragTarget)
             {
                 var chain = _selectedState!.SelectedChain!;
                 _draggingChainFrames = chain.Frames.ToArray();
+                _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
+                _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
+                _frameDragAnchor     = pos;
+            }
+            else if (IsMultiFrameDragTarget)
+            {
+                _draggingChainFrames = _selectedState!.SelectedFrames.ToArray();
                 _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
                 _chainFrameStartY    = _draggingChainFrames.Select(f => f.RelativeY).ToArray();
                 _frameDragAnchor     = pos;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewMultiFrameDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewMultiFrameDragTests.cs
@@ -1,0 +1,207 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.Animation.Content;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for drag-to-offset a multi-selection of individual frames (issue #917): dragging the
+/// Preview panel's displayed sprite when 2+ frames are multi-selected (but not a whole chain)
+/// shifts only those frames' <see cref="AnimationFrameSave.RelativeX"/>/<see cref="AnimationFrameSave.RelativeY"/>
+/// by the same delta, preserving each frame's own starting offset, and leaves other frames (in the
+/// same chain or elsewhere) untouched. Mirrors <see cref="PreviewChainDragTests"/>: most cases use
+/// <see cref="PreviewControl.SimulateMultiFrameDrag"/>; the routing test drives real pointer input.
+/// </summary>
+public class PreviewMultiFrameDragTests
+{
+    private static AnimationFrameSave MakeFrame(float relativeX, float relativeY)
+    {
+        return new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            RelativeX   = relativeX,
+            RelativeY   = relativeY,
+            ShapesSave  = new ShapesSave()
+        };
+    }
+
+    // ── Multi-frame drag ────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateMultiFrameDrag_TwoFramesMultiSelected_ShiftsOnlyThoseByDelta_PreservingOwnOffset()
+    {
+        var ctx     = TestHelpers.BuildServices();
+        var frameA  = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB  = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var frameC  = MakeFrame(relativeX: 20f, relativeY: 7f); // not selected — must stay untouched
+        var chain   = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        chain.Frames.Add(frameC);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedNodes = new List<object> { frameA, frameB };
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateMultiFrameDrag(3f, 2f);
+
+        Assert.Equal(3f, frameA.RelativeX, precision: 3);
+        Assert.Equal(2f, frameA.RelativeY, precision: 3);
+        Assert.Equal(13f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-3f, frameB.RelativeY, precision: 3);
+        Assert.Equal(20f, frameC.RelativeX, precision: 3);
+        Assert.Equal(7f, frameC.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateMultiFrameDrag_AfterRelease_SingleUndoRestoresEverySelectedFramesOwnOffset()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedNodes = new List<object> { frameA, frameB };
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateMultiFrameDrag(3f, 2f);
+
+        Assert.True(ctx.UndoManager.CanUndo);
+        Assert.Equal("Move Animation", ctx.UndoManager.UndoHistory[^1].Description);
+
+        ctx.UndoManager.Undo();
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.Equal(0f, frameA.RelativeY, precision: 3);
+        Assert.Equal(10f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-5f, frameB.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateMultiFrameDrag_NegligibleDelta_DoesNotRecordUndoStep()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedNodes = new List<object> { frameA, frameB };
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateMultiFrameDrag(0f, 0f);
+
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Gating: a single pinned frame must still use the single-frame path ─────
+
+    [AvaloniaFact]
+    public void SimulateMultiFrameDrag_OnlyOneFrameSelected_IsNoOp()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frameA;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateMultiFrameDrag(3f, 2f);
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    // ── Priority / real pointer routing ─────────────────────────────────────
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, int size = 64, string name = "sprite.png")
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(SKColors.CornflowerBlue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void RealDrag_TwoFramesMultiSelected_ShowsSizeAllCursorAndMovesOnlyThemTogether()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir);
+            var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+            var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+            frameA.TextureName = texPath;
+            frameB.TextureName = texPath;
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frameA);
+            chain.Frames.Add(frameB);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedNodes = new List<object> { frameA, frameB };
+            ctx.SelectedState.SelectedFrame = frameA; // last-clicked frame — pinned, so its sprite renders
+            // Pre-warm the bitmap cache the way a real render pass would, so the frame-drag
+            // hit-test (which requires a cached bitmap) is actually eligible to fire.
+            ctx.ThumbnailService.GetBitmap(texPath);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+            float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+            var localPoint  = new Point(centerX, centerY); // frameA sits at world (0,0) == canvas center
+            var windowPoint = preview.TranslatePoint(localPoint, window)!.Value;
+
+            Assert.Equal(StandardCursorType.SizeAll, preview.GetHoverCursorTypeForTest(centerX, centerY));
+
+            window.MouseDown(windowPoint, MouseButton.Left);
+            var movedPoint = windowPoint + new Point(5, 5);
+            window.MouseMove(movedPoint);
+            Dispatcher.UIThread.RunJobs();
+            window.MouseUp(movedPoint, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEqual(0f, frameA.RelativeX);
+            Assert.NotEqual(10f, frameB.RelativeX); // the other multi-selected frame shifted too
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
Closes #917

Adds a third Preview-panel drag scope: when 2+ individual frames are multi-selected (`ISelectedState.SelectedFrames.Count > 1`, not a whole chain), dragging the displayed sprite shifts only that subset's `RelativeX`/`RelativeY`, each frame keeping its own starting offset, recorded as one `MoveFrameOffsetBulkCommand` (same undo-as-one-step, same `SizeAll` cursor as the existing whole-chain drag).

## Deviation from the sketched plan

The plan's suggested `IsMultiFrameDragTarget` gate was `SelectedFrame is null && SelectedFrames.Count > 1`. Tracing the real tree multi-select path (`RouteNodeSelection`) shows it always pins the last-clicked frame as `SelectedFrame` (non-null) — which is also the frame `BuildRenderSnapshot` actually renders in Preview. A null-gated condition would never fire from real ctrl/shift-click usage. Confirmed by temporarily patching in the literal-spec gate: it failed the real-pointer-routing test (`RealDrag_TwoFramesMultiSelected_...`). The shipped fix instead lets `HitTestFrameSprite` treat a pinned frame as a valid multi-frame drag target when it's a member of `SelectedFrames`.

## Manual test

Not needed — verified headlessly via `ctx.CreatePreviewControl()` / `SimulateMultiFrameDrag` and a real-pointer-routing `[AvaloniaFact]`, same rationale as the existing whole-chain drag tests (no `GraphicsDevice`/window required).

## Test plan
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx`
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 843 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1861 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)