### PR TITLE
readme: add AnimationEditor MonoGame/KNI NuGet badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # FlatRedBall2
 
 [![NuGet](https://img.shields.io/nuget/vpre/FlatRedBall2.MonoGame?label=NuGet)](https://www.nuget.org/packages/FlatRedBall2.MonoGame)
+[![NuGet](https://img.shields.io/nuget/vpre/FlatRedBall.AnimationChain.MonoGame?label=AnimationEditor%20MonoGame)](https://www.nuget.org/packages/FlatRedBall.AnimationChain.MonoGame)
+[![NuGet](https://img.shields.io/nuget/vpre/FlatRedBall.AnimationChain.KNI?label=AnimationEditor%20KNI)](https://www.nuget.org/packages/FlatRedBall.AnimationChain.KNI)
 
 > **Early Preview** — This engine is in active development. APIs will change between releases.
 


### PR DESCRIPTION
## Summary
- Adds two NuGet version badges to the README alongside the existing FlatRedBall2 badge, for `FlatRedBall.AnimationChain.MonoGame` and `FlatRedBall.AnimationChain.KNI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)