### PR TITLE
Add automatic Animation Editor updates

### DIFF
--- a/.github/workflows/animation-editor.yml
+++ b/.github/workflows/animation-editor.yml
@@ -27,7 +27,9 @@ jobs:
         id: meta
         shell: pwsh
         run: |
-          $version = (Get-Date).ToString('yyyy.MM.dd')
+          # Velopack package versions use SemVer, whose numeric components cannot have leading
+          # zeroes. The assembly version receives this same three-part date value.
+          $version = (Get-Date).ToString('yyyy.M.d')
           $kind = "${{ github.event.inputs.release_kind }}"
           switch ($kind) {
             'release'    { $prefix='Release';    $prerelease='false'; $draft='false' }
@@ -167,8 +169,60 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # The legacy archives above remain available for manual/portable use. This separate,
+  # per-user Windows installer is the only managed-install channel in the first rollout.
+  # macOS and Linux stay on their existing artifacts until their signing/distribution paths are
+  # ready for the same treatment.
+  windows-updater:
+    needs: [meta, test]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish Windows updater build
+        run: >
+          dotnet publish
+          tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+          -c Release
+          -r win-x64
+          --self-contained
+          -p:PublishSingleFile=false
+          -p:Version=${{ needs.meta.outputs.version }}
+          -o dist/velopack/publish
+
+      - name: Install Velopack CLI
+        shell: pwsh
+        run: dotnet tool install --tool-path dist/velopack/tools vpk --version 1.2.0
+
+      - name: Package per-user Windows installer and update feed
+        shell: pwsh
+        run: >
+          dist/velopack/tools/vpk.exe pack
+          --packId FlatRedBall2.AnimationEditor
+          --packVersion ${{ needs.meta.outputs.version }}
+          --packDir dist/velopack/publish
+          --mainExe AnimationEditor.exe
+          --packTitle "Animation Editor"
+          --packAuthors "FlatRedBall Contributors"
+          --icon tools/AnimationEditorAvalonia/src/AnimationEditor.App/Assets/icons/AppIcon.ico
+          --outputDir dist/velopack/release
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnimationEditor-velopack-win-x64
+          path: dist/velopack/release/*
+          if-no-files-found: error
+          retention-days: 7
+
   release:
-    needs: [meta, build]
+    needs: [meta, build, windows-updater]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -207,6 +261,10 @@ jobs:
             dist/AnimationEditor-linux-x64.tar.gz
             dist/AnimationEditor-osx-x64.zip
             dist/AnimationEditor-osx-arm64.zip
+            dist/FlatRedBall2.AnimationEditor-win-Setup.exe
+            dist/FlatRedBall2.AnimationEditor-win-Portable.zip
+            dist/FlatRedBall2.AnimationEditor-*-full.nupkg
+            dist/releases.win.json
 
       # Moves a floating tag so /releases/tag/animationeditor-latest always resolves to the
       # newest release/prerelease build. Skipped for 'test' (draft) runs so the public link
@@ -237,3 +295,7 @@ jobs:
             dist/AnimationEditor-linux-x64.tar.gz
             dist/AnimationEditor-osx-x64.zip
             dist/AnimationEditor-osx-arm64.zip
+            dist/FlatRedBall2.AnimationEditor-win-Setup.exe
+            dist/FlatRedBall2.AnimationEditor-win-Portable.zip
+            dist/FlatRedBall2.AnimationEditor-*-full.nupkg
+            dist/releases.win.json

--- a/tools/AnimationEditorAvalonia/Directory.Packages.props
+++ b/tools/AnimationEditorAvalonia/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Skia" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
@@ -32,6 +32,7 @@
     <PackageVersion Include="NJsonSchema" Version="11.*" />
     <PackageVersion Include="SkiaSharp" Version="3.119.3-preview.1.1" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.7" />
+    <PackageVersion Include="Velopack" Version="1.2.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -18,10 +18,10 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- MainWindow is DI-only; runtime XAML instantiation is intentionally not supported -->
     <NoWarn>$(NoWarn);AVLN3001</NoWarn>
-    <!-- Release CI stamps -p:Version=yyyy.M.d (animation-editor.yml), which wins
-         here as an MSBuild global property. Local builds fall back to today's date in the same
-         format so UpdateChecker's version comparison (Update/UpdateChecker.cs) runs for real
-         instead of being skipped as an incomparable dev build. -->
+    <!-- Release CI stamps -p:Version=yyyy.M.d (animation-editor.yml), which wins here as an
+         MSBuild global property. Local builds keep a zero-padded display date; both formats are
+         valid System.Version values, so UpdateChecker's comparison runs for real instead of
+         being skipped as an incomparable dev build. -->
     <Version Condition="'$(Version)' == ''">$([System.DateTime]::Now.ToString('yyyy.MM.dd'))</Version>
   </PropertyGroup>
 
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
     <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="Velopack" />
   </ItemGroup>
 
   <!--

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -197,6 +197,7 @@ public partial class App : Application
 
         sc.AddSingleton<IGitHubReleaseClient, HttpGitHubReleaseClient>();
         sc.AddSingleton<IUpdateChecker, UpdateChecker>();
+        sc.AddSingleton<IApplicationUpdater, VelopackApplicationUpdater>();
 
         sc.AddTransient<MainWindow>(sp => new MainWindow(
             sp.GetRequiredService<IProjectManager>(),
@@ -212,7 +213,8 @@ public partial class App : Application
             sp.GetRequiredService<ProjectTreeThumbnailService>(),
             sp.GetRequiredService<IFileAssociationService>(),
             sp.GetRequiredService<IUpdateChecker>(),
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)));
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            sp.GetRequiredService<IApplicationUpdater>()));
 
         return sc.BuildServiceProvider();
     }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -271,9 +271,8 @@
             </DockPanel>
         </Border>
 
-        <!-- ── Update-available banner (issue #681) ── same "actionable info" tier as
-             DefaultHandlerBanner above; stays until dismissed or the app is updated,
-             so it doesn't get missed the way an auto-dismissing toast would. ── -->
+        <!-- ── Automatic-update banner (issue #982) ── only shown while a managed install
+             downloads an update, waits for an explicit restart, or needs a safe retry. ── -->
         <Border x:Name="UpdateAvailableBanner"
                 DockPanel.Dock="Top"
                 IsVisible="False"
@@ -289,14 +288,16 @@
                                 Orientation="Horizontal"
                                 Spacing="8"
                                 VerticalAlignment="Center">
-                        <Button x:Name="DownloadUpdateBtn"
-                                Content="Get Update"
-                                Padding="10,3"
-                                FontSize="12" />
-                        <Button x:Name="DismissUpdateBannerBtn"
-                                Content="Dismiss"
+                        <Button x:Name="RestartForUpdateBtn"
+                                Content="Restart to Update"
                                 Padding="10,3"
                                 FontSize="12"
+                                IsVisible="False" />
+                        <Button x:Name="RetryUpdateBtn"
+                                Content="Retry"
+                                Padding="10,3"
+                                FontSize="12"
+                                IsVisible="False"
                                 Background="Transparent"
                                 Foreground="{DynamicResource InkMid}" />
                     </StackPanel>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -58,6 +58,7 @@ public partial class MainWindow : Window
     private readonly ProjectTreeThumbnailService _projectTreeThumbnailService;
     private readonly IFileAssociationService _fileAssociation;
     private readonly IUpdateChecker _updateChecker;
+    private readonly IApplicationUpdater _applicationUpdater;
     private readonly IEditorDialogHost _dialogHost;
     private readonly FolderWatcher _pngFolderWatcher = new(PngFolderScanner.IsPngPath);
 
@@ -192,7 +193,7 @@ public partial class MainWindow : Window
     private FilePath SettingsFilePath =>
         AppSettingsLocation.ForApplicationDataRoot(_applicationDataRoot);
 
-    public MainWindow(
+    internal MainWindow(
         IProjectManager projectManager,
         ISelectedState selectedState,
         IAppCommands appCommands,
@@ -206,7 +207,8 @@ public partial class MainWindow : Window
         ProjectTreeThumbnailService projectTreeThumbnailService,
         IFileAssociationService fileAssociation,
         IUpdateChecker updateChecker,
-        string applicationDataRoot)
+        string applicationDataRoot,
+        IApplicationUpdater? applicationUpdater = null)
     {
         _applicationDataRoot = applicationDataRoot;
 
@@ -223,6 +225,7 @@ public partial class MainWindow : Window
         _projectTreeThumbnailService = projectTreeThumbnailService;
         _fileAssociation = fileAssociation;
         _updateChecker = updateChecker;
+        _applicationUpdater = applicationUpdater ?? new NoOpApplicationUpdater();
         _dialogHost = new WindowEditorDialogHost(this);
         // Desktop renders the tree with its own _treeRoots collection, so the controller
         // reads expand state from there (browser reads its AnimationTreeControl instead).
@@ -979,7 +982,7 @@ public partial class MainWindow : Window
         // offer a "Make default" button that does nothing useful. The manual "Set as
         // default" / "Don't show again" controls in Settings still work for anyone who
         // wants to try it.
-        _ = RunStartupUpdateCheckAsync();
+        _ = RunStartupUpdateDownloadAsync();
     }
 
     /// <summary>
@@ -1050,30 +1053,45 @@ public partial class MainWindow : Window
         }
     }
 
-    // ── Update-available banner (issue #681) ──────────────────────────────────
+    // ── Automatic-update banner (issue #982) ──────────────────────────────────
 
-    // Session-only (not persisted): dismissing just quiets the current run. The check
-    // re-runs (and can re-show the banner) on the next launch until the user actually updates.
-    private bool _updateBannerDismissed;
+    private bool _isDownloadingUpdate;
 
     private void WireUpdateAvailableBanner()
     {
-        DownloadUpdateBtn.Click += (_, _) => OpenUrl((string)DownloadUpdateBtn.Tag!);
-
-        DismissUpdateBannerBtn.Click += (_, _) =>
+        RestartForUpdateBtn.Click += (_, _) =>
         {
-            _updateBannerDismissed = true;
-            UpdateAvailableBanner.IsVisible = false;
+            try
+            {
+                SaveTabsToSettings();
+                _applicationUpdater.ApplyUpdateAndRestart();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Animation Editor update restart failed: {ex}");
+                ShowUpdateDownloadFailure("The update is ready, but restarting to install it failed. Please try again.");
+            }
         };
+
+        RetryUpdateBtn.Click += (_, _) => _ = RunStartupUpdateDownloadAsync();
     }
 
-    private void ShowUpdateAvailableBannerIfAppropriate(UpdateCheckResult result)
+    private void ShowUpdateDownloadFailure(string message)
     {
-        if (!result.IsUpdateAvailable || _updateBannerDismissed)
+        UpdateAvailableBannerText.Text = message;
+        RestartForUpdateBtn.IsVisible = false;
+        RetryUpdateBtn.IsVisible = true;
+        UpdateAvailableBanner.IsVisible = true;
+    }
+
+    private void ShowUpdateDownloadProgress(int percent)
+    {
+        if (!_isDownloadingUpdate)
             return;
 
-        UpdateAvailableBannerText.Text = $"Animation Editor v{result.LatestVersion} is available — you're on v{typeof(MainWindow).Assembly.GetName().Version}.";
-        DownloadUpdateBtn.Tag = result.ReleaseUrl ?? ReleasesUrl;
+        UpdateAvailableBannerText.Text = $"Downloading Animation Editor update ({percent}%)…";
+        RestartForUpdateBtn.IsVisible = false;
+        RetryUpdateBtn.IsVisible = false;
         UpdateAvailableBanner.IsVisible = true;
     }
 
@@ -2587,16 +2605,38 @@ public partial class MainWindow : Window
         await BuildAboutWindow(result).ShowDialog(this);
     }
 
-    /// <summary>
-    /// Silent startup check (issue #681) — respects <see cref="UpdateCheckPolicy"/>'s cache
-    /// window so re-launching the same day doesn't re-hit the GitHub API. Shows the persistent
-    /// <see cref="UpdateAvailableBanner"/> only when an update is actually available; never
-    /// blocks or errors visibly on failure.
-    /// </summary>
-    private async Task RunStartupUpdateCheckAsync()
+    private async Task RunStartupUpdateDownloadAsync()
     {
-        var result = await GetUpdateCheckResultAsync(forceRefresh: false);
-        ShowUpdateAvailableBannerIfAppropriate(result);
+        if (_isDownloadingUpdate)
+            return;
+
+        _isDownloadingUpdate = true;
+        ApplicationUpdateResult result;
+        try
+        {
+            result = await _applicationUpdater.DownloadUpdateAsync(percent =>
+                Dispatcher.UIThread.Post(() => ShowUpdateDownloadProgress(percent)));
+        }
+        finally
+        {
+            _isDownloadingUpdate = false;
+        }
+
+        switch (result.Status)
+        {
+            case ApplicationUpdateStatus.NoUpdate:
+                UpdateAvailableBanner.IsVisible = false;
+                break;
+            case ApplicationUpdateStatus.ReadyToRestart:
+                UpdateAvailableBannerText.Text = $"Animation Editor v{result.Version} is ready. Restart to install it.";
+                RestartForUpdateBtn.IsVisible = true;
+                RetryUpdateBtn.IsVisible = false;
+                UpdateAvailableBanner.IsVisible = true;
+                break;
+            case ApplicationUpdateStatus.Failed:
+                ShowUpdateDownloadFailure(result.FailureMessage!);
+                break;
+        }
     }
 
     /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
@@ -2,6 +2,7 @@
 using Avalonia;
 using System;
 using System.IO;
+using Velopack;
 
 namespace AnimationEditor.App;
 
@@ -13,6 +14,11 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Managed installs must initialize Velopack before any app code so an already-applied
+        // update can complete its bootstrap work. Local builds and legacy archive downloads
+        // pass through without changing their launch behavior.
+        VelopackApp.Build().SetAutoApplyOnStartup(false).Run();
+
         // Install crash logging first so even a failure during startup gets recorded.
         CrashLogging.Install(AppContext.BaseDirectory,
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/VelopackApplicationUpdater.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/VelopackApplicationUpdater.cs
@@ -37,18 +37,53 @@ internal enum ApplicationUpdateStatus
     Failed,
 }
 
+internal static class ApplicationUpdateSource
+{
+    internal const string Production = "https://github.com/vchelaru/FlatRedBall2";
+
+    private const string TestUpdateSourceEnvironmentVariable = "ANIMATION_EDITOR_TEST_UPDATE_SOURCE";
+
+    internal static string ForCurrentBuild()
+    {
+        // A local feed can validate the installed-app path without publishing a release. This is
+        // deliberately compiled out of Release builds so a shipped app has one trusted source.
+#if DEBUG
+        return Resolve(Environment.GetEnvironmentVariable(TestUpdateSourceEnvironmentVariable), isTestBuild: true);
+#else
+        return Resolve(testSource: null, isTestBuild: false);
+#endif
+    }
+
+    internal static string Resolve(string? testSource, bool isTestBuild)
+    {
+        if (isTestBuild && !string.IsNullOrWhiteSpace(testSource))
+            return testSource;
+
+        return Production;
+    }
+}
+
 internal sealed class VelopackApplicationUpdater : IApplicationUpdater
 {
-    private const string RepositoryUrl = "https://github.com/vchelaru/FlatRedBall2";
-
+    private readonly string _updateSource;
     private UpdateManager? _updateManager;
     private UpdateInfo? _downloadedUpdate;
+
+    public VelopackApplicationUpdater()
+        : this(ApplicationUpdateSource.ForCurrentBuild())
+    {
+    }
+
+    internal VelopackApplicationUpdater(string updateSource)
+    {
+        _updateSource = updateSource;
+    }
 
     public async Task<ApplicationUpdateResult> DownloadUpdateAsync(
         Action<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        var updateManager = new UpdateManager(new GithubSource(RepositoryUrl, accessToken: null, prerelease: false));
+        var updateManager = CreateUpdateManager();
 
         // Local development builds and the legacy archive distribution are not managed installs.
         // Their normal behavior is unchanged: they never attempt to overwrite themselves.
@@ -73,6 +108,14 @@ internal sealed class VelopackApplicationUpdater : IApplicationUpdater
             Debug.WriteLine($"Animation Editor update download failed: {ex}");
             return ApplicationUpdateResult.Failed("The update could not be downloaded. Please try again.");
         }
+    }
+
+    private UpdateManager CreateUpdateManager()
+    {
+        if (_updateSource.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
+            return new UpdateManager(new GithubSource(_updateSource, accessToken: null, prerelease: false));
+
+        return new UpdateManager(_updateSource);
     }
 
     public void ApplyUpdateAndRestart()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/VelopackApplicationUpdater.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/VelopackApplicationUpdater.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Velopack;
+using Velopack.Sources;
+
+namespace AnimationEditor.App.Services;
+
+internal interface IApplicationUpdater
+{
+    Task<ApplicationUpdateResult> DownloadUpdateAsync(
+        Action<int>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    void ApplyUpdateAndRestart();
+}
+
+internal sealed record ApplicationUpdateResult(
+    ApplicationUpdateStatus Status,
+    string? Version = null,
+    string? FailureMessage = null)
+{
+    public static readonly ApplicationUpdateResult NoUpdate = new(ApplicationUpdateStatus.NoUpdate);
+
+    public static ApplicationUpdateResult Failed(string message) =>
+        new(ApplicationUpdateStatus.Failed, FailureMessage: message);
+
+    public static ApplicationUpdateResult ReadyToRestart(Version version) =>
+        new(ApplicationUpdateStatus.ReadyToRestart, version.ToString());
+}
+
+internal enum ApplicationUpdateStatus
+{
+    NoUpdate,
+    ReadyToRestart,
+    Failed,
+}
+
+internal sealed class VelopackApplicationUpdater : IApplicationUpdater
+{
+    private const string RepositoryUrl = "https://github.com/vchelaru/FlatRedBall2";
+
+    private UpdateManager? _updateManager;
+    private UpdateInfo? _downloadedUpdate;
+
+    public async Task<ApplicationUpdateResult> DownloadUpdateAsync(
+        Action<int>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var updateManager = new UpdateManager(new GithubSource(RepositoryUrl, accessToken: null, prerelease: false));
+
+        // Local development builds and the legacy archive distribution are not managed installs.
+        // Their normal behavior is unchanged: they never attempt to overwrite themselves.
+        if (updateManager.CurrentVersion is null)
+            return ApplicationUpdateResult.NoUpdate;
+
+        try
+        {
+            var update = await updateManager.CheckForUpdatesAsync().ConfigureAwait(false);
+            if (update is null)
+                return ApplicationUpdateResult.NoUpdate;
+
+            await updateManager.DownloadUpdatesAsync(update, progress, cancellationToken).ConfigureAwait(false);
+            _updateManager = updateManager;
+            _downloadedUpdate = update;
+            return new ApplicationUpdateResult(
+                ApplicationUpdateStatus.ReadyToRestart,
+                update.TargetFullRelease.Version.ToString());
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Animation Editor update download failed: {ex}");
+            return ApplicationUpdateResult.Failed("The update could not be downloaded. Please try again.");
+        }
+    }
+
+    public void ApplyUpdateAndRestart()
+    {
+        if (_updateManager is null || _downloadedUpdate is null)
+            return;
+
+        _updateManager.ApplyUpdatesAndRestart(_downloadedUpdate);
+    }
+}
+
+internal sealed class NoOpApplicationUpdater : IApplicationUpdater
+{
+    public Task<ApplicationUpdateResult> DownloadUpdateAsync(
+        Action<int>? progress = null,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(ApplicationUpdateResult.NoUpdate);
+
+    public void ApplyUpdateAndRestart()
+    {
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/TestHelpers.cs
@@ -8,12 +8,31 @@ using AnimationEditor.Core.Update;
 
 namespace AnimationEditor.App.Tests;
 
-/// <summary>
-/// No-op <see cref="IUpdateChecker"/> for tests that don't care about the update check — never
-/// hits the network. Tests exercising the update-check wiring itself set
-/// <see cref="TestServices.UpdateChecker"/> to a fake with a canned <see cref="UpdateCheckResult"/>
-/// before calling <see cref="TestServices.CreateMainWindow"/>.
-/// </summary>
+internal sealed class FakeApplicationUpdater : IApplicationUpdater
+{
+    public ApplicationUpdateResult Result { get; set; } = ApplicationUpdateResult.NoUpdate;
+    public int DownloadCount { get; private set; }
+    public int RestartCount { get; private set; }
+    public int? ProgressToReport { get; set; }
+    public TaskCompletionSource<ApplicationUpdateResult>? PendingResult { get; set; }
+
+    public Task<ApplicationUpdateResult> DownloadUpdateAsync(
+        Action<int>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        DownloadCount++;
+        if (ProgressToReport is not null)
+            progress?.Invoke(ProgressToReport.Value);
+
+        if (PendingResult is not null)
+            return PendingResult.Task;
+
+        return Task.FromResult(Result);
+    }
+
+    public void ApplyUpdateAndRestart() => RestartCount++;
+}
+
 internal sealed class FakeUpdateChecker : IUpdateChecker
 {
     public UpdateCheckResult Result { get; set; } = UpdateCheckResult.NoUpdate;
@@ -48,6 +67,7 @@ internal sealed class TestServices
     public ProjectTreeThumbnailService ProjectTreeThumbnailService { get; } = new(diskCacheDirectory: null);
     public IFileAssociationService FileAssociationService { get; set; } = new NullFileAssociationService();
     public IUpdateChecker UpdateChecker { get; set; } = new FakeUpdateChecker();
+    public IApplicationUpdater ApplicationUpdater { get; set; } = new FakeApplicationUpdater();
 
     /// <summary>
     /// Unique-per-instance temp application-data root. Injected into the <see cref="MainWindow"/>
@@ -81,7 +101,7 @@ internal sealed class TestServices
         new MainWindow(
             ProjectManager, SelectedState, AppCommands, AppState,
             ApplicationEvents, IoManager, ObjectFinder, UndoManager, PendingCutState,
-            ThumbnailService, ProjectTreeThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot);
+            ThumbnailService, ProjectTreeThumbnailService, FileAssociationService, UpdateChecker, SettingsRoot, ApplicationUpdater);
 
     public WireframeControl CreateWireframeControl(System.Action<string>? showError = null)
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateCheckStartupTests.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Reflection;
-using System.Threading.Tasks;
-using AnimationEditor.Core.Models;
-using AnimationEditor.Core.Update;
+using AnimationEditor.App.Services;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -11,130 +8,65 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Tests for the update-check wiring (issue #681): the silent startup check drives the
-/// persistent <c>UpdateAvailableBanner</c> (a toast was tried first but auto-dismisses too
-/// fast for something worth acting on), and <c>GetUpdateCheckResultAsync</c> (reached via
-/// reflection — there's no non-modal public trigger; the About dialog's forced recheck goes
-/// through <c>Window.ShowDialog</c>, which deadlocks headless per the AvaloniaFact landmine)
-/// respects the 24h cache window and persists results to <c>AppSettingsModel</c>.
+/// Tests for the automatic update flow (issue #982). Desktop startup performs the download in
+/// the background, then exposes either a retry-safe failure state or an explicit restart action.
 /// </summary>
 public class UpdateCheckStartupTests
 {
-    private static Task<UpdateCheckResult> InvokeGetUpdateCheckResultAsync(MainWindow window, bool forceRefresh)
-    {
-        var method = typeof(MainWindow).GetMethod("GetUpdateCheckResultAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        return (Task<UpdateCheckResult>)method.Invoke(window, new object[] { forceRefresh })!;
-    }
-
-    private static AppSettingsModel GetAppSettings(MainWindow window) =>
-        (AppSettingsModel)typeof(MainWindow)
-            .GetField("_appSettings", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .GetValue(window)!;
-
     [AvaloniaFact]
-    public void Startup_UpdateAvailable_ShowsBanner()
+    public void RestartUpdateButton_Clicked_AppliesDownloadedUpdate()
     {
         var ctx = TestHelpers.BuildServices();
-        var fake = new FakeUpdateChecker
+        var fake = new FakeApplicationUpdater
         {
-            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
+            Result = ApplicationUpdateResult.ReadyToRestart(new Version(2026, 7, 17))
         };
-        ctx.UpdateChecker = fake;
+        ctx.ApplicationUpdater = fake;
+        var window = ctx.CreateMainWindow();
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var restartButton = window.FindControl<Button>("RestartForUpdateBtn");
+        restartButton!.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+
+        Assert.Equal(1, fake.RestartCount);
+    }
+
+    [AvaloniaFact]
+    public void Startup_UpdateDownloadFails_ShowsRetryAction()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ApplicationUpdater = new FakeApplicationUpdater
+        {
+            Result = ApplicationUpdateResult.Failed("The update could not be downloaded.")
+        };
         var window = ctx.CreateMainWindow();
 
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
         var banner = window.FindControl<Border>("UpdateAvailableBanner");
+        var retryButton = window.FindControl<Button>("RetryUpdateBtn");
         Assert.True(banner!.IsVisible);
+        Assert.True(retryButton!.IsVisible);
     }
 
     [AvaloniaFact]
-    public void Startup_NoUpdate_BannerStaysHidden()
+    public void Startup_UpdateDownloadInProgress_ShowsDownloadProgress()
     {
         var ctx = TestHelpers.BuildServices();
-        ctx.UpdateChecker = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
-        var window = ctx.CreateMainWindow();
-
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-
-        var banner = window.FindControl<Border>("UpdateAvailableBanner");
-        Assert.False(banner!.IsVisible);
-    }
-
-    [AvaloniaFact]
-    public void DismissUpdateBanner_HidesIt()
-    {
-        var ctx = TestHelpers.BuildServices();
-        ctx.UpdateChecker = new FakeUpdateChecker
+        ctx.ApplicationUpdater = new FakeApplicationUpdater
         {
-            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
+            ProgressToReport = 42,
+            PendingResult = new TaskCompletionSource<ApplicationUpdateResult>()
         };
         var window = ctx.CreateMainWindow();
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        var banner = window.FindControl<Border>("UpdateAvailableBanner");
-        Assert.True(banner!.IsVisible);
 
-        var dismissBtn = window.FindControl<Button>("DismissUpdateBannerBtn");
-        dismissBtn!.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
-
-        Assert.False(banner.IsVisible);
-    }
-
-    [AvaloniaFact]
-    public async Task GetUpdateCheckResultAsync_WithinCacheWindow_DoesNotRecheck()
-    {
-        var ctx = TestHelpers.BuildServices();
-        var fake = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
-        ctx.UpdateChecker = fake;
-        var window = ctx.CreateMainWindow();
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        var baseline = fake.CallCount; // OnOpened already ran the silent startup check once.
-
-        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: false);
-        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: false);
-
-        Assert.Equal(baseline, fake.CallCount);
-    }
-
-    [AvaloniaFact]
-    public async Task GetUpdateCheckResultAsync_ForceRefresh_AlwaysRechecks()
-    {
-        var ctx = TestHelpers.BuildServices();
-        var fake = new FakeUpdateChecker { Result = UpdateCheckResult.NoUpdate };
-        ctx.UpdateChecker = fake;
-        var window = ctx.CreateMainWindow();
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        var baseline = fake.CallCount;
-
-        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
-        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
-
-        Assert.Equal(baseline + 2, fake.CallCount);
-    }
-
-    [AvaloniaFact]
-    public async Task GetUpdateCheckResultAsync_PersistsResultToAppSettings()
-    {
-        var ctx = TestHelpers.BuildServices();
-        var fake = new FakeUpdateChecker
-        {
-            Result = new UpdateCheckResult(true, new Version(2026, 7, 17), "https://example.com/latest")
-        };
-        ctx.UpdateChecker = fake;
-        var window = ctx.CreateMainWindow();
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
-        await InvokeGetUpdateCheckResultAsync(window, forceRefresh: true);
-
-        var settings = GetAppSettings(window);
-        Assert.NotNull(settings.LastUpdateCheckUtc);
-        Assert.Equal("2026.7.17", settings.LatestKnownUpdateVersion);
-        Assert.Equal("https://example.com/latest", settings.LatestKnownUpdateUrl);
+        var progressText = window.FindControl<TextBlock>("UpdateAvailableBannerText");
+        Assert.Equal("Downloading Animation Editor update (42%)…", progressText!.Text);
     }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateSourceConfigurationTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/UpdateSourceConfigurationTests.cs
@@ -1,0 +1,47 @@
+using AnimationEditor.App.Services;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+public class UpdateSourceConfigurationTests
+{
+    [Fact]
+    public void ForCurrentBuild_NoTestSource_ReturnsProductionSource()
+    {
+        // Arrange
+        const string productionSource = "https://github.com/vchelaru/FlatRedBall2";
+
+        // Act
+        var result = ApplicationUpdateSource.ForCurrentBuild();
+
+        // Assert
+        Assert.Equal(productionSource, result);
+    }
+
+    [Fact]
+    public void Resolve_TestSourceNotAllowed_ReturnsProductionSource()
+    {
+        // Arrange
+        const string testSource = @"C:\\AnimationEditorTestFeed";
+        const string productionSource = "https://github.com/vchelaru/FlatRedBall2";
+
+        // Act
+        var result = ApplicationUpdateSource.Resolve(testSource, isTestBuild: false);
+
+        // Assert
+        Assert.Equal(productionSource, result);
+    }
+
+    [Fact]
+    public void Resolve_TestSourceProvided_ReturnsTestSource()
+    {
+        // Arrange
+        const string testSource = @"C:\\AnimationEditorTestFeed";
+
+        // Act
+        var result = ApplicationUpdateSource.Resolve(testSource, isTestBuild: true);
+
+        // Assert
+        Assert.Equal(testSource, result);
+    }
+}


### PR DESCRIPTION
Closes #982

## Summary

- Download and verify Windows updates automatically through the MIT-licensed Velopack framework, then require an explicit restart to install them.
- Show download progress, a safe retry action for failures, and an explicit restart button when an update is ready.
- Keep the legacy Windows ZIP and macOS/Linux archive artifacts; add a per-user Windows setup executable, portable fallback ZIP, package, and update feed to each release.
- Leave non-installed/dev/archive launches unchanged. macOS and Linux remain on their existing distribution paths in this first rollout.

## Verification

- `dotnet test tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx -c Release` (2,920 tests before this small test-only seam; the affected configuration tests pass in both Debug and Release).
- A local Windows `vpk` feed was built with an installable v2026.8.24 package plus v2026.8.25 full and delta packages.
- The test-only `ANIMATION_EDITOR_TEST_UPDATE_SOURCE` override is compiled only into Debug; a Release build ignores it even when it is set.

Manual test: needed before the first public updater-enabled release. A disposable local v1 → v2 installer/feed harness is prepared under ignored `diagnostics/manual-test/AnimationEditorUpdateVerification`; it must be run by a human because installing and clicking restart are user-visible system actions.
