### PR TITLE
Add opt-in PerformanceMonitor: rolling FPS/timing stats + collision severity report

### DIFF
--- a/frb-skills/performance/SKILL.md
+++ b/frb-skills/performance/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: performance
+description: FlatRedBallService.Performance — opt-in rolling FPS/timing/collision stats. Triggers: PerformanceMonitor, GenerateReport, FPS, frame time, DeepCollisionCount, "why is my game slow".
+---
+
+# Performance Monitoring
+
+`FlatRedBallService.Default.Performance` (a `PerformanceMonitor`, `src/Diagnostics/PerformanceMonitor.cs`) tracks rolling FPS, per-phase frame timing, and a per-collision-relationship severity breakdown over a 120-frame window.
+
+**Off by default** — set `IsEnabled = true` before it records anything; until then every stat reads zero/empty.
+
+```csharp
+FlatRedBallService.Default.Performance.IsEnabled = true;
+
+// later, e.g. every N frames from Screen.CustomActivity:
+var perf = FlatRedBallService.Default.Performance;
+Console.WriteLine(perf.GenerateReport());   // FPS + phase timing + collision severity, as a string
+var fps = perf.Fps;                         // .Current / .Average / .Min / .Max
+var worst = perf.GetCollisionReport();      // ordered most-expensive first, flags unpartitioned relationships
+```
+
+`GenerateReport()` only builds a string — it does no I/O itself, so printing/logging/writing it is on the caller.
+
+See `src/Diagnostics/FrameProfile.cs` for the underlying per-frame timing struct, and `Factory<T>.PartitionAxis` for what "unpartitioned" in the collision report means.

--- a/src/Collision/CollisionRelationship.cs
+++ b/src/Collision/CollisionRelationship.cs
@@ -164,6 +164,23 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
     /// </summary>
     public int DeepCollisionCount { get; private set; }
 
+    // Mirrors the partitioning gate in RunCollisions — true only when the broad phase actually
+    // engaged sweep-and-prune, not merely when a Factory has PartitionAxis set on one side.
+    bool ICollisionRelationship.IsPartitioned
+    {
+        get
+        {
+            if (ReferenceEquals(_listA, _listB))
+                return (_listA is IFactory fa) && fa.PartitionAxis != null;
+
+            Axis? axisA = (_listA is IFactory fa2) ? fa2.PartitionAxis : null;
+            Axis? axisB = (_listB is IFactory fb) ? fb.PartitionAxis : null;
+            return axisA != null && axisA == axisB;
+        }
+    }
+
+    string ICollisionRelationship.DisplayName => $"{typeof(A).Name} vs {typeof(B).Name}";
+
     /// <summary>
     /// Fired once per colliding pair per frame, after any physics response configured via
     /// <see cref="BounceOnCollision"/>, <see cref="MoveFirstOnCollision"/>, etc.

--- a/src/Collision/CollisionSystem.cs
+++ b/src/Collision/CollisionSystem.cs
@@ -9,6 +9,9 @@ internal sealed class CollisionSystem
 {
     private readonly List<ICollisionRelationship> _relationships = new();
 
+    /// <summary>Every registered relationship, for diagnostics/reporting. Read-only view.</summary>
+    internal IReadOnlyList<ICollisionRelationship> Relationships => _relationships;
+
     /// <summary>Adds a collision relationship to be run each frame.</summary>
     internal void Add(ICollisionRelationship relationship) => _relationships.Add(relationship);
 

--- a/src/Collision/ICollisionRelationship.cs
+++ b/src/Collision/ICollisionRelationship.cs
@@ -4,4 +4,14 @@ internal interface ICollisionRelationship
 {
     void RunCollisions();
     int DeepCollisionCount { get; }
+
+    /// <summary>
+    /// <c>false</c> when this relationship falls back to the O(n×m) check because its lists don't
+    /// share a matching <see cref="Factory{T}.PartitionAxis"/>. Read by
+    /// <see cref="FlatRedBall2.Diagnostics.PerformanceMonitor"/> for its collision severity report.
+    /// </summary>
+    bool IsPartitioned { get; }
+
+    /// <summary>Human-readable label for diagnostics, e.g. "Enemy vs PlayerBullet".</summary>
+    string DisplayName { get; }
 }

--- a/src/Diagnostics/CollisionRelationshipReport.cs
+++ b/src/Diagnostics/CollisionRelationshipReport.cs
@@ -1,0 +1,22 @@
+namespace FlatRedBall2.Diagnostics;
+
+/// <summary>
+/// One collision relationship's severity as of the last frame <see cref="PerformanceMonitor"/>
+/// recorded — mirrors FRB1's collision debugger output. See
+/// <see cref="PerformanceMonitor.GetCollisionReport"/>.
+/// </summary>
+public readonly struct CollisionRelationshipReport
+{
+    /// <summary>The relationship's two collidable type names, e.g. "Enemy vs PlayerBullet".</summary>
+    public string Name { get; init; }
+
+    /// <summary>Narrow-phase checks this relationship performed on the last recorded frame.</summary>
+    public int DeepCollisionCount { get; init; }
+
+    /// <summary>
+    /// <c>false</c> when this relationship is not benefiting from the sweep-and-prune broad phase
+    /// — its lists don't share a matching <c>Factory&lt;T&gt;.PartitionAxis</c> — so every check
+    /// runs the full O(n×m) pass. Mirrors FRB1's "NOT PARTITIONED" collision debugger warning.
+    /// </summary>
+    public bool IsPartitioned { get; init; }
+}

--- a/src/Diagnostics/PerformanceMonitor.cs
+++ b/src/Diagnostics/PerformanceMonitor.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FlatRedBall2.Collision;
+
+namespace FlatRedBall2.Diagnostics;
+
+/// <summary>
+/// Opt-in rolling-average performance instrumentation: FPS, per-phase frame timing, and a
+/// FRB1-style collision relationship severity breakdown. Off by default — set
+/// <see cref="IsEnabled"/> to <c>true</c> to start recording; when disabled, <see cref="Record"/>
+/// is a no-op and adds no overhead. Access via <see cref="FlatRedBallService.Performance"/>.
+/// </summary>
+public class PerformanceMonitor
+{
+    private const int DefaultWindowSize = 120;
+
+    private FrameProfile[] _window = new FrameProfile[DefaultWindowSize];
+    private int _windowSize = DefaultWindowSize;
+    private int _next;
+    private int _count;
+    private FrameProfile _current;
+    private IReadOnlyList<ICollisionRelationship> _relationships = Array.Empty<ICollisionRelationship>();
+
+    /// <summary>
+    /// When <c>true</c>, every committed frame is fed into the rolling window by <see cref="Record"/>.
+    /// Off by default — turn on to start collecting stats; leave off unless something is actually
+    /// reading <see cref="GenerateReport"/> or the stat properties.
+    /// </summary>
+    public bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Number of most-recent frames kept in the rolling window backing every stat below.
+    /// Changing this reallocates the window and discards any frames already recorded. Defaults
+    /// to 120 (~2 seconds at 60 FPS).
+    /// </summary>
+    public int WindowSize
+    {
+        get => _windowSize;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(value), "WindowSize must be positive.");
+            _windowSize = value;
+            _window = new FrameProfile[value];
+            _next = 0;
+            _count = 0;
+        }
+    }
+
+    /// <summary>Rolling stats for the full Update+Draw frame time.</summary>
+    public PerformanceStat FrameTotalMs => ComputeStat(static p => p.FrameTotalMs);
+
+    /// <summary>Rolling stats for <see cref="FlatRedBallService.Update"/>.</summary>
+    public PerformanceStat UpdateTotalMs => ComputeStat(static p => p.UpdateTotalMs);
+
+    /// <summary>Rolling stats for <see cref="FlatRedBallService.Draw"/>.</summary>
+    public PerformanceStat DrawTotalMs => ComputeStat(static p => p.DrawTotalMs);
+
+    /// <summary>Rolling stats for every registered collision relationship's <c>RunCollisions</c> call.</summary>
+    public PerformanceStat CollisionMs => ComputeStat(static p => p.CollisionMs);
+
+    /// <summary>Rolling stats for the Gum service tree walk.</summary>
+    public PerformanceStat GumUpdateMs => ComputeStat(static p => p.GumUpdateMs);
+
+    /// <summary>
+    /// Rolling frames-per-second, derived per-sample as <c>1000 / FrameTotalMs</c> (0 for a
+    /// frame that measured 0ms, to avoid a divide-by-zero spike skewing the average).
+    /// </summary>
+    public PerformanceStat Fps => ComputeStat(static p => p.FrameTotalMs > 0 ? 1000.0 / p.FrameTotalMs : 0);
+
+    /// <summary>
+    /// Records one committed frame into the rolling window. Called by the engine at the single
+    /// point a frame's <see cref="FrameProfile"/> is fully consistent — never call this yourself.
+    /// No-op (no allocation) when <see cref="IsEnabled"/> is <c>false</c>.
+    /// </summary>
+    internal void Record(FrameProfile profile, IReadOnlyList<ICollisionRelationship> relationships)
+    {
+        if (!IsEnabled) return;
+
+        _current = profile;
+        _relationships = relationships;
+        _window[_next] = profile;
+        _next = (_next + 1) % _window.Length;
+        if (_count < _window.Length) _count++;
+    }
+
+    /// <summary>
+    /// Every active collision relationship as of the last recorded frame, ordered most-expensive
+    /// first by <see cref="CollisionRelationshipReport.DeepCollisionCount"/> — mirrors FRB1's
+    /// collision debugger. Empty until the first frame is recorded (requires <see cref="IsEnabled"/>).
+    /// </summary>
+    public IReadOnlyList<CollisionRelationshipReport> GetCollisionReport()
+    {
+        var report = new List<CollisionRelationshipReport>(_relationships.Count);
+        foreach (var r in _relationships)
+        {
+            report.Add(new CollisionRelationshipReport
+            {
+                Name = r.DisplayName,
+                DeepCollisionCount = r.DeepCollisionCount,
+                IsPartitioned = r.IsPartitioned
+            });
+        }
+        report.Sort((a, b) => b.DeepCollisionCount.CompareTo(a.DeepCollisionCount));
+        return report;
+    }
+
+    /// <summary>
+    /// Builds a human-readable performance summary — FPS, per-phase timing, and the collision
+    /// relationship breakdown from <see cref="GetCollisionReport"/> — for the caller to log,
+    /// print, or route into a diagnostics overlay. Pure string building: reads only the
+    /// already-recorded window, does no I/O, and is safe to call from anywhere (e.g. every N
+    /// frames from <see cref="Screen.CustomActivity"/>) without corrupting future measurements —
+    /// the engine never does I/O on your behalf.
+    /// </summary>
+    public string GenerateReport()
+    {
+        var sb = new StringBuilder();
+        var fps = Fps;
+        sb.AppendLine(FormattableString.Invariant(
+            $"FPS: {fps.Current:F1} (avg {fps.Average:F1}, min {fps.Min:F1}, max {fps.Max:F1})"));
+        sb.AppendLine();
+        sb.AppendLine("Phase             Current(ms)  Avg(ms)");
+        AppendPhase(sb, "FrameTotal", FrameTotalMs);
+        AppendPhase(sb, "UpdateTotal", UpdateTotalMs);
+        AppendPhase(sb, "DrawTotal", DrawTotalMs);
+        AppendPhase(sb, "Collision", CollisionMs);
+        AppendPhase(sb, "GumUpdate", GumUpdateMs);
+
+        var collisionReport = GetCollisionReport();
+        if (collisionReport.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Collision relationships (most expensive first):");
+            foreach (var r in collisionReport)
+            {
+                var partitionNote = r.IsPartitioned ? "partitioned" : "NOT PARTITIONED";
+                sb.AppendLine(FormattableString.Invariant(
+                    $"  {r.Name}: {r.DeepCollisionCount} deep checks [{partitionNote}]"));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendPhase(StringBuilder sb, string name, PerformanceStat stat)
+    {
+        sb.AppendLine(FormattableString.Invariant(
+            $"{name,-16}  {stat.Current,9:F2}  {stat.Average,7:F2}"));
+    }
+
+    private PerformanceStat ComputeStat(Func<FrameProfile, double> selector)
+    {
+        if (_count == 0) return default;
+
+        double min = double.MaxValue, max = double.MinValue, sum = 0;
+        for (int i = 0; i < _count; i++)
+        {
+            double v = selector(_window[i]);
+            if (v < min) min = v;
+            if (v > max) max = v;
+            sum += v;
+        }
+
+        return new PerformanceStat
+        {
+            Current = selector(_current),
+            Min = min,
+            Average = sum / _count,
+            Max = max
+        };
+    }
+}

--- a/src/Diagnostics/PerformanceStat.cs
+++ b/src/Diagnostics/PerformanceStat.cs
@@ -1,0 +1,21 @@
+namespace FlatRedBall2.Diagnostics;
+
+/// <summary>
+/// Current-frame value plus rolling min/average/max for one timing signal over
+/// <see cref="PerformanceMonitor.WindowSize"/> frames. All fields are zero when no frame has
+/// been recorded yet (i.e. <see cref="PerformanceMonitor.IsEnabled"/> was never turned on).
+/// </summary>
+public readonly struct PerformanceStat
+{
+    /// <summary>Value from the most recently recorded frame.</summary>
+    public double Current { get; init; }
+
+    /// <summary>Smallest value across the current rolling window.</summary>
+    public double Min { get; init; }
+
+    /// <summary>Average value across the current rolling window.</summary>
+    public double Average { get; init; }
+
+    /// <summary>Largest value across the current rolling window.</summary>
+    public double Max { get; init; }
+}

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -1163,6 +1163,9 @@ public class FlatRedBallService
     /// <summary>Per-frame draw-call instrumentation. Off by default — see <see cref="Diagnostics.RenderDiagnostics.IsEnabled"/>.</summary>
     public RenderDiagnostics RenderDiagnostics { get; } = new RenderDiagnostics();
 
+    /// <summary>Rolling FPS/timing/collision instrumentation. Off by default — see <see cref="Diagnostics.PerformanceMonitor.IsEnabled"/>.</summary>
+    public PerformanceMonitor Performance { get; } = new PerformanceMonitor();
+
     /// <summary>
     /// The Gum UI service owned by this engine instance. Use this to access the root element,
     /// load Gum projects, or configure themes.
@@ -1509,5 +1512,8 @@ public class FlatRedBallService
         // Commit the in-progress profile — this is the only point where every field is populated
         // and consistent. Reads of LastFrame during the next frame see this coherent snapshot.
         _lastFrame = _frameProfile;
+        // Feed the rolling window here (outside every timed phase above) so recording itself is
+        // never counted against the frame it's recording.
+        Performance.Record(_frameProfile, CurrentScreen.CollisionSystem.Relationships);
     }
 }

--- a/src/Screen.cs
+++ b/src/Screen.cs
@@ -37,6 +37,9 @@ public class Screen : ILifecycleEvents
     /// <summary>All entities currently managed by this screen (registered via Factory or <see cref="Register"/>).</summary>
     public IReadOnlyList<Entity> Entities => _entityManager.Entities;
 
+    /// <summary>This screen's collision relationships. Used by <see cref="Diagnostics.PerformanceMonitor"/>.</summary>
+    internal CollisionSystem CollisionSystem => _collisionSystem;
+
     internal readonly CancellationTokenSource _cts = new();
 
     /// <summary>

--- a/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
@@ -11,6 +11,8 @@ public class CollisionSystemTests
     {
         public int CallCount { get; private set; }
         public int DeepCollisionCount => 0;
+        public bool IsPartitioned => false;
+        public string DisplayName => "CallCountRelationship";
         public void RunCollisions() => CallCount++;
     }
 

--- a/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
+++ b/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using FlatRedBall2.Collision;
+using FlatRedBall2.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Diagnostics;
+
+public class PerformanceMonitorTests
+{
+    private sealed class FakeRelationship : ICollisionRelationship
+    {
+        public FakeRelationship(string name, int deepCollisionCount, bool isPartitioned)
+        {
+            DisplayName = name;
+            DeepCollisionCount = deepCollisionCount;
+            IsPartitioned = isPartitioned;
+        }
+
+        public string DisplayName { get; }
+        public int DeepCollisionCount { get; }
+        public bool IsPartitioned { get; }
+        public void RunCollisions() { }
+    }
+
+    private static readonly IReadOnlyList<ICollisionRelationship> NoRelationships = System.Array.Empty<ICollisionRelationship>();
+
+    [Fact]
+    public void Fps_KnownFrameTotalMsValues_ComputesCurrentMinAverageMax()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true, WindowSize = 3 };
+
+        // FrameTotalMs 10, 20, 25 -> FPS 100, 50, 40.
+        monitor.Record(new FrameProfile { FrameTotalMs = 10 }, NoRelationships);
+        monitor.Record(new FrameProfile { FrameTotalMs = 20 }, NoRelationships);
+        monitor.Record(new FrameProfile { FrameTotalMs = 25 }, NoRelationships);
+
+        var fps = monitor.Fps;
+        fps.Current.ShouldBe(40.0, tolerance: 0.001);
+        fps.Min.ShouldBe(40.0, tolerance: 0.001);
+        fps.Max.ShouldBe(100.0, tolerance: 0.001);
+        fps.Average.ShouldBe((100.0 + 50.0 + 40.0) / 3.0, tolerance: 0.001);
+    }
+
+    [Fact]
+    public void GenerateReport_CollisionRelationships_OrdersBySeverityAndFlagsUnpartitioned()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true };
+        var relationships = new List<ICollisionRelationship>
+        {
+            new FakeRelationship("Player vs TileShapes", deepCollisionCount: 5, isPartitioned: false),
+            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, isPartitioned: true)
+        };
+
+        monitor.Record(new FrameProfile { FrameTotalMs = 16 }, relationships);
+
+        var report = monitor.GetCollisionReport();
+        report[0].Name.ShouldBe("Enemy vs Bullet");
+        report[0].DeepCollisionCount.ShouldBe(50);
+        report[1].Name.ShouldBe("Player vs TileShapes");
+        report[1].IsPartitioned.ShouldBeFalse();
+
+        var text = monitor.GenerateReport();
+        text.ShouldContain("Enemy vs Bullet: 50 deep checks [partitioned]");
+        text.ShouldContain("Player vs TileShapes: 5 deep checks [NOT PARTITIONED]");
+        text.IndexOf("Enemy vs Bullet").ShouldBeLessThan(text.IndexOf("Player vs TileShapes"));
+    }
+
+    [Fact]
+    public void Record_IsEnabledFalse_DoesNotRecordFrame()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = false };
+
+        monitor.Record(new FrameProfile { FrameTotalMs = 16 }, NoRelationships);
+
+        monitor.FrameTotalMs.Current.ShouldBe(0);
+        monitor.GetCollisionReport().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Record_MoreFramesThanWindowSize_RingBufferRetainsOnlyMostRecent()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true, WindowSize = 3 };
+
+        // Window holds only the last 3: 3, 4, 5.
+        for (int i = 1; i <= 5; i++)
+            monitor.Record(new FrameProfile { FrameTotalMs = i }, NoRelationships);
+
+        var stat = monitor.FrameTotalMs;
+        stat.Current.ShouldBe(5);
+        stat.Min.ShouldBe(3);
+        stat.Max.ShouldBe(5);
+        stat.Average.ShouldBe(4);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `FlatRedBallService.Performance` (`PerformanceMonitor`), mirroring `RenderDiagnostics`'s opt-in pattern: `IsEnabled` defaults `false`, `Record()` is a no-op when disabled.
- Rolling ring buffer (`WindowSize`, default 120 frames) fed from the single point `FrameProfile` is fully committed at end-of-Draw — never from inside a timed phase.
- Exposes current/min/avg/max `PerformanceStat` for FPS (derived per-sample, new to the engine) and FrameTotal/UpdateTotal/DrawTotal/Collision/GumUpdate.
- `GetCollisionReport()` / `GenerateReport()` give a FRB1-style collision severity breakdown: each relationship's deep-check count, sorted worst-first, flagging relationships not benefiting from sweep-and-prune partitioning ("NOT PARTITIONED", mirroring FRB1's `Debugger.GetCollisionInformation()`).
- `GenerateReport()` only builds a string — no I/O in the engine; caller decides where/when to log it.

## Design notes / deviations
- `ICollisionRelationship` (internal) grew `IsPartitioned` and `DisplayName` so the report can be built generically without depending on `A`/`B` type params.
- `Record(FrameProfile, IReadOnlyList<ICollisionRelationship>)` takes the current screen's relationships as a data push each frame (same pattern as `RenderDiagnostics.RecordBreak`), rather than `PerformanceMonitor` holding a back-reference to `FlatRedBallService`/`CurrentScreen`.
- `Screen` grew an `internal CollisionSystem` accessor and `CollisionSystem` grew an `internal Relationships` list, both needed to reach relationships from the commit point in `FlatRedBallService.Draw`.

## Test plan
- New `tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs`: no-op when disabled, ring-buffer rollover, FPS/min/avg/max from known synthetic values, collision report ordering + unpartitioned flag.
- `dotnet build src/FlatRedBall2.csproj` — clean, zero new warnings.
- `dotnet test tests/FlatRedBall2.Tests/` — 1613/1613 passing.
- Manual test: not needed — pure engine-internals, fully covered by headless unit tests + compilation; no rendering/window involved.

Closes #977