### PR TITLE
Fix: Close Project doesn't clear Project tab's .achx tree (#961)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2279,6 +2279,7 @@ public partial class MainWindow : Window
         ShowAchxPane();
         RebuildTabStrip();
         ProjectPanel.SyncSelectionToActiveFile(null);
+        ProjectPanel.Clear();
         RefreshTreeView();
         RefreshFilesPanel();
         UpdateTitle();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseProjectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CloseProjectTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -73,6 +75,32 @@ public class CloseProjectTests
             Assert.Empty(roots);
         }
         finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public async Task CloseProjectAsync_ProjectFolderOpen_ClearsProjectPanelTree()
+    {
+        var (window, ctx) = CreateWindow();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            new AnimationChainListSave().Save(Path.Combine(dir, "hero.achx"));
+
+            await window.OpenProjectFolderForTestAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            Assert.NotEmpty(window.ProjectPanel.TreeRoots);
+
+            await window.CloseProjectAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Empty(window.ProjectPanel.TreeRoots);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary
Closing a project (File > Close Project) reset `ProjectManager`/tabs/tree view but never cleared the Project tab's `.achx` file tree, so files from the previously-open folder stayed listed after close.

`CloseProjectAsync` (`MainWindow.axaml.cs`) now also calls `ProjectPanel.Clear()`, matching what `LoadProjectFolderAsync` populates via `ProjectPanel.SetEntries(...)`.

## Test plan
- Added `CloseProjectTests.CloseProjectAsync_ProjectFolderOpen_ClearsProjectPanelTree`: opens a project folder with one `.achx`, confirms `ProjectPanel.TreeRoots` is populated, closes the project, asserts `TreeRoots` is empty. Confirmed it fails before the fix (stale entry left in the tree) and passes after.
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 865 passed, 0 failed.

Manual test: not needed — fully covered by the new automated test plus compilation.

Closes #961
