### PR TITLE
AnimationEditor: delete recovery file when closing an untitled tab

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -790,6 +790,13 @@ public partial class MainWindow : Window
 
     private void CloseTab(TabEntry tab)
     {
+        // Closing an untitled tab is an explicit discard of its unsaved content -- clear any
+        // crash-recovery file autosave-on-edit wrote for it (AppCommands.SaveCurrentAnimationChainList
+        // writes there whenever FileName is null), or it re-prompts to restore already-discarded
+        // content on the next launch (#927).
+        if (IsUntitledTab(tab))
+            _ioManager.DeleteRecoveryFile();
+
         _tabManager.Close(tab.Path);
         var next = _tabManager.ActiveTab;
         if (next != null)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabCloseRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabCloseRecoveryTests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Reflection;
+using AnimationEditor.Core.Models;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #927: closing an untitled tab left the crash-recovery file on disk, so the next
+/// launch offered to restore content the user had just explicitly discarded by closing the
+/// tab. Autosave-on-edit (<c>AppCommands.SaveCurrentAnimationChainList</c>) writes the
+/// recovery file on every edit of an untitled document; closing that tab must clear it.
+/// </summary>
+public class TabCloseRecoveryTests
+{
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    private static void CloseTab(MainWindow window, TabEntry tab) =>
+        typeof(MainWindow)
+            .GetMethod("CloseTab", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, [tab]);
+
+    [AvaloniaFact]
+    public void ClosingUntitledTabWithRecoveryFile_DeletesRecoveryFile()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            // File -> New opens a fresh untitled tab.
+            window.FindControl<MenuItem>("MenuNew")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            // Editing an untitled document autosaves to the recovery file (FileName is null).
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(ctx.IoManager.RecoveryFileExists());
+
+            var tabManager = GetTabManager(window);
+            var tab = tabManager.Tabs.Single();
+
+            CloseTab(window, tab);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(ctx.IoManager.RecoveryFileExists());
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
Closes #927.

Autosave-on-edit (`AppCommands.SaveCurrentAnimationChainList`) writes the crash-recovery file on every edit of an untitled document. `MainWindow.CloseTab` never deleted it, so closing the tab (explicit discard) left a stale recovery file that got offered back on the next launch.

Fix: `CloseTab` deletes the recovery file when the closed tab is untitled.

Manual test: not needed — covered by `TabCloseRecoveryTests` (new, reproduces the bug then verifies the fix) plus the full App.Tests (851) and Core.Tests (1872) suites, both green.
