### PR TITLE
Add PNG usage overlay to the Animation Editor

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -97,6 +97,12 @@ being asked:
   telling the user to `cd` and `dotnet run`.
 - Do not invent a new gitignore line per project — everything manual-test-only goes in that one
   shared folder.
+- **Never launch the app process yourself (`dotnet run`, starting the exe) — not even when the
+  runnable target is an existing tool (e.g. AnimationEditorAvalonia) rather than a new sample with
+  its own `.sln` to scaffold.** Open the existing solution/project file so the human runs it their
+  own way (VS, `dotnet run`, whatever); if a fixture is needed to reach the test state, build the
+  fixture and say what to open/load, but stop there. Running it yourself pre-empts how the human
+  wants to drive their own manual check.
 
 # High-Level Project Structure
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1786,6 +1786,31 @@
                         <TextBlock Text="Zoom:" VerticalAlignment="Center" Margin="0,0,4,0"
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
                         <views:ZoomControl x:Name="PngZoom" VerticalAlignment="Center" />
+
+                        <!-- Divider -->
+                        <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
+                                Margin="4,0" VerticalAlignment="Center" />
+
+                        <!-- Analyze Image Usage (#953): scans every .achx/.achj under the project
+                             root and overlays color-coded rects for every frame that references
+                             this PNG. Explicit toggle, not automatic, since a whole-project scan
+                             is expensive; the result is cached per-PNG for the session. -->
+                        <ToggleButton x:Name="PngUsageOverlayToggle"
+                                      Classes="toolbarToggle"
+                                      Foreground="{DynamicResource Ink}"
+                                      VerticalAlignment="Center"
+                                      ToolTip.Tip="Highlight which animation chains use this image">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <svg:Svg Width="16" Height="16"
+                                         Path="avares://AnimationEditor.Views/Assets/icons/svg/IconChain.svg"
+                                         CurrentColor="{DynamicResource IconInk}"
+                                         VerticalAlignment="Center" />
+                                <TextBlock Text="Analyze Image Usage" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </ToggleButton>
+                        <TextBlock x:Name="PngUsageOverlayStatus" FontSize="11" Margin="6,0,0,0"
+                                   VerticalAlignment="Center" Foreground="{DynamicResource InkMid}"
+                                   IsVisible="False" />
                     </WrapPanel>
                 </Border>
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -246,6 +246,7 @@ public partial class MainWindow : Window
         WireWireframeControl();
         WirePngViewport();
         WirePngBlame();
+        WirePngUsageOverlay();
         WirePreviewControls();
         WireTreeView();
         WireWindowFileDrop();
@@ -612,6 +613,7 @@ public partial class MainWindow : Window
         PngPaneGrid.IsVisible = true;
         PngPane.IsVisible = true;
         SetSidebarForPng(true);
+        ResetPngUsageOverlay();
         // Decode the image off the UI thread so the tab appears immediately even for a large sheet;
         // a "Loading…" overlay shows until it's ready. The history load is likewise async.
         _pngTextureLoadInFlight = LoadPngTextureAsync(tab.Path.FullPath);
@@ -1532,6 +1534,153 @@ public partial class MainWindow : Window
             _pngShowingRevision = true;
         }
         PngPane.SetDiffRegions(regions, frame);
+    }
+
+    // ── PNG Usage Overlay wiring (#953) ────────────────────────────────────────
+
+    private readonly PngUsageScanService _pngUsageScanService = new();
+
+    // Session cache keyed by the PNG's absolute path, so re-toggling the overlay for the same
+    // image doesn't re-run the (potentially expensive) whole-project scan.
+    private readonly Dictionary<string, IReadOnlyList<UsageChainRegions>> _pngUsageCache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // Latest-wins guard: a tab switch or re-toggle while a scan is in flight supersedes it, mirroring
+    // _diffRequestId/_blameLoadId above.
+    private int _pngUsageScanRequestId;
+
+    // Single reused ContextMenu instance for the overlapping-chains disambiguation popup -- see the
+    // #472 comment on the tab context menu for why a fresh instance per click stacks/fails to dismiss.
+    private ContextMenu? _usageChainPickerMenu;
+
+    private void WirePngUsageOverlay()
+    {
+        PngUsageOverlayToggle.IsCheckedChanged += OnPngUsageOverlayToggled;
+        PngPane.UsageRegionsClicked += OnUsageRegionsClicked;
+    }
+
+    /// <summary>Hides the overlay, resets the toggle, and supersedes any in-flight scan -- called
+    /// whenever a (possibly different) PNG tab is shown, so a stale scan for the previous image
+    /// can never paint over the new one.</summary>
+    private void ResetPngUsageOverlay()
+    {
+        _pngUsageScanRequestId++;
+        PngUsageOverlayToggle.IsChecked = false;
+        PngPane.SetUsageRegions(Array.Empty<UsageChainRegions>());
+        PngUsageOverlayStatus.IsVisible = false;
+    }
+
+    private async void OnPngUsageOverlayToggled(object? sender, RoutedEventArgs e)
+    {
+        if (PngUsageOverlayToggle.IsChecked != true)
+        {
+            PngPane.SetUsageRegions(Array.Empty<UsageChainRegions>());
+            PngUsageOverlayStatus.IsVisible = false;
+            return;
+        }
+
+        var pngPath = PngPane.LoadedTexturePathCasePreserved;
+        if (string.IsNullOrEmpty(pngPath)) return;
+
+        if (_pngUsageCache.TryGetValue(pngPath, out var cached))
+        {
+            PngPane.SetUsageRegions(cached);
+            ShowPngUsageStatus(cached);
+            return;
+        }
+
+        int requestId = ++_pngUsageScanRequestId;
+        PngUsageOverlayStatus.Text = "Scanning project for usage…";
+        PngUsageOverlayStatus.IsVisible = true;
+
+        // Same root as the Files panel (#875): the explicitly-opened project folder wins over the
+        // achx-inferred fallback, and this works even with zero .achx tabs open.
+        string? root = _projectManager.ProjectFolderPath ?? _projectManager.ResolveFilesPanelRoot();
+        if (string.IsNullOrEmpty(root))
+        {
+            PngUsageOverlayStatus.Text = "No project folder open to scan.";
+            return;
+        }
+
+        var (width, height) = PngPane.BitmapSize;
+        if (width == 0 || height == 0) return;
+
+        IReadOnlyList<UsageChainRegions> groups;
+        try
+        {
+            groups = await _pngUsageScanService.ScanAsync(new DiskEditorFolder(root), pngPath, width, height);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[PngUsage] scan failed: {ex}");
+            if (requestId == _pngUsageScanRequestId)
+                PngUsageOverlayStatus.Text = "Usage scan failed.";
+            return;
+        }
+
+        if (requestId != _pngUsageScanRequestId) return; // superseded by a tab switch / re-toggle
+
+        _pngUsageCache[pngPath] = groups;
+        PngPane.SetUsageRegions(groups);
+        ShowPngUsageStatus(groups);
+    }
+
+    private void ShowPngUsageStatus(IReadOnlyList<UsageChainRegions> groups)
+    {
+        PngUsageOverlayStatus.Text = groups.Count == 0
+            ? "No chains reference this image."
+            : $"{groups.Count} chain(s) reference this image.";
+        PngUsageOverlayStatus.IsVisible = true;
+    }
+
+    /// <summary>
+    /// A single match navigates directly; overlapping chains (more than one candidate under the
+    /// click point) show a small picker popup so the user chooses which one to jump to.
+    /// </summary>
+    private void OnUsageRegionsClicked(IReadOnlyList<UsageChainRegions> candidates)
+    {
+        if (candidates.Count == 1)
+        {
+            _ = NavigateToUsageChainAsync(candidates[0]);
+            return;
+        }
+
+        _usageChainPickerMenu ??= new ContextMenu();
+        _usageChainPickerMenu.Items.Clear();
+        foreach (var candidate in candidates)
+        {
+            _usageChainPickerMenu.Items.Add(new MenuItem
+            {
+                Header = $"{candidate.Chain.Name} — {candidate.Entry.FileName}",
+                Command = new RelayCommand(() => _ = NavigateToUsageChainAsync(candidate)),
+            });
+        }
+        _usageChainPickerMenu.Placement = PlacementMode.Pointer;
+        _usageChainPickerMenu.Open(PngPane);
+    }
+
+    /// <summary>
+    /// Opens (or focuses) the chain's owning .achx as a normal tab and selects the chain, same as
+    /// picking it from the Project tree -- no prior helper in this codebase opened a *different*
+    /// file and selected a specific chain in it, so this sequences the two: load the file, let the
+    /// tree-rebuild dispatch (queued by <see cref="AppCommands.FinishLoadIntoEditor"/>) run, then
+    /// look the chain up by name in the freshly-loaded project and sync the tree selection to it.
+    /// </summary>
+    private async Task NavigateToUsageChainAsync(UsageChainRegions target)
+    {
+        if (target.Entry.File is not DiskEditorFile diskFile) return;
+
+        await OpenFileAsTab(diskFile.FullPath);
+        // The tree rebuild is dispatched (not awaited) by FinishLoadIntoEditor; flush the UI-thread
+        // queue so it has run before we look the chain up in _treeRoots.
+        await Dispatcher.UIThread.InvokeAsync(() => { });
+
+        var reloadedChain = _projectManager.AnimationChainListSave?.AnimationChains
+            .FirstOrDefault(c => c.Name == target.Chain.Name);
+        if (reloadedChain is null) return;
+
+        _selectedState.SelectedChain = reloadedChain;
+        SyncTreeSelection();
     }
 
     private void OnChainRegionChanged(AnimationChainSave chain)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PngUsageScanService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PngUsageScanService.cs
@@ -83,9 +83,11 @@ public sealed class PngUsageScanService
             var group = groups[i];
             var (r, g, b) = ChainUsageColorPalette.GetColor(i);
             var rects = group
-                .Select(m => new SKRect(
-                    Math.Min(m.Left, m.Right), Math.Min(m.Top, m.Bottom),
-                    Math.Max(m.Left, m.Right), Math.Max(m.Top, m.Bottom)))
+                .Select(m => new UsageFrameRegion(
+                    group.Key.Chain.Frames.IndexOf(m.Frame) + 1,
+                    new SKRect(
+                        Math.Min(m.Left, m.Right), Math.Min(m.Top, m.Bottom),
+                        Math.Max(m.Left, m.Right), Math.Max(m.Top, m.Bottom))))
                 .ToList();
 
             result.Add(new UsageChainRegions(group.Key.Entry, group.Key.Chain, new SKColor(r, g, b), rects));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PngUsageScanService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PngUsageScanService.cs
@@ -1,0 +1,96 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Rendering;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Orchestrates the "Analyze Image Usage" scan (issue #953): finds every animation-chain frame
+/// under a project root that references a given PNG, and groups the matches by chain with one
+/// color per chain for <see cref="PngPreviewControl.SetUsageRegions"/>.
+/// <para>
+/// Lives in <c>AnimationEditor.App</c> rather than alongside <see cref="AchxPngUsageScanner"/> in
+/// Core (or in <c>AnimationEditor.Views</c> like <c>ProjectTreeThumbnailService</c>) because it
+/// needs <see cref="DiskEditorFile.FullPath"/> to identify "is this resolved texture the PNG the
+/// user has open" by <see cref="FilePath"/> equality — a desktop-only concept neither Core nor
+/// Views has any notion of. The per-file scan/match logic itself stays path-agnostic in Core via
+/// an injected <c>isTargetTexture</c> predicate; only that predicate's concrete implementation
+/// (here) knows about paths.
+/// </para>
+/// </summary>
+public sealed class PngUsageScanService
+{
+    // Mirrors ProjectTreeThumbnailService's concurrency cap: a project with many .achx files
+    // shouldn't spike CPU or block the UI thread parsing all of them at once.
+    private const int MaxConcurrentScans = 4;
+
+    /// <summary>
+    /// Scans every <c>.achx</c>/<c>.achj</c> under <paramref name="rootFolder"/> for frames whose
+    /// texture resolves to <paramref name="targetPngPath"/>, and groups the results by chain —
+    /// one <see cref="UsageChainRegions"/> per chain, in a distinct color, sorted deterministically
+    /// so re-running the scan on an unchanged project yields the same colors.
+    /// </summary>
+    public async Task<IReadOnlyList<UsageChainRegions>> ScanAsync(
+        IEditorFolder rootFolder,
+        string targetPngPath,
+        int targetTextureWidth,
+        int targetTextureHeight,
+        CancellationToken cancellationToken = default)
+    {
+        var entries = await AchxFolderScanner.ScanAsync(rootFolder);
+
+        var targetPath = new FilePath(targetPngPath);
+        bool IsTargetTexture(IEditorFile file) =>
+            file is DiskEditorFile disk && new FilePath(disk.FullPath) == targetPath;
+
+        using var concurrency = new SemaphoreSlim(MaxConcurrentScans);
+        var perFileTasks = entries.Select(async entry =>
+        {
+            await concurrency.WaitAsync(cancellationToken);
+            try
+            {
+                // Task.Run: parsing + per-frame texture resolution is CPU/IO-bound work with
+                // nothing to yield on by itself (same reasoning as ProjectTreeThumbnailService).
+                return await Task.Run(
+                    () => AchxPngUsageScanner.FindMatchesAsync(
+                        entry, IsTargetTexture, targetTextureWidth, targetTextureHeight),
+                    cancellationToken);
+            }
+            finally
+            {
+                concurrency.Release();
+            }
+        });
+
+        var allMatches = (await Task.WhenAll(perFileTasks)).SelectMany(m => m).ToList();
+
+        var groups = allMatches
+            .GroupBy(m => (m.Entry, m.Chain))
+            .OrderBy(g => g.Key.Entry.RelativePath, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(g => g.Key.Chain.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var result = new List<UsageChainRegions>(groups.Count);
+        for (int i = 0; i < groups.Count; i++)
+        {
+            var group = groups[i];
+            var (r, g, b) = ChainUsageColorPalette.GetColor(i);
+            var rects = group
+                .Select(m => new SKRect(
+                    Math.Min(m.Left, m.Right), Math.Min(m.Top, m.Bottom),
+                    Math.Max(m.Left, m.Right), Math.Max(m.Top, m.Bottom)))
+                .ToList();
+
+            result.Add(new UsageChainRegions(group.Key.Entry, group.Key.Chain, new SKColor(r, g, b), rects));
+        }
+
+        return result;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxPngUsageScanner.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxPngUsageScanner.cs
@@ -1,0 +1,91 @@
+using FlatRedBall2.AnimationEditorCommon;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// One frame matched by <see cref="AchxPngUsageScanner"/>: the chain it belongs to (found inside
+/// <paramref name="Entry"/>'s parsed <c>.achx</c>) and its rect in texture-space pixels of the
+/// target PNG, already converted from UV if the source file used that <c>CoordinateType</c>.
+/// </summary>
+public sealed record PngUsageFrameMatch(
+    AchxFileEntry Entry,
+    AnimationChainSave Chain,
+    AnimationFrameSave Frame,
+    float Left, float Top, float Right, float Bottom);
+
+/// <summary>
+/// Finds every animation-chain frame across a project's <c>.achx</c>/<c>.achj</c> files that
+/// references a given target PNG (issue #953's "Analyze Image Usage" overlay) — which chain(s)
+/// use which regions of a spritesheet.
+/// </summary>
+public static class AchxPngUsageScanner
+{
+    /// <summary>
+    /// Parses <paramref name="entry"/> and returns every frame whose <c>TextureName</c> resolves
+    /// (relative to <see cref="AchxFileEntry.ParentFolder"/> — that file's own folder, not any
+    /// other project root) to <paramref name="isTargetTexture"/>. Frame rects come back in
+    /// texture-space pixels of a <paramref name="targetTextureWidth"/>×<paramref name="targetTextureHeight"/>
+    /// image. Returns empty (never throws) for an unreadable/malformed file or an unresolvable
+    /// texture reference — mirrors <c>ProjectTreeThumbnailService</c>'s "fall back to nothing"
+    /// contract for the same class of failure.
+    /// </summary>
+    public static async Task<IReadOnlyList<PngUsageFrameMatch>> FindMatchesAsync(
+        AchxFileEntry entry,
+        Func<IEditorFile, bool> isTargetTexture,
+        int targetTextureWidth,
+        int targetTextureHeight)
+    {
+        AnimationChainListSave acls;
+        try
+        {
+            string achxText;
+            await using (var stream = await entry.File.OpenReadAsync())
+            using (var reader = new StreamReader(stream))
+                achxText = await reader.ReadToEndAsync();
+            acls = AnimationChainListSave.FromString(achxText);
+        }
+        catch
+        {
+            return Array.Empty<PngUsageFrameMatch>();
+        }
+
+        var matches = new List<PngUsageFrameMatch>();
+
+        // Most .achx files point every frame at one texture; cache each distinct TextureName's
+        // resolve+match result so a chain with many frames doesn't re-resolve the same relative
+        // path once per frame.
+        var isMatchByTextureName = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var chain in acls.AnimationChains)
+        {
+            foreach (var frame in chain.Frames)
+            {
+                if (string.IsNullOrEmpty(frame.TextureName)) continue;
+
+                if (!isMatchByTextureName.TryGetValue(frame.TextureName, out var isMatch))
+                {
+                    var textureFile = await entry.ParentFolder.ResolveRelativeFileAsync(frame.TextureName);
+                    isMatch = textureFile is not null && isTargetTexture(textureFile);
+                    isMatchByTextureName[frame.TextureName] = isMatch;
+                }
+
+                if (!isMatch) continue;
+
+                var pixelFrame = acls.CoordinateType == TextureCoordinateType.Pixel
+                    ? frame
+                    : PixelFrameUvConverter.ToPixel(frame, targetTextureWidth, targetTextureHeight);
+
+                matches.Add(new PngUsageFrameMatch(
+                    entry, chain, frame,
+                    pixelFrame.LeftCoordinate, pixelFrame.TopCoordinate,
+                    pixelFrame.RightCoordinate, pixelFrame.BottomCoordinate));
+            }
+        }
+
+        return matches;
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PixelFrameUvConverter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PixelFrameUvConverter.cs
@@ -21,4 +21,21 @@ public static class PixelFrameUvConverter
         FlipHorizontal = frame.FlipHorizontal,
         FlipVertical = frame.FlipVertical,
     };
+
+    /// <summary>
+    /// Inverse of <see cref="ToUv"/>: converts a frame already in normalized UV (0-1) coordinates to
+    /// raw-pixel (<see cref="TextureCoordinateType.Pixel"/>), given the decoded texture's pixel size.
+    /// Used by the PNG usage-overlay scan (issue #953), which needs every matching frame's rect in
+    /// texture-space pixels regardless of the source .achx's on-disk <c>CoordinateType</c>.
+    /// </summary>
+    public static AnimationFrameSave ToPixel(AnimationFrameSave frame, int textureWidth, int textureHeight) => new()
+    {
+        TextureName = frame.TextureName,
+        LeftCoordinate = frame.LeftCoordinate * textureWidth,
+        RightCoordinate = frame.RightCoordinate * textureWidth,
+        TopCoordinate = frame.TopCoordinate * textureHeight,
+        BottomCoordinate = frame.BottomCoordinate * textureHeight,
+        FlipHorizontal = frame.FlipHorizontal,
+        FlipVertical = frame.FlipVertical,
+    };
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/ChainUsageColorPalette.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/ChainUsageColorPalette.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Deterministic, visually-distinct color per index — used by the PNG usage-overlay (issue #953)
+/// to give each matching animation chain its own outline/fill color. Steps hue by the golden angle
+/// (~137.5°) so consecutive indices land far apart on the color wheel regardless of how many
+/// chains are found, avoiding the visual clustering a plain <c>360/N</c> even split would produce
+/// for small N.
+/// </summary>
+public static class ChainUsageColorPalette
+{
+    private const float GoldenAngleDegrees = 137.508f;
+
+    /// <summary>Saturation/value are fixed (vivid, not too dark/light) — only hue varies by index.</summary>
+    public static (byte R, byte G, byte B) GetColor(int index)
+    {
+        float hue = (index * GoldenAngleDegrees) % 360f;
+        return HsvToRgb(hue, saturation: 0.65f, value: 0.95f);
+    }
+
+    private static (byte R, byte G, byte B) HsvToRgb(float hue, float saturation, float value)
+    {
+        float c = value * saturation;
+        float x = c * (1 - MathF.Abs(hue / 60f % 2 - 1));
+        float m = value - c;
+
+        (float r, float g, float b) = hue switch
+        {
+            < 60f => (c, x, 0f),
+            < 120f => (x, c, 0f),
+            < 180f => (0f, c, x),
+            < 240f => (0f, x, c),
+            < 300f => (x, 0f, c),
+            _ => (c, 0f, x),
+        };
+
+        return ((byte)((r + m) * 255f), (byte)((g + m) * 255f), (byte)((b + m) * 255f));
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PngPreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PngPreviewControl.cs
@@ -1,8 +1,10 @@
 using AnimationEditor.Core.Diff;
 using AnimationEditor.Core.Rendering;
+using Avalonia.Input;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace AnimationEditor.App.Controls;
@@ -26,6 +28,14 @@ public sealed class PngPreviewControl : TextureViewport
 
     // Diff-region outline: a warm red distinct from the wireframe's blue frame boxes.
     private static readonly SKColor RegionOutline = new(230, 74, 60, 235);
+
+    // Usage-overlay chain groups (issue #953), texture-space pixel rects per chain. Empty = hidden.
+    private IReadOnlyList<UsageChainRegions> _usageGroups = Array.Empty<UsageChainRegions>();
+
+    // Transparent fill + hard outline per rect (design decision on #953): overlapping regions from
+    // different chains simply stack their alpha, no special blend handling needed.
+    private const byte UsageFillAlpha = 60;
+    private const byte UsageStrokeAlpha = 220;
 
     // Framing: fit the changed region(s) to this fraction of the viewport (leaving surrounding
     // context), and never magnify past this zoom so a 1-pixel change centers instead of exploding.
@@ -91,6 +101,51 @@ public sealed class PngPreviewControl : TextureViewport
     /// <summary>Runs <see cref="StepDiffReveal"/> to completion synchronously.</summary>
     public void SettleDiffReveal() => _reveal.Settle();
 
+    /// <summary>
+    /// Replaces the "Analyze Image Usage" overlay (issue #953) with <paramref name="groups"/> — one
+    /// entry per animation chain that references the currently-displayed PNG, each in its own
+    /// color — and repaints. An empty list hides the overlay.
+    /// </summary>
+    public void SetUsageRegions(IReadOnlyList<UsageChainRegions> groups)
+    {
+        _usageGroups = groups;
+        InvalidateVisual();
+    }
+
+    /// <summary>Currently-shown usage-overlay groups. Test-only; production code drives this via
+    /// <see cref="SetUsageRegions"/>, not by reading it back.</summary>
+    public IReadOnlyList<UsageChainRegions> UsageRegions => _usageGroups;
+
+    /// <summary>
+    /// Fired when a left-click lands inside one or more usage-overlay rects. Empty click points (no
+    /// overlay shown, or the click missed every rect) never raise this. More than one candidate means
+    /// overlapping chains — the caller decides how to disambiguate (e.g. a candidate-picker popup).
+    /// </summary>
+    public event Action<IReadOnlyList<UsageChainRegions>>? UsageRegionsClicked;
+
+    /// <inheritdoc />
+    protected override void OnEditPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnEditPointerPressed(e);
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+
+        var pos = e.GetPosition(this);
+        HitTestUsageRegions(ScreenToTexture((float)pos.X, (float)pos.Y));
+    }
+
+    /// <summary>Test-only: simulates a click at a texture-space point, exercising the same hit test
+    /// as a real left-click (<see cref="OnEditPointerPressed"/>) without needing pointer routing.</summary>
+    public void SimulateUsageRegionClick(float textureX, float textureY) =>
+        HitTestUsageRegions(new SKPoint(textureX, textureY));
+
+    private void HitTestUsageRegions(SKPoint world)
+    {
+        if (_usageGroups.Count == 0) return;
+        var hits = _usageGroups.Where(g => g.Rects.Any(r => r.Contains(world))).ToList();
+        if (hits.Count > 0)
+            UsageRegionsClicked?.Invoke(hits);
+    }
+
     // Fits the combined bounds of all changed regions into the viewport and centers them.
     private void FrameRegions()
     {
@@ -119,23 +174,34 @@ public sealed class PngPreviewControl : TextureViewport
         // Texture-space rects captured on the UI thread for the render thread to draw.
         public List<SKRect> Boxes = new();
         public float RevealProgress = 1f;
+
+        // Usage-overlay groups (#953), captured alongside the diff boxes so one DrawOverlay pass
+        // draws both without either control state or a second snapshot type.
+        public List<UsageChainRegions> UsageGroups = new();
     }
 
     /// <inheritdoc />
     protected override TextureViewportSnapshot BuildSnapshot(double width, double height)
     {
-        var snap = new DiffSnapshot { DrawOverlay = DrawDiffOverlay, RevealProgress = _reveal.Progress };
+        var snap = new DiffSnapshot { DrawOverlay = DrawOverlays, RevealProgress = _reveal.Progress };
         PopulateBaseSnapshot(snap, width, height);
         foreach (var r in _diffRegions)
             // Inclusive pixel bounds → half-open rect: a 1-pixel region spans one pixel of width.
             snap.Boxes.Add(new SKRect(r.MinX, r.MinY, r.MaxX + 1, r.MaxY + 1));
+        snap.UsageGroups.AddRange(_usageGroups);
         return snap;
     }
 
     // Runs on the render thread from immutable snapshot data only — never touches live control state.
-    private static void DrawDiffOverlay(SKCanvas canvas, TextureViewportSnapshot snapshot)
+    private static void DrawOverlays(SKCanvas canvas, TextureViewportSnapshot snapshot)
     {
         var s = (DiffSnapshot)snapshot;
+        DrawDiffOverlay(canvas, s);
+        DrawUsageOverlay(canvas, s);
+    }
+
+    private static void DrawDiffOverlay(SKCanvas canvas, DiffSnapshot s)
+    {
         if (s.Boxes.Count == 0) return;
 
         float scale = RevealAnimation.Scale(s.RevealProgress);
@@ -154,6 +220,29 @@ public sealed class PngPreviewControl : TextureViewport
             if (scale != 1f)
                 screen = ScaleAround(screen, scale);
             canvas.DrawRect(screen, stroke);
+        }
+    }
+
+    // Transparent fill + hard outline per rect, one color per chain (#953 design decision) —
+    // overlapping regions from different chains stack their alpha with no special blend logic.
+    private static void DrawUsageOverlay(SKCanvas canvas, DiffSnapshot s)
+    {
+        foreach (var group in s.UsageGroups)
+        {
+            using var fill = new SKPaint { Color = group.Color.WithAlpha(UsageFillAlpha), Style = SKPaintStyle.Fill };
+            using var stroke = new SKPaint
+            {
+                Color = group.Color.WithAlpha(UsageStrokeAlpha),
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = 2f,
+                IsAntialias = true,
+            };
+            foreach (var rect in group.Rects)
+            {
+                var screen = s.TextureRectToScreen(rect);
+                canvas.DrawRect(screen, fill);
+                canvas.DrawRect(screen, stroke);
+            }
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PngPreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PngPreviewControl.cs
@@ -37,6 +37,10 @@ public sealed class PngPreviewControl : TextureViewport
     private const byte UsageFillAlpha = 60;
     private const byte UsageStrokeAlpha = 220;
 
+    // Rect currently under the mouse, for the "file (N)" hover tag — mirrors WireframeControl's
+    // _hoverFrame (#718). Null when nothing is hovered.
+    private (UsageChainRegions Group, UsageFrameRegion Frame)? _hoverUsageRegion;
+
     // Framing: fit the changed region(s) to this fraction of the viewport (leaving surrounding
     // context), and never magnify past this zoom so a 1-pixel change centers instead of exploding.
     private const float FocusFitFraction = 0.6f;
@@ -141,9 +145,73 @@ public sealed class PngPreviewControl : TextureViewport
     private void HitTestUsageRegions(SKPoint world)
     {
         if (_usageGroups.Count == 0) return;
-        var hits = _usageGroups.Where(g => g.Rects.Any(r => r.Contains(world))).ToList();
+        var hits = _usageGroups.Where(g => g.Rects.Any(fr => fr.Rect.Contains(world))).ToList();
         if (hits.Count > 0)
             UsageRegionsClicked?.Invoke(hits);
+    }
+
+    /// <inheritdoc />
+    protected override void OnEditPointerMoved(PointerEventArgs e)
+    {
+        base.OnEditPointerMoved(e);
+        var pos = e.GetPosition(this);
+        UpdateHoverUsageRegion(ScreenToTexture((float)pos.X, (float)pos.Y));
+    }
+
+    /// <inheritdoc />
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+        ClearHoverUsageRegion();
+    }
+
+    /// <summary>
+    /// Hit-tests <paramref name="world"/> against every rect across all usage groups (#953) and
+    /// updates <see cref="_hoverUsageRegion"/> for the "file (N)" hover tag. When two rects overlap,
+    /// the first match in iteration order wins — no disambiguation needed for a hover tooltip. Only
+    /// invalidates when the hovered rect identity actually changes.
+    /// </summary>
+    private void UpdateHoverUsageRegion(SKPoint world)
+    {
+        (UsageChainRegions Group, UsageFrameRegion Frame)? hit = null;
+        foreach (var group in _usageGroups)
+        {
+            foreach (var fr in group.Rects)
+            {
+                if (fr.Rect.Contains(world))
+                {
+                    hit = (group, fr);
+                    break;
+                }
+            }
+            if (hit != null) break;
+        }
+
+        bool sameHit = ReferenceEquals(hit?.Group, _hoverUsageRegion?.Group) &&
+            hit?.Frame.FrameIndex == _hoverUsageRegion?.Frame.FrameIndex;
+        if (!sameHit)
+        {
+            _hoverUsageRegion = hit;
+            InvalidateVisual();
+        }
+    }
+
+    private void ClearHoverUsageRegion()
+    {
+        if (_hoverUsageRegion != null)
+        {
+            _hoverUsageRegion = null;
+            InvalidateVisual();
+        }
+    }
+
+    /// <summary>Test-only: runs the same hover hit-test as <see cref="OnEditPointerMoved"/> for a
+    /// given screen point and returns the resolved <c>"file (N)"</c> label. Null when nothing is
+    /// hovered.</summary>
+    public string? GetUsageHoverLabelForScreenPoint(float screenX, float screenY)
+    {
+        UpdateHoverUsageRegion(ScreenToTexture(screenX, screenY));
+        return _hoverUsageRegion is { } h ? $"{h.Group.Entry.FileName} ({h.Frame.FrameIndex})" : null;
     }
 
     // Fits the combined bounds of all changed regions into the viewport and centers them.
@@ -178,6 +246,13 @@ public sealed class PngPreviewControl : TextureViewport
         // Usage-overlay groups (#953), captured alongside the diff boxes so one DrawOverlay pass
         // draws both without either control state or a second snapshot type.
         public List<UsageChainRegions> UsageGroups = new();
+
+        /// <summary>Texture-space bounds of the usage-overlay rect under the mouse; null when
+        /// nothing is hovered. Paired with <see cref="HoverLabel"/>, resolved on the UI thread in
+        /// <see cref="BuildSnapshot"/> so the render thread never touches <see cref="UsageChainRegions"/>.</summary>
+        public SKRect? HoverFrameBounds;
+        /// <summary>"file (N)" label for <see cref="HoverFrameBounds"/>; null when nothing is hovered.</summary>
+        public string? HoverLabel;
     }
 
     /// <inheritdoc />
@@ -189,6 +264,13 @@ public sealed class PngPreviewControl : TextureViewport
             // Inclusive pixel bounds → half-open rect: a 1-pixel region spans one pixel of width.
             snap.Boxes.Add(new SKRect(r.MinX, r.MinY, r.MaxX + 1, r.MaxY + 1));
         snap.UsageGroups.AddRange(_usageGroups);
+
+        if (_hoverUsageRegion is { } hover)
+        {
+            snap.HoverFrameBounds = hover.Frame.Rect;
+            snap.HoverLabel = $"{hover.Group.Entry.FileName} ({hover.Frame.FrameIndex})";
+        }
+
         return snap;
     }
 
@@ -198,6 +280,11 @@ public sealed class PngPreviewControl : TextureViewport
         var s = (DiffSnapshot)snapshot;
         DrawDiffOverlay(canvas, s);
         DrawUsageOverlay(canvas, s);
+
+        // Hover tag (mirrors WireframeControl's "Frame N" notch, #718): drawn last so it sits on
+        // top of every fill/outline.
+        if (s.HoverFrameBounds.HasValue && s.HoverLabel != null)
+            WireframeControl.DrawHoverLabel(canvas, s.TextureRectToScreen(s.HoverFrameBounds.Value), s.HoverLabel);
     }
 
     private static void DrawDiffOverlay(SKCanvas canvas, DiffSnapshot s)
@@ -237,9 +324,9 @@ public sealed class PngPreviewControl : TextureViewport
                 StrokeWidth = 2f,
                 IsAntialias = true,
             };
-            foreach (var rect in group.Rects)
+            foreach (var fr in group.Rects)
             {
-                var screen = s.TextureRectToScreen(rect);
+                var screen = s.TextureRectToScreen(fr.Rect);
                 canvas.DrawRect(screen, fill);
                 canvas.DrawRect(screen, stroke);
             }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/UsageChainRegions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/UsageChainRegions.cs
@@ -1,0 +1,19 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System.Collections.Generic;
+
+namespace AnimationEditor.App.Controls;
+
+/// <summary>
+/// One chain's worth of matched frame rects for the PNG usage overlay (issue #953) — everything
+/// <see cref="PngPreviewControl.SetUsageRegions"/> needs to draw one chain's boxes in its own color
+/// and, on a click, report which chain/file to navigate to. <see cref="Rects"/> are texture-space
+/// pixels, already normalized (Left&lt;Right, Top&lt;Bottom) so drawing/hit-testing never has to
+/// re-check axis order.
+/// </summary>
+public sealed record UsageChainRegions(
+    AchxFileEntry Entry,
+    AnimationChainSave Chain,
+    SKColor Color,
+    IReadOnlyList<SKRect> Rects);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/UsageChainRegions.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/UsageChainRegions.cs
@@ -8,12 +8,19 @@ namespace AnimationEditor.App.Controls;
 /// <summary>
 /// One chain's worth of matched frame rects for the PNG usage overlay (issue #953) — everything
 /// <see cref="PngPreviewControl.SetUsageRegions"/> needs to draw one chain's boxes in its own color
-/// and, on a click, report which chain/file to navigate to. <see cref="Rects"/> are texture-space
-/// pixels, already normalized (Left&lt;Right, Top&lt;Bottom) so drawing/hit-testing never has to
-/// re-check axis order.
+/// and, on a click, report which chain/file to navigate to. Each <see cref="UsageFrameRegion.Rect"/>
+/// is texture-space pixels, already normalized (Left&lt;Right, Top&lt;Bottom) so drawing/hit-testing
+/// never has to re-check axis order.
 /// </summary>
 public sealed record UsageChainRegions(
     AchxFileEntry Entry,
     AnimationChainSave Chain,
     SKColor Color,
-    IReadOnlyList<SKRect> Rects);
+    IReadOnlyList<UsageFrameRegion> Rects);
+
+/// <summary>
+/// One matched frame's texture-space rect within a <see cref="UsageChainRegions"/> group.
+/// <see cref="FrameIndex"/> is the frame's 1-based position within <c>Chain.Frames</c> — used for
+/// the hover tag's <c>"file (N)"</c> label, same numbering as the wireframe editor's "Frame N".
+/// </summary>
+public readonly record struct UsageFrameRegion(int FrameIndex, SKRect Rect);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -214,7 +214,7 @@ public class WireframeControl : TextureViewport
     /// of <paramref name="sr"/> (already screen-space), sized purely in fixed pixels so it never
     /// scales with zoom the way the frame rect itself does.
     /// </summary>
-    private static void DrawHoverLabel(SKCanvas canvas, SKRect sr, string label)
+    internal static void DrawHoverLabel(SKCanvas canvas, SKRect sr, string label)
     {
         const float PadX = 5f;
         const float PadY = 3f;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngUsageOverlayTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngUsageOverlayTests.cs
@@ -47,6 +47,28 @@ public class PngUsageOverlayTests
         return path;
     }
 
+    // Writes an achx with one chain containing two frames referencing the same texture, so the
+    // scan's 1-based FrameIndex assignment (frame's position within Chain.Frames) can be verified.
+    private static string WriteAchxTwoFrames(string dir, string fileName, string chainName, string textureName)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = textureName, FrameLength = 0.1f,
+            LeftCoordinate = 0, TopCoordinate = 0, RightCoordinate = 16, BottomCoordinate = 16,
+        });
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = textureName, FrameLength = 0.1f,
+            LeftCoordinate = 16, TopCoordinate = 0, RightCoordinate = 32, BottomCoordinate = 16,
+        });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
     // Pumps the dispatcher until the overlay status text moves off the transient "Scanning…"
     // message, or the bounded attempt count runs out (fails the assertions below, not hangs).
     private static async Task WaitForScanToFinishAsync(TextBlock status)
@@ -85,11 +107,48 @@ public class PngUsageOverlayTests
             var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
             var group = Assert.Single(pngPane.UsageRegions);
             Assert.Equal("Walk", group.Chain.Name);
-            var rect = Assert.Single(group.Rects);
-            Assert.Equal(0f, rect.Left, precision: 1);
-            Assert.Equal(0f, rect.Top, precision: 1);
-            Assert.Equal(32f, rect.Right, precision: 1);
-            Assert.Equal(16f, rect.Bottom, precision: 1);
+            var frameRegion = Assert.Single(group.Rects);
+            Assert.Equal(1, frameRegion.FrameIndex);
+            Assert.Equal(0f, frameRegion.Rect.Left, precision: 1);
+            Assert.Equal(0f, frameRegion.Rect.Top, precision: 1);
+            Assert.Equal(32f, frameRegion.Rect.Right, precision: 1);
+            Assert.Equal(16f, frameRegion.Rect.Bottom, precision: 1);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task PngUsageOverlayToggle_ChainWithMultipleFrames_AssignsOneBasedFrameIndexPerFrame()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pngPath = WriteRealPng(dir, "hero.png", 32, 16);
+            WriteAchxTwoFrames(dir, "walk.achx", "Walk", "hero.png");
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            window.OpenPngAsTab(pngPath);
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var toggle = window.FindControl<ToggleButton>("PngUsageOverlayToggle")!;
+            var status = window.FindControl<TextBlock>("PngUsageOverlayStatus")!;
+            toggle.IsChecked = true;
+            await WaitForScanToFinishAsync(status);
+
+            var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
+            var group = Assert.Single(pngPane.UsageRegions);
+            Assert.Equal(2, group.Rects.Count);
+            Assert.Equal(1, group.Rects[0].FrameIndex);
+            Assert.Equal(2, group.Rects[1].FrameIndex);
         }
         finally
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngUsageOverlayTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PngUsageOverlayTests.cs
@@ -1,0 +1,183 @@
+using AnimationEditor.App.Controls;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Wiring tests for the PNG usage overlay (issue #953): the "Analyze Image Usage" toggle in the PNG
+/// tab's toolbar scans the project for chains referencing the open PNG and overlays their frame
+/// rects; clicking a rect navigates to the owning chain.
+/// </summary>
+public class PngUsageOverlayTests
+{
+    private static string WriteRealPng(string dir, string fileName, int width, int height)
+    {
+        var path = Path.Combine(dir, fileName);
+        using var bmp = new SkiaSharp.SKBitmap(width, height, SkiaSharp.SKColorType.Rgba8888, SkiaSharp.SKAlphaType.Unpremul);
+        bmp.Erase(new SkiaSharp.SKColor(200, 120, 60, 255));
+        using var image = SkiaSharp.SKImage.FromBitmap(bmp);
+        using var data = image.Encode(SkiaSharp.SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    private static string WriteAchx(
+        string dir, string fileName, string chainName, string textureName,
+        float left, float top, float right, float bottom)
+    {
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave
+        {
+            TextureName = textureName, FrameLength = 0.1f,
+            LeftCoordinate = left, TopCoordinate = top, RightCoordinate = right, BottomCoordinate = bottom,
+        });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    // Pumps the dispatcher until the overlay status text moves off the transient "Scanning…"
+    // message, or the bounded attempt count runs out (fails the assertions below, not hangs).
+    private static async Task WaitForScanToFinishAsync(TextBlock status)
+    {
+        string scanning = "Scanning project for usage…";
+        for (int i = 0; i < 200 && status.Text == scanning; i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task PngUsageOverlayToggle_ChainReferencesOpenPng_ShowsMatchingRegion()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pngPath = WriteRealPng(dir, "hero.png", 64, 64);
+            WriteAchx(dir, "walk.achx", "Walk", "hero.png", left: 0, top: 0, right: 32, bottom: 16);
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            window.OpenPngAsTab(pngPath);
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var toggle = window.FindControl<ToggleButton>("PngUsageOverlayToggle")!;
+            var status = window.FindControl<TextBlock>("PngUsageOverlayStatus")!;
+            toggle.IsChecked = true;
+            await WaitForScanToFinishAsync(status);
+
+            var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
+            var group = Assert.Single(pngPane.UsageRegions);
+            Assert.Equal("Walk", group.Chain.Name);
+            var rect = Assert.Single(group.Rects);
+            Assert.Equal(0f, rect.Left, precision: 1);
+            Assert.Equal(0f, rect.Top, precision: 1);
+            Assert.Equal(32f, rect.Right, precision: 1);
+            Assert.Equal(16f, rect.Bottom, precision: 1);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task PngUsageOverlayToggle_UncheckedAfterScan_HidesRegions()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pngPath = WriteRealPng(dir, "hero.png", 32, 32);
+            WriteAchx(dir, "walk.achx", "Walk", "hero.png", left: 0, top: 0, right: 32, bottom: 32);
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            window.OpenPngAsTab(pngPath);
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var toggle = window.FindControl<ToggleButton>("PngUsageOverlayToggle")!;
+            var status = window.FindControl<TextBlock>("PngUsageOverlayStatus")!;
+            var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
+            toggle.IsChecked = true;
+            await WaitForScanToFinishAsync(status);
+            Assert.NotEmpty(pngPane.UsageRegions);
+
+            toggle.IsChecked = false;
+
+            Assert.Empty(pngPane.UsageRegions);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task UsageRegionsClicked_SingleMatch_NavigatesToOwningAchxAndSelectsChain()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var pngPath = WriteRealPng(dir, "hero.png", 64, 64);
+            WriteAchx(dir, "walk.achx", "Walk", "hero.png", left: 0, top: 0, right: 64, bottom: 64);
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            window.OpenPngAsTab(pngPath);
+            Dispatcher.UIThread.RunJobs();
+            await window.WhenPngTabLoaded();
+
+            var toggle = window.FindControl<ToggleButton>("PngUsageOverlayToggle")!;
+            var status = window.FindControl<TextBlock>("PngUsageOverlayStatus")!;
+            var pngPane = window.FindControl<PngPreviewControl>("PngPane")!;
+            toggle.IsChecked = true;
+            await WaitForScanToFinishAsync(status);
+            Assert.NotEmpty(pngPane.UsageRegions);
+
+            pngPane.SimulateUsageRegionClick(32f, 32f);   // inside the 0,0-64,64 rect
+
+            // Navigation opens the achx tab asynchronously (fire-and-forget from the click handler) --
+            // pump until the editor pane swaps back in, or fail out via the bounded loop.
+            var achxPane = window.FindControl<Grid>("AchxEditorPane")!;
+            for (int i = 0; i < 200 && !achxPane.IsVisible; i++)
+            {
+                Dispatcher.UIThread.RunJobs();
+                await Task.Delay(10);
+            }
+
+            Assert.True(achxPane.IsVisible);
+            Assert.False(pngPane.IsVisible);
+            Assert.Equal("Walk", ctx.SelectedState.SelectedChain?.Name);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxPngUsageScannerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxPngUsageScannerTests.cs
@@ -1,0 +1,165 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.AnimationEditorCommon;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+// Issue #953: the PNG usage-overlay scan finds every frame across a project's .achx/.achj files
+// whose texture resolves to a given target PNG, in texture-space pixel coordinates.
+public class AchxPngUsageScannerTests
+{
+    private const string Achx = """
+        <AnimationChainArraySave>
+            <CoordinateType>UV</CoordinateType>
+            <AnimationChain>
+                <Name>Walk</Name>
+                <Frame>
+                    <TextureName>hero.png</TextureName>
+                    <LeftCoordinate>0.25</LeftCoordinate>
+                    <RightCoordinate>0.75</RightCoordinate>
+                    <TopCoordinate>0</TopCoordinate>
+                    <BottomCoordinate>0.5</BottomCoordinate>
+                </Frame>
+            </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    private const string AchxPixelCoordinates = """
+        <AnimationChainArraySave>
+            <CoordinateType>Pixel</CoordinateType>
+            <AnimationChain>
+                <Name>Run</Name>
+                <Frame>
+                    <TextureName>hero.png</TextureName>
+                    <LeftCoordinate>16</LeftCoordinate>
+                    <RightCoordinate>48</RightCoordinate>
+                    <TopCoordinate>0</TopCoordinate>
+                    <BottomCoordinate>32</BottomCoordinate>
+                </Frame>
+            </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    private const string AchxOtherTexture = """
+        <AnimationChainArraySave>
+            <CoordinateType>UV</CoordinateType>
+            <AnimationChain>
+                <Name>Idle</Name>
+                <Frame>
+                    <TextureName>villain.png</TextureName>
+                    <LeftCoordinate>0</LeftCoordinate>
+                    <RightCoordinate>1</RightCoordinate>
+                    <TopCoordinate>0</TopCoordinate>
+                    <BottomCoordinate>1</BottomCoordinate>
+                </Frame>
+            </AnimationChain>
+        </AnimationChainArraySave>
+        """;
+
+    [Fact]
+    public async Task FindMatchesAsync_UvCoordinateType_ConvertsFrameToTargetPixelSize()
+    {
+        var hero = new FakeEditorFile("hero.png");
+        var folder = new FakeEditorFolder("Content");
+        folder.Files.Add(hero);
+        var entry = new AchxFileEntry(new FakeEditorFile("chain.achx", Achx), folder, "chain.achx");
+
+        var matches = await AchxPngUsageScanner.FindMatchesAsync(
+            entry, isTargetTexture: f => ReferenceEquals(f, hero),
+            targetTextureWidth: 64, targetTextureHeight: 64);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("Walk", match.Chain.Name);
+        Assert.Equal(16f, match.Left, tolerance: 0.001f);
+        Assert.Equal(48f, match.Right, tolerance: 0.001f);
+        Assert.Equal(0f, match.Top, tolerance: 0.001f);
+        Assert.Equal(32f, match.Bottom, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_PixelCoordinateType_PassesFrameThroughUnconverted()
+    {
+        var hero = new FakeEditorFile("hero.png");
+        var folder = new FakeEditorFolder("Content");
+        folder.Files.Add(hero);
+        var entry = new AchxFileEntry(new FakeEditorFile("chain.achx", AchxPixelCoordinates), folder, "chain.achx");
+
+        var matches = await AchxPngUsageScanner.FindMatchesAsync(
+            entry, isTargetTexture: f => ReferenceEquals(f, hero),
+            targetTextureWidth: 64, targetTextureHeight: 64);
+
+        var match = Assert.Single(matches);
+        Assert.Equal("Run", match.Chain.Name);
+        Assert.Equal(16f, match.Left, tolerance: 0.001f);
+        Assert.Equal(48f, match.Right, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_FrameReferencesDifferentTexture_IsExcluded()
+    {
+        var hero = new FakeEditorFile("hero.png");
+        var folder = new FakeEditorFolder("Content");
+        folder.Files.Add(hero);
+        folder.Files.Add(new FakeEditorFile("villain.png"));
+        var entry = new AchxFileEntry(new FakeEditorFile("chain.achx", AchxOtherTexture), folder, "chain.achx");
+
+        var matches = await AchxPngUsageScanner.FindMatchesAsync(
+            entry, isTargetTexture: f => ReferenceEquals(f, hero),
+            targetTextureWidth: 64, targetTextureHeight: 64);
+
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_TextureInNestedFolder_ResolvesRelativeToAchxOwnFolder()
+    {
+        // The achx lives in a "Sprites" subfolder and its texture reference is relative to THAT
+        // folder, not some other root -- ParentFolder must be what ResolveRelativeFileAsync uses.
+        var hero = new FakeEditorFile("hero.png");
+        var spritesFolder = new FakeEditorFolder("Sprites");
+        spritesFolder.Files.Add(hero);
+        var entry = new AchxFileEntry(new FakeEditorFile("chain.achx", Achx), spritesFolder, "Sprites/chain.achx");
+
+        var matches = await AchxPngUsageScanner.FindMatchesAsync(
+            entry, isTargetTexture: f => ReferenceEquals(f, hero),
+            targetTextureWidth: 64, targetTextureHeight: 64);
+
+        Assert.Single(matches);
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_MultipleAchxFiles_AggregatesMatchesFromEachEntry()
+    {
+        var hero = new FakeEditorFile("hero.png");
+        var folder = new FakeEditorFolder("Content");
+        folder.Files.Add(hero);
+        var walkEntry = new AchxFileEntry(new FakeEditorFile("walk.achx", Achx), folder, "walk.achx");
+        var runEntry = new AchxFileEntry(new FakeEditorFile("run.achx", AchxPixelCoordinates), folder, "run.achx");
+
+        bool IsTarget(IEditorFile f) => ReferenceEquals(f, hero);
+
+        var walkMatches = await AchxPngUsageScanner.FindMatchesAsync(walkEntry, IsTarget, 64, 64);
+        var runMatches = await AchxPngUsageScanner.FindMatchesAsync(runEntry, IsTarget, 64, 64);
+        var all = walkMatches.Concat(runMatches).ToList();
+
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, m => m.Chain.Name == "Walk");
+        Assert.Contains(all, m => m.Chain.Name == "Run");
+    }
+
+    [Fact]
+    public async Task FindMatchesAsync_MalformedAchx_ReturnsEmptyInsteadOfThrowing()
+    {
+        var hero = new FakeEditorFile("hero.png");
+        var folder = new FakeEditorFolder("Content");
+        folder.Files.Add(hero);
+        var entry = new AchxFileEntry(new FakeEditorFile("broken.achx", "not xml or json"), folder, "broken.achx");
+
+        var matches = await AchxPngUsageScanner.FindMatchesAsync(
+            entry, isTargetTexture: f => ReferenceEquals(f, hero), targetTextureWidth: 64, targetTextureHeight: 64);
+
+        Assert.Empty(matches);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainUsageColorPaletteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ChainUsageColorPaletteTests.cs
@@ -1,0 +1,25 @@
+using AnimationEditor.Core.Rendering;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class ChainUsageColorPaletteTests
+{
+    [Fact]
+    public void GetColor_EightConsecutiveIndices_AreAllDistinct()
+    {
+        var colors = Enumerable.Range(0, 8).Select(ChainUsageColorPalette.GetColor).ToList();
+
+        Assert.Equal(colors.Count, colors.Distinct().Count());
+    }
+
+    [Fact]
+    public void GetColor_SameIndex_IsDeterministic()
+    {
+        var first = ChainUsageColorPalette.GetColor(3);
+        var second = ChainUsageColorPalette.GetColor(3);
+
+        Assert.Equal(first, second);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PixelFrameUvConverterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PixelFrameUvConverterTests.cs
@@ -36,4 +36,23 @@ public class PixelFrameUvConverterTests
         Assert.True(uv.FlipHorizontal);
         Assert.True(uv.FlipVertical);
     }
+
+    // Issue #953: the PNG usage-overlay scan needs matched frames in pixel coordinates regardless
+    // of the source .achx's on-disk CoordinateType, so a UV-format frame needs the inverse of ToUv.
+    [Fact]
+    public void ToPixel_UvCoordinates_MultipliesByTextureSize()
+    {
+        var frame = new AnimationFrameSave
+        {
+            LeftCoordinate = 0.25f, RightCoordinate = 0.75f,
+            TopCoordinate = 0f, BottomCoordinate = 0.5f,
+        };
+
+        var pixel = PixelFrameUvConverter.ToPixel(frame, textureWidth: 64, textureHeight: 64);
+
+        Assert.Equal(16f, pixel.LeftCoordinate, tolerance: 0.001f);
+        Assert.Equal(48f, pixel.RightCoordinate, tolerance: 0.001f);
+        Assert.Equal(0f, pixel.TopCoordinate, tolerance: 0.001f);
+        Assert.Equal(32f, pixel.BottomCoordinate, tolerance: 0.001f);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/PngPreviewControlUsageHoverTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/PngPreviewControlUsageHoverTests.cs
@@ -1,0 +1,119 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Views.Tests;
+
+/// <summary>
+/// Issue #953: hovering a usage-overlay rect on the PNG tab shows a "&lt;achx file&gt; (N)" tag,
+/// reusing <see cref="AnimationEditor.App.Controls.WireframeControl.DrawHoverLabel"/>'s visual
+/// (issue #718's "Frame N" notch) with a different label.
+/// </summary>
+public class PngPreviewControlUsageHoverTests
+{
+    private static UsageChainRegions MakeGroup(string achxFileName, string chainName, params SKRect[] rects)
+    {
+        var entry = new AchxFileEntry(new FakeFile(achxFileName), new FakeFolder("Content"), achxFileName);
+        var chain = new AnimationChainSave { Name = chainName };
+        var frameRegions = new List<UsageFrameRegion>();
+        for (int i = 0; i < rects.Length; i++)
+            frameRegions.Add(new UsageFrameRegion(i + 1, rects[i]));
+        return new UsageChainRegions(entry, chain, SKColors.Red, frameRegions);
+    }
+
+    [AvaloniaFact]
+    public void GetUsageHoverLabelForScreenPoint_DifferentAchxFiles_UsesEachGroupsFileName()
+    {
+        var ctrl = new PngPreviewControl();
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.SetUsageRegions(new[]
+        {
+            MakeGroup("Hero.achx", "Walk", new SKRect(0, 0, 16, 16)),
+            MakeGroup("Enemy.achx", "Idle", new SKRect(20, 0, 36, 16)),
+        });
+
+        var label = ctrl.GetUsageHoverLabelForScreenPoint(28f, 8f);
+
+        Assert.Equal("Enemy.achx (1)", label);
+    }
+
+    [AvaloniaFact]
+    public void GetUsageHoverLabelForScreenPoint_MovedAwayAfterHoveringRegion_ReturnsNull()
+    {
+        var ctrl = new PngPreviewControl();
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.SetUsageRegions(new[] { MakeGroup("Hero.achx", "Walk", new SKRect(0, 0, 16, 16)) });
+        Assert.Equal("Hero.achx (1)", ctrl.GetUsageHoverLabelForScreenPoint(8f, 8f));
+
+        var label = ctrl.GetUsageHoverLabelForScreenPoint(100f, 100f);
+
+        Assert.Null(label);
+    }
+
+    [AvaloniaFact]
+    public void GetUsageHoverLabelForScreenPoint_OutsideAnyRegion_ReturnsNull()
+    {
+        var ctrl = new PngPreviewControl();
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.SetUsageRegions(new[] { MakeGroup("Hero.achx", "Walk", new SKRect(0, 0, 16, 16)) });
+
+        var label = ctrl.GetUsageHoverLabelForScreenPoint(100f, 100f);
+
+        Assert.Null(label);
+    }
+
+    [AvaloniaFact]
+    public void GetUsageHoverLabelForScreenPoint_OverRegion_ReturnsFileNameAndFrameIndex()
+    {
+        var ctrl = new PngPreviewControl();
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.SetUsageRegions(new[] { MakeGroup("Hero.achx", "Walk", new SKRect(0, 0, 32, 32)) });
+
+        var label = ctrl.GetUsageHoverLabelForScreenPoint(16f, 16f);
+
+        Assert.Equal("Hero.achx (1)", label);
+    }
+
+    [AvaloniaFact]
+    public void GetUsageHoverLabelForScreenPoint_OverSecondFrameOfChain_ReturnsFrameIndexTwo()
+    {
+        var ctrl = new PngPreviewControl();
+        ctrl.SetCamera(0f, 0f, 1f);
+        ctrl.SetUsageRegions(new[]
+        {
+            MakeGroup("Hero.achx", "Walk", new SKRect(0, 0, 16, 16), new SKRect(16, 0, 32, 16))
+        });
+
+        var label = ctrl.GetUsageHoverLabelForScreenPoint(24f, 8f); // inside the second rect
+
+        Assert.Equal("Hero.achx (2)", label);
+    }
+
+    private sealed class FakeFile : IEditorFile
+    {
+        public FakeFile(string name) => Name = name;
+        public string Name { get; }
+        public Task<Stream> OpenReadAsync() => throw new NotSupportedException();
+        public Task<Stream> OpenWriteAsync() => throw new NotSupportedException();
+        public Task<FolderEntrySnapshot> GetBasicPropertiesAsync() =>
+            Task.FromResult(new FolderEntrySnapshot(null, null));
+    }
+
+    private sealed class FakeFolder : IEditorFolder
+    {
+        public FakeFolder(string name) => Name = name;
+        public string Name { get; }
+#pragma warning disable CS1998 // no subfolders/items -- these entries are hand-built for the hover tests above
+        public async IAsyncEnumerable<IEditorFile> GetItemsAsync() { yield break; }
+        public async IAsyncEnumerable<IEditorFolder> GetSubfoldersAsync() { yield break; }
+#pragma warning restore CS1998
+        public Task<IEditorFile?> GetFileAsync(string name) => Task.FromResult<IEditorFile?>(null);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an "Analyze Image Usage" toggle to the PNG tab's toolbar: scans every `.achx`/`.achj` under the project root (bounded concurrency, cached per-PNG for the session) and overlays color-coded rects for every frame that references the open PNG.
- Clicking a rect opens/selects the owning chain's `.achx` tab; overlapping rects show a small candidate-picker popup.
- Explicitly out of scope (per issue discussion): flagging unused/uncovered pixel areas.

## Design notes
- `AchxPngUsageScanner` (Core, no SkiaSharp) takes an injected `isTargetTexture` predicate instead of doing path comparison itself — `IEditorFile` has no path concept (browser file handles aren't real paths), so only the desktop-only `PngUsageScanService` (App layer) supplies the concrete `FilePath`-equality predicate against `DiskEditorFile.FullPath`.
- `PixelFrameUvConverter.ToPixel` is the symmetric inverse of the existing `ToUv`, for achx files still on the legacy UV `CoordinateType`.
- `ChainUsageColorPalette` steps hue by the golden angle so per-chain colors stay visually distinct regardless of how many chains match.
- Click-to-navigate had no prior helper in this codebase for "open a different file and select a specific chain in it" — built by sequencing `MainWindow.OpenFileAsTab` + a `Dispatcher.UIThread.InvokeAsync` flush (the tree rebuild it triggers is dispatched, not awaited) + a chain lookup by name in the freshly-loaded project.
- The candidate-picker popup reuses the existing single-reused-`ContextMenu`-instance pattern from the tab context menu (avoids the menu-stacking issue noted there for issue #472).

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — TDD'd scan/match/coordinate-conversion logic (UV vs Pixel, multi-file aggregation, nested-folder resolution relative to each achx's own folder, wrong-texture exclusion, malformed-file handling) + color palette.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — no regressions.
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — new integration tests for the toggle-driven scan and click-to-navigate, plus full existing suite green (868 total).
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — clean.
- [x] Manual test: ran the app against a fixture project (`diagnostics/manual-test/PngUsageOverlay/`, gitignored) with overlapping and non-overlapping chain regions to verify the toggle, colors, click-to-navigate, and the disambiguation popup by hand.

Closes #953

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>