### PR TITLE
Add fill/outline toggle for selected frame rectangles

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1340,6 +1340,20 @@
                         <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
                                 Margin="4,0" VerticalAlignment="Center" />
 
+                        <ToggleButton x:Name="FillFramesCheck"
+                                      Classes="toolbarToggle"
+                                      Foreground="{DynamicResource Ink}"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,4,0"
+                                      IsChecked="True"
+                                      ToolTip.Tip="Fill selected/unselected frame rectangles (uncheck for outline only)">
+                            <TextBlock Text="Fill" VerticalAlignment="Center" />
+                        </ToggleButton>
+
+                        <!-- Divider -->
+                        <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
+                                Margin="4,0" VerticalAlignment="Center" />
+
                         <TextBlock Text="Zoom:" VerticalAlignment="Center" Margin="0,0,4,0"
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
                         <views:ZoomControl x:Name="WireframeZoom"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1340,20 +1340,6 @@
                         <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
                                 Margin="4,0" VerticalAlignment="Center" />
 
-                        <ToggleButton x:Name="FillFramesCheck"
-                                      Classes="toolbarToggle"
-                                      Foreground="{DynamicResource Ink}"
-                                      VerticalAlignment="Center"
-                                      Margin="0,0,4,0"
-                                      IsChecked="True"
-                                      ToolTip.Tip="Fill selected/unselected frame rectangles (uncheck for outline only)">
-                            <TextBlock Text="Fill" VerticalAlignment="Center" />
-                        </ToggleButton>
-
-                        <!-- Divider -->
-                        <Border Width="1" Height="18" Background="{DynamicResource LineBrush}"
-                                Margin="4,0" VerticalAlignment="Center" />
-
                         <TextBlock Text="Zoom:" VerticalAlignment="Center" Margin="0,0,4,0"
                                    Foreground="{DynamicResource InkMid}" FontSize="11" />
                         <views:ZoomControl x:Name="WireframeZoom"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1180,8 +1180,6 @@ public partial class MainWindow : Window
         SnapToGridCheck.IsCheckedChanged += OnSnapToGridChanged;
         GridSizeInput.Value = 16m;
         GridSizeInput.ValueChanged += (_, _) => ApplyGridSize();
-        FillFramesCheck.IsCheckedChanged += (_, _) =>
-            WireframeCtrl.FillFrames = FillFramesCheck.IsChecked == true;
         WireframeZoom.Attach(WireframeCtrl);
 
         // Default to Move mode
@@ -2638,6 +2636,7 @@ public partial class MainWindow : Window
                 ThemeDefaultBackgroundArgb = ToArgb(themedPalette.Background),
                 GuideLineArgb = _appSettings.GuideLineArgb,
                 ThemeDefaultGuideLineArgb = ToArgb(themedPalette.GuideLine),
+                FillFrameRectangles = _appSettings.FillFrameRectangles,
             },
             new Settings.SettingsWindowCallbacks
             {
@@ -2652,6 +2651,7 @@ public partial class MainWindow : Window
                 OnPickCustomCanvasBackground = PickCustomCanvasBackgroundAsync,
                 OnGuideLineChanged = SetGuideLineColor,
                 OnPickCustomGuideLine = PickCustomGuideLineColorAsync,
+                OnFillFrameRectanglesChanged = SetFillFrameRectangles,
             });
         _ = dialog.ShowDialog(this);
     }
@@ -5409,8 +5409,8 @@ public partial class MainWindow : Window
         MenuThemeSystem.IsChecked = _appSettings.Theme == AppTheme.System;
     }
 
-    // ── Canvas colors (background + guide line) ────────────────────────────────
-    // Both live in the Settings → Canvas Colors section; see SettingsWindowBuilder.
+    // ── Canvas colors (background + guide line + frame fill) ───────────────────
+    // All three live in the Settings → Colors section; see SettingsWindowBuilder.
 
     /// <summary>Pushes the persisted canvas-color overrides onto the canvases affected by each.</summary>
     private void ApplyPersistedCanvasColors()
@@ -5418,6 +5418,7 @@ public partial class MainWindow : Window
         WireframeCtrl.CanvasBackgroundOverride = _appSettings.CanvasBackgroundArgb;
         PreviewCtrl.CanvasBackgroundOverride   = _appSettings.CanvasBackgroundArgb;
         PreviewCtrl.GuideLineOverride          = _appSettings.GuideLineArgb;
+        WireframeCtrl.FillFrames               = _appSettings.FillFrameRectangles;
     }
 
     private void SetCanvasBackground(uint? argb)
@@ -5432,6 +5433,13 @@ public partial class MainWindow : Window
     {
         _appSettings.GuideLineArgb = argb;
         PreviewCtrl.GuideLineOverride = argb;
+        SaveSettingsFile();
+    }
+
+    private void SetFillFrameRectangles(bool value)
+    {
+        _appSettings.FillFrameRectangles = value;
+        WireframeCtrl.FillFrames = value;
         SaveSettingsFile();
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1180,6 +1180,8 @@ public partial class MainWindow : Window
         SnapToGridCheck.IsCheckedChanged += OnSnapToGridChanged;
         GridSizeInput.Value = 16m;
         GridSizeInput.ValueChanged += (_, _) => ApplyGridSize();
+        FillFramesCheck.IsCheckedChanged += (_, _) =>
+            WireframeCtrl.FillFrames = FillFramesCheck.IsChecked == true;
         WireframeZoom.Attach(WireframeCtrl);
 
         // Default to Move mode

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
@@ -138,7 +138,7 @@ public static class SettingsWindowBuilder
     {
         var fillCheck = new CheckBox
         {
-            Content = "Fill selected/unselected frame rectangles",
+            Content = "Fill Selection",
             IsChecked = model.FillFrameRectangles,
         };
         fillCheck.IsCheckedChanged += (_, _) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Settings/SettingsWindowBuilder.cs
@@ -29,6 +29,9 @@ public sealed class SettingsWindowModel
 
     /// <summary>The active theme's default guide-line color (packed <c>0xAARRGGBB</c>), shown when no override is set.</summary>
     public uint ThemeDefaultGuideLineArgb { get; init; }
+
+    /// <summary>Whether wireframe frame rectangles are drawn with a fill in addition to the stroke outline (#976).</summary>
+    public bool FillFrameRectangles { get; init; }
 }
 
 /// <summary>Callbacks from the settings dialog back to <see cref="MainWindow"/>.</summary>
@@ -49,6 +52,9 @@ public sealed class SettingsWindowCallbacks
 
     /// <summary>Opens a custom-color picker seeded with the current guide-line color; returns the chosen packed ARGB, or <c>null</c> if cancelled.</summary>
     public Func<Task<uint?>>? OnPickCustomGuideLine { get; init; }
+
+    /// <summary>Invoked with the new value when the "Fill frame rectangles" checkbox changes.</summary>
+    public Action<bool>? OnFillFrameRectanglesChanged { get; init; }
 }
 
 /// <summary>Builds the editor settings window. New sections belong here as the dialog grows.</summary>
@@ -130,6 +136,17 @@ public static class SettingsWindowBuilder
 
     private static Control BuildCanvasColorsSection(SettingsWindowModel model, SettingsWindowCallbacks callbacks)
     {
+        var fillCheck = new CheckBox
+        {
+            Content = "Fill selected/unselected frame rectangles",
+            IsChecked = model.FillFrameRectangles,
+        };
+        fillCheck.IsCheckedChanged += (_, _) =>
+        {
+            if (fillCheck.IsChecked is bool value)
+                callbacks.OnFillFrameRectanglesChanged?.Invoke(value);
+        };
+
         return new StackPanel
         {
             Spacing = 14,
@@ -149,6 +166,7 @@ public static class SettingsWindowBuilder
                     Array.Empty<(string, uint)>(),
                     callbacks.OnGuideLineChanged,
                     callbacks.OnPickCustomGuideLine),
+                fillCheck,
             },
         };
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -41,6 +41,13 @@ namespace AnimationEditor.Core.Models
         public uint? GuideLineArgb { get; set; }
 
         /// <summary>
+        /// When <c>true</c> (default), frame region rectangles in the wireframe panel are drawn
+        /// with a semi-transparent fill in addition to the stroke outline (#976). <c>false</c>
+        /// draws the outline only — a per-user viewing preference, alongside the canvas colors.
+        /// </summary>
+        public bool FillFrameRectangles { get; set; } = true;
+
+        /// <summary>
         /// When <c>true</c>, the editor never offers to register itself as the default
         /// application for <c>.achx</c> files. Set when the user clicks "Don't show again"
         /// on the file-association prompt. Defaults to <c>false</c> so the prompt can appear

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -52,6 +52,8 @@ public class WireframeControl : TextureViewport
     private sealed class WireframeSnapshot : TextureViewportSnapshot
     {
         public List<(SKRect Bounds, bool IsSelected)> Frames = new();
+        /// <summary>Mirrors <see cref="WireframeControl.FillFrames"/> (#976).</summary>
+        public bool FillFrames = true;
         public SKRect? SelectedHandleBounds;    // null → no handles drawn
         public bool ShowPreview;
         public SKRect PreviewRect;
@@ -115,8 +117,11 @@ public class WireframeControl : TextureViewport
             screenRects.Add((sr, isSelected));
         }
 
-        DrawFillLayer(canvas, screenRects, solidFill, isSelected: true, alpha: 45);
-        DrawFillLayer(canvas, screenRects, solidFill, isSelected: false, alpha: 18);
+        if (s.FillFrames)
+        {
+            DrawFillLayer(canvas, screenRects, solidFill, isSelected: true, alpha: 45);
+            DrawFillLayer(canvas, screenRects, solidFill, isSelected: false, alpha: 18);
+        }
 
         foreach (var (sr, isSelected) in screenRects)
         {
@@ -412,6 +417,18 @@ public class WireframeControl : TextureViewport
     /// a drop is simply ignored.
     /// </summary>
     public Func<AnimationChainSave?, AnimationFrameSave?, string, bool, Task<bool>>? HandlePngDrop { get; set; }
+
+    private bool _fillFrames = true;
+    /// <summary>
+    /// Toggles the semi-transparent fill drawn inside frame region rectangles (#976). When
+    /// <c>false</c>, only the stroke outline is drawn — useful when a fill obscures the
+    /// underlying texture (e.g. a mostly-transparent sprite sheet at low zoom).
+    /// </summary>
+    public bool FillFrames
+    {
+        get => _fillFrames;
+        set { _fillFrames = value; InvalidateVisual(); }
+    }
 
     // ── Injected services ─────────────────────────────────────────────────────
 
@@ -1143,6 +1160,7 @@ public class WireframeControl : TextureViewport
     {
         var snap = new WireframeSnapshot { DrawOverlay = DrawWireframeOverlay };
         PopulateBaseSnapshot(snap, width, height);
+        snap.FillFrames = _fillFrames;
         snap.ShowPreview = _showPreview;
         snap.PreviewRect = _previewRect;
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameFillToggleTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FrameFillToggleTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #976: a toolbar toggle controls whether frame region rectangles are drawn with a
+/// semi-transparent fill or as an outline only.
+/// </summary>
+public class FrameFillToggleTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        ctx.SelectedState.SelectedChain = null;
+        ctx.SelectedState.SelectedFrame = null;
+        ctx.SelectedState.SelectedNodes = new System.Collections.Generic.List<object>();
+        ctx.AppCommands.DoOnUiThread = a => a();
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+        ctx.AppState.OffsetMultiplier = 1f;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, SKColor color, int w = 64, int h = 64)
+    {
+        var path = Path.Combine(dir, $"{Guid.NewGuid():N}.png");
+        using var bm = new SKBitmap(w, h);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    /// <summary>
+    /// Loads a black texture, creates a single selected frame covering (16,16)-(48,48) on a
+    /// 64×64 sheet, and fixes the camera at pan=(0,0) zoom=1 so texture pixels map 1:1 to screen.
+    /// </summary>
+    private static (WireframeControl ctrl, string dir) BuildCtrlWithSelectedFrame(TestServices ctx)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var png = WriteSolidPng(dir, SKColors.Black);
+
+        var chain = new AnimationChainSave { Name = "C" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName      = Path.GetFileName(png),
+            LeftCoordinate   = 16f / 64f,
+            TopCoordinate    = 16f / 64f,
+            RightCoordinate  = 48f / 64f,
+            BottomCoordinate = 48f / 64f,
+        };
+        chain.Frames.Add(frame);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+        ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreateWireframeControl();
+        ctrl.LoadTexture(png);
+        ctrl.SetCamera(0, 0, 1);
+        return (ctrl, dir);
+    }
+
+    [AvaloniaFact]
+    public void FillFrames_DefaultsToTrue()
+    {
+        var ctx = ResetSingletons();
+        var ctrl = ctx.CreateWireframeControl();
+        Assert.True(ctrl.FillFrames);
+    }
+
+    /// <summary>
+    /// The interior of a selected frame's rectangle (away from the 1px stroke border) must
+    /// render as the plain black texture when FillFrames is off, but as a blue-tinted fill
+    /// when FillFrames is on.
+    /// </summary>
+    [AvaloniaFact]
+    public void FillFrames_False_InteriorMatchesRawTexture_NotBlueFill()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            ctrl.FillFrames = true;
+            using var bmFilled = ctrl.RenderToBitmap(64, 64);
+
+            ctrl.FillFrames = false;
+            using var bmOutline = ctrl.RenderToBitmap(64, 64);
+
+            // Sample inside the frame at (24,24) — off both the stroke border and the diagonal
+            // from frame-center (32,32), where the origin crosshair's horizontal/vertical arms
+            // would otherwise contaminate the sample.
+            var filledPixel   = bmFilled.GetPixel(24, 24);
+            var outlinePixel  = bmOutline.GetPixel(24, 24);
+
+            Assert.NotEqual(filledPixel, outlinePixel);
+            Assert.Equal(SKColors.Black, outlinePixel);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Disabling the fill must not remove the stroke outline — the frame's border pixels
+    /// should still differ from the surrounding unselected texture either way.
+    /// </summary>
+    [AvaloniaFact]
+    public void FillFrames_False_StrokeOutlineStillRenders()
+    {
+        var ctx = ResetSingletons();
+        var (ctrl, dir) = BuildCtrlWithSelectedFrame(ctx);
+        try
+        {
+            ctrl.FillFrames = false;
+            using var bm = ctrl.RenderToBitmap(64, 64);
+
+            // The stroke is drawn along the frame's edge (x=16..48, y=16..48); sample the top
+            // edge at (32,16), which should differ from the plain black background.
+            var edgePixel = bm.GetPixel(32, 16);
+            Assert.NotEqual(SKColors.Black, edgePixel);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SettingsWindowBuilderTests.cs
@@ -85,4 +85,33 @@ public class SettingsWindowBuilderTests
         // Swatch + "Theme Default" + "Custom…" only — no Black/White/Mid Gray presets.
         Assert.Equal(3, buttonsRow.Children.Count);
     }
+
+    [Fact]
+    public void BuildTabs_FillFrameRectanglesCheckBox_ReflectsModelValue()
+    {
+        var tabs = SettingsWindowBuilder.BuildTabs(
+            new SettingsWindowModel { FillFrameRectangles = false },
+            new SettingsWindowCallbacks());
+
+        var colorsSection = SectionOf((TabItem)tabs.Items[0]!);
+        var fillCheck = Assert.IsType<CheckBox>(colorsSection.Children[2]);
+
+        Assert.Equal(false, fillCheck.IsChecked);
+    }
+
+    [AvaloniaFact]
+    public void BuildTabs_FillFrameRectanglesCheckBox_ToggleInvokesCallback()
+    {
+        bool? received = null;
+        var tabs = SettingsWindowBuilder.BuildTabs(
+            new SettingsWindowModel { FillFrameRectangles = true },
+            new SettingsWindowCallbacks { OnFillFrameRectanglesChanged = v => received = v });
+
+        var colorsSection = SectionOf((TabItem)tabs.Items[0]!);
+        var fillCheck = (CheckBox)colorsSection.Children[2];
+
+        fillCheck.IsChecked = false;
+
+        Assert.Equal(false, received);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -169,6 +169,25 @@ public class AppSettingsModelTests
     }
 
     [Fact]
+    public void FillFrameRectangles_DefaultsToTrue()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.True(model.FillFrameRectangles);
+    }
+
+    [Fact]
+    public void FillFrameRectangles_SurvivesJsonRoundTrip()
+    {
+        var model = new AppSettingsModel { FillFrameRectangles = false };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.False(restored!.FillFrameRectangles);
+    }
+
+    [Fact]
     public void SuppressDefaultHandlerPrompt_DefaultsToFalse()
     {
         var model = new AppSettingsModel();


### PR DESCRIPTION
## Summary
- Adds a "Fill selected/unselected frame rectangles" checkbox to Settings → Colors (alongside canvas background / guide-line color), defaulting to checked (current behavior unchanged).
- Persisted in `AppSettingsModel.FillFrameRectangles` (JSON, per-user), so the choice survives restarts like the other canvas-color settings.
- Unchecking it draws only the stroke outline around frame rectangles — the semi-transparent fill is skipped for both selected and unselected tiers. Stroke always renders either way.

## Test plan
- `AppSettingsModelTests`: default-true, JSON round-trip.
- `SettingsWindowBuilderTests`: checkbox reflects model value, toggling invokes the callback.
- `FrameFillToggleTests` (AnimationEditor.App.Tests): fill-off leaves the frame interior matching the raw texture (no blue tint), stroke outline still renders with fill off.
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 877 passed.
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1918 passed.
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/` — 122 passed.

Closes #976
