### PR TITLE
AnimationEditor: Duplicate + Flip renames Left/Right, Up/Down in copy's name

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -9,6 +9,7 @@ using FlatRedBall2.Animation.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FilePath = AnimationEditor.Core.Paths.FilePath;
 using StringFunctions = AnimationEditor.Core.Utilities.StringFunctions;
@@ -1216,6 +1217,26 @@ namespace AnimationEditor.Core.CommandsAndState
             return copy;
         }
 
+        private static readonly Regex HorizontalDirectionToken = new(@"(Right|Left)(?![a-z])", RegexOptions.Compiled);
+        private static readonly Regex VerticalDirectionToken = new(@"(Up|Down)(?![a-z])", RegexOptions.Compiled);
+
+        // Swaps Left<->Right and/or Up<->Down direction tokens in a chain name (e.g. "WalkRight"
+        // flipped horizontally becomes "WalkLeft") so a flipped duplicate reads correctly instead
+        // of "WalkRightCopy". Ported from the old (pre-Avalonia) Animation Editor's duplicate+flip
+        // rename behavior (issue #920). A token must not be immediately followed by a lowercase
+        // letter, so it only matches a standalone PascalCase word ("WalkRight", trailing "Up") and
+        // not a prefix of a longer word ("Rightful", "Upgrade"). Returns the name unchanged if no
+        // requested-axis token is present.
+        private static string InvertDirectionTokens(string name, bool flipH, bool flipV)
+        {
+            var result = name;
+            if (flipH)
+                result = HorizontalDirectionToken.Replace(result, m => m.Value == "Right" ? "Left" : "Right");
+            if (flipV)
+                result = VerticalDirectionToken.Replace(result, m => m.Value == "Up" ? "Down" : "Up");
+            return result;
+        }
+
         public AnimationFrameSave? DuplicateFrame(AnimationFrameSave source, AnimationChainSave chain)
         {
             if (!chain.Frames.Contains(source)) return null;
@@ -1262,7 +1283,9 @@ namespace AnimationEditor.Core.CommandsAndState
             foreach (var source in ordered)
             {
                 var copy = CloneChainWithFlip(source, flipH, flipV);
-                copy.Name = StringFunctions.MakeStringUnique(source.Name + "Copy", existingNames, 2);
+                var invertedName = InvertDirectionTokens(source.Name, flipH, flipV);
+                var desiredName = invertedName != source.Name ? invertedName : source.Name + "Copy";
+                copy.Name = StringFunctions.MakeStringUnique(desiredName, existingNames, 2);
                 existingNames.Add(copy.Name);
                 items.Add((source, copy));
             }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainTests.cs
@@ -527,6 +527,146 @@ public class AppCommandsChainTests
         Assert.NotEqual(copy1!.Name, copy2!.Name);
     }
 
+    // ── DuplicateChain — direction-token rename on flip ────────────────────────
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_RenamesRightToLeft()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "WalkRight");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("WalkLeft", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_RenamesLeftToRight()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "WalkLeft");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("WalkRight", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipV_RenamesUpToDown()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "JumpUp");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipV: true);
+
+        Assert.Equal("JumpDown", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipV_RenamesDownToUp()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "JumpDown");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipV: true);
+
+        Assert.Equal("JumpUp", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipHAndFlipV_RenamesBothTokens()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "AttackUpRight");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true, flipV: true);
+
+        Assert.Equal("AttackDownLeft", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_WhenNameHasNoDirectionToken_FallsBackToCopySuffix()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Idle");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("IdleCopy", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_DoesNotMatchDirectionTokenInsideLongerWord()
+    {
+        // "Rightful" must not be treated as containing the "Right" token — a plain
+        // substring swap would corrupt it into "Leftful".
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Rightful");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("RightfulCopy", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipV_DoesNotMatchDirectionTokenInsideLongerWord()
+    {
+        // "Upgrade" must not be treated as containing the "Up" token.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "Upgrade");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipV: true);
+
+        Assert.Equal("UpgradeCopy", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_WhenInvertedNameAlreadyExists_MakesResultUnique()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "WalkRight");
+        TestHelpers.MakeChain(acls, "WalkLeft");   // pre-existing chain the flip would collide with
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("WalkLeft2", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChain_WithFlipH_IsCaseSensitiveAboutDirectionToken()
+    {
+        // Lowercase "right" is not the "Right" PascalCase token — falls back to Copy suffix.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var source = TestHelpers.MakeChain(acls, "walkright");
+
+        var copy = ctx.AppCommands.DuplicateChain(source, flipH: true);
+
+        Assert.Equal("walkrightCopy", copy!.Name);
+    }
+
+    [Fact]
+    public void DuplicateChains_WithFlipH_RenamesEachCopyIndependently()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var acls = ctx.Acls;
+        var walkRight = TestHelpers.MakeChain(acls, "WalkRight");
+        var runRight  = TestHelpers.MakeChain(acls, "RunRight");
+
+        var copies = ctx.AppCommands.DuplicateChains(new[] { walkRight, runRight }, flipH: true);
+
+        Assert.Equal(new[] { "WalkLeft", "RunLeft" }, copies.Select(c => c.Name));
+    }
+
     [Fact]
     public void DuplicateChain_WithCustomName_UsesProvidedName()
     {


### PR DESCRIPTION
## Summary
- Duplicate + Flip Horizontal/Vertical now swaps Right<->Left / Up<->Down in the copy's name (`WalkRight` -> `WalkLeft`) instead of always appending "Copy", matching the old (pre-Avalonia) editor's behavior.
- Falls back to the `<Name>Copy` suffix when the name has no direction token.
- Token match requires the token not be followed by a lowercase letter, so it only matches a standalone PascalCase word (`WalkRight`) and not a prefix of a longer word (`Rightful`, `Upgrade`).
- If the swapped name collides with an existing chain, the existing `StringFunctions.MakeStringUnique` path numbers it (`WalkLeft2`).

Closes #920.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1872/1872 passing (14 new tests covering rename on flipH/flipV/both, no-token fallback, substring-safety, case-sensitivity, name-collision uniquification, and independent batch renaming)
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ --filter Duplicate` — 19/19 passing, no regressions
