### PR TITLE
Fix silent content-prefetch 404s in web builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ CLAUDE.local.md
 # Gum bundle output (produced by `gumcli pack`; loose source is checked in)
 **/*.gumpkg
 
+# Content prefetch manifest generated at build time by FlatRedBall2.BlazorGL's
+# build/*.targets into each web project's wwwroot/
+**/wwwroot/content-manifest.json
+
 # Visual Studio / Rider / IDE
 **/.vs/
 

--- a/design/TODOS.md
+++ b/design/TODOS.md
@@ -102,9 +102,3 @@ This is a meaningful chunk of engine work — likely starts with the simpler spr
 ## Figma → Gum import path
 
 Designers want to author UI in Figma and have it appear in Gum without manual recreation. No existing converter — the open question is whether to (a) write a Figma plugin that emits `.gucx`/`.gusx` directly, (b) export Figma as SVG and rely on an SVG-import path in Gum (which depends on the SVG/Lottie work above), or (c) export Figma to Lottie and lean on the Lottie path. Each has tradeoffs in fidelity (what Figma features survive the round-trip), maintenance burden (the plugin path requires keeping up with Figma's API), and ordering (Lottie/SVG support unblocks paths b and c). Decide the strategy before estimating effort.
-
-## GenerateContentManifest output misses same-build static web asset collection
-
-`GenerateContentManifest` (`src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets`) runs `BeforeTargets="GenerateStaticWebAssetsManifest"`, but `wwwroot/**` static web assets are expanded from evaluation-time globs, so a manifest written mid-build is invisible to that build's static web asset collection. Verified empirically: after a clean build of a sample BlazorGL head, no `content-manifest.json` exists under `bin/.../wwwroot`; it only gets collected from the second build onward. Consequence: a fresh-checkout CI publish (`deploy-sample.yml`) deploys without the manifest, so `frb-host.js` prefetch silently does nothing in production even though the generated paths themselves are now correct.
-
-Fix directions to weigh: (a) emit fully-metadated `StaticWebAsset` items inside the target — fragile across SDK versions; (b) move generation pre-evaluation via a `.props`-time mechanism — invasive; (c) accept two-pass and make `deploy-sample.yml` build twice before publishing. Cheapest honest option is (c); decide deliberately.

--- a/design/TODOS.md
+++ b/design/TODOS.md
@@ -102,3 +102,9 @@ This is a meaningful chunk of engine work — likely starts with the simpler spr
 ## Figma → Gum import path
 
 Designers want to author UI in Figma and have it appear in Gum without manual recreation. No existing converter — the open question is whether to (a) write a Figma plugin that emits `.gucx`/`.gusx` directly, (b) export Figma as SVG and rely on an SVG-import path in Gum (which depends on the SVG/Lottie work above), or (c) export Figma to Lottie and lean on the Lottie path. Each has tradeoffs in fidelity (what Figma features survive the round-trip), maintenance burden (the plugin path requires keeping up with Figma's API), and ordering (Lottie/SVG support unblocks paths b and c). Decide the strategy before estimating effort.
+
+## GenerateContentManifest output misses same-build static web asset collection
+
+`GenerateContentManifest` (`src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets`) runs `BeforeTargets="GenerateStaticWebAssetsManifest"`, but `wwwroot/**` static web assets are expanded from evaluation-time globs, so a manifest written mid-build is invisible to that build's static web asset collection. Verified empirically: after a clean build of a sample BlazorGL head, no `content-manifest.json` exists under `bin/.../wwwroot`; it only gets collected from the second build onward. Consequence: a fresh-checkout CI publish (`deploy-sample.yml`) deploys without the manifest, so `frb-host.js` prefetch silently does nothing in production even though the generated paths themselves are now correct.
+
+Fix directions to weigh: (a) emit fully-metadated `StaticWebAsset` items inside the target — fragile across SDK versions; (b) move generation pre-evaluation via a `.props`-time mechanism — invasive; (c) accept two-pass and make `deploy-sample.yml` build twice before publishing. Cheapest honest option is (c); decide deliberately.

--- a/frb-skills/multiplatform-conversion/SKILL.md
+++ b/frb-skills/multiplatform-conversion/SKILL.md
@@ -185,7 +185,8 @@ Reference: `AutoEvalKniBlazorSample.BlazorGL`. Each sample's `.BlazorGL` head ow
 
 The `FlatRedBall2.BlazorGL` NuGet package includes a `.targets` file that auto-imports
 into consuming projects. On every build it enumerates all files under `wwwroot/Content/`
-and writes `wwwroot/content-manifest.json` — a JSON array of relative paths.
+and writes `wwwroot/content-manifest.json` — a JSON array of paths relative to `wwwroot`,
+each prefixed `Content/`.
 
 At runtime, `frb-host.js` fetches `content-manifest.json` and fires background `fetch()`
 for every listed file during `initRenderJS`. Both `fetch()` and the synchronous
@@ -196,6 +197,12 @@ network. Errors are silently swallowed (fire-and-forget).
 **No game author action required.** The manifest is generated automatically from whatever
 files exist in `wwwroot/Content/` at build time. Add or remove content files and the
 manifest stays in sync on the next build.
+
+**Landmine:** `build/*.targets` auto-import only happens for NuGet `PackageReference`
+consumers — a `ProjectReference` to the host project does **not** import them. That's why
+repo samples carry an explicit
+`<Import Project="...\FlatRedBall2.BlazorGL\build\FlatRedBall2.BlazorGL.targets" />`;
+without it, no manifest is ever generated. NuGet consumers need nothing.
 
 ## Verification
 

--- a/samples/PlatformKing/PlatformKing.BlazorGL/PlatformKing.BlazorGL.csproj
+++ b/samples/PlatformKing/PlatformKing.BlazorGL/PlatformKing.BlazorGL.csproj
@@ -41,6 +41,11 @@
     <ProjectReference Include="..\..\..\src\FlatRedBall2.BlazorGL\FlatRedBall2.BlazorGL.csproj" />
   </ItemGroup>
 
+  <!-- ProjectReference does not auto-import the referenced project's build/*.targets (that is a
+       NuGet-package-only mechanism), so import the content-manifest generator explicitly to get
+       what package consumers receive automatically. -->
+  <Import Project="..\..\..\src\FlatRedBall2.BlazorGL\build\FlatRedBall2.BlazorGL.targets" />
+
   <!--
     Raw runtime-loaded assets (TMX, JSON, PNG) must live in the project's PHYSICAL wwwroot/ so
     Blazor's static-web-asset manifest picks them up. `<Content Link="wwwroot\...">` only copies

--- a/samples/ShmupSpace/ShmupSpace.BlazorGL/ShmupSpace.BlazorGL.csproj
+++ b/samples/ShmupSpace/ShmupSpace.BlazorGL/ShmupSpace.BlazorGL.csproj
@@ -41,6 +41,11 @@
     <ProjectReference Include="..\..\..\src\FlatRedBall2.BlazorGL\FlatRedBall2.BlazorGL.csproj" />
   </ItemGroup>
 
+  <!-- ProjectReference does not auto-import the referenced project's build/*.targets (that is a
+       NuGet-package-only mechanism), so import the content-manifest generator explicitly to get
+       what package consumers receive automatically. -->
+  <Import Project="..\..\..\src\FlatRedBall2.BlazorGL\build\FlatRedBall2.BlazorGL.targets" />
+
   <!--
     Raw runtime-loaded assets (JSON, PNG, .achx) must live in the project's PHYSICAL wwwroot/ so
     Blazor's static-web-asset manifest picks them up. `<Content Link="wwwroot\...">` only copies

--- a/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
+++ b/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
@@ -55,24 +55,28 @@
   -->
   <Import Project="..\Solitaire.GumPackage.targets" />
 
-  <ItemGroup Condition="'$(UseGumPackage)' != 'true'">
-    <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.*"
-                      Exclude="..\Solitaire.Common\Content\**\*.mgcb;..\Solitaire.Common\Content\bin\**;..\Solitaire.Common\Content\obj\**;..\Solitaire.Common\Content\**\*.gumpkg" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(UseGumPackage)' == 'true'">
-    <!-- Ship everything outside GumProject/ as-is, plus the single .gumpkg from inside GumProject/. -->
-    <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.*"
-                      Exclude="..\Solitaire.Common\Content\**\*.mgcb;..\Solitaire.Common\Content\bin\**;..\Solitaire.Common\Content\obj\**;..\Solitaire.Common\Content\GumProject\**\*.*" />
-    <!-- Glob form ensures the CopyCommonRawAssetsToWwwroot target's %(RecursiveDir)
-         resolves to "GumProject\" so the file lands at wwwroot/Content/GumProject/GumProject.gumpkg
-         (sibling of where the .gumj would be in loose mode). -->
-    <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.gumpkg" />
-  </ItemGroup>
+  <!--
+    Items are computed INSIDE the target, not at evaluation time: on a fresh checkout the
+    .gumpkg does not exist until Common's PackGumProject runs during this same build, and an
+    evaluation-time glob misses it — silently shipping an empty wwwroot/Content and an empty
+    content-manifest.json. Recomputing here (after the ProjectReference chain has built)
+    sees it. No Inputs/Outputs up-to-date check: those attributes are evaluated before the
+    target body, so they could not see these items either; SkipUnchangedFiles keeps re-runs cheap.
+  -->
   <Target Name="CopyCommonRawAssetsToWwwroot"
-          BeforeTargets="GenerateStaticWebAssetsManifest;AssignTargetPaths"
-          Inputs="@(_CommonRawAssets)"
-          Outputs="@(_CommonRawAssets -> '$(MSBuildProjectDirectory)\wwwroot\Content\%(RecursiveDir)%(Filename)%(Extension)')">
+          BeforeTargets="GenerateStaticWebAssetsManifest;AssignTargetPaths">
+    <ItemGroup Condition="'$(UseGumPackage)' != 'true'">
+      <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.*"
+                        Exclude="..\Solitaire.Common\Content\**\*.mgcb;..\Solitaire.Common\Content\bin\**;..\Solitaire.Common\Content\obj\**;..\Solitaire.Common\Content\**\*.gumpkg" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(UseGumPackage)' == 'true'">
+      <!-- Ship everything outside GumProject/ as-is, plus the single .gumpkg from inside GumProject/. -->
+      <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.*"
+                        Exclude="..\Solitaire.Common\Content\**\*.mgcb;..\Solitaire.Common\Content\bin\**;..\Solitaire.Common\Content\obj\**;..\Solitaire.Common\Content\GumProject\**\*.*" />
+      <!-- Glob form ensures %(RecursiveDir) resolves to "GumProject\" so the file lands at
+           wwwroot/Content/GumProject/GumProject.gumpkg (sibling of where the .gumj would be in loose mode). -->
+      <_CommonRawAssets Include="..\Solitaire.Common\Content\**\*.gumpkg" />
+    </ItemGroup>
     <Copy SourceFiles="@(_CommonRawAssets)"
           DestinationFiles="@(_CommonRawAssets -> '$(MSBuildProjectDirectory)\wwwroot\Content\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />

--- a/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
+++ b/samples/Solitaire/Solitaire.BlazorGL/Solitaire.BlazorGL.csproj
@@ -41,6 +41,11 @@
     <ProjectReference Include="..\..\..\src\FlatRedBall2.BlazorGL\FlatRedBall2.BlazorGL.csproj" />
   </ItemGroup>
 
+  <!-- ProjectReference does not auto-import the referenced project's build/*.targets (that is a
+       NuGet-package-only mechanism), so import the content-manifest generator explicitly to get
+       what package consumers receive automatically. -->
+  <Import Project="..\..\..\src\FlatRedBall2.BlazorGL\build\FlatRedBall2.BlazorGL.targets" />
+
   <!--
     Common's Gum project files must land in the project's PHYSICAL wwwroot/Content/ so
     Blazor's static-web-asset manifest serves them. Source of truth lives in Common.

--- a/src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets
+++ b/src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets
@@ -13,8 +13,15 @@
       <_ContentFiles Include="$(MSBuildProjectDirectory)\wwwroot\Content\**\*.*"
                      Exclude="$(MSBuildProjectDirectory)\wwwroot\Content\**\content-manifest.json" />
     </ItemGroup>
+    <!-- Build the comma-separated quoted path list as a pure item transform (item lists
+         cannot be embedded next to literal text, hence the two-step property). -->
+    <PropertyGroup>
+      <_ContentManifestJson>@(_ContentFiles -> '&quot;%(RecursiveDir)%(Filename)%(Extension)&quot;', ',')</_ContentManifestJson>
+      <!-- JSON forbids unescaped backslashes; emit browser-style forward slashes. -->
+      <_ContentManifestJson>$(_ContentManifestJson.Replace('\','/'))</_ContentManifestJson>
+    </PropertyGroup>
     <WriteLinesToFile File="$(MSBuildProjectDirectory)\wwwroot\content-manifest.json"
-                     Lines="[%22@( _ContentFiles -> '%(RecursiveDir)%(Filename)%(Extension)' )%22]"
+                     Lines="[$(_ContentManifestJson)]"
                      Overwrite="true" />
   </Target>
 

--- a/src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets
+++ b/src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets
@@ -8,15 +8,19 @@
 
   <Target Name="GenerateContentManifest"
           BeforeTargets="GenerateStaticWebAssetsManifest"
-          Condition="Exists('$(MSBuildProjectDirectory)\wwwroot\Content')">
+          Condition="'$(DesignTimeBuild)' != 'true' AND Exists('$(MSBuildProjectDirectory)\wwwroot\Content')">
     <ItemGroup>
+      <!-- .gitignore is excluded: the deploy workflow deletes it from published output
+           (deploy-sample.yml), so prefetching it would just guarantee a 404. -->
       <_ContentFiles Include="$(MSBuildProjectDirectory)\wwwroot\Content\**\*.*"
-                     Exclude="$(MSBuildProjectDirectory)\wwwroot\Content\**\content-manifest.json" />
+                     Exclude="$(MSBuildProjectDirectory)\wwwroot\Content\**\content-manifest.json;$(MSBuildProjectDirectory)\wwwroot\Content\**\.gitignore" />
     </ItemGroup>
     <!-- Build the comma-separated quoted path list as a pure item transform (item lists
-         cannot be embedded next to literal text, hence the two-step property). -->
+         cannot be embedded next to literal text, hence the two-step property). %(RecursiveDir)
+         only captures what ** matched, i.e. paths relative to wwwroot/Content — the literal
+         "Content/" prefix restores wwwroot-relative paths. -->
     <PropertyGroup>
-      <_ContentManifestJson>@(_ContentFiles -> '&quot;%(RecursiveDir)%(Filename)%(Extension)&quot;', ',')</_ContentManifestJson>
+      <_ContentManifestJson>@(_ContentFiles -> '&quot;Content/%(RecursiveDir)%(Filename)%(Extension)&quot;', ',')</_ContentManifestJson>
       <!-- JSON forbids unescaped backslashes; emit browser-style forward slashes. -->
       <_ContentManifestJson>$(_ContentManifestJson.Replace('\','/'))</_ContentManifestJson>
     </PropertyGroup>


### PR DESCRIPTION
## Problem

`GenerateContentManifest` (FlatRedBall2.BlazorGL) writes `wwwroot/content-manifest.json`
so `frb-host.js` can prefetch content into the browser HTTP cache during loading screens.
Two issues meant the feature never worked end-to-end:

1. **Wrong paths.** Entries were built from `%(RecursiveDir)%(Filename)%(Extension)`, but
   `%(RecursiveDir)` only captures what `**` matched — paths came out relative to
   `wwwroot/Content`, while `frb-host.js` fetches each entry from the page root
   (`wwwroot`). Every prefetch silently 404'd inside its `.catch(() => {})`. TMX/tileset
   games were hit hardest on first level load.
2. **Dead in-repo code.** Samples reference FlatRedBall2.BlazorGL via `ProjectReference`,
   which does *not* auto-import `build/*.targets` (that is a NuGet-package-only mechanism),
   so nothing in-repo ever ran the target or generated a manifest.

## Changes

- `src/FlatRedBall2.BlazorGL/build/FlatRedBall2.BlazorGL.targets`
  - Prefix the literal `Content/` to restore wwwroot-relative paths.
  - Skip design-time builds (`'$(DesignTimeBuild)' != 'true'`) so IDE evaluation doesn't rewrite the file.
  - Exclude `wwwroot/Content/.gitignore`: the deploy workflow deletes `.gitignore` from published output (`deploy-sample.yml`), so prefetching it would guarantee a permanent 404.
- Three committed BlazorGL heads (`PlatformKing`, `ShmupSpace`, `Solitaire`): explicit
  `<Import Project="...\FlatRedBall2.BlazorGL\build\FlatRedBall2.BlazorGL.targets" />` with
  a comment explaining why (ProjectReference ≠ package import).
- `Solitaire.BlazorGL.csproj`: `_CommonRawAssets` moved from evaluation time into
  `CopyCommonRawAssetsToWwwroot`. On a fresh checkout the `.gumpkg` is gitignored and only
  exists after `Solitaire.Common`'s `PackGumProject` runs mid-build — an evaluation-time
  glob missed it, so cold CI builds shipped an empty `wwwroot/Content` and thus an empty
  manifest. Computing items inside the target (after the ProjectReference chain finishes)
  fixes it; `Inputs/Outputs` dropped since they evaluate before the target body anyway.
- Root `.gitignore`: `**/wwwroot/content-manifest.json` (generated artifact).
- `frb-skills/multiplatform-conversion/SKILL.md`: document the `Content/`-prefixed path
  format and the ProjectReference landmine.

## Templates intentionally untouched

`frb2-multiplatform` resolves FlatRedBall2 packages from nuget.org, not repo source — a
repo-relative `<Import>` would break every instantiated user project. Template consumers
pick up the fix automatically when the `FlatRedBall2.BlazorGL` package next publishes.

## Verification

No unit test — MSBuild target output is only observable through a full SDK build:

1. What blocked a test: the output is an artifact of the SDK's static-web-assets pipeline;
   `tests/` has no harness that executes `BeforeTargets` hooks against real SDK infra, and
   reproducing MSBuild glob semantics in-process would be testing a reimplementation.
2. Testable core extracted: none feasible; verification was artifact inspection instead —
   built `ShmupSpace.BlazorGL` and `PlatformKing.BlazorGL` and inspected the generated
   manifests: valid JSON, every entry `Content/`-prefixed and existing on disk, complete
   vs. disk in both directions (0 missing / 0 unlisted), nested dirs correct
   (`Content/Animations/...`), TMX/TSX tilemap content listed
   (`Content/Tiled/Level1.tmx`, `StandardTileset.tsx`, ...).
3. Residue left untested: the exact JSON string formatting (verified empirically above)
   and `frb-host.js`, which is unchanged and already fail-soft.

All three committed samples verified locally on this branch:

- `PlatformKing` / `ShmupSpace`: manifests complete vs. disk in both directions
  (0 missing / 0 unlisted), every entry `Content/`-prefixed, no `.gitignore` entry,
  nested dirs correct (`Content/Animations/...`, `Content/Tiled/Level1.tmx`).
- `Solitaire`: cold-checkout simulated (all `.gumpkg` artifacts deleted) → single build
  packs, copies, and lists `Content/GumProject/GumProject.gumpkg`; loose mode
  (`-p:UseGumPackage=false`) enumerates all 154 files with `.gumj` included.

Full suite: `dotnet test tests/FlatRedBall2.Tests/` — 1590 passed, 0 failed.

## Deploy verification (live)

A cold single `dotnet publish -o publish` — the exact invocation `deploy-sample.yml`
uses — deploys the manifest: publish-time wwwroot collection picks up the mid-build file.
(Only the intermediate `bin/.../wwwroot` of a plain build omits it, which is harmless —
bin is never served.) Confirmed end-to-end per sample by dispatching "Deploy Sample to
GitHub Pages" against **this branch** before review:

- **PlatformKing** — run https://github.com/vchelaru/FlatRedBall2/actions/runs/32529905880;
  live: https://vchelaru.github.io/FlatRedBall2/PlatformKing/content-manifest.json
  (entries `Content/`-prefixed; TMX/tileset files verified present under `PlatformKing/Content/Tiled/`)
- **ShmupSpace** — run https://github.com/vchelaru/FlatRedBall2/actions/runs/32535271914;
  live: https://vchelaru.github.io/FlatRedBall2/ShmupSpace/content-manifest.json
  (all 5 entries `Content/`-prefixed; spot-checked `/ShmupSpace/Content/Animations/ShmupSpace.achx` serves HTTP 200)
- **Solitaire** — run https://github.com/vchelaru/FlatRedBall2/actions/runs/32535507676;
  live: https://vchelaru.github.io/FlatRedBall2/Solitaire/content-manifest.json
  (`["Content/GumProject/GumProject.gumpkg"]`; the 279 KB bundle verified serving at
  `/Solitaire/Content/GumProject/GumProject.gumpkg`). CI runners are fresh checkouts, so
  this also validates the `_CommonRawAssets` cold-build fix end-to-end — before it, this
  exact run would have shipped an empty manifest.
