### PR TITLE
AnimationEditor: right-click delete for Project-tab files (#919)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1943,10 +1943,12 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Issue #919: right-click Delete on a Project-tree file row. Confirms first (the move isn't
-    /// undoable) then hands off to <see cref="DeleteToRecycleBin"/>. No explicit tree refresh here
-    /// -- the project folder watcher's <see cref="HandleProjectFolderChangesAsync"/> already
-    /// rescans on any create/delete under the watched folder (its <c>structureChanged</c> path),
-    /// the same as it would for an external deletion (e.g. `git pull`, another editor). Internal
+    /// undoable) then hands off to <see cref="DeleteToRecycleBin"/>. On success, also closes the
+    /// file's tab if it's open -- otherwise Save would silently resurrect it outside the recycle
+    /// bin. No explicit tree refresh -- the project folder watcher's
+    /// <see cref="HandleProjectFolderChangesAsync"/> already rescans on any create/delete under
+    /// the watched folder (its <c>structureChanged</c> path), the same as it would for an
+    /// external deletion (e.g. `git pull`, another editor). Internal
     /// (not private), same reason as <see cref="OpenProjectFolderForTestAsync"/>: production only
     /// ever reaches it via <see cref="Controls.ProjectPanelControl.FileDeleteRequested"/>, but
     /// tests exercise the confirm-gate/recycle-bin wiring directly.
@@ -1963,7 +1965,16 @@ public partial class MainWindow : Window
 
         var error = DeleteToRecycleBin(absolutePath);
         if (error is not null)
+        {
             ShowStatusMessage($"⚠ {error}", isError: true);
+            return;
+        }
+
+        // The file is gone -- leaving its tab open would let Save silently resurrect it outside
+        // the recycle bin, defeating the confirm dialog above. No "unsaved changes?" prompt here:
+        // the user already confirmed a destructive, non-undoable action.
+        if (_tabManager.Tabs.FirstOrDefault(t => t.Path == new FilePath(absolutePath)) is { } openTab)
+            CloseTab(openTab);
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -269,6 +269,7 @@ public partial class MainWindow : Window
         ProjectPanel.FolderRevealRequested += relativePath => RevealProjectFolderInExplorer(relativePath);
         ProjectPanel.FileRevealRequested += relativePath => RevealProjectFileInExplorer(relativePath);
         ProjectPanel.FileCopyPathRequested += relativePath => CopyProjectFilePathToClipboard(relativePath);
+        ProjectPanel.FileDeleteRequested += relativePath => _ = DeleteProjectFileAsync(relativePath);
         // Right-clicking blank space in the tree offers "New Animation" (#908) -- same flow as
         // File > New.
         ProjectPanel.NewAnimationRequested += () => OnNewClick(null, null!);
@@ -1939,6 +1940,40 @@ public partial class MainWindow : Window
 
         _ = TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(absolutePath);
     }
+
+    /// <summary>
+    /// Issue #919: right-click Delete on a Project-tree file row. Confirms first (the move isn't
+    /// undoable) then hands off to <see cref="DeleteToRecycleBin"/>. No explicit tree refresh here
+    /// -- the project folder watcher's <see cref="HandleProjectFolderChangesAsync"/> already
+    /// rescans on any create/delete under the watched folder (its <c>structureChanged</c> path),
+    /// the same as it would for an external deletion (e.g. `git pull`, another editor). Internal
+    /// (not private), same reason as <see cref="OpenProjectFolderForTestAsync"/>: production only
+    /// ever reaches it via <see cref="Controls.ProjectPanelControl.FileDeleteRequested"/>, but
+    /// tests exercise the confirm-gate/recycle-bin wiring directly.
+    /// </summary>
+    internal async Task DeleteProjectFileAsync(string relativePath)
+    {
+        var absolutePath = ResolveProjectFolderAbsolutePath(relativePath);
+        if (absolutePath is null) return;
+
+        var fileName = new FilePath(absolutePath).NoPath;
+        bool confirmed = await _appCommands.ConfirmAsync(
+            $"Delete \"{fileName}\"? This cannot be undone.", "Delete File");
+        if (!confirmed) return;
+
+        var error = DeleteToRecycleBin(absolutePath);
+        if (error is not null)
+            ShowStatusMessage($"⚠ {error}", isError: true);
+    }
+
+    /// <summary>
+    /// Test seam for the actual OS recycle-bin move -- defaults to <see cref="RecycleBin.Delete"/>.
+    /// UI-layer-only (used by exactly one caller, <see cref="DeleteProjectFileAsync"/>), same
+    /// reasoning as <see cref="ShowTwoButtonDialogAsync"/> for not living on the shared
+    /// <c>IAppCommands</c> delegate surface: it doesn't need ~20 unrelated test stubs to know
+    /// about it.
+    /// </summary>
+    internal Func<string, string?> DeleteToRecycleBin { get; set; } = RecycleBin.Delete;
 
     private void OnTitleFileCopyPathClick(object? sender, RoutedEventArgs e)
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -84,6 +84,14 @@ public partial class ProjectPanelControl : UserControl
     public event Action<string>? FileCopyPathRequested;
 
     /// <summary>
+    /// Raised when the user picks "Delete" for a file row (issue #919). Carries the file's
+    /// <see cref="AchxTreeNodeVm.RelativePath"/> for the host to resolve, same as
+    /// <see cref="FolderRevealRequested"/>. The host owns confirming and the actual
+    /// recycle-bin move -- this control only reports the request.
+    /// </summary>
+    public event Action<string>? FileDeleteRequested;
+
+    /// <summary>
     /// Raised when the user picks "New Animation" from the context menu shown on right-clicking
     /// blank space in the tree, i.e. no node under the cursor (issue #908). The host resolves what
     /// "new" means (desktop/browser both currently reuse their existing File → New flow).
@@ -361,6 +369,12 @@ public partial class ProjectPanelControl : UserControl
             var copyPathItem = new MenuItem { Header = "Copy Full Path" };
             copyPathItem.Click += (_, _) => FileCopyPathRequested?.Invoke(fileNode.RelativePath);
             ProjectTree.ContextMenu.Items.Add(copyPathItem);
+
+            ProjectTree.ContextMenu.Items.Add(new Separator());
+
+            var deleteItem = new MenuItem { Header = "Delete" };
+            deleteItem.Click += (_, _) => FileDeleteRequested?.Invoke(fileNode.RelativePath);
+            ProjectTree.ContextMenu.Items.Add(deleteItem);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/RecycleBin.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/RecycleBin.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Moves a file to the OS trash/recycle bin instead of permanently deleting it (issue #919).
+/// </summary>
+public static class RecycleBin
+{
+    /// <summary>
+    /// Moves <paramref name="absolutePath"/> to the system trash. Returns <c>null</c> on
+    /// success, or an error message when the file is missing or the platform call fails.
+    /// </summary>
+    public static string? Delete(string absolutePath)
+    {
+        if (string.IsNullOrEmpty(absolutePath))
+            return "No file path was provided.";
+
+        if (!File.Exists(absolutePath))
+            return $"File not found: {absolutePath}";
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(
+                    absolutePath,
+                    Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
+                    Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                // Finder both moves the file into Trash and de-duplicates the destination name
+                // itself, so there's no manual collision handling needed here (unlike Linux).
+                var script = $"tell application \"Finder\" to delete POSIX file \"{absolutePath}\"";
+                using var process = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "osascript",
+                    ArgumentList = { "-e", script },
+                    UseShellExecute = false,
+                });
+                process?.WaitForExit();
+            }
+            else
+            {
+                MoveToLinuxTrash(absolutePath);
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"Could not move to recycle bin: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Implements the freedesktop.org home-Trash spec directly instead of shelling out to
+    /// <c>gio trash</c>/<c>kioclient</c> -- neither is guaranteed present on every distro or
+    /// window manager, while <c>$XDG_DATA_HOME/Trash/files</c> plus a sibling <c>.trashinfo</c>
+    /// is the same on-disk layout GNOME/KDE file managers themselves read to offer "Restore".
+    /// </summary>
+    private static void MoveToLinuxTrash(string absolutePath)
+    {
+        var dataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+        if (string.IsNullOrEmpty(dataHome))
+            dataHome = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+
+        var trashFiles = Path.Combine(dataHome, "Trash", "files");
+        var trashInfo = Path.Combine(dataHome, "Trash", "info");
+        Directory.CreateDirectory(trashFiles);
+        Directory.CreateDirectory(trashInfo);
+
+        var name = Path.GetFileName(absolutePath);
+        var destName = name;
+        var suffix = 1;
+        while (File.Exists(Path.Combine(trashFiles, destName)) ||
+               File.Exists(Path.Combine(trashInfo, destName + ".trashinfo")))
+        {
+            destName = $"{Path.GetFileNameWithoutExtension(name)}.{suffix++}{Path.GetExtension(name)}";
+        }
+
+        File.WriteAllText(Path.Combine(trashInfo, destName + ".trashinfo"),
+            "[Trash Info]\n" +
+            $"Path={Uri.EscapeDataString(absolutePath)}\n" +
+            $"DeletionDate={DateTime.Now:yyyy-MM-ddTHH:mm:ss}\n");
+        File.Move(absolutePath, Path.Combine(trashFiles, destName));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFileDeleteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFileDeleteTests.cs
@@ -1,6 +1,11 @@
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
 using Avalonia.Headless.XUnit;
+using FlatRedBall2.Animation.Content;
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -23,6 +28,22 @@ namespace AnimationEditor.App.Tests;
 /// </summary>
 public class ProjectFileDeleteTests
 {
+    private static string WriteAchx(string dir, string fileName)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "walk.png", FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
     [AvaloniaFact]
     public async Task DeleteProjectFileAsync_UserDeclinesConfirm_DoesNotCallRecycleBin()
     {
@@ -68,6 +89,58 @@ public class ProjectFileDeleteTests
             await window.DeleteProjectFileAsync("hero.achx");
 
             Assert.Equal(achx, recycledPath);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    // Issue #919 follow-up: deleting a file that's open in a tab must close that tab -- otherwise
+    // Save would silently resurrect the file outside the recycle bin, defeating the confirm dialog.
+    [AvaloniaFact]
+    public async Task DeleteProjectFileAsync_FileOpenInTab_ClosesTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achx = WriteAchx(dir, "hero.achx");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            await window.OpenFileAsTab(achx);
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+            window.DeleteToRecycleBin = _ => null;
+
+            await window.DeleteProjectFileAsync("hero.achx");
+
+            var tabManager = GetTabManager(window);
+            Assert.DoesNotContain(tabManager.Tabs, t => t.Path == new FilePath(achx));
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    // Delete failing (e.g. permission denied) must leave the open tab alone -- nothing was
+    // actually removed from disk, so closing it would just lose the user's place for no reason.
+    [AvaloniaFact]
+    public async Task DeleteProjectFileAsync_RecycleBinFails_LeavesTabOpen()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achx = WriteAchx(dir, "hero.achx");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            await window.OpenFileAsTab(achx);
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+            window.DeleteToRecycleBin = _ => "Could not move to recycle bin: access denied.";
+
+            await window.DeleteProjectFileAsync("hero.achx");
+
+            var tabManager = GetTabManager(window);
+            Assert.Contains(tabManager.Tabs, t => t.Path == new FilePath(achx));
         }
         finally { window.Close(); Directory.Delete(dir, true); }
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFileDeleteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectFileDeleteTests.cs
@@ -1,0 +1,98 @@
+using Avalonia.Headless.XUnit;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #919 -- right-click Delete on a Project-tree file row. <see cref="ProjectPanelControlTests"/>
+/// (Views.Tests) covers the context menu and event-raising; these tests cover MainWindow's
+/// <c>DeleteProjectFileAsync</c> confirm-gate and its handoff to the <c>DeleteToRecycleBin</c> seam.
+/// The seam is stubbed in every test, so the real OS recycle-bin move (<see cref="RecycleBin"/>'s
+/// platform branches) is never exercised here -- see <c>RecycleBinTests</c> for the pure guard
+/// clauses that are exercised without touching a real recycle bin/trash.
+///
+/// <c>ConfirmAsync</c> must be re-stubbed on <c>ctx.AppCommands</c> AFTER
+/// <see cref="TestServices.CreateMainWindow"/>, not before: the constructor's <c>WireAppCommands</c>
+/// unconditionally overwrites it with the real modal dialog (see the animation-editor-testing
+/// skill's "[AvaloniaFact] is a last resort" landmine on this exact delegate). <c>ctx.AppCommands</c>
+/// and MainWindow's own <c>_appCommands</c> are the same instance, so mutating it post-construction
+/// still reaches the window.
+/// </summary>
+public class ProjectFileDeleteTests
+{
+    [AvaloniaFact]
+    public async Task DeleteProjectFileAsync_UserDeclinesConfirm_DoesNotCallRecycleBin()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achx = Path.Combine(dir, "hero.achx");
+        File.WriteAllText(achx, "not a real achx, never read");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(false);
+            string? recycledPath = null;
+            window.DeleteToRecycleBin = path => { recycledPath = path; return null; };
+
+            await window.DeleteProjectFileAsync("hero.achx");
+
+            Assert.Null(recycledPath);
+            Assert.True(File.Exists(achx));
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public async Task DeleteProjectFileAsync_UserConfirms_CallsRecycleBinWithAbsolutePath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achx = Path.Combine(dir, "hero.achx");
+        File.WriteAllText(achx, "not a real achx, never read");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+            string? recycledPath = null;
+            window.DeleteToRecycleBin = path => { recycledPath = path; return null; };
+
+            await window.DeleteProjectFileAsync("hero.achx");
+
+            Assert.Equal(achx, recycledPath);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public async Task DeleteProjectFileAsync_RecycleBinReturnsError_ShowsErrorBanner()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var achx = Path.Combine(dir, "hero.achx");
+        File.WriteAllText(achx, "not a real achx, never read");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+            window.DeleteToRecycleBin = _ => "Could not move to recycle bin: access denied.";
+
+            await window.DeleteProjectFileAsync("hero.achx");
+
+            Assert.True(window.Notifications.ErrorBanner.IsVisible);
+            Assert.Contains("access denied", window.Notifications.ErrorBannerText.Text, StringComparison.Ordinal);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecycleBinTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/RecycleBinTests.cs
@@ -1,0 +1,30 @@
+using AnimationEditor.App.Services;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #919 — right-click Delete on a Project-tree file moves it to the OS recycle bin.
+/// Only <see cref="RecycleBin"/>'s guard clauses are covered here; the actual platform move
+/// (Windows <c>FileIO.FileSystem.DeleteFile</c>, macOS <c>osascript</c>, Linux trash-spec write)
+/// is OS-side-effecting the same way <see cref="ShellExplorer.RevealFile"/>'s <c>Process.Start</c>
+/// calls are -- deliberately left untested rather than actually touching a developer's real
+/// recycle bin/trash on every test run.
+/// </summary>
+public class RecycleBinTests
+{
+    [Fact]
+    public void Delete_EmptyPath_ReturnsError()
+    {
+        Assert.Equal("No file path was provided.", RecycleBin.Delete(string.Empty));
+    }
+
+    [Fact]
+    public void Delete_FileDoesNotExist_ReturnsNotFoundError()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "AnimationEditorRecycleBinTests_missing.achx");
+
+        Assert.Equal($"File not found: {missing}", RecycleBin.Delete(missing));
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -230,6 +230,7 @@ public class ProjectPanelControlTests
 
     // Issue #886: right-click a file row -> "Open Containing Folder" + "Copy Full Path", same
     // headers as the document tab strip's context menu (#881/#884) for the equivalent open file.
+    // Issue #919 added "Delete" after a separator.
     [AvaloniaFact]
     public void RightClickingFileRow_WithRevealSupported_ShowsOpenFolderAndCopyPathItems()
     {
@@ -244,7 +245,30 @@ public class ProjectPanelControlTests
 
             var headers = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
                 .Select(i => i.Header).ToArray();
-            Assert.Equal(new object?[] { "Open Containing Folder", "Copy Full Path" }, headers);
+            Assert.Equal(new object?[] { "Open Containing Folder", "Copy Full Path", "Delete" }, headers);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ClickingDelete_RaisesFileDeleteRequestedWithRelativePath()
+    {
+        var control = new Controls.ProjectPanelControl { SupportsRevealInExplorer = true };
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClick(window, control, control.TreeRoots[0].Children[0]); // "hero.achx" under "Sprites"
+            string? requested = null;
+            control.FileDeleteRequested += path => requested = path;
+
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Single(i => (string)i.Header! == "Delete");
+            item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+
+            Assert.Equal("Sprites/hero.achx", requested);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
## Summary
- Right-click a `.achx`/`.achj` in the Project tab's file tree → **Delete**, after a separator following "Copy Full Path".
- Confirms first (not undoable), then moves the file to the OS recycle bin/trash instead of permanently deleting it: Windows via `FileIO.FileSystem.DeleteFile(..., RecycleOption.SendToRecycleBin)` (ships in the shared framework, no new package); macOS via `osascript`/Finder; Linux via a direct freedesktop.org home-Trash write (no `gio`/`kioclient` dependency).
- No explicit tree refresh — the existing project-folder watcher already rescans on any create/delete under the watched folder, same as an external deletion.

## Manual test
Needed (real right-click UX + real recycle bin/trash behavior — the actual OS move is deliberately left untested, same precedent as `ShellExplorer.RevealFile`'s `Process.Start`). Launched `AnimationEditor.App` pointed at a scratch copy of `manual-test-content/shmup-space` under `diagnostics/manual-test/` (gitignored, not pushed) so it's ready to click through.

## Test plan
- [x] `AnimationEditor.Views.Tests` (113 passed) — context menu shows "Delete" after a separator; clicking raises `FileDeleteRequested` with the relative path.
- [x] `AnimationEditor.App.Tests` (843 passed) — confirm-gate wiring: decline → recycle-bin seam not called, file untouched; confirm → seam called with the resolved absolute path; seam error → surfaces via the error banner.
- [x] `AnimationEditor.Core.Tests` (1861 passed), `AnimationEditor.DocScreenshots` (6 passed) — unaffected, run as regression check.
- [x] Verified TDD: temporarily removed the confirm-gate's early return and reran — the decline test failed red, confirming the test is meaningful.

Closes #919
