### PR TITLE
Fix Gum project path resolution for nested Glue projects

### DIFF
--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -274,6 +274,47 @@ public class FlatRedBallService
     }
 
     /// <summary>
+    /// <see cref="Glue.GlueLoadResult.GumProjectFile"/> rebased onto <paramref name="project"/>'s
+    /// content root and re-expressed relative to <paramref name="contentRootDirectory"/>, or null
+    /// when it names none.
+    /// </summary>
+    /// <remarks>
+    /// <c>GumProjectFile</c> is authored the same as every other <c>ReferencedFileSave.Name</c> —
+    /// relative to the <c>.gluj</c>'s own folder — so it first needs the same rebasing
+    /// <see cref="Glue.GlueContentSource"/> already does for every other reference, giving a path
+    /// relative to the executable folder (what <c>TitleContainer</c> resolves against).
+    /// <para>
+    /// Gum resolves the project path it's handed differently: against <c>Game.Content.RootDirectory</c>
+    /// (<paramref name="contentRootDirectory"/>, normally <c>"Content"</c>), the same as any
+    /// <c>ContentManager.Load</c> call, and it adds that prefix itself. So the executable-relative path
+    /// has that same prefix stripped back off before being handed over — leaving it in would have Gum
+    /// double it and look one <c>Content/</c> folder too deep. A Glue project that does not live under
+    /// the game's <c>Content</c> folder at all falls outside what Gum's single content root can resolve
+    /// — this returns the executable-relative path unchanged in that case, best-effort.
+    /// </para>
+    /// </remarks>
+    internal static string? ResolveGlueGumProjectFile(Glue.GlueProject? project, string contentRootDirectory)
+    {
+        if (project?.Result.GumProjectFile is not string relative)
+            return null;
+
+        string? glueProjectDirectory = project.Content?.ContentRoot;
+        if (string.IsNullOrEmpty(glueProjectDirectory))
+            return relative;
+
+        string combined = Path.Combine(glueProjectDirectory, relative).Replace('\\', '/');
+
+        string prefix = contentRootDirectory.Replace('\\', '/').Trim('/');
+        if (prefix.Length == 0)
+            return combined;
+
+        string prefixWithSlash = prefix + "/";
+        return combined.StartsWith(prefixWithSlash, StringComparison.OrdinalIgnoreCase)
+            ? combined.Substring(prefixWithSlash.Length)
+            : combined;
+    }
+
+    /// <summary>
     /// Reads the <c>.gluj</c> and its element files from <see cref="OutputContentRoot"/> rather than
     /// the process working directory, which is the project folder under <c>dotnet run</c> and the
     /// output folder under a debugger — so the plain-relative read would find a different (stale)
@@ -449,7 +490,8 @@ public class FlatRedBallService
             LoadGlueProject(glueProjectFile);
         }
 
-        if ((settings?.GumProjectFile ?? GlueProject?.Result.GumProjectFile) is string gumProjectFile)
+        if ((settings?.GumProjectFile ?? ResolveGlueGumProjectFile(GlueProject, game.Content.RootDirectory))
+            is string gumProjectFile)
         {
             _gum.Initialize(game, gumProjectFile);
 #pragma warning disable CS0618 // Gum marks this as obsolete, but it's just because it's still experimental. It's okay.

--- a/tests/FlatRedBall2.Tests/Glue/GlueContentRootTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueContentRootTests.cs
@@ -66,6 +66,30 @@ public class GlueContentRootTests : IDisposable
         service.GlueProject!.Content!.ContentRoot.ShouldBe(Path.Combine("Content", "FrbEditor"));
     }
 
+    private const string GlujWithGumProject = @"{
+        ""FileVersion"": 68,
+        ""GlobalFiles"": [ { ""Name"": ""GumProject/GumProject.gumx"" } ]
+    }";
+
+    [Fact]
+    public void LoadGlueProject_GlujInItsOwnFolder_ResolvesGumProjectRelativeToThatFolder()
+    {
+        var service = new FlatRedBallService { OutputContentRoot = _output };
+        var relativeGluj = "Content/FrbEditor/MyGame.gluj";
+        var full = Path.Combine(_output, relativeGluj);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, GlujWithGumProject);
+
+        service.LoadGlueProject(relativeGluj);
+
+        // The .gumx is authored relative to the .gluj's own folder (like every other referenced
+        // file), so the resolved path must carry that folder forward - but Gum resolves what it's
+        // handed against Game.Content.RootDirectory itself, so that same "Content/" segment must come
+        // back off rather than being handed to Gum twice.
+        FlatRedBallService.ResolveGlueGumProjectFile(service.GlueProject, "Content")
+            .ShouldBe("FrbEditor/GumProject/GumProject.gumx");
+    }
+
     [Fact]
     public void Load_AReferencedFileBesideTheGluj_ResolvesWithoutAContentSegment()
     {

--- a/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueGumInstantiationTests.cs
@@ -59,15 +59,17 @@ public sealed class GlueGumFixture : IDisposable
         Path.Combine(AppContext.BaseDirectory, "Glue", "Fixtures", "DoorsDemo");
 
     /// <summary>
-    /// Stages the fixture's Gum project next to the test binary, because Gum's FileManager resolves
-    /// every path against the app's own Content folder rather than the Glue project's. A real game
-    /// needs no equivalent: its Content folder *is* the Glue project's.
+    /// Stages the fixture's Gum project under the test binary's own <c>Content/</c> folder, at the
+    /// same path the Glue project's directory occupies relative to the executable - because Gum
+    /// resolves whatever path it is handed against <c>Game.Content.RootDirectory</c>, unlike the rest
+    /// of a Glue project's references, which resolve directly against the executable folder. A real
+    /// game needs no equivalent: its Glue project already lives inside its own <c>Content/</c> folder.
     /// </summary>
     private static void StageFixtureContent()
     {
         CopyDirectory(
             Path.Combine(FixtureDirectory, "Content", "GumProject"),
-            Path.Combine(AppContext.BaseDirectory, "Content", "GumProject"));
+            Path.Combine(AppContext.BaseDirectory, "Content", "Glue", "Fixtures", "DoorsDemo", "GumProject"));
     }
 
     private static void CopyDirectory(string source, string destination)


### PR DESCRIPTION
## Summary
- `GumProjectFile` was handed to Gum as-authored (relative to the `.gluj`'s own folder) instead of rebased onto it like every other Glue reference — a Gum project nested inside the Glue project's folder resolved one level too shallow, throwing "Could not find main project file".
- Gum resolves what it's handed against `Game.Content.RootDirectory` itself, unlike `GlueContentSource` (resolves via `TitleContainer` against the executable folder) — so the rebased path needs that `Content/` prefix stripped back off before being handed to Gum.
- Added `FlatRedBallService.ResolveGlueGumProjectFile` to do both steps; fixed `GlueGumInstantiationTests`' fixture staging, which had been masking this bug by copying the Gum project directly to `Content/GumProject` instead of its true nested location.

## Test plan
- [x] `GlueContentRootTests` — new failing-first test proving the rebase + prefix-strip
- [x] Full suite: `dotnet test tests/FlatRedBall2.Tests/` — 1591 passed

https://claude.ai/code/session_01C1cbWTiyGFpkbEcNLyzVPm