### PR TITLE
Mark Desktop project as default startup in slnx templates

### DIFF
--- a/templates/frb2-desktop/MyGame.slnx
+++ b/templates/frb2-desktop/MyGame.slnx
@@ -1,4 +1,4 @@
 <Solution>
-  <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" />
+  <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" DefaultStartup="true" />
   <Project Path="MyGame.Common/MyGame.Common.csproj" />
 </Solution>

--- a/templates/frb2-multiplatform/MyGame.slnx
+++ b/templates/frb2-multiplatform/MyGame.slnx
@@ -1,5 +1,5 @@
 <Solution>
-  <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" />
+  <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" DefaultStartup="true" />
   <Project Path="MyGame.BlazorGL/MyGame.BlazorGL.csproj" />
   <Project Path="MyGame.Common/MyGame.Common.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- New FRB2 projects opened startup on whichever project sorts alphabetically first (e.g. AnimationChain.Common after source-linking), not the game's Desktop project - `.slnx` has no declaration-order fallback the way classic `.sln` does.
- Add `DefaultStartup="true"` to the Desktop project entry in both `frb2-desktop` and `frb2-multiplatform` templates.

## Test plan
- [ ] `dotnet new frb2-desktop` from local template source, open the generated `.slnx` in VS, confirm Desktop is startup on first open