### PR TITLE
Fix standalone build of FlatRedBall2.csproj

### DIFF
--- a/src/FlatRedBall2.csproj
+++ b/src/FlatRedBall2.csproj
@@ -47,7 +47,7 @@
       reference the AspNetCore.Components / JSInterop assemblies. AnimationChain.Common is its own
       MonoGame-free project (see ProjectReference below) for the same reason.
     -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);FlatRedBall2.BlazorGL\**;AnimationChain.MonoGame\**;AnimationChain.Common\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);FlatRedBall2.BlazorGL\**;AnimationChain.MonoGame\**;AnimationChain.Common\**;Animation.Content\**;AnimationEditorCommon\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <!-- Backend-agnostic packages -->

--- a/src/Movement/PathFollower.cs
+++ b/src/Movement/PathFollower.cs
@@ -1,5 +1,6 @@
 using System;
 using FlatRedBall2.Math;
+using Path = FlatRedBall2.Math.Path;
 
 namespace FlatRedBall2.Movement;
 


### PR DESCRIPTION
## Summary
- `DefaultItemExcludes` was missing `Animation.Content\**` and `AnimationEditorCommon\**`, so their generated `obj/AssemblyInfo.cs` files got swept into `FlatRedBall2.csproj`'s own compile glob, colliding with its generated AssemblyInfo (CS0579, ~90 errors).
- `PathFollower.cs`'s `Path` property/ctor param was ambiguous between `FlatRedBall2.Math.Path` and `System.IO.Path` (CS0104); added an explicit `using` alias.

Surfaced because a downstream Glue fix links a game project to FlatRedBall2 by source instead of the published NuGet package, which actually compiles this project directly for the first time.

## Test plan
- [x] `dotnet build src/FlatRedBall2.csproj -c Debug` — 0 errors (was ~94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4CB9PJp1yMGRDuXKbHzLn