### PR TITLE
Tiled: support all object shapes as CreateEntities spawn markers

### DIFF
--- a/frb-skills/levels/SKILL.md
+++ b/frb-skills/levels/SKILL.md
@@ -89,7 +89,7 @@ For a collision boundary that doesn't match the tile grid (an irregular wall, a 
 
 `CreateEntities` scans both **object layers** (for precisely-placed tile objects) and **regular tile layers** (for tiles painted with Tiled's brush). Any tile whose Class matches the requested name becomes one entity — use whichever authoring path fits the designer's workflow. Painted tile layers support class-level (tileset type) custom properties but not instance-level overrides — Tiled has no per-cell property mechanism for painted tiles.
 
-The Class-name convention disambiguates intent via *which method you call*: `GenerateCollisionFromClass("SolidCollision")` turns matching tiles into static `TileShapes` geometry; `CreateEntities("Coin", factory)` turns matching tiles into factory-spawned entities. The two methods never fight over the same tile — pick one per Class.
+The Class-name convention disambiguates intent via *which method you call*: `GenerateCollisionFromClass("SolidCollision")` turns matching tiles into static `TileShapes` geometry; `CreateEntities("Coin", factory)` turns matching tiles into factory-spawned entities. Pick one method per Class. If a Class must feed both, call `CreateEntities` **first**: it consumes what it matches (clears the tile, removes the object), while `GenerateCollisionFromClass` consumes nothing — so collision-first builds the shape before the removal and you get a shape *and* an entity.
 
 Place tile objects on Tiled object layers (using tiles with a Class set in the tileset). Game code spawns entities from them with `CreateEntities`:
 

--- a/frb-skills/tmx/SKILL.md
+++ b/frb-skills/tmx/SKILL.md
@@ -51,8 +51,8 @@ This covers `.tmx`, `.tsx`, and `.png` files in the `Content/Tiled/` directory.
 Read `.claude/templates/Tiled/StandardTileset.tsx` for the full list of tile IDs and their Classes. The tileset's `firstgid` is 1, so **GID in CSV = tile id + 1**. GID 0 means empty (no tile). GID 1 is `SolidCollision` — used in virtually every game as the primary wall/floor/ceiling tile.
 
 Tiles fall into two categories:
-- **Collision tiles** (e.g., `SolidCollision`, `JumpThroughCollision`) — place on tile layers, consumed by `GenerateCollisionFromClass`. Hand-drawn rectangle/polygon `<object>`s on an object layer with a matching Class are consumed too (see "Collision from an object layer" below) — useful for a boundary shape that doesn't align to the stamp grid.
-- **Entity marker tiles** (e.g., `Coin`, `PlayerSpawn`, `Boss`, `BreakableCollision`) — place on object layers for precise per-entity placement, or paint them on regular tile layers for grid-aligned bulk spawns (e.g., rows of breakable bricks). Either way, `map.CreateEntities()` finds both and by default removes the source tile after spawning so it doesn't double-draw under the entity (opt out with `removeSourceTiles: false`). See the `levels` skill for the API.
+- **Collision tiles** (e.g., `SolidCollision`, `JumpThroughCollision`) — place on tile layers, consumed by `GenerateCollisionFromClass`. Hand-drawn rectangle/polygon `<object>`s on an object layer with a matching Class are matched too (see "Collision from an object layer" below) — useful for a boundary shape that doesn't align to the stamp grid.
+- **Entity marker tiles** (e.g., `Coin`, `PlayerSpawn`, `Boss`, `BreakableCollision`) — place on object layers for precise per-entity placement, or paint them on regular tile layers for grid-aligned bulk spawns (e.g., rows of breakable bricks). Either way, `map.CreateEntities()` finds both and by default removes the source after spawning, so one Tiled source becomes exactly one runtime object (opt out with `removeSourceTiles: false`). Any object shape can be a marker, not just tile objects — a bare `<point>` or rectangle with a matching Class spawns too. See the `levels` skill for the API and the call-order rule.
 
 ## Layer Conventions
 
@@ -159,7 +159,7 @@ Adjacent sub-cell rects participate in `SolidSides` seam suppression: if two sub
 
 ### Add an object layer for entity spawns
 
-Object layers hold tile objects that represent entity spawn positions. Each tile object references a tile from the tileset via its GID. The tile's Class determines the entity type. Add an `<objectgroup>` after the tile layers:
+Object layers hold spawn markers. A tile object references a tile from the tileset via its GID and inherits that tile's Class; any other shape (`<point>`, `<ellipse>`, a bare rectangle, a `<polygon>`) needs the `class` attribute set on the `<object>` itself. Add an `<objectgroup>` after the tile layers:
 
 ```xml
 <objectgroup id="2" name="Entities">

--- a/src/Tiled/ObjectLayerEntry.cs
+++ b/src/Tiled/ObjectLayerEntry.cs
@@ -24,7 +24,10 @@ namespace FlatRedBall2.Tiled;
 /// zero for objects not tied to a tile.
 /// </param>
 /// <param name="Properties">
-/// Custom properties as strings, keyed by name. For tile-insert objects this merges the tile's
+/// Custom properties as strings, keyed by name. Lookups are case-insensitive, because Tiled
+/// authors mix casing freely and nothing validates it — a case-sensitive miss here would be
+/// silent. For the same reason keys that differ only by case collapse into one entry, so this
+/// can hold fewer keys than the TMX declares. For tile-insert objects this merges the tile's
 /// class-level properties (defined on the tile's type in the tileset) with instance-level
 /// properties, instance values winning on collision — the same merge
 /// <see cref="TileMap.CreateEntities{T}"/> performs. Empty if the object has no properties.

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -781,12 +781,21 @@ public class TileMap
     /// <remarks>
     /// <para>
     /// On object layers every Tiled shape can act as a spawn marker: tile-insert objects,
-    /// rectangles, ellipses, and unsized shapes such as points and polygons. Tile-insert
-    /// objects anchor at their bottom-left corner; rectangle and ellipse objects anchor at
-    /// their top-left corner; unsized shapes spawn exactly at their position regardless of
-    /// <paramref name="origin"/>. Non-tile objects have no tileset tile behind them — their
-    /// class must be set on the object itself, only instance-level properties apply, and a
-    /// declared <c>TiledGid</c> entity property receives 0.
+    /// rectangles, ellipses, and shapes with no usable extent such as points, polygons, and
+    /// polylines. Tile-insert objects anchor at their bottom-left corner; rectangle and ellipse
+    /// objects anchor at their top-left corner. A text object's bounding box is not treated as
+    /// extent — like a point, it spawns at its position. Non-tile objects have no tileset tile
+    /// behind them — their class must be set on the object itself, only instance-level properties
+    /// apply, and a declared <c>TiledGid</c> entity property receives 0.
+    /// </para>
+    /// <para>
+    /// Object rotation is honored. <paramref name="origin"/> picks a point on the marker's own
+    /// body and that point rotates with it, around the object's stored <c>(x,y)</c> — Tiled's
+    /// pivot is the position, <b>not</b> the bounding-box center, so a rotated marker's center can
+    /// land well away from where the unrotated box sat. This matches
+    /// <see cref="GenerateCollisionFromClass"/>, so an entity and a collision shape built from the
+    /// same rotated object agree. Shapes with no extent are unaffected — rotation has nothing to
+    /// swing. Contrast with <see cref="GetObjectLayerData"/>, which reports unrotated placements.
     /// </para>
     /// <para>
     /// Tiled custom properties are automatically applied to matching public instance properties
@@ -940,14 +949,15 @@ public class TileMap
         Origin origin,
         out float worldX,
         out float worldY,
-        out Dictionary<string, TilemapPropertyValue> mergedProps,
+        [MaybeNullWhen(false)] out Dictionary<string, TilemapPropertyValue> mergedProps,
         out int gid)
     {
         switch (obj)
         {
             case TilemapTileObject tileObj when MatchesClass(tileObj, className):
             {
-                (worldX, worldY) = ConvertToWorldSpace(tileObj, origin);
+                (worldX, worldY) = ResolveSpawnPoint(
+                    tileObj.Position, tileObj.Size, tileObj.Rotation, origin, bottomLeftAnchored: true);
 
                 // Class-level properties come from the placed tile's definition in the tileset.
                 var classProps = tileObj.Tile.GetTileData(_tilemap!.Tilesets)?.Properties;
@@ -958,12 +968,8 @@ public class TileMap
 
             case TilemapRectangleObject rectObj when MatchesClassName(rectObj.Class, className):
             {
-                // Rectangle objects anchor at their top-left corner in Tiled (Y-down).
-                float left = _x + rectObj.Position.X;
-                float top = _y - rectObj.Position.Y;
-                float w = rectObj.Size.X;
-                float h = rectObj.Size.Y;
-                (worldX, worldY) = OriginOffsetFromCenter(left + w / 2f, top - h / 2f, w, h, origin);
+                (worldX, worldY) = ResolveSpawnPoint(
+                    rectObj.Position, rectObj.Size, rectObj.Rotation, origin, bottomLeftAnchored: false);
                 mergedProps = BuildMergedPropertySnapshot(classProps: null, rectObj.Properties);
                 gid = 0;
                 return true;
@@ -971,11 +977,9 @@ public class TileMap
 
             case TilemapEllipseObject ellipseObj when MatchesClassName(ellipseObj.Class, className):
             {
-                float cx = _x + ellipseObj.Center.X;
-                float cy = _y - ellipseObj.Center.Y;
-                float w = ellipseObj.Size.X;
-                float h = ellipseObj.Size.Y;
-                (worldX, worldY) = OriginOffsetFromCenter(cx, cy, w, h, origin);
+                // An ellipse's Position is its bounding rect's top-left, same anchor as a rect.
+                (worldX, worldY) = ResolveSpawnPoint(
+                    ellipseObj.Position, ellipseObj.Size, ellipseObj.Rotation, origin, bottomLeftAnchored: false);
                 mergedProps = BuildMergedPropertySnapshot(classProps: null, ellipseObj.Properties);
                 gid = 0;
                 return true;
@@ -983,13 +987,13 @@ public class TileMap
 
             default:
             {
-                // Unsized shapes: the position IS the marker location, so every Origin
-                // resolves to it (width/height are zero).
+                // Unsized shapes — point, polygon, polyline, text, plain. With zero extent every
+                // Origin lands on the position, and rotation has no lever arm to swing.
                 if (!MatchesClassName(obj.Class, className))
                     break;
 
-                (worldX, worldY) = OriginOffsetFromCenter(
-                    _x + obj.Position.X, _y - obj.Position.Y, 0f, 0f, origin);
+                (worldX, worldY) = ResolveSpawnPoint(
+                    obj.Position, XnaVector2.Zero, obj.Rotation, origin, bottomLeftAnchored: false);
                 mergedProps = BuildMergedPropertySnapshot(classProps: null, obj.Properties);
                 gid = 0;
                 return true;
@@ -998,9 +1002,45 @@ public class TileMap
 
         worldX = 0f;
         worldY = 0f;
-        mergedProps = new Dictionary<string, TilemapPropertyValue>();
+        mergedProps = null;
         gid = 0;
         return false;
+    }
+
+    /// <summary>
+    /// Converts a Tiled object's placement into the world-space point an entity spawns at.
+    /// <paramref name="origin"/> picks a point on the object's own unrotated body; that point is
+    /// then rotated around the object's position — Tiled's pivot is the stored <c>(x,y)</c>,
+    /// <b>not</b> the bounding-box center — and flipped from Tiled's Y-down space into Y-up world
+    /// space with the map's own offset folded in. Matches the pivot convention
+    /// <see cref="TileMapCollisions"/> uses, so an entity and a collision shape generated from the
+    /// same rotated marker land in the same place. Pass <c>bottomLeftAnchored: true</c> for
+    /// tile-insert objects, whose position is their bottom-left corner so the body extends to
+    /// negative local Y; rectangles, ellipses, and unsized shapes anchor at their top-left.
+    /// </summary>
+    private (float x, float y) ResolveSpawnPoint(
+        XnaVector2 position, XnaVector2 size, float rotation, Origin origin, bool bottomLeftAnchored)
+    {
+        float w = size.X;
+        float h = size.Y;
+
+        // Offset from the pivot to the requested origin, in the object's own Y-down local space.
+        (float offsetX, float offsetY) = origin switch
+        {
+            Origin.Center => (w / 2f, h / 2f),
+            Origin.TopCenter => (w / 2f, 0f),
+            Origin.BottomCenter => (w / 2f, h),
+            Origin.TopLeft => (0f, 0f),
+            Origin.TopRight => (w, 0f),
+            Origin.BottomLeft => (0f, h),
+            Origin.BottomRight => (w, h),
+            _ => (w / 2f, h / 2f),
+        };
+        if (bottomLeftAnchored)
+            offsetY -= h;
+
+        var (rotatedX, rotatedY) = TileMapCollisions.RotateAroundOrigin(offsetX, offsetY, rotation);
+        return (_x + position.X + rotatedX, _y - (position.Y + rotatedY));
     }
 
     private void ScanTileLayer<T>(
@@ -1156,27 +1196,6 @@ public class TileMap
                string.Equals(objectClass, className, StringComparison.OrdinalIgnoreCase);
     }
 
-    private (float x, float y) ConvertToWorldSpace(TilemapTileObject tileObj, Origin origin)
-    {
-        // Tiled tile objects have position at the bottom-left corner, Y-down from map top-left.
-        float bottomLeftX = _x + tileObj.Position.X;
-        float bottomLeftY = _y - tileObj.Position.Y;
-
-        float w = tileObj.Size.X;
-        float h = tileObj.Size.Y;
-
-        return origin switch
-        {
-            Origin.Center => (bottomLeftX + w / 2f, bottomLeftY + h / 2f),
-            Origin.BottomCenter => (bottomLeftX + w / 2f, bottomLeftY),
-            Origin.TopCenter => (bottomLeftX + w / 2f, bottomLeftY + h),
-            Origin.BottomLeft => (bottomLeftX, bottomLeftY),
-            Origin.TopLeft => (bottomLeftX, bottomLeftY + h),
-            Origin.BottomRight => (bottomLeftX + w, bottomLeftY),
-            Origin.TopRight => (bottomLeftX + w, bottomLeftY + h),
-            _ => (bottomLeftX + w / 2f, bottomLeftY + h / 2f),
-        };
-    }
 
     private static Dictionary<string, PropertyInfo> BuildPropertyMap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()
     {

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -684,7 +684,7 @@ public class TileMap
 
     private static Dictionary<string, string> StringifyProperties(Dictionary<string, TilemapPropertyValue> merged)
     {
-        var result = new Dictionary<string, string>(merged.Count);
+        var result = new Dictionary<string, string>(merged.Count, StringComparer.OrdinalIgnoreCase);
         foreach (var (key, value) in merged)
         {
             var s = value.AsString();

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -775,10 +775,19 @@ public class TileMap
 
     /// <summary>
     /// Creates entities from tiles whose class matches <paramref name="className"/>. Scans
-    /// both object layers (for precisely-placed tile objects) and regular tile layers (for
+    /// both object layers (for precisely-placed markers) and regular tile layers (for
     /// painted grid cells). Both sources feed into the same factory call.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// On object layers every Tiled shape can act as a spawn marker: tile-insert objects,
+    /// rectangles, ellipses, and unsized shapes such as points and polygons. Tile-insert
+    /// objects anchor at their bottom-left corner; rectangle and ellipse objects anchor at
+    /// their top-left corner; unsized shapes spawn exactly at their position regardless of
+    /// <paramref name="origin"/>. Non-tile objects have no tileset tile behind them — their
+    /// class must be set on the object itself, only instance-level properties apply, and a
+    /// declared <c>TiledGid</c> entity property receives 0.
+    /// </para>
     /// <para>
     /// Tiled custom properties are automatically applied to matching public instance properties
     /// on the entity via reflection (case-insensitive name match). Supported property types:
@@ -800,8 +809,9 @@ public class TileMap
     /// </para>
     /// </remarks>
     /// <param name="className">
-    /// The tile class to match (case-insensitive). Checked on the object first, then on the
-    /// tile definition in the tileset.
+    /// The tile class to match (case-insensitive). For tile-insert objects this is checked on
+    /// the object first, then on the tile definition in the tileset; for every other object
+    /// shape only the object's own Class is checked.
     /// </param>
     /// <param name="factory">The factory to create entities with.</param>
     /// <param name="origin">
@@ -809,8 +819,8 @@ public class TileMap
     /// </param>
     /// <param name="removeSourceTiles">
     /// When <c>true</c> (default), each source tile is cleared after the entity spawns — the
-    /// painted cell is set to empty and the tile-object is removed from its object layer — so
-    /// the tile visual does not double-draw under the spawned entity. Contrast with
+    /// painted cell is set to empty and the matched object is removed from its object layer —
+    /// so the tile visual does not double-draw under the spawned entity. Contrast with
     /// <see cref="GenerateCollisionFromClass"/>, which leaves source tiles visible because the
     /// tile itself is the visual. In-memory only; the on-disk TMX is never modified and a fresh
     /// load re-applies the removal. Pass <c>false</c> to keep the source tile visible (e.g.,
@@ -876,25 +886,14 @@ public class TileMap
         Action<T>? configure) where T : Entity, new()
     {
         // Collect matches first so we can mutate the layer's object list after iteration.
-        List<TilemapTileObject>? toRemove = null;
+        List<TilemapObject>? toRemove = null;
         bool lazy = factory.LazySpawn != LazySpawnMode.Disabled;
 
         foreach (var obj in objectLayer.Objects)
         {
-            if (obj is not TilemapTileObject tileObj)
+            if (!TryResolveSpawn(obj, className, origin,
+                    out var worldX, out var worldY, out var mergedProps, out var gid))
                 continue;
-
-            if (!MatchesClass(tileObj, className))
-                continue;
-
-            var (worldX, worldY) = ConvertToWorldSpace(tileObj, origin);
-
-            // Snapshot the merged property bag now — the live TilemapProperties on the tile
-            // object is about to be dropped by removeSourceTiles, so both the eager and lazy
-            // paths use the same self-contained merged dictionary.
-            var classProps = tileObj.Tile.GetTileData(_tilemap!.Tilesets)?.Properties;
-            var mergedProps = BuildMergedPropertySnapshot(classProps, tileObj.Properties);
-            int gid = tileObj.Tile.GlobalId;
 
             if (lazy)
             {
@@ -915,12 +914,91 @@ public class TileMap
             }
 
             if (removeSourceTiles)
-                (toRemove ??= new List<TilemapTileObject>()).Add(tileObj);
+                (toRemove ??= new List<TilemapObject>()).Add(obj);
         }
 
         if (toRemove != null)
             foreach (var obj in toRemove)
                 objectLayer.RemoveObject(obj);
+    }
+
+    /// <summary>
+    /// Resolves an object-layer entry into an entity spawn point. Handles every Tiled shape:
+    /// tile-insert objects (bottom-left anchor + tileset class/property merge), rectangle and
+    /// ellipse objects (top-left anchor), and unsized shapes — point, polygon, polyline, text,
+    /// plain — whose position is the spawn point itself. Non-tile objects have no tileset tile
+    /// behind them, so only instance-level properties apply and <c>TiledGid</c> resolves to 0.
+    /// Returns <c>false</c> when the object doesn't match <paramref name="className"/>. The
+    /// returned property bag is a self-contained snapshot (never the live TilemapProperties),
+    /// safe to close over for lazy-spawn replay after the source objects are removed.
+    /// </summary>
+    private bool TryResolveSpawn(
+        TilemapObject obj,
+        string className,
+        Origin origin,
+        out float worldX,
+        out float worldY,
+        out Dictionary<string, TilemapPropertyValue> mergedProps,
+        out int gid)
+    {
+        switch (obj)
+        {
+            case TilemapTileObject tileObj when MatchesClass(tileObj, className):
+            {
+                (worldX, worldY) = ConvertToWorldSpace(tileObj, origin);
+
+                // Class-level properties come from the placed tile's definition in the tileset.
+                var classProps = tileObj.Tile.GetTileData(_tilemap!.Tilesets)?.Properties;
+                mergedProps = BuildMergedPropertySnapshot(classProps, tileObj.Properties);
+                gid = tileObj.Tile.GlobalId;
+                return true;
+            }
+
+            case TilemapRectangleObject rectObj when MatchesClassName(rectObj.Class, className):
+            {
+                // Rectangle objects anchor at their top-left corner in Tiled (Y-down).
+                float left = _x + rectObj.Position.X;
+                float top = _y - rectObj.Position.Y;
+                float w = rectObj.Size.X;
+                float h = rectObj.Size.Y;
+                (worldX, worldY) = OriginOffsetFromCenter(left + w / 2f, top - h / 2f, w, h, origin);
+                mergedProps = BuildMergedPropertySnapshot(classProps: null, rectObj.Properties);
+                gid = 0;
+                return true;
+            }
+
+            case TilemapEllipseObject ellipseObj when MatchesClassName(ellipseObj.Class, className):
+            {
+                float cx = _x + ellipseObj.Center.X;
+                float cy = _y - ellipseObj.Center.Y;
+                float w = ellipseObj.Size.X;
+                float h = ellipseObj.Size.Y;
+                (worldX, worldY) = OriginOffsetFromCenter(cx, cy, w, h, origin);
+                mergedProps = BuildMergedPropertySnapshot(classProps: null, ellipseObj.Properties);
+                gid = 0;
+                return true;
+            }
+
+            default:
+            {
+                // Unsized shapes: the position IS the marker location, so every Origin
+                // resolves to it (width/height are zero).
+                if (!MatchesClassName(obj.Class, className))
+                    break;
+
+                (worldX, worldY) = OriginOffsetFromCenter(
+                    _x + obj.Position.X, _y - obj.Position.Y, 0f, 0f, origin);
+                mergedProps = BuildMergedPropertySnapshot(classProps: null, obj.Properties);
+                gid = 0;
+                return true;
+            }
+        }
+
+        worldX = 0f;
+        worldY = 0f;
+        mergedProps = new Dictionary<string, TilemapPropertyValue>();
+        gid = 0;
+        return false;
     }
 
     private void ScanTileLayer<T>(
@@ -985,13 +1063,15 @@ public class TileMap
     /// <summary>
     /// Merges class-level tile properties (from the tile's type in the tileset) with
     /// instance-level properties (set on an individual object-layer tile-object), instance
-    /// values winning on key collisions. Returns a plain snapshot dictionary — not a live view —
+    /// values winning on key collisions. Keys are compared case-insensitively — Tiled authors
+    /// freely mix <c>pos</c> and <c>Pos</c>, and <see cref="ApplyProperties{T}"/> looks entries
+    /// up by C# property name. Returns a plain snapshot dictionary — not a live view —
     /// so it's safe to close over for lazy-spawn replay after the source objects are mutated.
     /// </summary>
     private static Dictionary<string, TilemapPropertyValue> BuildMergedPropertySnapshot(
         TilemapProperties? classProps, TilemapProperties? instanceProps)
     {
-        var merged = new Dictionary<string, TilemapPropertyValue>();
+        var merged = new Dictionary<string, TilemapPropertyValue>(StringComparer.OrdinalIgnoreCase);
         if (classProps != null)
             foreach (var kvp in classProps)
                 merged[kvp.Key] = kvp.Value;
@@ -1061,12 +1141,17 @@ public class TileMap
     {
         // Check the object's own Class first (inherits from tile class in Tiled).
         if (!string.IsNullOrEmpty(tileObj.Class))
-            return string.Equals(tileObj.Class, className, StringComparison.OrdinalIgnoreCase);
+            return MatchesClassName(tileObj.Class, className);
 
         // Fall back to the tile definition's Class in the tileset.
         var tileData = tileObj.Tile.GetTileData(_tilemap!.Tilesets);
-        return tileData != null &&
-               string.Equals(tileData.Class, className, StringComparison.OrdinalIgnoreCase);
+        return tileData != null && MatchesClassName(tileData.Class, className);
+    }
+
+    private static bool MatchesClassName(string? objectClass, string className)
+    {
+        return !string.IsNullOrEmpty(objectClass) &&
+               string.Equals(objectClass, className, StringComparison.OrdinalIgnoreCase);
     }
 
     private (float x, float y) ConvertToWorldSpace(TilemapTileObject tileObj, Origin origin)

--- a/src/Tiled/TileMap.cs
+++ b/src/Tiled/TileMap.cs
@@ -818,13 +818,15 @@ public class TileMap
     /// Which point on the tile becomes the entity's position. Default is <see cref="Origin.Center"/>.
     /// </param>
     /// <param name="removeSourceTiles">
-    /// When <c>true</c> (default), each source tile is cleared after the entity spawns — the
-    /// painted cell is set to empty and the matched object is removed from its object layer —
-    /// so the tile visual does not double-draw under the spawned entity. Contrast with
-    /// <see cref="GenerateCollisionFromClass"/>, which leaves source tiles visible because the
-    /// tile itself is the visual. In-memory only; the on-disk TMX is never modified and a fresh
-    /// load re-applies the removal. Pass <c>false</c> to keep the source tile visible (e.g.,
-    /// the tile is both a spawn marker and intentional background art).
+    /// When <c>true</c> (default), each matched source is consumed — the painted cell is set
+    /// to empty and the matched object is removed from its object layer — so one Tiled source
+    /// produces exactly one runtime object. Without it a visible tile double-draws under the
+    /// spawned entity, and a rectangle or polygon is also picked up as a collision shape by
+    /// <see cref="GenerateCollisionFromClass"/>. That method consumes nothing, so when the same
+    /// class feeds both, call <c>CreateEntities</c> <b>first</b> — generating collision first
+    /// builds the shape before the removal happens, leaving you with both. In-memory only; the
+    /// on-disk TMX is never modified and a fresh load re-applies the removal. Pass <c>false</c>
+    /// to keep the source (e.g., the tile is both a spawn marker and intentional background art).
     /// </param>
     /// <param name="configure">
     /// Optional callback invoked on each spawned entity after position assignment and Tiled

--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -359,7 +359,7 @@ public static class TileMapCollisions
     // transforms instead of using sin/cos — this keeps axis-alignment detection
     // (TryGetAxisAlignedBounds) from being defeated by trig floating-point noise at exactly the
     // angles (0/90/180/270) that matter most for staying a plain AARect.
-    private static (float x, float y) RotateAroundOrigin(float x, float y, float rotationRadians)
+    internal static (float x, float y) RotateAroundOrigin(float x, float y, float rotationRadians)
     {
         const float snapEps = 1e-4f;
         float quarterTurns = rotationRadians / (MathF.PI / 2f);

--- a/src/Tiled/TileMapCollisions.cs
+++ b/src/Tiled/TileMapCollisions.cs
@@ -29,7 +29,10 @@ namespace FlatRedBall2.Tiled;
 /// <para>
 /// Object matching checks <see cref="TilemapRectangleObject"/> and <see cref="TilemapPolygonObject"/>
 /// entries directly — tile objects (Tiled's "Insert Tile" tool) are not matched; use
-/// <see cref="TileMap.CreateEntities"/> for those.
+/// <see cref="TileMap.CreateEntities"/> for those. Note that <c>CreateEntities</c> matches
+/// rectangles and polygons too, so one shape can feed either system. Nothing here consumes what
+/// it matches, so if the same class feeds both, run <c>CreateEntities</c> first and let it remove
+/// the object — otherwise the shape is built before the removal and you get a shape and an entity.
 /// </para>
 /// <para>
 /// Rectangle objects support any position, size, and rotation that's an exact multiple of 90
@@ -282,7 +285,9 @@ public static class TileMapCollisions
     /// per cell (axis-aligned rectangles) or registered as a free-floating shape (polygons) so it's
     /// still found regardless of which cell the querying shape occupies.
     /// Tile objects (placed with Tiled's "Insert Tile" tool) are not matched here — use
-    /// <see cref="TileMap.CreateEntities"/> for those.
+    /// <see cref="TileMap.CreateEntities"/> for those. Matched objects stay on the layer: this
+    /// method consumes nothing, so a rectangle or polygon whose class <c>CreateEntities</c> also
+    /// asks for yields both a shape and an entity unless <c>CreateEntities</c> ran first.
     /// </summary>
     private static void AddMatchingObjects(
         TilemapObjectLayer layer,

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
@@ -796,4 +796,124 @@ public class TileMapCreateEntitiesTests
         factory[0].X.ShouldBe(32f);
         factory[0].Y.ShouldBe(-48f);
     }
+
+    // ============================================================================================
+    // Rotated object markers
+    // ============================================================================================
+
+    [Fact]
+    public void CreateEntities_RectangleObjectRotated180Degrees_SpawnsAtRotatedCenter()
+    {
+        // Same geometry as TileMapCollisionsTests'
+        // GenerateFromClass_ObjectLayerRect180DegreesRotated_PivotsAroundPositionNotCenter, so the
+        // two paths can be compared directly. Tiled rotates clockwise around the object's own
+        // (x,y), NOT its bounding-box center: position (16,0) size (16,8) rotated 180 deg lands on
+        // the opposite side of the pivot, occupying world X:[0,16] Y:[0,8] — center (8,4). Ignoring
+        // Rotation puts the entity at (24,-4), which is outside the marker entirely.
+        var tilemap = BuildTilemap(2, 2, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1,
+            position: new XnaVec2(16f, 0f),
+            size: new XnaVec2(16f, 8f))
+        {
+            Class = "Coin",
+            Rotation = System.MathF.PI,
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(8f);
+        created[0].Y.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void CreateEntities_TileObjectRotated90Degrees_SpawnsAtRotatedCenter()
+    {
+        // Tile objects anchor at their bottom-left, so the tile sits ABOVE its own (x,y) in
+        // Tiled's Y-down space: position (16,32) size 16 occupies Tiled X:[16,32] Y:[16,32],
+        // center offset (8,-8) from the pivot. Rotating 90 deg clockwise about the pivot maps
+        // that offset to (8,8), i.e. Tiled center (24,40) -> world (24,-40). Unrotated the same
+        // marker centers at world (24,-24), so this fails if Rotation is dropped.
+        var tileData = new TilemapTileData(0) { Class = "Coin" };
+        var tilemap = BuildTilemap(4, 4, 16, new[] { tileData },
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapTileObject(
+            id: 1,
+            position: new XnaVec2(16f, 32f),
+            tile: new TilemapTile(globalId: 1),
+            size: new XnaVec2(16f, 16f))
+        {
+            Rotation = System.MathF.PI / 2f,
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(24f);
+        created[0].Y.ShouldBe(-40f);
+    }
+
+    [Fact]
+    public void CreateEntities_EllipseObjectRotated180Degrees_SpawnsAtRotatedCenter()
+    {
+        // Ellipses anchor at their bounding rect's top-left, same as rectangles: position (16,0)
+        // size (16,8) puts the center 8 right and 4 down of the pivot. Rotated 180 deg that
+        // offset flips to (-8,-4) -> Tiled center (8,-4) -> world (8,4).
+        var tilemap = BuildTilemap(2, 2, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapEllipseObject(
+            id: 1,
+            position: new XnaVec2(16f, 0f),
+            size: new XnaVec2(16f, 8f))
+        {
+            Class = "Coin",
+            Rotation = System.MathF.PI,
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(8f);
+        created[0].Y.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void CreateEntities_PointObjectRotated_IgnoresRotation()
+    {
+        // A point has no extent, so there is nothing for rotation to swing around its own pivot.
+        // Guards the shared rotation path from moving zero-size markers.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+            Rotation = System.MathF.PI / 4f,
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created[0].X.ShouldBe(32f);
+        created[0].Y.ShouldBe(-48f);
+    }
 }

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
@@ -916,4 +916,283 @@ public class TileMapCreateEntitiesTests
         created[0].X.ShouldBe(32f);
         created[0].Y.ShouldBe(-48f);
     }
+
+    // ============================================================================================
+    // Object shapes with no usable extent — polygon, polyline, text
+    // ============================================================================================
+
+    [Fact]
+    public void CreateEntities_PolygonObject_SpawnsAtObjectPosition()
+    {
+        // A polygon's Position is its origin vertex, not a centroid or a bounding-box corner —
+        // the marker point is the position itself, so Origin has nothing to offset against.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPolygonObject(
+            id: 1,
+            position: new XnaVec2(16f, 48f),
+            points: new[] { new XnaVec2(0f, 0f), new XnaVec2(16f, 16f), new XnaVec2(0f, 16f) })
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(16f);
+        created[0].Y.ShouldBe(-48f);
+    }
+
+    [Fact]
+    public void CreateEntities_PolylineObject_SpawnsAtObjectPosition()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPolylineObject(
+            id: 1,
+            position: new XnaVec2(48f, 16f),
+            points: new[] { new XnaVec2(0f, 0f), new XnaVec2(32f, 0f) })
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(48f);
+        created[0].Y.ShouldBe(-16f);
+    }
+
+    [Fact]
+    public void CreateEntities_TextObject_IgnoresBoundingSizeAndSpawnsAtPosition()
+    {
+        // TilemapTextObject carries a Size (the text's wrap box), but that box is a typesetting
+        // hint, not a marker body — treating it as extent would put Origin.Center in the middle of
+        // the text block instead of on the authored point. Expected (16,-32), not (48,-40).
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapTextObject(
+            id: 1,
+            position: new XnaVec2(16f, 32f),
+            size: new XnaVec2(64f, 16f),
+            text: "spawn here")
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(16f);
+        created[0].Y.ShouldBe(-32f);
+    }
+
+    // ============================================================================================
+    // Map offset folded into non-tile object placement
+    // ============================================================================================
+
+    [Fact]
+    public void CreateEntities_RectangleObjectOnOffsetMap_FoldsMapPositionIntoSpawnPoint()
+    {
+        // Map top-left at (100,200); rect at Tiled (16,48) size 16 -> world top-left (116,152),
+        // center (124,144). Proves the map's own offset reaches the rectangle path.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(16f, 48f), size: new XnaVec2(16f, 16f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap, x: 100f, y: 200f);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created[0].X.ShouldBe(124f);
+        created[0].Y.ShouldBe(144f);
+    }
+
+    [Fact]
+    public void CreateEntities_EllipseObjectOnOffsetMap_FoldsMapPositionIntoSpawnPoint()
+    {
+        // Map top-left at (100,200); ellipse bounding rect at Tiled (16,48) size (16,8) -> center
+        // offset (8,4) from the anchor -> world (124,148).
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapEllipseObject(
+            id: 1, position: new XnaVec2(16f, 48f), size: new XnaVec2(16f, 8f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap, x: 100f, y: 200f);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, Origin.Center);
+
+        created[0].X.ShouldBe(124f);
+        created[0].Y.ShouldBe(148f);
+    }
+
+    [Fact]
+    public void CreateEntities_RectangleObject_DefaultRemovesSourceObject()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(16f, 48f), size: new XnaVec2(16f, 16f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        tileMap.CreateEntities("Coin", factory);
+
+        ((TilemapObjectLayer)tilemap.Layers[1]).Objects.Count.ShouldBe(0);
+    }
+
+    // ============================================================================================
+    // Property key casing across every property source
+    // ============================================================================================
+
+    [Fact]
+    public void CreateEntities_PaintedCell_ClassPropertyKeyCasingDiffers_StillApplies()
+    {
+        var tileData = new TilemapTileData(0) { Class = "Coin" };
+        tileData.Properties.SetInt("worth", 50);
+        var tilemap = BuildTilemap(4, 4, 16, new[] { tileData }, new[] { (1, 2, 0) });
+        var tileMap = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<PropertyEntity>(screen);
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created[0].Worth.ShouldBe(50);
+    }
+
+    [Fact]
+    public void CreateEntities_TileObject_ClassPropertyKeyCasingDiffers_StillApplies()
+    {
+        var tileData = new TilemapTileData(0) { Class = "Coin" };
+        tileData.Properties.SetInt("worth", 50);
+        var tilemap = BuildTilemap(4, 4, 16, new[] { tileData },
+            placements: System.Array.Empty<(int, int, int)>());
+        tilemap.Layers.Add(BuildObjectLayer("Entities", new[]
+        {
+            (id: 1, localId: 0, x: 16f, y: 48f, size: 16),
+        }));
+        var tileMap = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<PropertyEntity>(screen);
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created[0].Worth.ShouldBe(50);
+    }
+
+    [Fact]
+    public void CreateEntities_InstanceAndClassPropertyKeysDifferOnlyByCase_InstanceStillWins()
+    {
+        // The tileset declares "Worth" and the placed instance overrides "worth". Merged with an
+        // ordinal comparer both keys survive and the class-level one wins the lookup, so the
+        // instance override silently does nothing. Instance must win regardless of casing.
+        var tileData = new TilemapTileData(0) { Class = "Coin" };
+        tileData.Properties.SetInt("Worth", 50);
+        var tilemap = BuildTilemap(4, 4, 16, new[] { tileData },
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        var tileObj = new TilemapTileObject(
+            id: 1,
+            position: new XnaVec2(16f, 48f),
+            tile: new TilemapTile(globalId: 1),
+            size: new XnaVec2(16, 16));
+        tileObj.Properties.SetInt("worth", 99);
+        objLayer.AddObject(tileObj);
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<PropertyEntity>(screen);
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created[0].Worth.ShouldBe(99);
+    }
+
+    // ============================================================================================
+    // Consume-once contract with GenerateCollisionFromClass
+    // ============================================================================================
+
+    [Fact]
+    public void CreateEntities_RectangleObjectThenGenerateCollision_ObjectIsAlreadyConsumed()
+    {
+        // CreateEntities removes what it matches, so a class feeding both systems must run
+        // CreateEntities first — the later collision pass finds nothing left to build from.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0f, 0f), size: new XnaVec2(16f, 16f))
+        {
+            Class = "Door",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Door", factory);
+        var collision = tileMap.GenerateCollisionFromClass("Door");
+
+        created.Count.ShouldBe(1);
+        collision.AllTiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreateEntities_GenerateCollisionFirst_ShapeAndEntityBothExist()
+    {
+        // The mirror of the above: collision generation consumes nothing, so running it first
+        // leaves the object in place for CreateEntities and one marker yields two runtime objects.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1, position: new XnaVec2(0f, 0f), size: new XnaVec2(16f, 16f))
+        {
+            Class = "Door",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var collision = tileMap.GenerateCollisionFromClass("Door");
+        var created = tileMap.CreateEntities("Door", factory);
+
+        collision.AllTiles.ShouldHaveSingleItem();
+        created.Count.ShouldBe(1);
+    }
 }

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapCreateEntitiesTests.cs
@@ -433,6 +433,7 @@ public class TileMapCreateEntitiesTests
     private class PropertyEntity : Entity
     {
         public int Worth { get; set; }
+        public string? Label { get; set; }
         public int TiledGid { get; set; }
     }
 
@@ -621,5 +622,178 @@ public class TileMapCreateEntitiesTests
         var created = tileMap.CreateEntities("Coin", factory);
 
         created[0].TiledGid.ShouldBe(1ul); // FirstGlobalId (1) + localId (0)
+    }
+
+    // ============================================================================================
+    // Non-tile object shapes — point / rectangle markers spawn too
+    // ============================================================================================
+
+    [Theory]
+    [InlineData(Origin.Center)]
+    [InlineData(Origin.BottomLeft)]
+    [InlineData(Origin.TopRight)]
+    public void CreateEntities_PointObject_SpawnsAtPointRegardlessOfOrigin(Origin origin)
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, origin);
+
+        created.Count.ShouldBe(1);
+        created[0].X.ShouldBe(32f);
+        created[0].Y.ShouldBe(-48f);
+    }
+
+    [Fact]
+    public void CreateEntities_PointObject_DefaultRemovesSourceObject()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        tileMap.CreateEntities("Coin", factory);
+
+        var objectLayer = (TilemapObjectLayer)tilemap.Layers[1];
+        objectLayer.Objects.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CreateEntities_PointObject_InstancePropertyAppliesAndTiledGidIsZero()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        var pointObj = new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+        };
+        pointObj.Properties.SetInt("Worth", 99);
+        objLayer.AddObject(pointObj);
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<PropertyEntity>(screen);
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created[0].Worth.ShouldBe(99);
+        created[0].TiledGid.ShouldBe(0); // point objects carry no gid
+    }
+
+    [Fact]
+    public void CreateEntities_InstancePropertyKeyCasingDifference_AppliesCaseInsensitively()
+    {
+        // Tiled authors freely mix property casing (e.g. "pos" vs the C# "Pos"); matching
+        // must be case-insensitive or the value silently never reaches the entity.
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        var pointObj = new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+        };
+        pointObj.Properties.SetString("label", "gold");
+        objLayer.AddObject(pointObj);
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var screen = new TestScreen { Engine = new FlatRedBallService() };
+        var factory = new Factory<PropertyEntity>(screen);
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created[0].Label.ShouldBe("gold");
+    }
+
+    [Fact]
+    public void CreateEntities_NonMatchingPointObject_IsSkippedAndLeftIntact()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Solid",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory);
+
+        created.Count.ShouldBe(0); // "Solid" point doesn't match "Coin"
+        ((TilemapObjectLayer)tilemap.Layers[1]).Objects.Count.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(Origin.Center, 24f, -56f)]
+    [InlineData(Origin.BottomLeft, 16f, -64f)]
+    [InlineData(Origin.TopRight, 32f, -48f)]
+    public void CreateEntities_RectangleObject_OriginPlacesEntityAtExpectedCorner(Origin origin, float expectedX, float expectedY)
+    {
+        // Rectangle objects anchor at their top-left corner in Tiled: pos (16, 48), size 16
+        // → world top-left (16, -48), center (24, -56).
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapRectangleObject(
+            id: 1,
+            position: new XnaVec2(16f, 48f),
+            size: new XnaVec2(16f, 16f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+
+        var created = tileMap.CreateEntities("Coin", factory, origin);
+
+        created[0].X.ShouldBe(expectedX);
+        created[0].Y.ShouldBe(expectedY);
+    }
+
+    [Fact]
+    public void CreateEntities_LazyMode_PointObjectSpawnsAtRecordedPosition()
+    {
+        var tilemap = BuildTilemap(4, 4, 16,
+            tileDataEntries: System.Array.Empty<TilemapTileData>(),
+            placements: System.Array.Empty<(int, int, int)>());
+        var objLayer = new TilemapObjectLayer("Entities");
+        objLayer.AddObject(new TilemapPointObject(id: 1, position: new XnaVec2(32f, 48f))
+        {
+            Class = "Coin",
+        });
+        tilemap.Layers.Add(objLayer);
+        var tileMap = new TileMap(tilemap);
+        var (_, factory) = NewFactory();
+        factory.LazySpawn = LazySpawnMode.OneShot;
+
+        tileMap.CreateEntities("Coin", factory);
+        tileMap.LazySpawner.Update(left: 0f, right: 100f, bottom: -100f, top: 100f);
+
+        factory.Count.ShouldBe(1);
+        factory[0].X.ShouldBe(32f);
+        factory[0].Y.ShouldBe(-48f);
     }
 }

--- a/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
+++ b/tests/FlatRedBall2.Tests/Tiled/TileMapGetObjectLayerDataTests.cs
@@ -275,4 +275,45 @@ public class TileMapGetObjectLayerDataTests
         entries[0].Properties["Terrain"].ShouldBe("sand");
         entries[0].Properties["Side"].ShouldBe("top");
     }
+
+    [Fact]
+    public void GetObjectLayerData_PropertyKeyCasingDiffers_StillFound()
+    {
+        // Tiled authors mix casing freely, and CreateEntities already matches property names
+        // case-insensitively. A caller reading the same object through this method must not have
+        // to guess the author's capitalization — a miss here is silent, not an exception.
+        var rectObj = new TilemapRectangleObject(id: 1, position: new XnaVec2(0, 0), size: new XnaVec2(16, 16));
+        rectObj.Properties.SetString("zone", "Water");
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(rectObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].Properties["Zone"].ShouldBe("Water");
+    }
+
+    [Fact]
+    public void GetObjectLayerData_TileObjectInstanceKeyDiffersInCaseFromClassKey_InstanceWins()
+    {
+        // The tileset declares "Terrain" and the placed instance overrides "terrain". The two
+        // collapse to a single entry, and the instance value wins — matching the merge
+        // CreateEntities performs, so both readers report the same value for the same object.
+        var tileData = new TilemapTileData(0) { Class = "Coast" };
+        tileData.Properties.SetString("Terrain", "grass");
+        var tileset = new TilemapTileset(name: "ts", texture: null!, tileWidth: 16, tileHeight: 16, tileCount: 1, columns: 1);
+        tileset.FirstGlobalId = 1;
+        tileset.AddTileData(tileData);
+        var tileObj = new TilemapTileObject(
+            id: 1, position: new XnaVec2(16, 48), tile: new TilemapTile(globalId: 1), size: new XnaVec2(16, 16));
+        tileObj.Properties.SetString("terrain", "sand");
+        var layer = new TilemapObjectLayer("Water");
+        layer.AddObject(tileObj);
+        var tileMap = new TileMap(BuildObjectOnlyTilemap(2, 2, 16, layer, tileset));
+
+        var entries = tileMap.GetObjectLayerData("Water");
+
+        entries[0].Properties.Count.ShouldBe(1);
+        entries[0].Properties["Terrain"].ShouldBe("sand");
+    }
 }


### PR DESCRIPTION
## Summary

\CreateEntities\ now resolves every Tiled object type on object layers into entity spawn points, not just tile-insert objects:

- **\TilemapPointObject\**: spawns at its position; origin is ignored (zero size).
- **\TilemapRectangleObject\**: anchor at top-left, width/height feed origin offset.
- **\TilemapEllipseObject\**: anchor at center, size feeds origin offset.
- **Polyline / text / plain objects**: position is the spawn point (zero size).
- **\TilemapTileObject\ (existing)**: bottom-left anchor, tileset class + properties.

Non-tile objects have no tileset tile behind them so only instance-level properties apply and \TiledGid\ resolves to 0.

### Additional fixes

- \BuildMergedPropertySnapshot\ keys are now **case-insensitive** (\OrdinalIgnoreCase\) so Tiled authors who mix \pos\ / \Pos\ don't silently lose values.
- Extracted \MatchesClassName\ helper shared across tile-object and non-tile object class checks.
- \ScanObjectLayer\ removal list widened from \List<TilemapTileObject>\ to \List<TilemapObject>\ since any object type can match.

### Tests

New \TileMapCreateEntitiesTests\ covering:
- Point objects: spawn position, removal, instance properties, TiledGid=0, lazy mode
- Rectangle objects: origin-based placement
- Case-insensitive property keys
- Non-matching objects left intact

\\\
Passed!  - Failed: 0, Passed: 44, Skipped: 0, Total: 44
\\\

Closes #984