### PR TITLE
Rename GitHub Actions workflows for clarity

### DIFF
--- a/.github/workflows/animation-editor.yml
+++ b/.github/workflows/animation-editor.yml
@@ -1,4 +1,4 @@
-name: Build and Release Animation Editor
+name: AnimationEditor
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-animation-editor-web.yml
+++ b/.github/workflows/deploy-animation-editor-web.yml
@@ -1,4 +1,4 @@
-name: Deploy Animation Editor (Web) to GitHub Pages
+name: AnimationEditor Web
 
 # #535 M4: publish the Avalonia.Browser build of the Animation Editor (tools/AnimationEditorAvalonia/
 # src/AnimationEditor.Browser) as a static site under this repo's GitHub Pages, at /FlatRedBall2/AnimationEditor/.

--- a/.github/workflows/deploy-sample.yml
+++ b/.github/workflows/deploy-sample.yml
@@ -1,4 +1,4 @@
-name: Deploy Sample to GitHub Pages
+name: Samples
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-animationchain-packages.yml
+++ b/.github/workflows/publish-animationchain-packages.yml
@@ -1,4 +1,4 @@
-name: Publish AnimationChain Packages
+name: AnimationChain Nugets
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish FlatRedBall2
+name: FlatRedBall2 Nugets
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: All Tests
 
 on:
   push:

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -18,7 +18,7 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- MainWindow is DI-only; runtime XAML instantiation is intentionally not supported -->
     <NoWarn>$(NoWarn);AVLN3001</NoWarn>
-    <!-- Release CI stamps -p:Version=yyyy.M.d (build-and-release-animation-editor.yml), which wins
+    <!-- Release CI stamps -p:Version=yyyy.M.d (animation-editor.yml), which wins
          here as an MSBuild global property. Local builds fall back to today's date in the same
          format so UpdateChecker's version comparison (Update/UpdateChecker.cs) runs for real
          instead of being skipped as an incomparable dev build. -->

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateChecker.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Update/UpdateChecker.cs
@@ -3,7 +3,7 @@ namespace AnimationEditor.Core.Update;
 /// <summary>
 /// Compares the running assembly version against the latest published GitHub release.
 /// Release CI stamps the assembly version as <c>yyyy.M.d</c> (see
-/// build-and-release-animation-editor.yml's <c>-p:Version</c>), so a plain <see cref="Version"/>
+/// animation-editor.yml's <c>-p:Version</c>), so a plain <see cref="Version"/>
 /// comparison against the release's publish date is the whole algorithm — no tag-name parsing
 /// needed. <c>AnimationEditor.App.csproj</c> falls back to today's date in the same format when
 /// <c>Version</c> isn't passed in, so local builds compare for real too. <see cref="MinReleaseYear"/>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UpdateCheckerTests.cs
@@ -6,7 +6,7 @@ namespace AnimationEditor.Core.Tests;
 /// <summary>
 /// Tests for <see cref="UpdateChecker"/> against a fake <see cref="IGitHubReleaseClient"/> —
 /// no real network traffic. Release CI stamps the assembly version as yyyy.M.d (see
-/// build-and-release-animation-editor.yml), so a plain <see cref="Version"/> comparison against
+/// animation-editor.yml), so a plain <see cref="Version"/> comparison against
 /// the release's publish date is the whole algorithm.
 /// </summary>
 public class UpdateCheckerTests


### PR DESCRIPTION
## Summary
- Build and Release Animation Editor -> AnimationEditor (file renamed to animation-editor.yml)
- Deploy Animation Editor (Web) to GitHub Pages -> AnimationEditor Web
- Deploy Sample to GitHub Pages -> Samples
- Publish AnimationChain Packages -> AnimationChain Nugets
- Publish FlatRedBall2 -> FlatRedBall2 Nugets
- Tests -> All Tests

Also deleted the 3 stale "Copilot cloud agent" runs (dynamic workflow left over from PR #348) so it no longer shows in Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2n4BtCxRe2ZQupJ715QqW