### PR TITLE
AnimationEditor: prompt to save an untitled tab's content before closing

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -408,7 +408,7 @@ public partial class MainWindow : Window
                 Margin = new Avalonia.Thickness(2, 0, 2, 0),
             };
             Grid.SetColumn(closeBtn, 1);
-            closeBtn.Click += (_, _) => CloseTab(captured);
+            closeBtn.Click += (_, _) => _ = CloseTabAsync(captured);
 
             row.Children.Add(label);
             row.Children.Add(closeBtn);
@@ -451,7 +451,7 @@ public partial class MainWindow : Window
             tabMenu.Items.Add(new MenuItem
             {
                 Header = "Close Tab",
-                Command = new RelayCommand(() => CloseTab(captured)),
+                Command = new RelayCommand(() => _ = CloseTabAsync(captured)),
             });
             tabBorder.ContextMenu = tabMenu;
 
@@ -527,7 +527,7 @@ public partial class MainWindow : Window
 
                 if (uk == PointerUpdateKind.MiddleButtonReleased)
                 {
-                    CloseTab(captured);
+                    _ = CloseTabAsync(captured);
                     args.Handled = true;
                     return;
                 }
@@ -788,7 +788,52 @@ public partial class MainWindow : Window
     /// </summary>
     public async Task OpenFileAsTab(string filePath) => await LoadAnimationFileAsync(filePath);
 
-    private void CloseTab(TabEntry tab)
+    /// <summary>
+    /// Closes <paramref name="tab"/>, prompting to save first when it is an untitled tab that
+    /// has actual content (issue #928) -- an untitled tab that was never edited (or was edited
+    /// back to empty) closes silently, same as before. "Save" runs the normal Save-As flow;
+    /// declining it (dialog cancelled) leaves the tab open rather than closing with no file
+    /// written. "Don't Save" and the empty-tab fast path both fall through to
+    /// <see cref="CloseTabCore"/>, which is what clears the crash-recovery file (#927).
+    /// </summary>
+    private async Task CloseTabAsync(TabEntry tab)
+    {
+        if (tab.Kind == TabKind.Achx && IsUntitledTab(tab) && UntitledTabHasContent(tab))
+        {
+            var choice = await ShowSaveDiscardCancelDialogAsync(
+                $"\"{tab.DisplayName}\" has unsaved changes. Save before closing?",
+                "Unsaved Changes");
+            if (choice == SaveDiscardCancelChoice.Cancel) return;
+
+            if (choice == SaveDiscardCancelChoice.Save)
+            {
+                if (tab != _tabManager.ActiveTab)
+                    await ActivateTabAsync(tab);
+
+                await _appCommands.SaveCurrentAnimationChainListAsync();
+                if (string.IsNullOrEmpty(_projectManager.FileName))
+                    return; // Save As was cancelled -- leave the tab open, nothing was written.
+
+                // A successful save renames the sentinel tab in place (the CurrentFileChanged
+                // handler's Rename), which replaces the TabEntry instance -- re-resolve through
+                // ActiveTab rather than closing the now-stale `tab` reference.
+                tab = _tabManager.ActiveTab ?? tab;
+            }
+        }
+
+        CloseTabCore(tab);
+    }
+
+    /// <summary>
+    /// True when <paramref name="tab"/>'s document has actual content worth prompting to save
+    /// (issue #928) -- reads the live model for the active tab, or the cached snapshot captured
+    /// when a background tab was last left (<see cref="TabController.CaptureLeavingTab"/>).
+    /// </summary>
+    private bool UntitledTabHasContent(TabEntry tab) =>
+        (tab == _tabManager.ActiveTab ? _projectManager.AnimationChainListSave : tab.CachedEditorModel)
+            is { AnimationChains.Count: > 0 };
+
+    private void CloseTabCore(TabEntry tab)
     {
         // Closing an untitled tab is an explicit discard of its unsaved content -- clear any
         // crash-recovery file autosave-on-edit wrote for it (AppCommands.SaveCurrentAnimationChainList
@@ -1038,6 +1083,7 @@ public partial class MainWindow : Window
         _appCommands.ConfirmAsync = ShowConfirmDialogAsync;
         _appCommands.PromptStringAsync = ShowStringInputDialogAsync;
         ShowTwoButtonDialogAsync = ShowTwoButtonDialogAsyncCore;
+        ShowSaveDiscardCancelDialogAsync = ShowSaveDiscardCancelDialogAsyncCore;
 
         // File dialog service
         _appCommands.FileDialogService = new Services.AvaloniaFileDialogService(this);
@@ -1981,7 +2027,7 @@ public partial class MainWindow : Window
         // the recycle bin, defeating the confirm dialog above. No "unsaved changes?" prompt here:
         // the user already confirmed a destructive, non-undoable action.
         if (_tabManager.Tabs.FirstOrDefault(t => t.Path == new FilePath(absolutePath)) is { } openTab)
-            CloseTab(openTab);
+            CloseTabCore(openTab);
     }
 
     /// <summary>
@@ -5139,7 +5185,7 @@ public partial class MainWindow : Window
     {
         if (IsUntitledTab(tab)) return;
         var filePath = tab.Path.FullPath;
-        CloseTab(tab);
+        CloseTabCore(tab);
         var window = App.CreateDetachedWindow();
         window.Show();
         _ = window.OpenFileAsTab(filePath);
@@ -5363,6 +5409,17 @@ public partial class MainWindow : Window
     private Task<bool> ShowTwoButtonDialogAsyncCore(
         string message, string title, string confirmLabel, string cancelLabel) =>
         EditorDialogs.ConfirmAsync(_dialogHost, message, title, confirmLabel, cancelLabel);
+
+    /// <summary>
+    /// Test seam for the Save / Don't Save / Cancel prompt shown by
+    /// <see cref="CloseTabAsync"/> when closing an untitled tab that has content. Same
+    /// reasoning as <see cref="ShowTwoButtonDialogAsync"/> for living here instead of on the
+    /// shared <c>IAppCommands</c> delegate surface.
+    /// </summary>
+    internal Func<string, string, Task<SaveDiscardCancelChoice>> ShowSaveDiscardCancelDialogAsync { get; set; } = null!;
+
+    private Task<SaveDiscardCancelChoice> ShowSaveDiscardCancelDialogAsyncCore(string message, string title) =>
+        EditorDialogs.ConfirmSaveDiscardCancelAsync(_dialogHost, message, title);
 
     /// <summary>
     /// Wires ENTER → <paramref name="onConfirm"/> and ESC → <paramref name="onCancel"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
@@ -7,6 +7,14 @@ using FlatRedBall2.Animation.Content;
 
 namespace AnimationEditor.Views.Dialogs;
 
+/// <summary>Result of <see cref="EditorDialogs.ConfirmSaveDiscardCancelAsync"/>.</summary>
+public enum SaveDiscardCancelChoice
+{
+    Save,
+    Discard,
+    Cancel,
+}
+
 public static class EditorDialogs
 {
     private readonly record struct FrameTimeChoice(float TotalDuration, bool KeepProportional);
@@ -28,6 +36,28 @@ public static class EditorDialogs
         dialog.Cancel = () => dialog.Complete(false);
         panel.Children.Add(BuildButtonRow(
             (confirmLabel, dialog.Confirm),
+            (cancelLabel, dialog.Cancel)));
+        return host.ShowAsync(dialog);
+    }
+
+    /// <summary>
+    /// Three-way Save / Don't Save / Cancel prompt (e.g. closing a tab with unsaved changes).
+    /// Enter triggers Save, Escape (or the window's close button) triggers Cancel.
+    /// </summary>
+    public static Task<SaveDiscardCancelChoice> ConfirmSaveDiscardCancelAsync(
+        IEditorDialogHost host, string message, string title,
+        string saveLabel = "Save", string discardLabel = "Don't Save", string cancelLabel = "Cancel")
+    {
+        var panel = new StackPanel { Margin = new Thickness(16), Spacing = 12 };
+        panel.Children.Add(new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap });
+
+        var dialog = new EditorDialog<SaveDiscardCancelChoice>(
+            new EditorDialogOptions(title, 420, 160), panel, cancelResult: SaveDiscardCancelChoice.Cancel);
+        dialog.Confirm = () => dialog.Complete(SaveDiscardCancelChoice.Save);
+        dialog.Cancel = () => dialog.Complete(SaveDiscardCancelChoice.Cancel);
+        panel.Children.Add(BuildButtonRow(
+            (saveLabel, dialog.Confirm),
+            (discardLabel, () => dialog.Complete(SaveDiscardCancelChoice.Discard)),
             (cancelLabel, dialog.Cancel)));
         return host.ShowAsync(dialog);
     }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseLastTabTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseLastTabTests.cs
@@ -39,11 +39,11 @@ public class CloseLastTabTests
             .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(window)!;
 
-    private static void CloseTab(MainWindow window, TabEntry tab)
+    private static async System.Threading.Tasks.Task CloseTabAsync(MainWindow window, TabEntry tab)
     {
         var method = typeof(MainWindow)
-            .GetMethod("CloseTab", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        method.Invoke(window, [tab]);
+            .GetMethod("CloseTabAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (System.Threading.Tasks.Task)method.Invoke(window, [tab])!;
     }
 
     [AvaloniaFact]
@@ -95,7 +95,7 @@ public class CloseLastTabTests
             var tabManager = GetTabManager(window);
             var tabA = tabManager.Tabs.First(t => t.Path == new FilePath(pathA));
 
-            CloseTab(window, tabA);
+            await CloseTabAsync(window, tabA);
             Dispatcher.UIThread.RunJobs();
 
             Assert.Empty(tabManager.Tabs);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectPanelTabSwitchSyncTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ProjectPanelTabSwitchSyncTests.cs
@@ -156,8 +156,8 @@ public class ProjectPanelTabSwitchSyncTests
             var tabB = tabManager.Tabs.First(t => t.Path == new FilePath(pathB));
 
             var closeTabMethod = typeof(MainWindow)
-                .GetMethod("CloseTab", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-            closeTabMethod.Invoke(window, [tabB]);
+                .GetMethod("CloseTabAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            await (Task)closeTabMethod.Invoke(window, [tabB])!;
             Dispatcher.UIThread.RunJobs();
 
             Assert.NotNull(window.ProjectPanel.SelectedEntry);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabCloseRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TabCloseRecoveryTests.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using AnimationEditor.Core.Models;
+using AnimationEditor.Views.Dialogs;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
@@ -14,6 +16,8 @@ namespace AnimationEditor.App.Tests;
 /// launch offered to restore content the user had just explicitly discarded by closing the
 /// tab. Autosave-on-edit (<c>AppCommands.SaveCurrentAnimationChainList</c>) writes the
 /// recovery file on every edit of an untitled document; closing that tab must clear it.
+/// This tab has content, so closing it also raises the #928 save prompt -- stub straight to
+/// "Don't Save" since discard-then-cleanup is what this test is verifying.
 /// </summary>
 public class TabCloseRecoveryTests
 {
@@ -22,17 +26,18 @@ public class TabCloseRecoveryTests
             .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(window)!;
 
-    private static void CloseTab(MainWindow window, TabEntry tab) =>
-        typeof(MainWindow)
-            .GetMethod("CloseTab", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(window, [tab]);
+    private static async Task CloseTabAsync(MainWindow window, TabEntry tab) =>
+        await (Task)typeof(MainWindow)
+            .GetMethod("CloseTabAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, [tab])!;
 
     [AvaloniaFact]
-    public void ClosingUntitledTabWithRecoveryFile_DeletesRecoveryFile()
+    public async Task ClosingUntitledTabWithRecoveryFile_DeletesRecoveryFile()
     {
         var ctx = TestHelpers.BuildServices();
         var window = ctx.CreateMainWindow();
         window.Show();
+        window.ShowSaveDiscardCancelDialogAsync = (_, _) => Task.FromResult(SaveDiscardCancelChoice.Discard);
         try
         {
             // File -> New opens a fresh untitled tab.
@@ -48,7 +53,7 @@ public class TabCloseRecoveryTests
             var tabManager = GetTabManager(window);
             var tab = tabManager.Tabs.Single();
 
-            CloseTab(window, tab);
+            await CloseTabAsync(window, tab);
             Dispatcher.UIThread.RunJobs();
 
             Assert.False(ctx.IoManager.RecoveryFileExists());

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UntitledTabCloseSavePromptTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UntitledTabCloseSavePromptTests.cs
@@ -1,0 +1,158 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Views.Dialogs;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #928: closing an untitled tab that has actual content must prompt to save it first,
+/// separate from #927's "already-empty tab closes silently" case. "Has content" is any
+/// document with at least one chain -- the same proxy <c>TabController.EnsureCurrentDocumentHasTab</c>
+/// already uses to decide whether a fresh untitled document is worth a tab at all, since there
+/// is no separate dirty flag (autosave-on-edit continuously writes the crash-recovery file
+/// instead of tracking one).
+/// </summary>
+public class UntitledTabCloseSavePromptTests
+{
+    private sealed class StubFileDialogService(string? path) : IFileDialogService
+    {
+        public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription) =>
+            Task.FromResult(path);
+
+        public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    private static async Task CloseTabAsync(MainWindow window, TabEntry tab) =>
+        await (Task)typeof(MainWindow)
+            .GetMethod("CloseTabAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, [tab])!;
+
+    private static void FileNew(MainWindow window)
+    {
+        window.FindControl<MenuItem>("MenuNew")!
+              .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public async Task ClosingEmptyUntitledTab_DoesNotPrompt()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        bool promptShown = false;
+        window.ShowSaveDiscardCancelDialogAsync = (_, _) =>
+        {
+            promptShown = true;
+            return Task.FromResult(SaveDiscardCancelChoice.Cancel);
+        };
+        try
+        {
+            FileNew(window);
+            var tab = GetTabManager(window).Tabs.Single();
+
+            await CloseTabAsync(window, tab);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(promptShown);
+            Assert.Empty(GetTabManager(window).Tabs);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public async Task ClosingUntitledTabWithContent_Cancel_LeavesTabOpen()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        window.ShowSaveDiscardCancelDialogAsync = (_, _) => Task.FromResult(SaveDiscardCancelChoice.Cancel);
+        try
+        {
+            FileNew(window);
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+            var tab = GetTabManager(window).Tabs.Single();
+
+            await CloseTabAsync(window, tab);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(GetTabManager(window).Tabs);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public async Task ClosingUntitledTabWithContent_Save_WritesFileAndClosesTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var savePath = Path.Combine(dir, "hero.achx");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        // MainWindow's constructor (WireAppCommands) overwrites FileDialogService with the real
+        // Avalonia one, so the stub must be installed after construction, not before.
+        ctx.AppCommands.FileDialogService = new StubFileDialogService(savePath);
+        window.Show();
+        window.ShowSaveDiscardCancelDialogAsync = (_, _) => Task.FromResult(SaveDiscardCancelChoice.Save);
+        try
+        {
+            FileNew(window);
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+            var tab = GetTabManager(window).Tabs.Single();
+
+            await CloseTabAsync(window, tab);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(File.Exists(savePath));
+            Assert.Contains("Walk", File.ReadAllText(savePath));
+            Assert.Empty(GetTabManager(window).Tabs);
+            Assert.False(ctx.IoManager.RecoveryFileExists());
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ClosingUntitledTabWithContent_SaveThenCancelFilePicker_LeavesTabOpen()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        ctx.AppCommands.FileDialogService = new StubFileDialogService(null);
+        window.Show();
+        window.ShowSaveDiscardCancelDialogAsync = (_, _) => Task.FromResult(SaveDiscardCancelChoice.Save);
+        try
+        {
+            FileNew(window);
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+            var tab = GetTabManager(window).Tabs.Single();
+
+            await CloseTabAsync(window, tab);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(GetTabManager(window).Tabs);
+            Assert.Null(ctx.ProjectManager.FileName);
+        }
+        finally { window.Close(); }
+    }
+}


### PR DESCRIPTION
Closes #928.

Closing an untitled tab with real content (at least one chain) discarded it silently -- autosave-on-edit only writes the crash-recovery file, there's no separate dirty flag. Empty untitled tabs (never edited, or edited back to empty) still close silently, unchanged from #927.

**Design decision** ("what counts as unsaved changes" with no dirty flag): a document has content when it has at least one animation chain -- the same proxy `TabController.EnsureCurrentDocumentHasTab` already uses to decide whether a fresh untitled document is worth a tab at all.

**Change**: `CloseTab` split into `CloseTabAsync` (the 3 interactive close actions: tab ✕, context menu, middle-click) and `CloseTabCore` (the 2 non-interactive callers that must never prompt -- deleting a project file's open tab, detaching a tab). `CloseTabAsync` shows a new Save / Don't Save / Cancel dialog (`EditorDialogs.ConfirmSaveDiscardCancelAsync`) when the tab is untitled and has content. Save runs the normal Save-As flow and re-resolves the tab through `ActiveTab` afterward, since a successful save renames the sentinel tab in place (replacing the `TabEntry` instance).

Manual test: not needed -- covered headlessly through the real `MainWindow`/dialog/tab-manager wiring (`UntitledTabCloseSavePromptTests`, new); full App.Tests (855), Core.Tests (1873), and Views.Tests (113) suites all green.
