### PR TITLE
Fix Ctrl+click create-frame-from-region lowercasing texture name

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1560,7 +1560,10 @@ public partial class MainWindow : Window
         var primaryChain = selectedChains.Count > 0 ? selectedChains[0] : _selectedState.SelectedChain;
         if (primaryChain is null) return;
 
-        var texPath = WireframeCtrl.LoadedTexturePath;
+        // Must use the case-preserved accessor, not LoadedTexturePath (a lowercased cache key) --
+        // otherwise the frame's TextureName gets written with the wrong case on a case-sensitive
+        // filesystem (#941).
+        var texPath = WireframeCtrl.LoadedTexturePathCasePreserved;
         if (string.IsNullOrEmpty(texPath)) return;
 
         var (bitmapW, bitmapH) = WireframeCtrl.BitmapSize;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -457,8 +457,7 @@ public partial class App : Application
             // ThumbnailService's cache and existing frames actually use. The texture being
             // edited is always whichever one the selected chain's frames already reference, so
             // reuse that name directly rather than deriving one from the fake path.
-            var textureName = selectedState.SelectedFrame?.TextureName
-                ?? chain.Frames.FirstOrDefault()?.TextureName;
+            var textureName = AppCommands.ResolveRegionFrameTextureName(selectedState.SelectedFrame, chain);
             if (string.IsNullOrEmpty(textureName)) return;
 
             var (bitmapW, bitmapH) = wireframe.BitmapSize;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -774,6 +774,18 @@ namespace AnimationEditor.Core.CommandsAndState
             return null;
         }
 
+        /// <summary>
+        /// Resolves the texture name a create-frame-from-region frame should use when no real
+        /// on-disk path is available to derive one from (the browser build's
+        /// <c>FrameCreatedFromRegion</c> handler -- see <c>AnimationEditor.Browser/App.axaml.cs</c>).
+        /// Prefers the currently selected frame's texture; falls back to the chain's first frame.
+        /// Extracted so this stays testable in <c>AnimationEditor.Core.Tests</c> without a WASM
+        /// host (issue #941).
+        /// </summary>
+        public static string? ResolveRegionFrameTextureName(
+            AnimationFrameSave? selectedFrame, AnimationChainSave chain)
+            => selectedFrame?.TextureName ?? chain.Frames.FirstOrDefault()?.TextureName;
+
         public void MoveChain(AnimationChainSave chain, int delta)
         {
             var chains = _pm.AnimationChainListSave?.AnimationChains;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/TextureViewport.cs
@@ -242,6 +242,10 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
     // safe to draw from the Avalonia render thread.
     private SKImage? _image;
     protected string? _loadedTexturePath;
+    // Real on-disk case of _loadedTexturePath (which is lowercased -- see LoadedTexturePath's
+    // doc comment). Kept in lockstep with _loadedTexturePath so callers that persist the path
+    // (e.g. MainWindow.OnFrameCreatedFromRegion) never write a lowercased texture name (#941).
+    private string? _loadedTexturePathCasePreserved;
 
     // Bumped by every load/swap so an in-flight LoadTextureAsync decode that finishes after a newer
     // load can detect it was superseded and discard its result instead of painting stale pixels.
@@ -292,8 +296,18 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
 
     // ── Public properties ─────────────────────────────────────────────────────
 
-    /// <summary>Absolute path of the currently displayed texture, or null.</summary>
+    /// <summary>
+    /// Lowercased, slash-normalized absolute path of the currently displayed texture, or null.
+    /// This is a comparison/cache key only (see <see cref="LoadTexture(string?,SKBitmap?)"/>'s
+    /// <c>norm</c>) -- it does NOT reflect the real on-disk case. Callers that persist the path
+    /// (saving a frame's TextureName, displaying it to the user) must use
+    /// <see cref="LoadedTexturePathCasePreserved"/> instead, or a case-sensitive filesystem
+    /// (Linux/web) will fail to find the file later (#941).
+    /// </summary>
     public string? LoadedTexturePath => _loadedTexturePath;
+
+    /// <summary>Absolute path of the currently displayed texture in its real on-disk case, or null.</summary>
+    public string? LoadedTexturePathCasePreserved => _loadedTexturePathCasePreserved;
 
     /// <summary>Pixel dimensions of the loaded bitmap (0×0 when nothing is loaded).</summary>
     public (int Width, int Height) BitmapSize =>
@@ -534,7 +548,7 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
             return true;
         }
 
-        BeginTextureSwap(norm);
+        BeginTextureSwap(norm, casePreserved);
 
         if (knownBitmap != null)
         {
@@ -588,7 +602,7 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
             return true;
         }
 
-        BeginTextureSwap(norm);
+        BeginTextureSwap(norm, casePreserved);
         OnTextureLoaded(null);   // blank now; a subclass can show "Loading…"
         InvalidateVisual();
 
@@ -619,12 +633,13 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
 
     // Saves the leaving texture's camera, sets the new identity, and blanks the current image so the
     // view is empty until the (possibly async) decode installs the new one.
-    private void BeginTextureSwap(string? norm)
+    private void BeginTextureSwap(string? norm, string? casePreserved)
     {
         if (_loadedTexturePath != null)
             _cameraByTexture[_loadedTexturePath] = (_panX, _panY, _zoom);
 
         _loadedTexturePath = norm;
+        _loadedTexturePathCasePreserved = casePreserved;
         // Drop (don't Dispose) the previous image: a render op on the compositor thread may still be
         // drawing it (BuildSnapshot shares _image directly). Releasing the reference lets GC reclaim
         // it once no in-flight draw holds it — deferred drop, mirroring ThumbnailService (#514).
@@ -647,6 +662,7 @@ public class TextureViewport : Control, IZoomTarget, IPanScrollTarget
             // decoded — corrupt/truncated/mislabeled PNG, zero-byte file, or a locked file. Handing
             // null to SKImage.FromBitmap would crash the dispatcher (#479); stay unloaded instead.
             _loadedTexturePath = null;
+            _loadedTexturePathCasePreserved = null;
             OnTextureLoaded(_bitmap);
             return false;
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameCreatedFromRegionTextureCaseTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameCreatedFromRegionTextureCaseTests.cs
@@ -1,0 +1,130 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #941: a frame created via Ctrl+click / magic-wand
+/// (<c>MainWindow.OnFrameCreatedFromRegion</c>) must store the texture's exact on-disk
+/// case, not the lowercased cache-key form that <see cref="WireframeControl.LoadedTexturePath"/>
+/// exposes for comparison purposes.
+/// </summary>
+public class FrameCreatedFromRegionTextureCaseTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => System.Threading.Tasks.Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static WireframeControl GetWireframe(MainWindow w)
+        => w.FindControl<WireframeControl>("WireframeCtrl")
+           ?? throw new InvalidOperationException("WireframeCtrl not found");
+
+    private static string WriteSolidPng(string dir, string name, SKColor color, int size = 64)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void CtrlClick_MixedCaseOnDiskTexture_NewFrameKeepsExactOnDiskCase()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // On-disk filename is mixed-case; the bug lowercased it via LoadedTexturePath.
+            var png  = WriteSolidPng(dir, "Items.png", SKColors.Red, size: 64);
+            var achx = Path.Combine(dir, "test.achx");
+            ctx.ProjectManager.FileName = achx;
+
+            var chain = new AnimationChainSave { Name = "Idle" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            var wireframe = GetWireframe(window);
+            wireframe.LoadTexture(png);
+            wireframe.SetCamera(0f, 0f, 1f);
+
+            wireframe.SimulatePlainCtrlClick(32, 32);
+
+            Assert.Single(chain.Frames);
+            Assert.EndsWith("Items.png", chain.Frames[0].TextureName);
+        }
+        finally
+        {
+            ctx.SelectedState.SelectedFrame = null;
+            ctx.SelectedState.SelectedChain = null;
+            ctx.ProjectManager.FileName     = string.Empty;
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void CtrlClick_SecondFrameOnSameChain_AlsoKeepsExactOnDiskCase()
+    {
+        // Issue #941's actual repro: the FIRST frame (via drag-drop) gets the right case;
+        // a SECOND frame added via Ctrl+click on the same already-loaded texture regressed.
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var png  = WriteSolidPng(dir, "Items.png", SKColors.Red, size: 64);
+            var achx = Path.Combine(dir, "test.achx");
+            ctx.ProjectManager.FileName = achx;
+
+            var chain = new AnimationChainSave { Name = "Idle" };
+            chain.Frames.Add(new AnimationFrameSave
+            {
+                TextureName = "Items.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+            });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+
+            var wireframe = GetWireframe(window);
+            wireframe.LoadTexture(png);
+            wireframe.SetCamera(0f, 0f, 1f);
+
+            wireframe.SimulatePlainCtrlClick(32, 32);
+
+            Assert.Equal(2, chain.Frames.Count);
+            Assert.EndsWith("Items.png", chain.Frames[1].TextureName);
+        }
+        finally
+        {
+            ctx.SelectedState.SelectedFrame = null;
+            ctx.SelectedState.SelectedChain = null;
+            ctx.ProjectManager.FileName     = string.Empty;
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeTextureTests.cs
@@ -440,6 +440,37 @@ public class WireframeTextureTests
         finally { System.IO.Directory.Delete(dir, true); }
     }
 
+    // ── LoadedTexturePathCasePreserved reflects exact on-disk case (issue #941) ───
+
+    /// <summary>
+    /// <see cref="WireframeControl.LoadedTexturePath"/> is intentionally lowercased (it is a
+    /// cache/comparison key). <see cref="WireframeControl.LoadedTexturePathCasePreserved"/>
+    /// must return the exact on-disk case instead, so callers that persist the path (e.g.
+    /// Ctrl+click create-frame-from-region) never write a lowercased texture name into the
+    /// .achx (issue #941).
+    /// </summary>
+    [AvaloniaFact]
+    public void Wireframe_LoadedTexturePathCasePreserved_ReflectsExactOnDiskCase()
+    {
+        var ctx = ResetSingletons();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        try
+        {
+            var png = WriteSolidPng(dir, "Tex.png", SKColors.Cyan);
+            var ctrl = ctx.CreateWireframeControl();
+
+            Assert.Null(ctrl.LoadedTexturePathCasePreserved);
+
+            ctrl.LoadTexture(png);
+
+            Assert.NotNull(ctrl.LoadedTexturePathCasePreserved);
+            Assert.True(ctrl.LoadedTexturePathCasePreserved!.EndsWith("Tex.png", System.StringComparison.Ordinal),
+                $"LoadedTexturePathCasePreserved should end with exact-case 'Tex.png'; got: {ctrl.LoadedTexturePathCasePreserved}");
+        }
+        finally { System.IO.Directory.Delete(dir, true); }
+    }
+
     // ── BitmapSize matches loaded texture ─────────────────────────────────────
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationCloneHelperTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AnimationCloneHelperTests.cs
@@ -50,6 +50,18 @@ public class AnimationCloneHelperTests
         Assert.Equal(source.ColorOperation, copy.ColorOperation);
     }
 
+    // #941: TextureName is a verbatim string copy with no path normalization, so a mixed-case
+    // on-disk name must survive clone/duplicate/copy-paste unchanged.
+    [Fact]
+    public void CloneFrame_MixedCaseTextureName_PreservesExactCase()
+    {
+        var source = new AnimationFrameSave { TextureName = "Items.PNG" };
+
+        var copy = AnimationCloneHelper.CloneFrame(source);
+
+        Assert.Equal("Items.PNG", copy.TextureName);
+    }
+
     // #937: cloning (duplicate frame/chain, copy-paste) must preserve ShapesSave presence like
     // every other path now does -- a shapeless source frame must not gain an empty ShapesSave
     // through the clone, or the copy bakes an empty shapesSave/ShapeCollectionSave block on save.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
@@ -215,6 +215,20 @@ public class AppCommandsFrameTests
         Assert.Equal("real.png", target.Frames[0].TextureName);
     }
 
+    // Issue #941: the "+" button / inherit path copies TextureName verbatim (a plain string
+    // assignment, no path normalization), so mixed on-disk case must survive unchanged.
+    [Fact]
+    public void AddFrame_ChainHasFrames_InheritsLastFrameTextureExactCase()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run");
+        ctx.AppCommands.AddFrame(chain, "Items.PNG");
+
+        ctx.AppCommands.AddFrame(chain); // no texture → inherit previous frame
+
+        Assert.Equal("Items.PNG", chain.Frames[^1].TextureName);
+    }
+
     [Fact]
     public void AddFrame_ChainHasFrames_InheritsLastFrameRegion()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsResolveRegionFrameTextureNameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsResolveRegionFrameTextureNameTests.cs
@@ -1,0 +1,46 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.AnimationEditorCommon;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="AppCommands.ResolveRegionFrameTextureName"/> -- the pure logic behind
+/// the browser build's create-frame-from-region handler (<c>AnimationEditor.Browser/App.axaml.cs</c>),
+/// extracted so it's testable without a WASM host (issue #941).
+/// </summary>
+public class AppCommandsResolveRegionFrameTextureNameTests
+{
+    [Fact]
+    public void SelectedFrameHasTexture_ReturnsSelectedFrameTextureExactCase()
+    {
+        var chain = new AnimationChainSave();
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "Chain.PNG" });
+        var selected = new AnimationFrameSave { TextureName = "Selected.PNG" };
+
+        var result = AppCommands.ResolveRegionFrameTextureName(selected, chain);
+
+        Assert.Equal("Selected.PNG", result);
+    }
+
+    [Fact]
+    public void NoSelectedFrame_ReturnsFirstChainFrameTextureExactCase()
+    {
+        var chain = new AnimationChainSave();
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "First.PNG" });
+
+        var result = AppCommands.ResolveRegionFrameTextureName(null, chain);
+
+        Assert.Equal("First.PNG", result);
+    }
+
+    [Fact]
+    public void NoSelectedFrameAndEmptyChain_ReturnsNull()
+    {
+        var chain = new AnimationChainSave();
+
+        var result = AppCommands.ResolveRegionFrameTextureName(null, chain);
+
+        Assert.Null(result);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropProcessorTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureDropProcessorTests.cs
@@ -170,6 +170,27 @@ public class TextureDropProcessorTests
         Assert.Contains("/", tex);
     }
 
+    // ── Case preservation (issue #941) ────────────────────────────────────────
+    // Drag-drop reads the OS drag payload's real-case path directly (never through the
+    // lowercased WireframeControl.LoadedTexturePath cache key), so it was never affected by
+    // #941 -- this locks that in as a regression guard.
+
+    [Fact]
+    public void ApplyPngDrop_MixedCaseOnDiskTexture_PreservesExactCase()
+    {
+        var chain = new AnimationChainSave();
+
+        var result = TextureDropProcessor.ApplyPngDrop(
+            chain,
+            null,
+            TestPaths.Abs("Project", "Content", "Items.PNG"),
+            TestPaths.Abs("Project", "Animations", "Player.achx"),
+            createFrameOnCtrl: false);
+
+        Assert.Equal(TextureDropResult.CreatedFrame, result);
+        Assert.Equal("../Content/Items.PNG", chain.Frames[0].TextureName);
+    }
+
     // ── Unsaved project (achxFileName == null) ────────────────────────────────
     // Root cause: these all previously returned NotApplied, silently breaking
     // drag-drop on projects that hadn't been saved yet.


### PR DESCRIPTION
## Summary
- `WireframeControl.LoadedTexturePath` is intentionally a lowercased cache key (`FilePath.Standardized`). `MainWindow.OnFrameCreatedFromRegion` (the Ctrl+click / magic-wand create-frame handler) read it directly and wrote the lowercased value into the new frame's `TextureName`, so a frame added via Ctrl+click on an already-loaded texture got the wrong case while drag-drop's first frame (which never goes through this path) kept the correct on-disk case.
- Added `TextureViewport.LoadedTexturePathCasePreserved`, tracked alongside the existing lowercased identity everywhere it's set (`BeginTextureSwap`, decode-failure clear), and switched `OnFrameCreatedFromRegion` to use it. Clarified `LoadedTexturePath`'s XML doc to say explicitly it's a comparison key, not for persistence/display.
- Extracted the browser build's create-frame-from-region texture resolution (`AnimationEditor.Browser/App.axaml.cs`) into `AppCommands.ResolveRegionFrameTextureName` so it's unit-testable without a WASM host.

## Every TextureName-setting path checked, with exact-case (not `OrdinalIgnoreCase`) tests
- **Ctrl+click / magic-wand create-frame-from-region (desktop)** — the actual bug. New `FrameCreatedFromRegionTextureCaseTests.cs`, including the exact repro (drag-drop frame 1 correct case, Ctrl+click frame 2 on the same chain/texture regressed).
- **Drag-drop** (`TextureDropProcessor`) — already correct (reads the OS drag payload directly, never through the lowercased cache key); added a mixed-case regression guard.
- **`+` button / AddFrame texture inheritance** (`AppCommands.AddFrame` → `ResolveInheritedFrame`) — already correct (verbatim string copy); added a mixed-case regression guard.
- **Clone/duplicate/paste** (`AnimationCloneHelper.CloneFrame`) — already correct (verbatim copy); added a mixed-case regression guard.
- **Save-time normalization** (`TexturePathHelper.NormalizeStoredTextureName` / `ProjectManager.SaveAnimationChainList`) — already had a case-preservation test (`SaveAnimationChainList_TextureNameCasePreserved_WhenRewrittenToRelative`, from #936); no gap.
- **Browser build's create-frame-from-region handler** — already correct by design (reuses an existing frame's `TextureName` verbatim instead of deriving from the fake path); extracted to `AppCommands.ResolveRegionFrameTextureName` and covered directly.

Confirmed the App.Tests regression tests actually catch the bug: reverted the `MainWindow` one-line fix, re-ran, saw both new tests fail with `"items.png"` vs expected `"Items.png"` (the exact bug), then restored the fix and confirmed green.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1897 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 859 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — 113 passed
- [x] Verified new tests are red before the fix, green after (see above)

**Manual-test verdict: not needed.** Everything touched is headless-testable UI/state logic (string identity, event handler wiring) — no rendering or pixel output changed.

Closes #941