### PR TITLE
Let Save As pick .achj or .achx in AnimationEditor

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/AvaloniaFileDialogService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/AvaloniaFileDialogService.cs
@@ -1,6 +1,8 @@
 using AnimationEditor.Core.IO;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AnimationEditor.App.Services;
@@ -11,19 +13,22 @@ internal sealed class AvaloniaFileDialogService : IFileDialogService
 
     public AvaloniaFileDialogService(Window owner) => _owner = owner;
 
-    public async Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    public async Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices)
     {
+        // One FilePickerFileType per choice (rather than one type with multiple patterns) so the
+        // OS save dialog lets the user pick achj vs. achx from the "Save as type" dropdown, and
+        // appends whichever extension is currently selected there.
+        var orderedChoices = fileTypeChoices
+            .OrderByDescending(c => c.Extension == defaultExtension)
+            .ToArray();
+
         var file = await _owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
         {
             Title = title,
             DefaultExtension = defaultExtension,
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType(fileTypeDescription)
-                {
-                    Patterns = new[] { $"*.{defaultExtension}" }
-                }
-            }
+            FileTypeChoices = orderedChoices
+                .Select(c => new FilePickerFileType(c.Description) { Patterns = new[] { $"*.{c.Extension}" } })
+                .ToArray()
         });
         return file?.Path.LocalPath;
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -414,7 +414,7 @@ namespace AnimationEditor.Core.CommandsAndState
         /// for a brand-new, never-saved file (#872 -- .achj is the default going forward), or
         /// whatever extension the loaded file already has (typically <c>achx</c>, preserving the
         /// on-disk format of an opened legacy file). The user can still pick the other format
-        /// from the dialog's file-type filter.
+        /// from the dialog's file-type dropdown (#973).
         /// </remarks>
         public async Task SaveCurrentAnimationChainListAsync()
         {
@@ -424,7 +424,12 @@ namespace AnimationEditor.Core.CommandsAndState
             var defaultExtension = string.IsNullOrEmpty(currentExtension) ? "achj" : currentExtension;
 
             var path = await FileDialogService.PickSaveFileAsync(
-                "Save Animation Chain", defaultExtension, $"Animation Chain (*.{defaultExtension})");
+                "Save Animation Chain", defaultExtension,
+                new[]
+                {
+                    new FileTypeChoice("achj", "Animation Chain JSON (*.achj)"),
+                    new FileTypeChoice("achx", "Animation Chain XML (*.achx)")
+                });
 
             if (string.IsNullOrEmpty(path)) return;
 
@@ -448,7 +453,7 @@ namespace AnimationEditor.Core.CommandsAndState
             if (acls == null) return;
 
             var path = await FileDialogService.PickSaveFileAsync(
-                "Export to PixiJS", "json", "PixiJS Spritesheet (*.json)");
+                "Export to PixiJS", "json", new[] { new FileTypeChoice("json", "PixiJS Spritesheet (*.json)") });
             if (string.IsNullOrEmpty(path)) return;
 
             var result = Export.PixiJsSpriteSheetExporter.Export(acls, _pm.GetTextureSizeInPixels);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileDialogService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/IFileDialogService.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace AnimationEditor.Core.IO;
+
+/// <summary>One selectable entry in a save dialog's file-type dropdown, e.g. ("achj", "Animation Chain JSON (*.achj)").</summary>
+public readonly record struct FileTypeChoice(string Extension, string Description);
 
 /// <summary>
 /// Abstracts native file-picker dialogs so that commands depending on them
@@ -9,9 +13,11 @@ namespace AnimationEditor.Core.IO;
 public interface IFileDialogService
 {
     /// <summary>
-    /// Show a save-file dialog. Returns the chosen path, or <c>null</c> if cancelled.
+    /// Show a save-file dialog offering every entry in <paramref name="fileTypeChoices"/> as a
+    /// selectable file type, with <paramref name="defaultExtension"/> chosen initially. Returns
+    /// the chosen path, or <c>null</c> if cancelled.
     /// </summary>
-    Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription);
+    Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices);
 
     /// <summary>
     /// Show an open-file dialog. Returns the chosen path, or <c>null</c> if cancelled.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileDialogService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NullFileDialogService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace AnimationEditor.Core.IO;
@@ -11,7 +12,7 @@ public sealed class NullFileDialogService : IFileDialogService
 {
     public static readonly NullFileDialogService Instance = new();
 
-    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices)
         => Task.FromResult<string?>(null);
 
     public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowMenuFlowTests.cs
@@ -379,7 +379,7 @@ internal sealed class MenuFlowStubFileDialogService : IFileDialogService
 
     public MenuFlowStubFileDialogService(string? path) => _path = path;
 
-    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices)
         => Task.FromResult(_path);
 
     public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription)

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UntitledTabCloseSavePromptTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UntitledTabCloseSavePromptTests.cs
@@ -25,7 +25,7 @@ public class UntitledTabCloseSavePromptTests
 {
     private sealed class StubFileDialogService(string? path) : IFileDialogService
     {
-        public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription) =>
+        public Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices) =>
             Task.FromResult(path);
 
         public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription) =>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsSaveAsTests.cs
@@ -1,7 +1,9 @@
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
 using FlatRedBall2.AnimationEditorCommon;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -171,6 +173,37 @@ public class AppCommandsSaveAsTests : IDisposable
         Assert.Equal("achj", dialog.RequestedDefaultExtension);
     }
 
+    // ── File-type dropdown offers both formats (#973) ──────────────────────────
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_AchxFileAlreadyLoaded_OffersBothAchjAndAchxChoices()
+    {
+        var loadedPath = Path.Combine(_dir.Path, "loaded.achx");
+        var dialog = new CapturingFileDialogService(Path.Combine(_dir.Path, "out.achx"));
+        ctx.AppCommands.FileDialogService = dialog;
+        ctx.ProjectManager.FileName = loadedPath;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal(
+            new[] { "achj", "achx" },
+            dialog.RequestedFileTypeChoices!.Select(c => c.Extension).OrderBy(e => e));
+    }
+
+    [Fact]
+    public async Task SaveCurrentAnimationChainListAsync_NewFile_OffersBothAchjAndAchxChoices()
+    {
+        var dialog = new CapturingFileDialogService(Path.Combine(_dir.Path, "out.achj"));
+        ctx.AppCommands.FileDialogService = dialog;
+        ctx.ProjectManager.FileName = null;
+
+        await ctx.AppCommands.SaveCurrentAnimationChainListAsync();
+
+        Assert.Equal(
+            new[] { "achj", "achx" },
+            dialog.RequestedFileTypeChoices!.Select(c => c.Extension).OrderBy(e => e));
+    }
+
     [Fact]
     public async Task SaveCurrentAnimationChainListAsync_SavedFile_ContainsChainData()
     {
@@ -196,14 +229,14 @@ internal sealed class StubFileDialogService : IFileDialogService
 
     public StubFileDialogService(string? path) => _path = path;
 
-    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices)
         => Task.FromResult(_path);
 
     public Task<string?> PickOpenFileAsync(string title, string defaultExtension, string fileTypeDescription)
         => Task.FromResult(_path);
 }
 
-/// <summary>Test double that records the requested default extension and returns a fixed path.</summary>
+/// <summary>Test double that records the requested default extension/file-type choices and returns a fixed path.</summary>
 internal sealed class CapturingFileDialogService : IFileDialogService
 {
     private readonly string? _path;
@@ -211,10 +244,12 @@ internal sealed class CapturingFileDialogService : IFileDialogService
     public CapturingFileDialogService(string? path) => _path = path;
 
     public string? RequestedDefaultExtension { get; private set; }
+    public IReadOnlyList<FileTypeChoice>? RequestedFileTypeChoices { get; private set; }
 
-    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, string fileTypeDescription)
+    public Task<string?> PickSaveFileAsync(string title, string defaultExtension, IReadOnlyList<FileTypeChoice> fileTypeChoices)
     {
         RequestedDefaultExtension = defaultExtension;
+        RequestedFileTypeChoices = fileTypeChoices;
         return Task.FromResult(_path);
     }
 


### PR DESCRIPTION
## Summary
- Save As locked the file-type filter to whichever extension was already loaded (or achj for new files) — a .achj file could never be re-saved as .achx and vice versa.
- `IFileDialogService.PickSaveFileAsync` now takes a list of `FileTypeChoice(Extension, Description)`; Save As offers both Animation Chain JSON (*.achj) and Animation Chain XML (*.achx) in the dialog's type dropdown, with the current/default format pre-selected.

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1916 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 872 passed

https://claude.ai/code/session_01EcqBL4jBciP5s5KiUJJHnj