### PR TITLE
Pin AutomationMode reader-loop contract and stop leaking its thread

### DIFF
--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -16,6 +16,10 @@ internal class AutomationMode
     // currently connected doesn't spin the reader thread in a tight loop.
     private const int EofRetryDelayMs = 25;
 
+    // Signalled by Stop(). Doubles as the EOF wait handle so a stop is observed immediately
+    // instead of after the remainder of a Sleep.
+    private readonly ManualResetEventSlim _stopSignal = new(false);
+
     private readonly FlatRedBallService _engine;
     private readonly System.IO.TextWriter _output;
     private readonly Action<string> _log;
@@ -48,9 +52,29 @@ internal class AutomationMode
     internal void Start(System.IO.TextReader? input = null)
     {
         var reader = input ?? CreateStandardInputReader();
-        var thread = new Thread(() => ReaderLoop(reader)) { IsBackground = true, Name = "AutomationMode.Reader" };
-        thread.Start();
+        ReaderThread = new Thread(() => ReaderLoop(reader)) { IsBackground = true, Name = "AutomationMode.Reader" };
+        ReaderThread.Start();
     }
+
+    /// <summary>
+    /// The thread running <see cref="ReaderLoop"/>, or null before <see cref="Start"/>.
+    /// </summary>
+    /// <remarks>
+    /// Background by design: <see cref="ReaderLoop"/> has no natural end (see its remarks), so the
+    /// only thing keeping it from holding the process open at exit is the CLR tearing background
+    /// threads down rather than joining them.
+    /// </remarks>
+    internal Thread? ReaderThread { get; private set; }
+
+    /// <summary>
+    /// Ends <see cref="ReaderLoop"/> at its next EOF retry. Idempotent; safe from any thread.
+    /// </summary>
+    /// <remarks>
+    /// A loop currently blocked inside <c>ReadLine()</c> on a real stdin handle stays blocked until
+    /// that read returns — the stop is observed on the next pass, not the instant it is signalled.
+    /// That is acceptable precisely because the thread is background: nothing waits on it.
+    /// </remarks>
+    internal void Stop() => _stopSignal.Set();
 
     /// <summary>
     /// Reads stdin as a raw stream rather than through <see cref="Console.In"/>.
@@ -136,12 +160,13 @@ internal class AutomationMode
 
     // A null from ReadLine() means "no data right now," not "stream closed for good" — a
     // named-pipe stdin reports EOF whenever no writer is currently connected, then resumes
-    // delivering data once a new writer reopens it. Only a read exception is treated as
-    // terminal. See issue #773.
+    // delivering data once a new writer reopens it. So nulls are retried without limit; capping
+    // them would abandon stdin during any writer gap longer than the cap. Only a read exception
+    // or an explicit Stop() is terminal. See issues #773 and #985.
     internal void ReaderLoop(System.IO.TextReader reader)
     {
         bool waitingForData = false;
-        while (true)
+        while (!_stopSignal.IsSet)
         {
             string? line;
             try
@@ -161,7 +186,7 @@ internal class AutomationMode
                     waitingForData = true;
                     _log("[AutomationMode] ReaderLoop: input stream reported EOF; retrying.");
                 }
-                Thread.Sleep(EofRetryDelayMs);
+                _stopSignal.Wait(EofRetryDelayMs);
                 continue;
             }
 

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -1280,13 +1280,16 @@ public class FlatRedBallService
     /// </remarks>
     public void Shutdown()
     {
+        // Released before the _game guard: the reader thread does not depend on _game, and an
+        // engine that only ever had automation started on it (tests) must still get it back.
+        _automationMode?.Stop();
+        _automationMode = null;
+
         if (_game is null)
             return;
 
         TeardownCurrentScreen();
         CurrentScreen = new Screen();
-
-        _automationMode = null;
 
         _gum.Uninitialize();
 

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using FlatRedBall2.Automation;
 using FlatRedBall2.Input;
 using FlatRedBall2.Rendering;
@@ -546,6 +547,41 @@ public class AutomationModeReaderLoopTests
         }
     }
 
+    // Always at EOF, and counts how many times it was asked. Models a FIFO that no writer has
+    // attached to yet — the case the retry loop exists for.
+    private class AlwaysNullReader : System.IO.TextReader
+    {
+        private int _readCount;
+        public int ReadCount => Volatile.Read(ref _readCount);
+        public override string? ReadLine()
+        {
+            Interlocked.Increment(ref _readCount);
+            return null;
+        }
+    }
+
+    // Pins the reconnectable-FIFO contract from issue #773: a null from ReadLine() means "no writer
+    // attached right now," not "closed for good," so the loop must keep polling however many nulls
+    // it sees. Issue #985 proposed capping this at 5 consecutive nulls — at the loop's 25ms retry
+    // delay that abandons stdin after ~125ms, well inside normal harness startup latency. This test
+    // fails if such a cap is ever added.
+    [Fact]
+    public void ReaderLoop_PersistentNull_KeepsRetryingUntilStopped()
+    {
+        var reader = new AlwaysNullReader();
+        var mode = new AutomationMode(new FlatRedBallService(), new StringWriter(), log: _ => { });
+        var thread = new Thread(() => mode.ReaderLoop(reader)) { IsBackground = true };
+
+        thread.Start();
+        // 10 reads is double any cap the issue proposed, so surviving them rules one out.
+        SpinWait.SpinUntil(() => reader.ReadCount >= 10, TimeSpan.FromSeconds(5)).ShouldBeTrue();
+        thread.IsAlive.ShouldBeTrue();
+
+        mode.Stop();
+
+        thread.Join(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+    }
+
     [Fact]
     public void ReaderLoop_ReadThrows_LogsAndReturns()
     {
@@ -567,6 +603,40 @@ public class AutomationModeReaderLoopTests
         mode.ReaderLoop(reader);
 
         mode.TryAdvanceFrame(0).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Shutdown_WithAutomationModeActive_StopsReaderThread()
+    {
+        var reader = new AlwaysNullReader();
+        var engine = new FlatRedBallService();
+        engine.StartAutomationMode(seed: 0, input: reader, output: new StringWriter());
+        SpinWait.SpinUntil(() => reader.ReadCount >= 2, TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+        engine.Shutdown();
+
+        // 150ms is 6x the loop's 25ms retry delay, so an in-flight retry has drained well before
+        // the first sample and a still-running loop would add several reads between the two.
+        Thread.Sleep(150);
+        var settled = reader.ReadCount;
+        Thread.Sleep(150);
+        reader.ReadCount.ShouldBe(settled);
+    }
+
+    // The reader loop is intentionally endless (see ReaderLoop_PersistentNull_KeepsRetryingUntilStopped),
+    // so IsBackground is the only thing keeping it from holding the process open: the CLR tears
+    // background threads down at exit instead of waiting on them. Issue #985 assumed the opposite
+    // and attributed a nonzero test-host exit code to this thread.
+    [Fact]
+    public void Start_ReaderThread_IsBackground()
+    {
+        var mode = new AutomationMode(new FlatRedBallService(), new StringWriter(), log: _ => { });
+
+        mode.Start(new StringReader(string.Empty));
+
+        mode.ReaderThread.ShouldNotBeNull();
+        mode.ReaderThread!.IsBackground.ShouldBeTrue();
+        mode.Stop();
     }
 }
 

--- a/tests/FlatRedBall2.Tests/Automation/AutomationSeedTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationSeedTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using FlatRedBall2.Utilities;
 using Shouldly;
@@ -5,45 +7,25 @@ using Xunit;
 
 namespace FlatRedBall2.Tests.Automation;
 
-public class AutomationSeedTests
+public class AutomationSeedTests : IDisposable
 {
-    [Fact]
-    public void StartAutomationMode_WithSeed_ProducesDeterministicRandomSequence()
+    private readonly List<FlatRedBallService> _engines = new();
+
+    // Automation mode starts a reader thread that polls its input until stopped. Without this
+    // teardown every test here leaves one behind for the rest of the test-host process.
+    public void Dispose()
     {
-        var a = new FlatRedBallService();
-        var b = new FlatRedBallService();
-
-        a.StartAutomationMode(seed: 1234, input: new StringReader(string.Empty));
-        b.StartAutomationMode(seed: 1234, input: new StringReader(string.Empty));
-
-        for (int i = 0; i < 16; i++)
-            a.Random.Next().ShouldBe(b.Random.Next());
+        foreach (var engine in _engines)
+            engine.Shutdown();
     }
 
-    [Fact]
-    public void StartAutomationMode_DifferentSeeds_ProduceDifferentSequences()
+    // Empty input keeps the reader at EOF for the whole test — these cover seeding, not commands.
+    private FlatRedBallService AutomatedEngine(int? seed)
     {
-        var a = new FlatRedBallService();
-        var b = new FlatRedBallService();
-
-        a.StartAutomationMode(seed: 1, input: new StringReader(string.Empty));
-        b.StartAutomationMode(seed: 2, input: new StringReader(string.Empty));
-
-        // First int from two distinct seeds should differ — astronomically unlikely otherwise.
-        a.Random.Next().ShouldNotBe(b.Random.Next());
-    }
-
-    [Fact]
-    public void StartAutomationMode_NoSeed_StillDeterministic()
-    {
-        var a = new FlatRedBallService();
-        var b = new FlatRedBallService();
-
-        a.StartAutomationMode(input: new StringReader(string.Empty));
-        b.StartAutomationMode(input: new StringReader(string.Empty));
-
-        for (int i = 0; i < 16; i++)
-            a.Random.Next().ShouldBe(b.Random.Next());
+        var engine = new FlatRedBallService();
+        _engines.Add(engine);
+        engine.StartAutomationMode(seed: seed, input: new StringReader(string.Empty));
+        return engine;
     }
 
     [Fact]
@@ -59,5 +41,35 @@ public class AutomationSeedTests
             if (a.Random.Next() != b.Random.Next()) anyDifferent = true;
 
         anyDifferent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StartAutomationMode_DifferentSeeds_ProduceDifferentSequences()
+    {
+        var a = AutomatedEngine(seed: 1);
+        var b = AutomatedEngine(seed: 2);
+
+        // First int from two distinct seeds should differ — astronomically unlikely otherwise.
+        a.Random.Next().ShouldNotBe(b.Random.Next());
+    }
+
+    [Fact]
+    public void StartAutomationMode_NoSeed_StillDeterministic()
+    {
+        var a = AutomatedEngine(seed: null);
+        var b = AutomatedEngine(seed: null);
+
+        for (int i = 0; i < 16; i++)
+            a.Random.Next().ShouldBe(b.Random.Next());
+    }
+
+    [Fact]
+    public void StartAutomationMode_WithSeed_ProducesDeterministicRandomSequence()
+    {
+        var a = AutomatedEngine(seed: 1234);
+        var b = AutomatedEngine(seed: 1234);
+
+        for (int i = 0; i < 16; i++)
+            a.Random.Next().ShouldBe(b.Random.Next());
     }
 }


### PR DESCRIPTION
Closes #985.

## The reported bug isn't real

`Start()` creates the reader thread with `IsBackground = true`, and the CLR tears background threads down at exit rather than waiting on them, so this thread cannot produce a nonzero exit code. Verified: full suite exits 0 (1644 passed), and 9 of the last 10 `tests.yml` runs were green. The one failure was an unrelated WIP test failure on `feature/tiled-non-tile-markers`, fixed on the next push.

Two real things came out of it anyway.

## 1. Nothing guarded the behavior the issue proposed changing

Nulls from `ReadLine()` are retried without limit on purpose (#773): a named-pipe stdin reports EOF whenever no writer is attached, then resumes once one reopens it. The issue proposed capping that at 5 consecutive nulls, which at the loop's 25ms retry delay abandons stdin after ~125ms, well inside normal harness startup latency.

The existing `ReaderLoop_TransientNullThenData_ProcessesLineAfterGap` uses `nullCount: 2`, so it **passes with that cap installed**. The regression could have landed green. `ReaderLoop_PersistentNull_KeepsRetryingUntilStopped` now fails on it, confirmed by actually applying the cap and watching it go red.

## 2. The thread genuinely never terminated

`Shutdown()` nulled `_automationMode` without stopping the loop, and returned early when `_game` was null, so tests could never reach the teardown. Seven pollers accumulated per test run. It's a production leak too: a game calling `Shutdown()` left the thread holding stdin.

- `AutomationMode` gains `Stop()` and an observable `ReaderThread`. The EOF wait is `_stopSignal.Wait(25)` instead of `Thread.Sleep(25)`, so a stop is seen immediately rather than after the remaining delay.
- `Shutdown()` stops the reader before the `_game` guard. Verified load-bearing: moving it below the guard fails `Shutdown_WithAutomationModeActive_StopsReaderThread`.
- `AutomationSeedTests` disposes its engines. `AutomationModeEngineWiringTests` already had `Shutdown()` in a `finally`; that call is now effective instead of a no-op.

No new public API. `Stop()` and `ReaderThread` are internal on an internal class.

## Tests

1644 passed, 0 failed, exit 0. Each of the three new tests confirmed red before green.

## Why the issue looked real

Worth recording, since the next reader will hit the same trap. `ReaderLoop` reads as an unconditional `while (true)` with one `return`; the `IsBackground = true` that defuses it sits 90 lines away in an object initializer inside `Start()`. And a test run prints 7 copies of `[AutomationMode] ReaderLoop: input stream reported EOF; retrying.`, which looks exactly like a hang if you already suspect one. Those lines are still emitted (they're accurate), but they're now backed by threads that actually exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dUm5318S5gTVjPytp5fxy
