### PR TITLE
Add a reusable FlankerNumericField [−][value][+] control

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -874,8 +874,7 @@
                                                 <Grid ColumnDefinitions="78,*,Auto">
                                                     <TextBlock Text="Length" VerticalAlignment="Center"
                                                                Foreground="{DynamicResource InkMid}" FontSize="11" />
-                                                    <NumericUpDown x:Name="PropFrameLen" Grid.Column="1"
-                                                                   ShowButtonSpinner="True"
+                                                    <viewsControls:FlankerNumericField x:Name="PropFrameLen" Grid.Column="1"
                                                                    Minimum="0.001" Maximum="60"
                                                                    Increment="0.05" FormatString="0.000" />
                                                     <TextBlock Text="s" Grid.Column="2"
@@ -1332,27 +1331,10 @@
                             </StackPanel>
                         </ToggleButton>
 
-                        <Border BorderBrush="{DynamicResource LineBrush}"
-                                BorderThickness="1" CornerRadius="4" ClipToBounds="True"
-                                Height="26" Margin="0,0,2,0" VerticalAlignment="Center"
-                                IsEnabled="{Binding #SnapToGridCheck.IsChecked}">
-                            <DockPanel>
-                                <Button x:Name="GridSizeMinusBtn" DockPanel.Dock="Left"
-                                        Classes="flanker" Content="−" Width="22"
-                                        BorderBrush="{DynamicResource LineBrush}" BorderThickness="0,0,1,0" />
-                                <Button x:Name="GridSizePlusBtn" DockPanel.Dock="Right"
-                                        Classes="flanker" Content="+" Width="22"
-                                        BorderBrush="{DynamicResource LineBrush}" BorderThickness="1,0,0,0" />
-                                <!-- MinWidth/MinHeight 0 (#501): keep the field from overflowing its
-                                     center slot over the −/+ buttons; Fluent forces a min ~64×32. -->
-                                <TextBox x:Name="GridSizeInput" Text="16"
-                                         HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                                         Background="Transparent" BorderThickness="0" Padding="4,0" FontSize="11"
-                                         MinWidth="0" MinHeight="0"
-                                         Height="26" VerticalAlignment="Center"
-                                         KeyDown="OnGridSizeInputKeyDown" />
-                            </DockPanel>
-                        </Border>
+                        <viewsControls:FlankerNumericField x:Name="GridSizeInput"
+                                                            Margin="0,0,2,0" VerticalAlignment="Center"
+                                                            IsEnabled="{Binding #SnapToGridCheck.IsChecked}"
+                                                            Minimum="1" Maximum="512" Increment="1" FormatString="0" />
 
                         <!-- Divider -->
                         <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
@@ -1557,28 +1539,10 @@
                                              CurrentColor="{DynamicResource IconInk}"
                                              VerticalAlignment="Center" HorizontalAlignment="Center" />
                                 </Button>
-                                <Border BorderBrush="{DynamicResource LineBrush}"
-                                        BorderThickness="1" CornerRadius="4" ClipToBounds="True"
-                                        Height="26" Width="92" VerticalAlignment="Center"
-                                        ToolTip.Tip="Playback speed (1.0 = runtime speed)">
-                                    <DockPanel>
-                                        <Button x:Name="SpeedDownBtn" DockPanel.Dock="Left"
-                                                Classes="flanker" Content="−" Width="22"
-                                                BorderBrush="{DynamicResource LineBrush}" BorderThickness="0,0,1,0" />
-                                        <Button x:Name="SpeedUpBtn" DockPanel.Dock="Right"
-                                                Classes="flanker" Content="+" Width="22"
-                                                BorderBrush="{DynamicResource LineBrush}" BorderThickness="1,0,0,0" />
-                                        <!-- MinWidth/MinHeight 0 (#501): Fluent forces a TextBox min size
-                                             (~64×32); in this fixed-width pill the center slot is narrower,
-                                             so without this the textbox overflows centered and its focus
-                                             highlight bleeds over the −/+ buttons. -->
-                                        <TextBox x:Name="SpeedInput" Text="1.0"
-                                                 HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                                                 Background="Transparent" BorderThickness="0" Padding="4,0" FontSize="11"
-                                                 MinWidth="0" MinHeight="0"
-                                                 Height="26" VerticalAlignment="Center" />
-                                    </DockPanel>
-                                </Border>
+                                <viewsControls:FlankerNumericField x:Name="SpeedInput"
+                                                                    Width="92" VerticalAlignment="Center"
+                                                                    ToolTip.Tip="Playback speed (1.0 = runtime speed)"
+                                                                    Minimum="0.1" Maximum="10" Increment="0.1" FormatString="0.0#" />
                             </StackPanel>
                         </Border>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1176,9 +1176,8 @@ public partial class MainWindow : Window
         MoveModeToggle.IsCheckedChanged += OnMoveModeToggled;
         MagicWandToggle.IsCheckedChanged += OnMagicWandToggled;
         SnapToGridCheck.IsCheckedChanged += OnSnapToGridChanged;
-        GridSizeInput.LostFocus += OnGridSizeInputLostFocus;
-        GridSizePlusBtn.Click  += OnGridSizePlusBtnClick;
-        GridSizeMinusBtn.Click += OnGridSizeMinusBtnClick;
+        GridSizeInput.Value = 16m;
+        GridSizeInput.ValueChanged += (_, _) => ApplyGridSize();
         WireframeZoom.Attach(WireframeCtrl);
 
         // Default to Move mode
@@ -1251,43 +1250,12 @@ public partial class MainWindow : Window
         SaveCompanionFile();
     }
 
-    private int GetGridSizeFromInput() => NumericToolbarInput.ParseGridSize(GridSizeInput.Text);
-
-    private void OnGridSizeInputLostFocus(object? sender, RoutedEventArgs e) => ApplyGridSize();
-
-    private void OnGridSizeInputKeyDown(object? sender, KeyEventArgs e)
-    {
-        if (e.Key == Key.Enter)
-        {
-            ApplyGridSize();
-            e.Handled = true;
-        }
-    }
+    private int GetGridSizeFromInput() => (int)(GridSizeInput.Value ?? 16m);
 
     private void ApplyGridSize()
     {
-        int size = GetGridSizeFromInput();
-        GridSizeInput.Text = size.ToString();
         if (SnapToGridCheck.IsChecked == true)
-            WireframeCtrl.SetGrid(true, size);
-        SaveCompanionFile();
-    }
-
-    private void OnGridSizePlusBtnClick(object? sender, RoutedEventArgs e)
-    {
-        int size = Math.Min(GetGridSizeFromInput() + 1, 512);
-        GridSizeInput.Text = size.ToString();
-        if (SnapToGridCheck.IsChecked == true)
-            WireframeCtrl.SetGrid(true, size);
-        SaveCompanionFile();
-    }
-
-    private void OnGridSizeMinusBtnClick(object? sender, RoutedEventArgs e)
-    {
-        int size = Math.Max(GetGridSizeFromInput() - 1, 1);
-        GridSizeInput.Text = size.ToString();
-        if (SnapToGridCheck.IsChecked == true)
-            WireframeCtrl.SetGrid(true, size);
+            WireframeCtrl.SetGrid(true, GetGridSizeFromInput());
         SaveCompanionFile();
     }
 
@@ -1670,7 +1638,7 @@ public partial class MainWindow : Window
         try
         {
             SnapToGridCheck.IsChecked = settings.SnapToGrid;
-            GridSizeInput.Text        = settings.GridSize.ToString();
+            GridSizeInput.Value       = settings.GridSize;
             WireframeCtrl.SetGrid(settings.SnapToGrid, settings.GridSize);
 
             WireframeCtrl.SetZoomPercent(settings.WireframeZoomPercent);
@@ -4476,7 +4444,7 @@ public partial class MainWindow : Window
             PropCircleX, PropCircleY, PropCircleRadius);
     }
 
-    private void SealOnLostFocus(params NumericUpDown[] inputs)
+    private void SealOnLostFocus(params InputElement[] inputs)
     {
         foreach (var input in inputs)
             input.LostFocus += (_, _) => _appCommands.SealPendingEdits();
@@ -4665,6 +4633,22 @@ public partial class MainWindow : Window
     /// with a "(mixed)" placeholder when the selected frames disagree on that property.
     /// </summary>
     private static void SetValueOrMixed(NumericUpDown control, IReadOnlyList<decimal> values)
+    {
+        if (values.Distinct().Count() == 1)
+        {
+            control.Value = values[0];
+            control.PlaceholderText = string.Empty;
+        }
+        else
+        {
+            control.Value = null;
+            control.PlaceholderText = "(mixed)";
+        }
+    }
+
+    /// <summary>Overload of <see cref="SetValueOrMixed(NumericUpDown, IReadOnlyList{decimal})"/> for
+    /// <see cref="FlankerNumericField"/>-based inspector fields (e.g. PropFrameLen).</summary>
+    private static void SetValueOrMixed(FlankerNumericField control, IReadOnlyList<decimal> values)
     {
         if (values.Distinct().Count() == 1)
         {
@@ -4986,19 +4970,9 @@ public partial class MainWindow : Window
 
     private void WirePlaybackControls()
     {
-        SpeedInput.LostFocus += (_, _) => ApplySpeedFromInput();
-        SpeedUpBtn.Click   += (_, _) =>
-        {
-            double s = Math.Min(Math.Round(GetSpeedFromInput() + 0.1, 1), 10.0);
-            SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
-            PreviewCtrl.SpeedMultiplier = s;
-        };
-        SpeedDownBtn.Click += (_, _) =>
-        {
-            double s = Math.Max(Math.Round(GetSpeedFromInput() - 0.1, 1), 0.1);
-            SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
-            PreviewCtrl.SpeedMultiplier = s;
-        };
+        SpeedInput.Value = 1.0m;
+        SpeedInput.ValueChanged += (_, _) =>
+            PreviewCtrl.SpeedMultiplier = (double)(SpeedInput.Value ?? 1.0m);
     }
 
     // ── Timeline transport: Play/Pause button + click-drag scrubbing (#432) ───
@@ -5077,15 +5051,6 @@ public partial class MainWindow : Window
             double travelWidth = Math.Max(0, _timelineFrames[result.FrameIndex].Width - TimelineFrameVm.PlayheadWidth);
             _timelineFrames[result.FrameIndex].ScrubberOffset = Math.Min(result.LocalX, travelWidth);
         }
-    }
-
-    private double GetSpeedFromInput() => NumericToolbarInput.ParseSpeed(SpeedInput.Text);
-
-    private void ApplySpeedFromInput()
-    {
-        double s = GetSpeedFromInput();
-        SpeedInput.Text = NumericToolbarInput.FormatSpeed(s);
-        PreviewCtrl.SpeedMultiplier = s;
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -919,98 +919,33 @@ public partial class App : Application
         ToolTip.SetTip(snapToGridCheck, "Snap to Grid");
         // Ensure the wireframe starts with grid off (matches desktop's WireframeCtrl.SetGrid(false, 16)).
         wireframe.SetGrid(false, 16);
-        var gridSizeInput = new TextBox
+        // FlankerNumericField (#963) is the canonical "[−][value][+]" pill -- its own template
+        // already carries the border/DynamicResource wiring the old hand-rolled Border+DockPanel
+        // version needed .Bind(..., GetResourceObservable(...)) calls for.
+        var gridSizeInput = new FlankerNumericField
         {
-            Text = "16",
-            HorizontalContentAlignment = HorizontalAlignment.Center,
-            VerticalContentAlignment = VerticalAlignment.Center,
-            Background = Avalonia.Media.Brushes.Transparent,
-            BorderThickness = new Thickness(0),
-            Padding = new Thickness(4, 0),
-            FontSize = 11,
-            MinWidth = 0,
-            MinHeight = 0,
-            Height = 26,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        // Classes="flanker" (ThemeStyles) zeros MinHeight/Padding and centers content — without
-        // it Fluent's default button chrome top-aligns "−"/"+" inside the 26px pill.
-        var gridSizeMinusBtn = new Button
-        {
-            Classes = { "flanker" },
-            Content = "−",
-            Width = 22,
-            Height = 26,
-            BorderThickness = new Thickness(0, 0, 1, 0),
-        };
-        gridSizeMinusBtn.Bind(Button.BorderBrushProperty, gridSizeMinusBtn.GetResourceObservable("LineBrush"));
-        var gridSizePlusBtn = new Button
-        {
-            Classes = { "flanker" },
-            Content = "+",
-            Width = 22,
-            Height = 26,
-            BorderThickness = new Thickness(1, 0, 0, 0),
-        };
-        gridSizePlusBtn.Bind(Button.BorderBrushProperty, gridSizePlusBtn.GetResourceObservable("LineBrush"));
-
-        int GetGridSizeFromInput() => NumericToolbarInput.ParseGridSize(gridSizeInput.Text);
-
-        void ApplyGrid()
-        {
-            var size = GetGridSizeFromInput();
-            gridSizeInput.Text = size.ToString();
-            wireframe.SetGrid(snapToGridCheck.IsChecked == true, size);
-        }
-
-        var gridSizeDock = new DockPanel();
-        DockPanel.SetDock(gridSizeMinusBtn, Dock.Left);
-        DockPanel.SetDock(gridSizePlusBtn, Dock.Right);
-        gridSizeDock.Children.Add(gridSizeMinusBtn);
-        gridSizeDock.Children.Add(gridSizePlusBtn);
-        gridSizeDock.Children.Add(gridSizeInput);
-        var gridSizePill = new Border
-        {
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(4),
-            ClipToBounds = true,
-            Height = 26,
             Margin = new Thickness(0, 0, 2, 0),
             VerticalAlignment = VerticalAlignment.Center,
             IsEnabled = false,
-            Child = gridSizeDock,
+            Minimum = 1m,
+            Maximum = 512m,
+            Increment = 1m,
+            FormatString = "0",
+            Value = 16m,
         };
-        gridSizePill.Bind(Border.BorderBrushProperty, gridSizePill.GetResourceObservable("LineBrush"));
 
         // Click (same as Onion Skin / Guides) — IsCheckedChanged alone was unreliable in the
         // browser Fluent ToggleButton path after the toolbar-placement pass; Click always fires
         // after the toggle flips and is the path the other view toggles already use.
         void OnGridToggle()
         {
-            gridSizePill.IsEnabled = snapToGridCheck.IsChecked == true;
-            ApplyGrid();
+            gridSizeInput.IsEnabled = snapToGridCheck.IsChecked == true;
+            wireframe.SetGrid(snapToGridCheck.IsChecked == true, (int)(gridSizeInput.Value ?? 16m));
         }
         snapToGridCheck.Click += (_, _) => OnGridToggle();
         snapToGridCheck.IsCheckedChanged += (_, _) => OnGridToggle();
-        gridSizeInput.LostFocus += (_, _) => ApplyGrid();
-        gridSizeInput.KeyDown += (_, e) =>
-        {
-            if (e.Key == Key.Enter)
-            {
-                ApplyGrid();
-                e.Handled = true;
-            }
-        };
-        gridSizeMinusBtn.Click += (_, _) =>
-        {
-            gridSizeInput.Text = Math.Max(GetGridSizeFromInput() - 1, 1).ToString();
-            ApplyGrid();
-        };
-        gridSizePlusBtn.Click += (_, _) =>
-        {
-            gridSizeInput.Text = Math.Min(GetGridSizeFromInput() + 1, 512).ToString();
-            ApplyGrid();
-        };
+        gridSizeInput.ValueChanged += (_, _) =>
+            wireframe.SetGrid(snapToGridCheck.IsChecked == true, (int)(gridSizeInput.Value ?? 16m));
 
         // PixiJsSpriteSheetExporter.Export is the same pure, already-tested core desktop's
         // AppCommands.ExportToPixiJsAsync calls -- what differs here is entirely the output path:
@@ -1081,7 +1016,7 @@ public partial class App : Application
                 editModePill,
                 ToolbarDivider(),
                 snapToGridCheck,
-                gridSizePill,
+                gridSizeInput,
                 ToolbarDivider(),
                 wireframeZoomLabel,
                 wireframeZoom,
@@ -1286,80 +1221,19 @@ public partial class App : Application
         playPauseButton.Click += (_, _) => preview.TogglePlayPause();
         preview.IsPlayingChanged += UpdatePlayPauseChrome;
 
-        var speedInput = new TextBox
+        var speedPill = new FlankerNumericField
         {
-            Text = "1.0",
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Center,
-            VerticalContentAlignment = VerticalAlignment.Center,
-            TextAlignment = Avalonia.Media.TextAlignment.Center,
-            Background = Avalonia.Media.Brushes.Transparent,
-            BorderThickness = new Thickness(0),
-            Padding = new Thickness(4, 0),
-            FontSize = 11,
-            MinWidth = 0,
-            MinHeight = 0,
-            Height = 26,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        double GetSpeedFromInput() => NumericToolbarInput.ParseSpeed(speedInput.Text);
-        void ApplySpeedFromInput()
-        {
-            double s = GetSpeedFromInput();
-            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
-            preview.SpeedMultiplier = s;
-        }
-        speedInput.LostFocus += (_, _) => ApplySpeedFromInput();
-        var speedDownButton = new Button
-        {
-            Classes = { "flanker" },
-            Content = "−",
-            Width = 22,
-        };
-        speedDownButton.Bind(Button.BorderBrushProperty, speedDownButton.GetResourceObservable("LineBrush"));
-        speedDownButton.Click += (_, _) =>
-        {
-            double s = Math.Max(Math.Round(GetSpeedFromInput() - 0.1, 1), 0.1);
-            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
-            preview.SpeedMultiplier = s;
-        };
-        var speedUpButton = new Button
-        {
-            Classes = { "flanker" },
-            Content = "+",
-            Width = 22,
-        };
-        speedUpButton.Bind(Button.BorderBrushProperty, speedUpButton.GetResourceObservable("LineBrush"));
-        speedUpButton.Click += (_, _) =>
-        {
-            double s = Math.Min(Math.Round(GetSpeedFromInput() + 0.1, 1), 10.0);
-            speedInput.Text = NumericToolbarInput.FormatSpeed(s);
-            preview.SpeedMultiplier = s;
-        };
-        var speedPill = new Border
-        {
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(4),
-            ClipToBounds = true,
-            Height = 26,
             Width = 92,
             VerticalAlignment = VerticalAlignment.Center,
-            Child = new DockPanel
-            {
-                Children =
-                {
-                    speedDownButton,
-                    speedUpButton,
-                    speedInput,
-                },
-            },
+            Minimum = 0.1m,
+            Maximum = 10m,
+            Increment = 0.1m,
+            FormatString = "0.0#",
+            Value = 1.0m,
         };
         ToolTip.SetTip(speedPill, "Playback speed (1.0 = runtime speed)");
-        speedPill.Bind(Border.BorderBrushProperty, speedPill.GetResourceObservable("LineBrush"));
-        DockPanel.SetDock(speedDownButton, Dock.Left);
-        speedDownButton.BorderThickness = new Thickness(0, 0, 1, 0);
-        DockPanel.SetDock(speedUpButton, Dock.Right);
-        speedUpButton.BorderThickness = new Thickness(1, 0, 0, 0);
+        speedPill.ValueChanged += (_, _) =>
+            preview.SpeedMultiplier = (double)(speedPill.Value ?? 1.0m);
 
         void RefreshTimelineStrip()
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/NumericToolbarInput.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Utilities/NumericToolbarInput.cs
@@ -4,21 +4,15 @@ using System.Globalization;
 namespace AnimationEditor.Core.Utilities;
 
 /// <summary>
-/// Pure parse/clamp/format rules for the toolbar's numeric text inputs (grid size, playback
-/// speed). Shared by the desktop and browser hosts so the two can't drift out of sync.
+/// Pure parse/clamp rule backing <c>AnimationEditor.Views.Controls.FlankerNumericField</c>'s
+/// commit path (the "[−][value][+]" numeric field shared by every toolbar/inspector/dialog
+/// numeric input across the desktop and browser hosts, #963).
 /// </summary>
 public static class NumericToolbarInput
 {
-    /// <summary>Formats a speed value for display, trimming trailing zeros beyond one decimal (e.g. 1.25 -> "1.25", 2.0 -> "2.0").</summary>
-    public static string FormatSpeed(double speed) => speed.ToString("0.0#");
-
-    /// <summary>Parses a grid-size input, clamping to [1, 512]. Falls back to 16 if the text doesn't parse or is below 1.</summary>
-    public static int ParseGridSize(string? text)
-        => int.TryParse(text, out int v) && v >= 1 ? Math.Min(v, 512) : 16;
-
-    /// <summary>Parses a playback-speed input (invariant culture), clamping to [0.1, 10.0]. Falls back to 1.0 if the text doesn't parse.</summary>
-    public static double ParseSpeed(string? text)
-        => double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double v)
-            ? Math.Clamp(v, 0.1, 10.0)
-            : 1.0;
+    /// <summary>Parses a decimal input (invariant culture), clamping to [<paramref name="min"/>, <paramref name="max"/>]. Falls back to <paramref name="fallback"/> if the text doesn't parse.</summary>
+    public static decimal ParseClamp(string? text, decimal min, decimal max, decimal fallback)
+        => decimal.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal v)
+            ? Math.Clamp(v, min, max)
+            : fallback;
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/FlankerNumericField.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/FlankerNumericField.axaml
@@ -1,0 +1,33 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AnimationEditor.Views.Controls.FlankerNumericField"
+             x:Name="Root">
+    <!--
+        #963: the canonical "[−][value][+]" numeric field — a plain Border > DockPanel > two
+        flanker Buttons + a TextBox, exactly the structure GridSize/Speed already got right.
+        Deliberately NOT a re-templated NumericUpDown/ButtonSpinner: NumericUpDown draws its own
+        outer border *around* ButtonSpinner, so restyling only the inner ButtonSpinner template
+        (the first cut of #957) nests two borders and looks cramped. No hardcoded Width here —
+        consumers size the root exactly like they already do for NumericUpDown/the raw TextBox
+        versions this replaces.
+    -->
+    <Border BorderBrush="{DynamicResource LineBrush}" BorderThickness="1" CornerRadius="4"
+            ClipToBounds="True" Height="26">
+        <DockPanel>
+            <Button x:Name="MinusBtn" DockPanel.Dock="Left"
+                    Classes="flanker" Content="−" Width="22"
+                    BorderBrush="{DynamicResource LineBrush}" BorderThickness="0,0,1,0" />
+            <Button x:Name="PlusBtn" DockPanel.Dock="Right"
+                    Classes="flanker" Content="+" Width="22"
+                    BorderBrush="{DynamicResource LineBrush}" BorderThickness="1,0,0,0" />
+            <!-- MinWidth/MinHeight 0 (#501): keep the field from overflowing its center slot over
+                 the −/+ buttons; Fluent forces a min ~64×32. -->
+            <TextBox x:Name="ValueBox"
+                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                     Background="Transparent" BorderThickness="0" Padding="4,0" FontSize="11"
+                     MinWidth="0" MinHeight="0"
+                     Height="26" VerticalAlignment="Center"
+                     PlaceholderText="{Binding #Root.PlaceholderText}" />
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/FlankerNumericField.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/FlankerNumericField.axaml.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Globalization;
+using AnimationEditor.Core.Utilities;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace AnimationEditor.Views.Controls;
+
+/// <summary>
+/// Reusable "[−][value][+]" numeric field (#963): a plain Border/DockPanel/Button+TextBox, the
+/// structure GridSize/Speed already got right, extracted so every consumer stops re-copying it
+/// (or worse, re-templating <see cref="NumericUpDown"/>'s ButtonSpinner, which nests an extra
+/// border around the flanker buttons — the mistake #957's first cut made).
+/// </summary>
+public partial class FlankerNumericField : UserControl
+{
+    public static readonly StyledProperty<decimal?> ValueProperty =
+        AvaloniaProperty.Register<FlankerNumericField, decimal?>(nameof(Value));
+
+    public decimal? Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public static readonly StyledProperty<decimal> MinimumProperty =
+        AvaloniaProperty.Register<FlankerNumericField, decimal>(nameof(Minimum), decimal.MinValue);
+
+    public decimal Minimum
+    {
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
+
+    public static readonly StyledProperty<decimal> MaximumProperty =
+        AvaloniaProperty.Register<FlankerNumericField, decimal>(nameof(Maximum), decimal.MaxValue);
+
+    public decimal Maximum
+    {
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
+
+    public static readonly StyledProperty<decimal> IncrementProperty =
+        AvaloniaProperty.Register<FlankerNumericField, decimal>(nameof(Increment), 1m);
+
+    public decimal Increment
+    {
+        get => GetValue(IncrementProperty);
+        set => SetValue(IncrementProperty, value);
+    }
+
+    public static readonly StyledProperty<string> FormatStringProperty =
+        AvaloniaProperty.Register<FlankerNumericField, string>(nameof(FormatString), "0.###");
+
+    public string FormatString
+    {
+        get => GetValue(FormatStringProperty);
+        set => SetValue(FormatStringProperty, value);
+    }
+
+    /// <summary>Shown in <c>ValueBox</c> when <see cref="Value"/> is null (the multi-select
+    /// "mixed value" convention -- see MainWindow's SetValueOrMixed).</summary>
+    public static readonly StyledProperty<string?> PlaceholderTextProperty =
+        AvaloniaProperty.Register<FlankerNumericField, string?>(nameof(PlaceholderText));
+
+    public string? PlaceholderText
+    {
+        get => GetValue(PlaceholderTextProperty);
+        set => SetValue(PlaceholderTextProperty, value);
+    }
+
+    /// <summary>Raised whenever <see cref="Value"/> changes -- typing+Enter/focus-loss, a +/-
+    /// click, or a programmatic assignment (mirrors NumericUpDown.ValueChanged, which fires on
+    /// every write regardless of origin; a caller that must ignore programmatic writes already
+    /// guards with its own suppress flag around the assignment, e.g. MainWindow's
+    /// _suppressPropRefresh around SetValueOrMixed).</summary>
+    public event EventHandler? ValueChanged;
+
+    static FlankerNumericField()
+    {
+        // Registered once per type (not per instance) -- AvaloniaProperty.Changed is a shared,
+        // class-wide observable, so subscribing inside the instance constructor would add one
+        // handler per instance created and fire N times once N instances exist.
+        ValueProperty.Changed.AddClassHandler<FlankerNumericField>((c, _) => c.OnValueChanged());
+    }
+
+    public FlankerNumericField()
+    {
+        InitializeComponent();
+
+        MinusBtn.Click += (_, _) => Step(-1);
+        PlusBtn.Click += (_, _) => Step(1);
+
+        ValueBox.LostFocus += (_, _) =>
+        {
+            Commit();
+            // Re-raise on this control so external `control.LostFocus += ...` subscribers (e.g.
+            // SealOnLostFocus) keep working -- focus lands on ValueBox, not on this UserControl,
+            // so its own inherited LostFocus never fires on its own. LostFocusEvent is declared as
+            // RoutedEvent<FocusChangedEventArgs> (not the plain base RoutedEventArgs), so a handler
+            // registered via the strongly-typed LostFocus CLR event throws InvalidCastException if
+            // raised with a bare RoutedEventArgs instance.
+            RaiseEvent(new FocusChangedEventArgs(LostFocusEvent));
+        };
+        ValueBox.AddHandler(KeyDownEvent, OnValueBoxKeyDown);
+    }
+
+    private void OnValueBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter) return;
+        Commit();
+        e.Handled = true;
+    }
+
+    private void OnValueChanged()
+    {
+        ValueBox.Text = Format(Value);
+        ValueChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Step(int direction)
+    {
+        decimal current = Value ?? Minimum;
+        Value = Math.Clamp(current + direction * Increment, Minimum, Maximum);
+    }
+
+    private void Commit()
+    {
+        decimal fallback = Value ?? Minimum;
+        decimal parsed = NumericToolbarInput.ParseClamp(ValueBox.Text, Minimum, Maximum, fallback);
+
+        // Value's setter only raises OnValueChanged (which reformats ValueBox.Text) when the
+        // parsed value actually differs -- reformat explicitly here too so stray/uncommitted text
+        // (e.g. "0.1500" parsing to the already-current 0.15) always snaps back to FormatString.
+        if (Value == parsed)
+            ValueBox.Text = Format(parsed);
+        else
+            Value = parsed;
+    }
+
+    private string Format(decimal? value) =>
+        value?.ToString(FormatString, CultureInfo.InvariantCulture) ?? string.Empty;
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:AnimationEditor.Views.Controls"
              x:Class="AnimationEditor.Views.Controls.InspectorControl">
     <!--
         Phase 9 (#649): sectioned headers matching desktop MainWindow's inline inspector naming
@@ -63,8 +64,7 @@
                     <Grid ColumnDefinitions="Auto,*" MinWidth="120">
                         <TextBlock Text="Length (s)" VerticalAlignment="Center" Margin="0,0,8,0"
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
-                        <NumericUpDown x:Name="FrameLengthInput" x:FieldModifier="Public" Grid.Column="1"
-                                       ShowButtonSpinner="True"
+                        <controls:FlankerNumericField x:Name="FrameLengthInput" x:FieldModifier="Public" Grid.Column="1"
                                        Minimum="0.001" Maximum="60" Increment="0.01" FormatString="0.###" />
                     </Grid>
                 </StackPanel>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml
@@ -64,6 +64,7 @@
                         <TextBlock Text="Length (s)" VerticalAlignment="Center" Margin="0,0,8,0"
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
                         <NumericUpDown x:Name="FrameLengthInput" x:FieldModifier="Public" Grid.Column="1"
+                                       ShowButtonSpinner="True"
                                        Minimum="0.001" Maximum="60" Increment="0.01" FormatString="0.###" />
                     </Grid>
                 </StackPanel>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/InspectorControl.axaml.cs
@@ -104,7 +104,7 @@ public partial class InspectorControl : UserControl
     /// of <paramref name="inputs"/> loses focus, so the next edit to that field starts a fresh
     /// undo entry instead of merging into the one just closed (#897).
     /// </summary>
-    private void SealOnLostFocus(params NumericUpDown[] inputs)
+    private void SealOnLostFocus(params InputElement[] inputs)
     {
         foreach (var input in inputs)
             input.LostFocus += (_, _) => _appCommands?.SealPendingEdits();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Views.Controls;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
@@ -108,7 +109,7 @@ public static class EditorDialogs
         var originalLengths = chain.Frames.Select(f => f.FrameLength).ToArray();
         bool didEdit = false;
 
-        var durationInput = new NumericUpDown
+        var durationInput = new FlankerNumericField
         {
             Value = (decimal)totalDuration,
             Minimum = 0m,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeIconResources.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeIconResources.axaml
@@ -5,11 +5,8 @@
          AnimationEditor.Browser. SVG assets live under AnimationEditor.Views/Assets/icons/svg/;
          see docs/BROWSER_ICON_SYSTEM_DECISION.md. -->
 
-    <!-- Flanking +/- spinner (a "flanker" pill: [−][value][+]) — replaces Fluent's default
-         stacked-chevron spinner for all ButtonSpinner/NumericUpDown. Reuses the Button.flanker
-         style (ThemeStyles.axaml) so it matches the GridSize/Speed pill widgets (#957).
-         Safe because every NumericUpDown except PropFrameLen (desktop MainWindow.axaml) and
-         FrameLengthInput (browser InspectorControl.axaml) has ShowButtonSpinner="False". -->
+    <!-- Compact stacked chevron spinner — replaces Fluent default for all ButtonSpinner/NumericUpDown.
+         Safe because every NumericUpDown except PropFrameLen has ShowButtonSpinner="False". -->
     <ControlTheme x:Key="{x:Type ButtonSpinner}" TargetType="ButtonSpinner">
         <Setter Property="Foreground"   Value="{DynamicResource TextControlForeground}" />
         <Setter Property="Background"   Value="{DynamicResource TextControlBackground}" />
@@ -17,7 +14,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="MinHeight"    Value="0" />
-        <Setter Property="Padding"      Value="4,0" />
+        <Setter Property="Padding"      Value="8,0,4,0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment"   Value="Center" />
         <Setter Property="Template">
@@ -28,22 +25,36 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}">
                         <DockPanel>
-                            <RepeatButton Name="PART_DecreaseButton"
-                                          DockPanel.Dock="Left"
-                                          Classes="flanker"
-                                          Content="−"
-                                          Width="22"
-                                          BorderBrush="{DynamicResource LineBrush}"
-                                          BorderThickness="0,0,1,0"
-                                          IsVisible="{TemplateBinding ShowButtonSpinner}" />
-                            <RepeatButton Name="PART_IncreaseButton"
-                                          DockPanel.Dock="Right"
-                                          Classes="flanker"
-                                          Content="+"
-                                          Width="22"
-                                          BorderBrush="{DynamicResource LineBrush}"
-                                          BorderThickness="1,0,0,0"
-                                          IsVisible="{TemplateBinding ShowButtonSpinner}" />
+                            <StackPanel Name="PART_SpinnerPanel"
+                                        DockPanel.Dock="Right"
+                                        Orientation="Vertical"
+                                        Width="18"
+                                        VerticalAlignment="Center"
+                                        Spacing="1"
+                                        IsVisible="{TemplateBinding ShowButtonSpinner}">
+                                <RepeatButton Name="PART_IncreaseButton"
+                                              HorizontalAlignment="Stretch"
+                                              HorizontalContentAlignment="Center"
+                                              VerticalContentAlignment="Center"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              MinWidth="0" MinHeight="0" Padding="2">
+                                    <svg:Svg Width="7" Height="7"
+                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChevronUp.svg"
+                                             CurrentColor="{DynamicResource IconInkMuted}" />
+                                </RepeatButton>
+                                <RepeatButton Name="PART_DecreaseButton"
+                                              HorizontalAlignment="Stretch"
+                                              HorizontalContentAlignment="Center"
+                                              VerticalContentAlignment="Center"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              MinWidth="0" MinHeight="0" Padding="2">
+                                    <svg:Svg Width="7" Height="7"
+                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChevronDown.svg"
+                                             CurrentColor="{DynamicResource IconInkMuted}" />
+                                </RepeatButton>
+                            </StackPanel>
                             <ContentPresenter Name="PART_ContentPresenter"
                                               Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeIconResources.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeIconResources.axaml
@@ -5,8 +5,11 @@
          AnimationEditor.Browser. SVG assets live under AnimationEditor.Views/Assets/icons/svg/;
          see docs/BROWSER_ICON_SYSTEM_DECISION.md. -->
 
-    <!-- Compact stacked chevron spinner — replaces Fluent default for all ButtonSpinner/NumericUpDown.
-         Safe because every NumericUpDown except PropFrameLen has ShowButtonSpinner="False". -->
+    <!-- Flanking +/- spinner (a "flanker" pill: [−][value][+]) — replaces Fluent's default
+         stacked-chevron spinner for all ButtonSpinner/NumericUpDown. Reuses the Button.flanker
+         style (ThemeStyles.axaml) so it matches the GridSize/Speed pill widgets (#957).
+         Safe because every NumericUpDown except PropFrameLen (desktop MainWindow.axaml) and
+         FrameLengthInput (browser InspectorControl.axaml) has ShowButtonSpinner="False". -->
     <ControlTheme x:Key="{x:Type ButtonSpinner}" TargetType="ButtonSpinner">
         <Setter Property="Foreground"   Value="{DynamicResource TextControlForeground}" />
         <Setter Property="Background"   Value="{DynamicResource TextControlBackground}" />
@@ -14,7 +17,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="MinHeight"    Value="0" />
-        <Setter Property="Padding"      Value="8,0,4,0" />
+        <Setter Property="Padding"      Value="4,0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment"   Value="Center" />
         <Setter Property="Template">
@@ -25,36 +28,22 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}">
                         <DockPanel>
-                            <StackPanel Name="PART_SpinnerPanel"
-                                        DockPanel.Dock="Right"
-                                        Orientation="Vertical"
-                                        Width="18"
-                                        VerticalAlignment="Center"
-                                        Spacing="1"
-                                        IsVisible="{TemplateBinding ShowButtonSpinner}">
-                                <RepeatButton Name="PART_IncreaseButton"
-                                              HorizontalAlignment="Stretch"
-                                              HorizontalContentAlignment="Center"
-                                              VerticalContentAlignment="Center"
-                                              Background="Transparent"
-                                              BorderThickness="0"
-                                              MinWidth="0" MinHeight="0" Padding="2">
-                                    <svg:Svg Width="7" Height="7"
-                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChevronUp.svg"
-                                             CurrentColor="{DynamicResource IconInkMuted}" />
-                                </RepeatButton>
-                                <RepeatButton Name="PART_DecreaseButton"
-                                              HorizontalAlignment="Stretch"
-                                              HorizontalContentAlignment="Center"
-                                              VerticalContentAlignment="Center"
-                                              Background="Transparent"
-                                              BorderThickness="0"
-                                              MinWidth="0" MinHeight="0" Padding="2">
-                                    <svg:Svg Width="7" Height="7"
-                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChevronDown.svg"
-                                             CurrentColor="{DynamicResource IconInkMuted}" />
-                                </RepeatButton>
-                            </StackPanel>
+                            <RepeatButton Name="PART_DecreaseButton"
+                                          DockPanel.Dock="Left"
+                                          Classes="flanker"
+                                          Content="−"
+                                          Width="22"
+                                          BorderBrush="{DynamicResource LineBrush}"
+                                          BorderThickness="0,0,1,0"
+                                          IsVisible="{TemplateBinding ShowButtonSpinner}" />
+                            <RepeatButton Name="PART_IncreaseButton"
+                                          DockPanel.Dock="Right"
+                                          Classes="flanker"
+                                          Content="+"
+                                          Width="22"
+                                          BorderBrush="{DynamicResource LineBrush}"
+                                          BorderThickness="1,0,0,0"
+                                          IsVisible="{TemplateBinding ShowButtonSpinner}" />
                             <ContentPresenter Name="PART_ContentPresenter"
                                               Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CopyPasteFocusGateTests.cs
@@ -1,15 +1,18 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
+using AnimationEditor.Views.Controls;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FlatRedBall2.AnimationEditorCommon;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -55,7 +58,9 @@ public class CopyPasteFocusGateTests
                 new List<AnimationFrameSave> { new() { TextureName = "run.png", FrameLength = 0.1f } });
             await window.Clipboard!.SetTextAsync(xml);
 
-            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            // SpeedInput is a FlankerNumericField (#963); focus lands on its inner ValueBox TextBox.
+            var speedInput = window.FindControl<FlankerNumericField>("SpeedInput")!
+                .GetVisualDescendants().OfType<TextBox>().First();
             speedInput.Focus();
             Dispatcher.UIThread.RunJobs();
 
@@ -156,7 +161,9 @@ public class CopyPasteFocusGateTests
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
             await window.Clipboard!.SetTextAsync("plain text");
 
-            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            // SpeedInput is a FlankerNumericField (#963); focus lands on its inner ValueBox TextBox.
+            var speedInput = window.FindControl<FlankerNumericField>("SpeedInput")!
+                .GetVisualDescendants().OfType<TextBox>().First();
             speedInput.Focus();
             Dispatcher.UIThread.RunJobs();
 
@@ -251,7 +258,9 @@ public class CopyPasteFocusGateTests
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
             ctx.SelectedState.SelectedFrame = chain.Frames[0];
 
-            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            // SpeedInput is a FlankerNumericField (#963); focus lands on its inner ValueBox TextBox.
+            var speedInput = window.FindControl<FlankerNumericField>("SpeedInput")!
+                .GetVisualDescendants().OfType<TextBox>().First();
             speedInput.Focus();
             Dispatcher.UIThread.RunJobs();
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DuplicateShortcutTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/DuplicateShortcutTests.cs
@@ -1,13 +1,16 @@
 using AnimationEditor.Core;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
+using AnimationEditor.Views.Controls;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FlatRedBall2.AnimationEditorCommon;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -179,7 +182,9 @@ public class DuplicateShortcutTests
             ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
             ctx.SelectedState.SelectedFrame = chain.Frames[0];
 
-            var speedInput = window.FindControl<TextBox>("SpeedInput")!;
+            // SpeedInput is a FlankerNumericField (#963); focus lands on its inner ValueBox TextBox.
+            var speedInput = window.FindControl<FlankerNumericField>("SpeedInput")!
+                .GetVisualDescendants().OfType<TextBox>().First();
             speedInput.Focus();
             Dispatcher.UIThread.RunJobs();
             Assert.IsType<TextBox>(window.FocusManager?.GetFocusedElement());

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.App.Controls;
+using AnimationEditor.Views.Controls;
 using System;
 using System.Linq;
 using Avalonia;
@@ -20,13 +21,17 @@ namespace AnimationEditor.App.Tests;
 /// the textbox background/border opaque, at which point the focus highlight bleeds over the buttons.
 /// Each field sets MinWidth/MinHeight 0 so it shrinks to its slot. These tests assert the value field
 /// never horizontally overlaps either flanker button.
+///
+/// GridSizeInput/SpeedInput/PropFrameLen (#963) are all the shared <see cref="FlankerNumericField"/>
+/// control, so their −/+ buttons (MinusBtn/PlusBtn) live inside that control's own template, not the
+/// window's namescope -- resolved the same way as ZoomControl's buttons below.
 /// </summary>
 public class FlankerFieldLayoutTests
 {
     [AvaloniaTheory]
-    [InlineData("GridSizeInput", "GridSizeMinusBtn", "GridSizePlusBtn")]
-    [InlineData("SpeedInput", "SpeedDownBtn", "SpeedUpBtn")]
-    public void FlankerField_StaysBetweenButtons(string fieldName, string minusName, string plusName)
+    [InlineData("GridSizeInput")]
+    [InlineData("SpeedInput")]
+    public void FlankerNumericField_FieldStaysBetweenButtons(string fieldName)
     {
         var ctx = TestHelpers.BuildServices();
         var window = ctx.CreateMainWindow();
@@ -37,22 +42,49 @@ public class FlankerFieldLayoutTests
 
         try
         {
-            var field = window.FindControl<Control>(fieldName)
+            var field = window.FindControl<FlankerNumericField>(fieldName)
                 ?? throw new InvalidOperationException($"{fieldName} not found");
-            var minus = window.FindControl<Button>(minusName)
-                ?? throw new InvalidOperationException($"{minusName} not found");
-            var plus = window.FindControl<Button>(plusName)
-                ?? throw new InvalidOperationException($"{plusName} not found");
 
-            AssertFieldBetweenButtons(fieldName, field, minus, plus);
+            AssertFieldBetweenFlankerButtons(fieldName, field);
         }
         finally { window.Close(); }
     }
 
-    // The shared ZoomControl (wireframe + preview toolbars) has the same flanker layout, but its
-    // −/+ buttons and percent field live in the control's own namescope, so they're resolved by
-    // descending each ZoomControl's subtree rather than by window-level name lookup. PngZoom is
-    // excluded: its pane is collapsed by default so it isn't laid out.
+    // #963: PropFrameLen only lays out once a frame is selected (its containing PropFramePanel
+    // starts IsVisible="False"), so it needs its own scenario rather than joining the theory above.
+    [AvaloniaFact]
+    public void PropFrameLen_FieldStaysBetweenFlankerButtons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Width = 1400;
+        window.Height = 900;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propFrameLen = window.FindControl<FlankerNumericField>("PropFrameLen")
+                ?? throw new InvalidOperationException("PropFrameLen not found");
+
+            AssertFieldBetweenFlankerButtons("PropFrameLen", propFrameLen);
+        }
+        finally { window.Close(); }
+    }
+
+    // The shared ZoomControl (wireframe + preview toolbars) has the same flanker layout but is not
+    // a FlankerNumericField (its percent-preset/dropdown logic is a different domain, #963), so its
+    // −/+ buttons and percent field are resolved separately here. PngZoom is excluded: its pane is
+    // collapsed by default so it isn't laid out.
     [AvaloniaTheory]
     [InlineData("WireframeZoom")]
     [InlineData("PreviewZoom")]
@@ -80,49 +112,18 @@ public class FlankerFieldLayoutTests
         finally { window.Close(); }
     }
 
-    // #957: PropFrameLen's ButtonSpinner is re-templated to the same flanker layout so its
-    // −/+ buttons sit left/right of the value instead of Fluent's stacked chevrons. Its
-    // PART_DecreaseButton/PART_IncreaseButton live inside ButtonSpinner's own control template
-    // (not the window's namescope), so they're resolved the same way as ZoomControl's buttons.
-    [AvaloniaFact]
-    public void PropFrameLen_FieldStaysBetweenFlankerButtons()
+    private static void AssertFieldBetweenFlankerButtons(string fieldName, FlankerNumericField field)
     {
-        var ctx = TestHelpers.BuildServices();
-        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
-        ctx.ProjectManager.FileName = null;
-        var window = ctx.CreateMainWindow();
-        window.Width = 1400;
-        window.Height = 900;
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
+        var buttons = field.GetVisualDescendants().OfType<Button>().ToList();
+        var minus = buttons.First(b => b.Name == "MinusBtn");
+        var plus = buttons.First(b => b.Name == "PlusBtn");
 
-        try
-        {
-            // PropFrameLen's containing panel (PropFramePanel) starts IsVisible="False" and is
-            // only shown once a frame is selected — until then it has zero size and its
-            // ButtonSpinner template parts aren't laid out.
-            var chain = new AnimationChainSave { Name = "Walk" };
-            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave() };
-            chain.Frames.Add(frame);
-            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
-            ctx.SelectedState.SelectedFrame = frame;
-            Dispatcher.UIThread.RunJobs();
-
-            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")
-                ?? throw new InvalidOperationException("PropFrameLen not found");
-
-            var buttons = propFrameLen.GetVisualDescendants().OfType<Button>().ToList();
-            var minus = buttons.First(b => b.Name == "PART_DecreaseButton");
-            var plus = buttons.First(b => b.Name == "PART_IncreaseButton");
-
-            AssertFieldBetweenButtons("PropFrameLen", propFrameLen, minus, plus);
-        }
-        finally { window.Close(); }
+        AssertFieldBetweenButtons(fieldName, field, minus, plus);
     }
 
     private static void AssertFieldBetweenButtons(string fieldName, Control field, Button minus, Button plus)
     {
-        // The value field is either a TextBox directly (SpeedInput, GridSizeInput) or the inner
+        // The value field is either a TextBox directly (FlankerNumericField's ValueBox) or the inner
         // TextBox of an AutoCompleteBox (the ZoomControl percent field). The inner TextBox is what
         // carries the focus background/border, so measure its edges — not the outer control's.
         var textBox = field as TextBox
@@ -135,11 +136,7 @@ public class FlankerFieldLayoutTests
         double fieldLeft = textBox.TranslatePoint(new Point(0, 0), dock)!.Value.X;
         double fieldRight = textBox.TranslatePoint(new Point(textBox.Bounds.Width, 0), dock)!.Value.X;
 
-        // PropFrameLen's field sits one nested TemplatedControl layer deeper than the hand-rolled
-        // DockPanel fields (NumericUpDown -> ButtonSpinner -> DockPanel), which measures the
-        // shared 1px divider border as touching rather than 0.5px clear; 1.5 still catches a real
-        // overlap (the #501 bug bled several pixels) while tolerating that extra rounding layer.
-        const double eps = 1.5;
+        const double eps = 0.5;
         Assert.True(fieldLeft >= minus.Bounds.Right - eps,
             $"{fieldName}: field left {fieldLeft} overlaps − button (right edge {minus.Bounds.Right})");
         Assert.True(fieldRight <= plus.Bounds.Left + eps,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FlankerFieldLayoutTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FlatRedBall2.AnimationEditorCommon;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -79,6 +80,46 @@ public class FlankerFieldLayoutTests
         finally { window.Close(); }
     }
 
+    // #957: PropFrameLen's ButtonSpinner is re-templated to the same flanker layout so its
+    // −/+ buttons sit left/right of the value instead of Fluent's stacked chevrons. Its
+    // PART_DecreaseButton/PART_IncreaseButton live inside ButtonSpinner's own control template
+    // (not the window's namescope), so they're resolved the same way as ZoomControl's buttons.
+    [AvaloniaFact]
+    public void PropFrameLen_FieldStaysBetweenFlankerButtons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Width = 1400;
+        window.Height = 900;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            // PropFrameLen's containing panel (PropFramePanel) starts IsVisible="False" and is
+            // only shown once a frame is selected — until then it has zero size and its
+            // ButtonSpinner template parts aren't laid out.
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave() };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")
+                ?? throw new InvalidOperationException("PropFrameLen not found");
+
+            var buttons = propFrameLen.GetVisualDescendants().OfType<Button>().ToList();
+            var minus = buttons.First(b => b.Name == "PART_DecreaseButton");
+            var plus = buttons.First(b => b.Name == "PART_IncreaseButton");
+
+            AssertFieldBetweenButtons("PropFrameLen", propFrameLen, minus, plus);
+        }
+        finally { window.Close(); }
+    }
+
     private static void AssertFieldBetweenButtons(string fieldName, Control field, Button minus, Button plus)
     {
         // The value field is either a TextBox directly (SpeedInput, GridSizeInput) or the inner
@@ -94,7 +135,11 @@ public class FlankerFieldLayoutTests
         double fieldLeft = textBox.TranslatePoint(new Point(0, 0), dock)!.Value.X;
         double fieldRight = textBox.TranslatePoint(new Point(textBox.Bounds.Width, 0), dock)!.Value.X;
 
-        const double eps = 0.5;
+        // PropFrameLen's field sits one nested TemplatedControl layer deeper than the hand-rolled
+        // DockPanel fields (NumericUpDown -> ButtonSpinner -> DockPanel), which measures the
+        // shared 1px divider border as touching rather than 0.5px clear; 1.5 still catches a real
+        // overlap (the #501 bug bled several pixels) while tolerating that extra rounding layer.
+        const double eps = 1.5;
         Assert.True(fieldLeft >= minus.Bounds.Right - eps,
             $"{fieldName}: field left {fieldLeft} overlaps − button (right edge {minus.Bounds.Right})");
         Assert.True(fieldRight <= plus.Bounds.Left + eps,

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameTextureNameMultiSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameTextureNameMultiSelectTests.cs
@@ -1,11 +1,14 @@
 using AnimationEditor.Core.IO;
+using AnimationEditor.Views.Controls;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FlatRedBall2.AnimationEditorCommon;
 using SkiaSharp;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace AnimationEditor.App.Tests;
@@ -81,8 +84,10 @@ public class FrameTextureNameMultiSelectTests
             propTextureName.Focus();
             FlushUi();
             propTextureName.Text = "b.png";
-            // Move focus away to raise LostFocus, which ApplyTextureName is wired to.
-            window.FindControl<NumericUpDown>("PropFrameLen")!.Focus();
+            // Move focus away to raise LostFocus, which ApplyTextureName is wired to. PropFrameLen
+            // is a FlankerNumericField (#963); focus lands on its inner ValueBox TextBox.
+            window.FindControl<FlankerNumericField>("PropFrameLen")!
+                .GetVisualDescendants().OfType<TextBox>().First().Focus();
             FlushUi();
 
             Assert.Equal("b.png", f0.TextureName);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/HeadlessTreeViewTests.cs
@@ -5,6 +5,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.ViewModels;
+using AnimationEditor.Views.Controls;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -1085,7 +1086,7 @@ public class HeadlessTreeViewTests
             ctx.SelectedState.SelectedFrame = frame;
             Dispatcher.UIThread.RunJobs();
 
-            var frameLen = window.FindControl<NumericUpDown>("PropFrameLen")
+            var frameLen = window.FindControl<FlankerNumericField>("PropFrameLen")
                 ?? throw new InvalidOperationException("PropFrameLen not found");
             frameLen.Value = 0.55m;
             Dispatcher.UIThread.RunJobs();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiSelectPropertyPanelTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.IO;
+using AnimationEditor.Views.Controls;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -49,7 +50,7 @@ public class MultiSelectPropertyPanelTests
             ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
             FlushUi();
 
-            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+            var propFrameLen = window.FindControl<FlankerNumericField>("PropFrameLen")!;
 
             Assert.Null(propFrameLen.Value);
             Assert.Equal("(mixed)", propFrameLen.PlaceholderText);
@@ -73,7 +74,7 @@ public class MultiSelectPropertyPanelTests
             ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
             FlushUi();
 
-            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+            var propFrameLen = window.FindControl<FlankerNumericField>("PropFrameLen")!;
 
             Assert.Equal(0.25m, propFrameLen.Value);
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropFrameLenFlankerButtonTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropFrameLenFlankerButtonTests.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using AnimationEditor.Core;
+using AnimationEditor.Views.Controls;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
@@ -14,11 +14,10 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// #957: PropFrameLen's ButtonSpinner is re-templated to flank the value with +/- buttons
-/// (<c>[−][value][+]</c>) instead of Fluent's stacked chevrons. These tests drive a real click on
-/// the re-templated <c>PART_IncreaseButton</c>/<c>PART_DecreaseButton</c> parts to confirm the
-/// click reaches Avalonia's built-in NumericUpDown increment/decrement/clamp logic, not just that
-/// the template compiles.
+/// #963: PropFrameLen is a <see cref="FlankerNumericField"/> (the reusable "[−][value][+]" pill
+/// GridSize/Speed pioneered) rather than a re-templated NumericUpDown/ButtonSpinner. These tests
+/// drive a real click on its internal MinusBtn/PlusBtn parts to confirm the click reaches
+/// FlankerNumericField's own increment/decrement/clamp logic, not just that the markup compiles.
 /// </summary>
 public class PropFrameLenFlankerButtonTests
 {
@@ -42,11 +41,11 @@ public class PropFrameLenFlankerButtonTests
         Dispatcher.UIThread.RunJobs();
     }
 
-    private static RepeatButton FindTemplatePart(NumericUpDown numeric, string partName)
-        => numeric.GetVisualDescendants().OfType<RepeatButton>().First(b => b.Name == partName);
+    private static Button FindPart(FlankerNumericField field, string partName)
+        => field.GetVisualDescendants().OfType<Button>().First(b => b.Name == partName);
 
     [AvaloniaFact]
-    public void PartIncreaseButton_Clicked_IncrementsFrameLengthByIncrement()
+    public void PlusBtn_Clicked_IncrementsFrameLengthByIncrement()
     {
         var (window, ctx) = CreateWindow();
         try
@@ -58,10 +57,10 @@ public class PropFrameLenFlankerButtonTests
             ctx.SelectedState.SelectedFrame = frame;
             Dispatcher.UIThread.RunJobs();
 
-            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
-            var increaseButton = FindTemplatePart(propFrameLen, "PART_IncreaseButton");
+            var propFrameLen = window.FindControl<FlankerNumericField>("PropFrameLen")!;
+            var plusBtn = FindPart(propFrameLen, "PlusBtn");
 
-            RealClick(window, increaseButton);
+            RealClick(window, plusBtn);
 
             // Increment="0.05" on PropFrameLen (MainWindow.axaml).
             Assert.Equal(0.15f, frame.FrameLength, 3);
@@ -70,7 +69,7 @@ public class PropFrameLenFlankerButtonTests
     }
 
     [AvaloniaFact]
-    public void PartDecreaseButton_ClickedBelowMinimum_ClampsToMinimum()
+    public void MinusBtn_ClickedBelowMinimum_ClampsToMinimum()
     {
         var (window, ctx) = CreateWindow();
         try
@@ -82,11 +81,11 @@ public class PropFrameLenFlankerButtonTests
             ctx.SelectedState.SelectedFrame = frame;
             Dispatcher.UIThread.RunJobs();
 
-            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
-            var decreaseButton = FindTemplatePart(propFrameLen, "PART_DecreaseButton");
+            var propFrameLen = window.FindControl<FlankerNumericField>("PropFrameLen")!;
+            var minusBtn = FindPart(propFrameLen, "MinusBtn");
 
             // Minimum="0.001" on PropFrameLen (MainWindow.axaml); one 0.05 decrement from 0.03 must clamp, not go negative.
-            RealClick(window, decreaseButton);
+            RealClick(window, minusBtn);
 
             Assert.Equal(0.001f, frame.FrameLength, 3);
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropFrameLenFlankerButtonTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PropFrameLenFlankerButtonTests.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using AnimationEditor.Core;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.AnimationEditorCommon;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// #957: PropFrameLen's ButtonSpinner is re-templated to flank the value with +/- buttons
+/// (<c>[−][value][+]</c>) instead of Fluent's stacked chevrons. These tests drive a real click on
+/// the re-templated <c>PART_IncreaseButton</c>/<c>PART_DecreaseButton</c> parts to confirm the
+/// click reaches Avalonia's built-in NumericUpDown increment/decrement/clamp logic, not just that
+/// the template compiles.
+/// </summary>
+public class PropFrameLenFlankerButtonTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void RealClick(MainWindow window, Control target)
+    {
+        var local = new Point(target.Bounds.Width / 2, target.Bounds.Height / 2);
+        var p = target.TranslatePoint(local, window)!.Value;
+        window.MouseDown(p, MouseButton.Left);
+        window.MouseUp(p, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static RepeatButton FindTemplatePart(NumericUpDown numeric, string partName)
+        => numeric.GetVisualDescendants().OfType<RepeatButton>().First(b => b.Name == partName);
+
+    [AvaloniaFact]
+    public void PartIncreaseButton_Clicked_IncrementsFrameLengthByIncrement()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave(), FrameLength = 0.1f };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+            var increaseButton = FindTemplatePart(propFrameLen, "PART_IncreaseButton");
+
+            RealClick(window, increaseButton);
+
+            // Increment="0.05" on PropFrameLen (MainWindow.axaml).
+            Assert.Equal(0.15f, frame.FrameLength, 3);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void PartDecreaseButton_ClickedBelowMinimum_ClampsToMinimum()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var frame = new AnimationFrameSave { TextureName = "f0.png", ShapesSave = new ShapesSave(), FrameLength = 0.03f };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedFrame = frame;
+            Dispatcher.UIThread.RunJobs();
+
+            var propFrameLen = window.FindControl<NumericUpDown>("PropFrameLen")!;
+            var decreaseButton = FindTemplatePart(propFrameLen, "PART_DecreaseButton");
+
+            // Minimum="0.001" on PropFrameLen (MainWindow.axaml); one 0.05 decrement from 0.03 must clamp, not go negative.
+            RealClick(window, decreaseButton);
+
+            Assert.Equal(0.001f, frame.FrameLength, 3);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NumericToolbarInputTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NumericToolbarInputTests.cs
@@ -6,58 +6,42 @@ namespace AnimationEditor.Core.Tests;
 public class NumericToolbarInputTests
 {
     [Fact]
-    public void FormatSpeed_FractionalValue_ReturnsTrimmedDecimal()
+    public void ParseClamp_AboveMax_ClampsToMax()
     {
-        var result = NumericToolbarInput.FormatSpeed(1.25);
+        var result = NumericToolbarInput.ParseClamp("999", min: 0m, max: 60m, fallback: 1m);
 
-        Assert.Equal("1.25", result);
+        Assert.Equal(60m, result);
     }
 
     [Fact]
-    public void ParseGridSize_AboveMax_ClampsTo512()
+    public void ParseClamp_BelowMin_ClampsToMin()
     {
-        var result = NumericToolbarInput.ParseGridSize("9999");
+        var result = NumericToolbarInput.ParseClamp("-5", min: 0.001m, max: 60m, fallback: 1m);
 
-        Assert.Equal(512, result);
+        Assert.Equal(0.001m, result);
     }
 
     [Fact]
-    public void ParseGridSize_NonNumericText_FallsBackTo16()
+    public void ParseClamp_NonNumericText_ReturnsFallback()
     {
-        var result = NumericToolbarInput.ParseGridSize("abc");
+        var result = NumericToolbarInput.ParseClamp("abc", min: 0m, max: 60m, fallback: 0.1m);
 
-        Assert.Equal(16, result);
+        Assert.Equal(0.1m, result);
     }
 
     [Fact]
-    public void ParseGridSize_ValidText_ReturnsParsedValue()
+    public void ParseClamp_NullText_ReturnsFallback()
     {
-        var result = NumericToolbarInput.ParseGridSize("32");
+        var result = NumericToolbarInput.ParseClamp(null, min: 0m, max: 60m, fallback: 0.1m);
 
-        Assert.Equal(32, result);
+        Assert.Equal(0.1m, result);
     }
 
     [Fact]
-    public void ParseSpeed_BelowMin_ClampsToPoint1()
+    public void ParseClamp_ValidText_ReturnsParsedValue()
     {
-        var result = NumericToolbarInput.ParseSpeed("0.01");
+        var result = NumericToolbarInput.ParseClamp("0.15", min: 0m, max: 60m, fallback: 1m);
 
-        Assert.Equal(0.1, result, precision: 6);
-    }
-
-    [Fact]
-    public void ParseSpeed_NonNumericText_FallsBackTo1()
-    {
-        var result = NumericToolbarInput.ParseSpeed("nope");
-
-        Assert.Equal(1.0, result, precision: 6);
-    }
-
-    [Fact]
-    public void ParseSpeed_ValidText_ReturnsParsedValue()
-    {
-        var result = NumericToolbarInput.ParseSpeed("2.5");
-
-        Assert.Equal(2.5, result, precision: 6);
+        Assert.Equal(0.15m, result);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AdjustFrameTimeLiveEditTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/AdjustFrameTimeLiveEditTests.cs
@@ -3,6 +3,7 @@ using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.CommandsAndState.Commands;
 using AnimationEditor.Core.Data;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Views.Controls;
 using AnimationEditor.Views.Dialogs;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -84,7 +85,7 @@ public class AdjustFrameTimeLiveEditTests
         var host = new ScriptedDialogHost(
             interact: content =>
             {
-                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                var durationInput = ((StackPanel)content).Children.OfType<FlankerNumericField>().Single();
                 durationInput.Value = 0.8m; // was 0.4 total (0.1 + 0.3) -> doubles proportionally
                 Assert.Equal(0.2f, chain.Frames[0].FrameLength, 3);
                 Assert.Equal(0.6f, chain.Frames[1].FrameLength, 3);
@@ -102,7 +103,7 @@ public class AdjustFrameTimeLiveEditTests
         var host = new ScriptedDialogHost(
             interact: content =>
             {
-                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                var durationInput = ((StackPanel)content).Children.OfType<FlankerNumericField>().Single();
                 durationInput.Value = 0.8m;
             },
             confirm: false);
@@ -137,7 +138,7 @@ public class AdjustFrameTimeLiveEditTests
         var host = new ScriptedDialogHost(
             interact: content =>
             {
-                var durationInput = ((StackPanel)content).Children.OfType<NumericUpDown>().Single();
+                var durationInput = ((StackPanel)content).Children.OfType<FlankerNumericField>().Single();
                 durationInput.Value = 0.8m;
                 durationInput.Value = 1.2m; // a second live edit; must coalesce, not add a 2nd entry
             },


### PR DESCRIPTION
## Summary
The first cut of this PR re-templated `NumericUpDown`'s internal `ButtonSpinner` to flank +/- buttons around `PropFrameLen`'s value. That was the wrong approach: `NumericUpDown` draws its own outer border *around* `ButtonSpinner`, so restyling only the inner part nests two borders and renders cramped -- unlike GridSize/Speed's plain `Border > DockPanel > Button+TextBox` structure, which was always correct.

This revision extracts that proven structure into a real reusable control, **`FlankerNumericField`** (`AnimationEditor.Views/Controls/FlankerNumericField.axaml(.cs)`), and migrates every `[−][value][+]` numeric field onto it:
- Desktop inspector `PropFrameLen`, and the toolbar's GridSize/Speed fields (`MainWindow.axaml`)
- Browser inspector `FrameLengthInput`, and the browser's own hand-rolled GridSize/Speed pills (`AnimationEditor.Browser/App.axaml.cs`) -- a pre-existing 4th/5th copy of the same pattern, unified here too so the goal ("stop drifting into more one-off copies") is actually achieved
- The "Adjust All Frame Time" dialog's duration field (`EditorDialogs.cs`)

`ButtonSpinner`'s `ControlTemplate` override in `ThemeIconResources.axaml` is reverted back to the pre-#957 stacked-chevron default -- confirmed via grep that nothing sets `ShowButtonSpinner="True"` anymore, so it's fully inert.

`NumericToolbarInput.ParseGridSize`/`ParseSpeed`/`FormatSpeed` are deleted (dead once GridSize/Speed stopped hand-parsing text via their own click/LostFocus handlers). `NumericToolbarInput.ParseClamp` is the new shared parse+clamp core, TDD'd first (failing test confirmed before implementation), backing `FlankerNumericField`'s commit path.

`ZoomControl` was deliberately left untouched -- it already renders correctly and its percent-preset/dropdown logic is different enough that forcing it onto `FlankerNumericField` wasn't worth the regression risk.

Closes #957

## Test plan
- [x] `NumericToolbarInputTests.ParseClamp_*` (TDD: written and confirmed failing before `ParseClamp` existed).
- [x] `FlankerFieldLayoutTests`: unified GridSize/Speed/PropFrameLen under one `FlankerNumericField`-descent pattern (previously GridSize/Speed used window-level names, PropFrameLen needed ButtonSpinner-specific tolerance -- both simplified now that all three share the identical control/template). Verified red against the old nested-ButtonSpinner template, green against the new one.
- [x] `PropFrameLenFlankerButtonTests`: real `MouseDown`/`MouseUp` clicks on `FlankerNumericField`'s internal `MinusBtn`/`PlusBtn` parts.
- [x] `AdjustFrameTimeLiveEditTests`, `MultiSelectPropertyPanelTests`, `HeadlessTreeViewTests`, `FrameTextureNameMultiSelectTests`, `CopyPasteFocusGateTests`, `DuplicateShortcutTests`: updated to target `FlankerNumericField` (some needed a focus-target fix -- `UserControl` isn't itself focusable, so tests that focus `SpeedInput`/`PropFrameLen` to simulate "text box focused" now focus the control's inner `ValueBox` TextBox).
- [x] Full suites green: `AnimationEditor.Core.Tests` (1905), `AnimationEditor.Views.Tests` (117), `AnimationEditor.App.Tests` (868). Full solution builds clean (0 warnings beyond a pre-existing, unrelated WASM `NativeFileReference` warning).
- [x] Manual test: done. Launched `AnimationEditor.App`, opened a real (crash-recovered) project with real chains/frames, and drove the UI directly (real mouse clicks via Win32 `SetCursorPos`/`mouse_event`, screenshotted the live window): confirmed the inspector TIMING row (`[−] 0.075 [+] s`), the toolbar's GridSize (`[−] 16 [+]`) and Speed pills, and the "Adjust All Frame Time" dialog (`[−] 0.3 [+]`) all render as a single clean bordered pill -- matching the existing GridSize/Zoom look exactly, no nested double-border cramping. Closed without saving (unrelated recovered content, not test data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gazg5B8EhShm6ntfH683kN