### PR TITLE
Add Chat on Discord to AnimationEditor Help menu

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -151,6 +151,8 @@
                         <MenuItem Header="_Keyboard Shortcuts" x:Name="MenuShowShortcuts"
                                   ToggleType="CheckBox" />
                         <MenuItem Header="View _Log"      x:Name="MenuViewLog" />
+                        <Separator />
+                        <MenuItem Header="Chat on _Discord" x:Name="MenuChatOnDiscord" />
                         <MenuItem Header="_About"         x:Name="MenuAbout" />
                     </MenuItem>
                 </Menu>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2086,6 +2086,7 @@ public partial class MainWindow : Window
         MenuExportPixiJs.Click += OnExportPixiJsClick;
         MenuAbout.Click  += OnAboutClick;
         MenuViewLog.Click += OnViewLogClick;
+        MenuChatOnDiscord.Click += (_, _) => OpenUrl("https://discord.gg/qBGnE8JwgP");
         // ToggleType="CheckBox" flips IsChecked before Click fires, so just apply the new state.
         // F3 itself is dispatched through the hotkey registry (see WireKeyboard/BuildHotkeyDefinitions).
         MenuShowDiagnostics.Click += (_, _) => ApplyDiagnostics(MenuShowDiagnostics.IsChecked == true);


### PR DESCRIPTION
## Summary
- Adds "Chat on Discord" under Help, linking to https://discord.gg/qBGnE8JwgP via the existing `OpenUrl` helper.

## Test plan
- [x] `dotnet build` AnimationEditor.App succeeds