### PR TITLE
Add File > Close Project

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -92,6 +92,9 @@
                         <MenuItem Header="_Load..."       x:Name="MenuLoad" />
                         <MenuItem Header="Load _Recent"   x:Name="MenuLoadRecent" />
                         <MenuItem Header="Open _Project Folder…" x:Name="MenuOpenProjectFolder" />
+                        <Separator />
+                        <MenuItem Header="_Close Project" x:Name="MenuCloseProject" />
+                        <Separator />
                         <MenuItem Header="_Save"          x:Name="MenuSave" />
                         <MenuItem Header="Save _As..."    x:Name="MenuSaveAs" />
                         <MenuItem Header="_Export">

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2080,6 +2080,7 @@ public partial class MainWindow : Window
         MenuNew.Click    += OnNewClick;
         MenuLoad.Click   += OnLoadClick;
         MenuOpenProjectFolder.Click += OnOpenProjectFolderClick;
+        MenuCloseProject.Click += OnCloseProjectClick;
         MenuSave.Click   += OnSaveClick;
         MenuSaveAs.Click += OnSaveAsClick;
         MenuExportPixiJs.Click += OnExportPixiJsClick;
@@ -2245,6 +2246,51 @@ public partial class MainWindow : Window
     }
 
     private void OnOpenProjectFolderClick(object? sender, RoutedEventArgs e) => _ = OpenProjectFolderAsync();
+
+    private void OnCloseProjectClick(object? sender, RoutedEventArgs e) => _ = CloseProjectAsync();
+
+    /// <summary>
+    /// Closes the current project (issue #948): resets <see cref="ProjectManager"/>,
+    /// <see cref="SelectedState"/>, and the undo stack (<see cref="IAppCommands.CloseProject"/>),
+    /// and clears every open tab and the Open Project Folder scope -- the same blank state as a
+    /// fresh app launch. Prompts once via <see cref="IAppCommands.ConfirmAsync"/> when any open
+    /// tab is Untitled with actual content: a named/saved tab is already persisted to disk by
+    /// the autosave-on-edit path (see the <see cref="AppCommands"/> constructor comment), so only
+    /// unsaved Untitled content is actually at risk of being discarded here -- same risk model
+    /// <see cref="CloseTabAsync"/> already uses per-tab.
+    /// </summary>
+    internal async Task CloseProjectAsync()
+    {
+        int atRiskCount = _tabManager.Tabs.Count(t => IsUntitledTab(t) && UntitledTabHasContent(t));
+        if (atRiskCount > 0)
+        {
+            string noun = atRiskCount == 1 ? "tab has" : "tabs have";
+            bool confirmed = await _appCommands.ConfirmAsync(
+                $"{atRiskCount} untitled {noun} unsaved content that will be discarded. Close the project anyway?",
+                "Close Project");
+            if (!confirmed) return;
+        }
+
+        _tabManager.RestoreFrom(Array.Empty<string>(), null);
+        _projectFolderWatcher.Watch(null);
+        _appCommands.CloseProject();
+
+        ShowAchxPane();
+        RebuildTabStrip();
+        ProjectPanel.SyncSelectionToActiveFile(null);
+        RefreshTreeView();
+        RefreshFilesPanel();
+        UpdateTitle();
+        UpdateStatusBar();
+        _appCommands.SyncHotReloadWatcher();
+
+        // "Close" is an explicit action, unlike a normal exit -- don't let the next launch
+        // silently reopen what was just closed (mirrors clearing the in-memory state above).
+        _appSettings.OpenTabPaths = new List<string>();
+        _appSettings.ActiveTabPath = null;
+        _appSettings.LastProjectFolderPath = null;
+        SaveSettingsFile();
+    }
 
     /// <summary>
     /// Open Project Folder (#770): picks a folder, then loads + persists it via

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1572,6 +1572,22 @@ namespace AnimationEditor.Core.CommandsAndState
             _events.RaiseAnimationChainsChanged();
         }
 
+        /// <inheritdoc cref="IAppCommands.CloseProject"/>
+        public void CloseProject()
+        {
+            _pm.AnimationChainListSave = new AnimationChainListSave();
+            _pm.FileName = null;
+            _pm.ProjectFolderPath = null;
+            _pm.OnDiskCoordinateType = FlatRedBall2.AnimationEditorCommon.TextureCoordinateType.Pixel;
+            _selectedState.Reset();
+            _undoManager.Clear();
+            // No content survives a close, so remove any crash-recovery file rather than
+            // writing a fresh one for an empty project (unlike NewFile, which still fires
+            // AnimationChainsChanged and lets the autosave path write one).
+            _ioManager.DeleteRecoveryFile();
+            RefreshTreeViewRequested?.Invoke();
+        }
+
         // ── WF09: Create frame from magic-wand pixel bounds ───────────────────
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -248,6 +248,17 @@ namespace AnimationEditor.Core.CommandsAndState
         bool AddMultipleFrames(AnimationChainSave chain, int count, bool incrementUV);
         List<AnimationFrameSave> AdjustUVAfterResize(string absoluteTextureFilePath, int oldWidth, int oldHeight, int newWidth, int newHeight);
         void NewFile();
+
+        /// <summary>
+        /// Resets the editor to the same blank state as a fresh app launch with no project
+        /// ever opened: empty <c>ProjectManager.AnimationChainListSave</c>, cleared
+        /// <c>ProjectManager.FileName</c> and <c>ProjectManager.ProjectFolderPath</c>, cleared
+        /// selection, and a cleared undo stack. Deletes any crash-recovery file rather than
+        /// writing a fresh one, since there is no content left to protect. Does not touch open
+        /// tabs or tab-scoped UI -- callers with a tab strip (the desktop app) must close those
+        /// separately.
+        /// </summary>
+        void CloseProject();
         void AddFrameFromPixelBounds(AnimationChainSave chain, string textureName, int minX, int minY, int maxX, int maxY, int bitmapWidth, int bitmapHeight);
         void SetFrameTextureName(AnimationFrameSave frame, string? textureName);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseProjectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseProjectTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #948: File → Close Project must reset the editor to the same blank state as a fresh
+/// app launch -- ProjectManager, SelectedState, undo stack, tabs, and the tree UI.
+/// </summary>
+public class CloseProjectTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        return (window, ctx);
+    }
+
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    [AvaloniaFact]
+    public void MenuCloseProject_Click_ClearsTreeTabsAndProjectState()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // Add a chain to the currently-open (untitled) document and register it as a tab,
+            // matching how a real "New" document with content becomes a tab.
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            typeof(MainWindow)
+                .GetMethod("EnsureCurrentEditorContentHasTab", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, null);
+            Dispatcher.UIThread.RunJobs();
+
+            var tabManager = GetTabManager(window);
+            Assert.NotEmpty(tabManager.Tabs);
+
+            window.FindControl<MenuItem>("MenuCloseProject")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(tabManager.Tabs);
+            Assert.Null(ctx.ProjectManager.FileName);
+            Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+
+            var tree  = window.FindControl<TreeView>("AnimTree")!;
+            var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+            Assert.Empty(roots);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public async Task CloseProjectAsync_UnsavedUntitledTabDeclined_LeavesProjectUntouched()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            // File > New opens a genuine, active Untitled tab (unlike EnsureCurrentEditorContentHasTab,
+            // which only registers a background tab); give it content so it is at risk of being discarded.
+            window.FindControl<MenuItem>("MenuNew")!
+                  .RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+            ctx.AppCommands.AddAnimationChainWithName("Walk");
+            Dispatcher.UIThread.RunJobs();
+
+            var tabManager = GetTabManager(window);
+            Assert.NotEmpty(tabManager.Tabs);
+
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(false);
+
+            await window.CloseProjectAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEmpty(tabManager.Tabs);
+            Assert.NotEmpty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsCloseProjectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsCloseProjectTests.cs
@@ -1,0 +1,94 @@
+using AnimationEditor.Core.CommandsAndState;
+using FlatRedBall2.AnimationEditorCommon;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #948: File > Close Project must reset the editor to the same blank state as a fresh
+// app launch -- ProjectManager, SelectedState, and the undo stack -- so a user can switch
+// projects without relaunching, and so #949's before/after memory measurement gets a clean
+// baseline between runs.
+[Collection("SequentialSingletons")]
+public class AppCommandsCloseProjectTests
+{
+    private readonly TestServices ctx = TestHelpers.SetupFreshAcls();
+
+    [Fact]
+    public void CloseProject_CreatesEmptyAcls()
+    {
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(
+            new AnimationChainSave { Name = "Existing" });
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
+        Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
+    }
+
+    [Fact]
+    public void CloseProject_ClearsFileName()
+    {
+        ctx.ProjectManager.FileName = TestPaths.Abs("some", "file.achx");
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.Null(ctx.ProjectManager.FileName);
+    }
+
+    [Fact]
+    public void CloseProject_ClearsProjectFolderPath()
+    {
+        ctx.ProjectManager.ProjectFolderPath = TestPaths.AbsDir("some", "project");
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.Null(ctx.ProjectManager.ProjectFolderPath);
+    }
+
+    [Fact]
+    public void CloseProject_ClearsSelectedChain()
+    {
+        var chain = new AnimationChainSave { Name = "A" };
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.SelectedState.SelectedChain = chain;
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.Null(ctx.SelectedState.SelectedChain);
+    }
+
+    [Fact]
+    public void CloseProject_ClearsUndoStack()
+    {
+        var chain = new AnimationChainSave { Name = "A" };
+        ctx.AppCommands.AddFrame(chain); // pushes an undo entry
+        Assert.True(ctx.UndoManager.CanUndo);
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.False(ctx.UndoManager.CanUndo);
+        Assert.False(ctx.UndoManager.CanRedo);
+    }
+
+    [Fact]
+    public void CloseProject_FiresRefreshTreeViewRequested()
+    {
+        bool fired = false;
+        ctx.AppCommands.RefreshTreeViewRequested += () => fired = true;
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void CloseProject_DeletesRecoveryFile()
+    {
+        ctx.IoManager.WriteRecoveryFile(ctx.ProjectManager.AnimationChainListSave);
+        Assert.True(ctx.IoManager.RecoveryFileExists());
+
+        ctx.AppCommands.CloseProject();
+
+        Assert.False(ctx.IoManager.RecoveryFileExists());
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -48,6 +48,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.ActivateTabContentAsync)]            = Category.MutatingNotUndoable, // tab switch load or cache restore
         [nameof(IAppCommands.ReloadAchxFromDisk)]                 = Category.MutatingNotUndoable, // hot-reload; clears the undo stack on success
         [nameof(IAppCommands.NewFile)]                            = Category.MutatingNotUndoable, // resets the project; clears the undo stack
+        [nameof(IAppCommands.CloseProject)]                       = Category.MutatingNotUndoable, // resets the project; clears the undo stack
         [nameof(IAppCommands.SaveCurrentAnimationChainList)]      = Category.MutatingNotUndoable, // writes a file; no model change
         [nameof(IAppCommands.SaveCurrentAnimationChainListAsync)] = Category.MutatingNotUndoable, // writes a file; no model change
         [nameof(IAppCommands.ExportToPixiJsAsync)]                = Category.MutatingNotUndoable, // writes a PixiJS json; no model change


### PR DESCRIPTION
## Summary
- Adds `AppCommands.CloseProject()` (Core, testable): resets `ProjectManager` (`AnimationChainListSave`, `FileName`, `ProjectFolderPath`, `OnDiskCoordinateType`), `SelectedState`, and the undo stack, and deletes any crash-recovery file.
- Adds `MainWindow.CloseProjectAsync()`, wired to a new **File > Close Project** menu item: clears every open tab, the tab strip, the tree, and the Open Project Folder watcher/scope, then calls `CloseProject()` above.
- Prompts once via `ConfirmAsync` only when an open Untitled tab holds unsaved content -- named/saved tabs are already autosaved to disk on every edit, so nothing else is at risk of being discarded.
- Also clears persisted session settings (`OpenTabPaths`, `ActiveTabPath`, `LastProjectFolderPath`) so an explicit Close doesn't silently reopen on next launch.

## Test plan
- [x] `AppCommandsCloseProjectTests` (Core `[Fact]`, 7 tests) -- ACLS reset, FileName/ProjectFolderPath cleared, selection cleared, undo stack cleared, tree-refresh event fires, recovery file deleted.
- [x] `CloseProjectTests` (App `[AvaloniaFact]`, 2 tests) -- real menu click clears tabs/tree/project state through a live `MainWindow`; declining the confirm prompt for an unsaved Untitled tab leaves everything untouched (verified this assertion actually catches a regression before restoring the real gate).
- [x] Full `AnimationEditor.Core.Tests` (1907) and `AnimationEditor.App.Tests` (864) suites pass.
- Manual test: not needed -- fully covered by headless Core/App tests per this repo's `[AvaloniaFact]`/`CreateMainWindow()` pattern; no rendering/pixel output involved.

Closes #948