### PR TITLE
Make Adjust All Frame Time live-preview with Cancel revert / OK apply

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1473,7 +1473,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => FrameTimeScaler.ApplyKeepProportional(chain.Frames, targetTotalDuration),
                 this, _events, refreshWireframe: false,
-                "Scale Frame Times"));
+                "Scale Frame Times", coalesceKind: "ScaleFrameTimes"));
         }
 
         /// <summary>
@@ -1488,7 +1488,7 @@ namespace AnimationEditor.Core.CommandsAndState
                 chain.Frames,
                 () => FrameTimeScaler.ApplySetAllSame(chain.Frames, targetTotalDuration),
                 this, _events, refreshWireframe: false,
-                "Scale Frame Times"));
+                "Scale Frame Times", coalesceKind: "ScaleFrameTimes"));
         }
 
         // ── F12: Add Multiple Frames ──────────────────────────────────────────
@@ -1773,6 +1773,13 @@ namespace AnimationEditor.Core.CommandsAndState
 
         /// <inheritdoc cref="IAppCommands.SealPendingEdits"/>
         public void SealPendingEdits() => _undoManager.SealCoalescing();
+
+        /// <inheritdoc cref="IAppCommands.DiscardPendingEdits"/>
+        public void DiscardPendingEdits()
+        {
+            if (_undoManager.CanUndo)
+                _undoManager.Undo();
+        }
 
         /// <inheritdoc cref="IAppCommands.HasSameFrameNameCollision"/>
         public bool HasSameFrameNameCollision(IReadOnlyList<object> shapes) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -331,6 +331,15 @@ namespace AnimationEditor.Core.CommandsAndState
         void SealPendingEdits();
 
         /// <summary>
+        /// Reverts the in-progress coalesced edit started since the last <see cref="SealPendingEdits"/>
+        /// boundary — e.g. Cancel on a live-preview dialog like "Adjust All Frame Time" that applies
+        /// each change immediately so the preview stays in sync. No-op if nothing is on the undo
+        /// stack. This is a thin wrapper over <see cref="Commands.IUndoManager.Undo"/>, so the
+        /// discarded edit still lands on the redo stack like any other undo.
+        /// </summary>
+        void DiscardPendingEdits();
+
+        /// <summary>
         /// True when two or more of <paramref name="shapes"/> (AARectSave and/or CircleSave) are
         /// owned by the same frame — batch-applying one literal name to all of them would collide,
         /// since shape names only need to be unique within a frame, not across frames.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
@@ -86,6 +86,13 @@ public static class EditorDialogs
         return host.ShowAsync(dialog);
     }
 
+    /// <summary>
+    /// Every field edit applies immediately (so the preview stays in sync while the dialog is
+    /// open) instead of waiting for OK. Cancel — via its button, Escape, or the window's close
+    /// button, all of which resolve to a null choice — discards those live edits with
+    /// <see cref="IAppCommands.DiscardPendingEdits"/>; OK seals them into a normal undo entry
+    /// with <see cref="IAppCommands.SealPendingEdits"/>.
+    /// </summary>
     public static async Task ShowAdjustFrameTimeAsync(
         IEditorDialogHost host, IAppCommands appCommands, AnimationChainSave chain)
     {
@@ -94,6 +101,12 @@ public static class EditorDialogs
         int frameCount = chain.Frames.Count;
         float totalDuration = chain.Frames.Sum(f => f.FrameLength);
         bool canProportional = totalDuration > 0f;
+
+        // Original per-frame lengths, captured once. Live edits always scale from this snapshot
+        // (not from whatever the previous live edit left behind) so switching between "Keep
+        // Proportional" and "Set All Frames Same" mid-dialog can't flatten the original ratios.
+        var originalLengths = chain.Frames.Select(f => f.FrameLength).ToArray();
+        bool didEdit = false;
 
         var durationInput = new NumericUpDown
         {
@@ -125,9 +138,21 @@ public static class EditorDialogs
                 perFrameLabel.Text = $"Each frame: {value / frameCount:F3} seconds";
         }
 
-        durationInput.ValueChanged += (_, _) => UpdateLabel();
-        radioSetAll.IsCheckedChanged += (_, _) => UpdateLabel();
-        radioProportional.IsCheckedChanged += (_, _) => UpdateLabel();
+        void ApplyLive()
+        {
+            for (int i = 0; i < chain.Frames.Count; i++)
+                chain.Frames[i].FrameLength = originalLengths[i];
+            didEdit = true;
+            float value = (float)(durationInput.Value ?? 0m);
+            if (radioProportional.IsChecked == true)
+                appCommands.ScaleFrameTimesProportional(chain, value);
+            else
+                appCommands.ScaleFrameTimesSetAllSame(chain, value);
+        }
+
+        durationInput.ValueChanged += (_, _) => { UpdateLabel(); ApplyLive(); };
+        radioSetAll.IsCheckedChanged += (_, _) => { UpdateLabel(); if (radioSetAll.IsChecked == true) ApplyLive(); };
+        radioProportional.IsCheckedChanged += (_, _) => { UpdateLabel(); if (radioProportional.IsChecked == true) ApplyLive(); };
         UpdateLabel();
 
         var panel = new StackPanel { Margin = new Thickness(12), Spacing = 8 };
@@ -145,11 +170,13 @@ public static class EditorDialogs
         panel.Children.Add(BuildButtonRow(("OK", dialog.Confirm), ("Cancel", dialog.Cancel)));
 
         var choice = await host.ShowAsync(dialog);
-        if (choice is not { } result) return;
-        if (result.KeepProportional)
-            appCommands.ScaleFrameTimesProportional(chain, result.TotalDuration);
-        else
-            appCommands.ScaleFrameTimesSetAllSame(chain, result.TotalDuration);
+        if (choice is null)
+        {
+            if (didEdit)
+                appCommands.DiscardPendingEdits();
+            return;
+        }
+        appCommands.SealPendingEdits();
     }
 
     public static async Task ShowAddMultipleFramesAsync(

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -120,6 +120,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SetRectPropsBulk)]             = Category.MutatingUndoable,
         [nameof(IAppCommands.SetCirclePropsBulk)]           = Category.MutatingUndoable,
         [nameof(IAppCommands.SealPendingEdits)]             = Category.NonMutating, // resets undo-coalescing state only
+        [nameof(IAppCommands.DiscardPendingEdits)]          = Category.MutatingNotUndoable, // reverts via Undo(); not itself a new undo entry
         [nameof(IAppCommands.HasSameFrameNameCollision)]    = Category.NonMutating,
         [nameof(IAppCommands.PasteChains)]                  = Category.MutatingUndoable,
         [nameof(IAppCommands.PasteFrames)]                  = Category.MutatingUndoable,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AdjustFrameTimeLiveEditTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AdjustFrameTimeLiveEditTests.cs
@@ -1,0 +1,154 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Data;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Views.Dialogs;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.AnimationEditorCommon;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.Views.Tests;
+
+/// <summary>
+/// #956: "Adjust All Frame Time" should apply every field edit immediately (so the preview
+/// updates live), Cancel should revert those live edits, and OK should keep them.
+/// </summary>
+public class AdjustFrameTimeLiveEditTests
+{
+    private sealed class FakeProjectManager : IProjectManager
+    {
+        public AnimationChainListSave? AnimationChainListSave { get; set; }
+        public TileMapInformationList TileMapInformationList { get; set; } = new();
+        public FilePath[] ReferencedPngs => Array.Empty<FilePath>();
+        public string? FileName { get; set; }
+        public string? ProjectFolderPath { get; set; }
+        public TextureCoordinateType OnDiskCoordinateType { get; set; }
+
+        public void LoadAnimationChain(
+            FilePath fileName,
+            AnimationChainListSave? preParsed = null,
+            IReadOnlyDictionary<string, (int Width, int Height)>? knownTextureSizes = null) { }
+
+        public void SaveAnimationChainList(string targetPath) { }
+        public void SaveAnimationChainList(System.IO.Stream stream) { }
+        public string? ResolveFilesPanelRoot() => null;
+        public (int Width, int Height)? GetTextureSizeInPixels(string textureName) => null;
+
+        public IReadOnlyList<string> FindMissingTextures(AnimationChainListSave acls, string achxDirectory) =>
+            Array.Empty<string>();
+    }
+
+    /// <summary>Runs <paramref name="interact"/> against the dialog's content while it is still
+    /// open (so it can assert on the live-applied state), then resolves with Confirm or Cancel.</summary>
+    private sealed class ScriptedDialogHost(Action<Control> interact, bool confirm) : IEditorDialogHost
+    {
+        public async Task<T> ShowAsync<T>(EditorDialog<T> dialog)
+        {
+            interact(dialog.Content);
+            if (confirm) dialog.Confirm(); else dialog.Cancel();
+            return await dialog.Result;
+        }
+    }
+
+    private static (AnimationChainSave Chain, IAppCommands AppCommands, IUndoManager UndoManager) Setup()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "sheet.png", FrameLength = 0.1f });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "sheet.png", FrameLength = 0.3f });
+        acls.AnimationChains.Add(chain);
+
+        var pm = new FakeProjectManager { AnimationChainListSave = acls };
+        var selectedState = new SelectedState(pm);
+        var events = new ApplicationEvents();
+        var ioManager = new IoManager(new AppState(events, selectedState));
+        var objectFinder = new ObjectFinder(pm);
+        var undoManager = new UndoManager();
+        var appCommands = new AppCommands(pm, selectedState, events, ioManager, objectFinder, undoManager);
+
+        return (chain, appCommands, undoManager);
+    }
+
+    [AvaloniaFact]
+    public async Task DurationEdit_AppliesLiveWhileDialogIsOpen()
+    {
+        var (chain, appCommands, _) = Setup();
+
+        var host = new ScriptedDialogHost(
+            interact: content =>
+            {
+                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                durationInput.Value = 0.8m; // was 0.4 total (0.1 + 0.3) -> doubles proportionally
+                Assert.Equal(0.2f, chain.Frames[0].FrameLength, 3);
+                Assert.Equal(0.6f, chain.Frames[1].FrameLength, 3);
+            },
+            confirm: true);
+
+        await EditorDialogs.ShowAdjustFrameTimeAsync(host, appCommands, chain);
+    }
+
+    [AvaloniaFact]
+    public async Task Cancel_RevertsLiveEditsBackToOriginalFrameLengths()
+    {
+        var (chain, appCommands, undoManager) = Setup();
+
+        var host = new ScriptedDialogHost(
+            interact: content =>
+            {
+                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                durationInput.Value = 0.8m;
+            },
+            confirm: false);
+
+        await EditorDialogs.ShowAdjustFrameTimeAsync(host, appCommands, chain);
+
+        Assert.Equal(0.1f, chain.Frames[0].FrameLength, 3);
+        Assert.Equal(0.3f, chain.Frames[1].FrameLength, 3);
+        Assert.False(undoManager.CanUndo);
+    }
+
+    [AvaloniaFact]
+    public async Task Cancel_WithNoEdits_DoesNotTouchTheUndoStack()
+    {
+        var (chain, appCommands, undoManager) = Setup();
+        appCommands.SetAllFrameLengths(chain, 0.5f);
+        Assert.True(undoManager.CanUndo);
+
+        var host = new ScriptedDialogHost(interact: _ => { }, confirm: false);
+        await EditorDialogs.ShowAdjustFrameTimeAsync(host, appCommands, chain);
+
+        // The unrelated entry pushed before the dialog opened must survive untouched.
+        Assert.True(undoManager.CanUndo);
+        Assert.Equal(0.5f, chain.Frames[0].FrameLength, 3);
+    }
+
+    [AvaloniaFact]
+    public async Task Ok_SealsLiveEditsIntoASingleUndoEntry()
+    {
+        var (chain, appCommands, undoManager) = Setup();
+
+        var host = new ScriptedDialogHost(
+            interact: content =>
+            {
+                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                durationInput.Value = 0.8m;
+                durationInput.Value = 1.2m; // a second live edit; must coalesce, not add a 2nd entry
+            },
+            confirm: true);
+
+        await EditorDialogs.ShowAdjustFrameTimeAsync(host, appCommands, chain);
+
+        Assert.True(undoManager.CanUndo);
+        undoManager.Undo();
+        Assert.Equal(0.1f, chain.Frames[0].FrameLength, 3);
+        Assert.Equal(0.3f, chain.Frames[1].FrameLength, 3);
+        Assert.False(undoManager.CanUndo);
+    }
+}


### PR DESCRIPTION
## Summary
- "Adjust All Frame Time" now applies every field edit live (via the normal undoable command path, coalesced into one undo entry) so the preview updates while dragging/typing, matching the rest of the inspector's coalescing pattern.
- Cancel — button, Escape, or the window's close button, all of which resolve to a null choice — discards the live edits via a new `IAppCommands.DiscardPendingEdits()` (thin wrapper over `IUndoManager.Undo`).
- OK seals the live edits into a normal undo entry via the existing `IAppCommands.SealPendingEdits()`.
- Live scaling always recomputes from the frame lengths captured when the dialog opened, so switching between "Keep Proportional" and "Set All Frames Same" mid-dialog can't flatten the original ratios.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1907 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — 117 passed (incl. 4 new tests: live-apply, cancel-reverts, cancel-with-no-edits-is-a-noop, OK-seals-one-undo-entry)
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 864 passed
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — clean

Manual test: not needed — covered by the headless `[AvaloniaFact]` tests exercising the real dialog controls (`NumericUpDown`/`RadioButton`) plus the App.Tests suite through `MainWindow`.

Closes #956
