### PR TITLE
Report timer resolution and platform in the perf report

### DIFF
--- a/frb-skills/performance/SKILL.md
+++ b/frb-skills/performance/SKILL.md
@@ -21,4 +21,12 @@ var worst = perf.GetCollisionReport();      // ordered most-expensive first, fla
 
 `GenerateReport()` only builds a string — it does no I/O itself, so printing/logging/writing it is on the caller.
 
+## Timer resolution (web)
+
+`GenerateReport()` opens with a `Platform:` line and the measured clock step (`TimerResolutionMs`, probed once via `ProfileClock.MeasureResolutionMs`).
+
+**Landmine:** browsers coarsen their clock as a Spectre mitigation — ~1ms on Firefox/Safari, ~0.1ms on Chrome — and `Stopwatch.Frequency` does not reflect it. Whole-pass totals stay accurate (start/end errors cancel), but any per-phase number smaller than one step reads as 0 or one full step and nothing between. The report warns automatically above 0.5ms.
+
+Set `PlatformLabel` from the host — the engine targets `net10.0` and cannot read `navigator.userAgent` itself.
+
 See `src/Diagnostics/FrameProfile.cs` for the underlying per-frame timing struct, and `Factory<T>.PartitionAxis` for what "unpartitioned" in the collision report means.

--- a/src/Diagnostics/PerformanceMonitor.cs
+++ b/src/Diagnostics/PerformanceMonitor.cs
@@ -15,6 +15,12 @@ public class PerformanceMonitor
 {
     private const int DefaultWindowSize = 120;
 
+    // Above this step, per-phase numbers are dominated by clock quantization rather than real
+    // work: a typical phase costs a few ms, so a half-millisecond step already swamps it.
+    private const double CoarseTimerResolutionMs = 0.5;
+
+    private double? _timerResolutionMs;
+
     private FrameProfile[] _window = new FrameProfile[DefaultWindowSize];
     private int _windowSize = DefaultWindowSize;
     private int _next;
@@ -46,6 +52,32 @@ public class PerformanceMonitor
             _next = 0;
             _count = 0;
         }
+    }
+
+    /// <summary>
+    /// Optional human-readable name for the host platform — set this to the browser name on web
+    /// builds. The engine targets plain <c>net10.0</c> and so cannot read <c>navigator.userAgent</c>
+    /// itself; the game supplies it via JS interop. Shown by <see cref="GenerateReport"/>, and used
+    /// to tailor the advice when <see cref="TimerResolutionMs"/> is too coarse to trust.
+    /// Null means "unknown", which suppresses only the platform-specific advice, not the warning.
+    /// </summary>
+    public string? PlatformLabel { get; set; }
+
+    /// <summary>
+    /// Smallest observable step of the clock behind every <see cref="FrameProfile"/> measurement,
+    /// in milliseconds. Probed on first read (a brief busy-wait, bounded to roughly one clock step
+    /// per sample), then cached.
+    /// <para>
+    /// Check this before trusting a per-phase breakdown. Browsers coarsen their clock as a Spectre
+    /// mitigation, and a phase costing well under one step reads as either 0 or one full step and
+    /// nothing in between. Whole-pass totals stay accurate regardless — their start and end errors
+    /// cancel — so it is only the small per-phase numbers that degrade.
+    /// </para>
+    /// </summary>
+    public double TimerResolutionMs
+    {
+        get => _timerResolutionMs ??= ProfileClock.MeasureResolutionMs();
+        internal set => _timerResolutionMs = value;
     }
 
     /// <summary>Rolling stats for the full Update+Draw frame time.</summary>
@@ -117,6 +149,7 @@ public class PerformanceMonitor
     public string GenerateReport()
     {
         var sb = new StringBuilder();
+        AppendPlatformAndTimerResolution(sb);
         var fps = Fps;
         sb.AppendLine(FormattableString.Invariant(
             $"FPS: {fps.Current:F1} (avg {fps.Average:F1}, min {fps.Min:F1}, max {fps.Max:F1})"));
@@ -142,6 +175,32 @@ public class PerformanceMonitor
         }
 
         return sb.ToString();
+    }
+
+    private void AppendPlatformAndTimerResolution(StringBuilder sb)
+    {
+        var resolution = TimerResolutionMs;
+        sb.AppendLine(FormattableString.Invariant(
+            $"Platform: {PlatformLabel ?? "unknown"} — timer resolution {resolution:F2}ms"));
+
+        if (resolution < CoarseTimerResolutionMs)
+        {
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine("[!] Clock is too coarse — per-phase timings below are unreliable. Totals");
+        sb.AppendLine("    (FrameTotal / UpdateTotal / DrawTotal) are still accurate; only the");
+        sb.AppendLine("    small per-phase numbers are dominated by quantization error.");
+
+        if (PlatformLabel != null && PlatformLabel.Contains("Firefox", StringComparison.OrdinalIgnoreCase))
+        {
+            sb.AppendLine("    Firefox rounds its clock to 1ms unless the page is cross-origin isolated");
+            sb.AppendLine("    (Cross-Origin-Opener-Policy: same-origin plus Cross-Origin-Embedder-Policy:");
+            sb.AppendLine("    require-corp). Profiling in Chrome (~0.1ms) is the quicker fix.");
+        }
+
+        sb.AppendLine();
     }
 
     private static void AppendPhase(StringBuilder sb, string name, PerformanceStat stat)

--- a/src/Diagnostics/ProfileClock.cs
+++ b/src/Diagnostics/ProfileClock.cs
@@ -3,12 +3,46 @@ using System.Diagnostics;
 namespace FlatRedBall2.Diagnostics;
 
 // High-resolution timestamp helper used by Screen.Update / FlatRedBallService.Update / Draw to
-// fill in FrameProfile fields. Stopwatch.GetTimestamp is RDTSC-backed on x64 (~5-10ns per call),
-// cheap enough to leave on per-frame in release.
+// fill in FrameProfile fields. RDTSC-backed on desktop x64 (~5-10ns per call), cheap enough to
+// leave on per-frame in release.
+//
+// Under WebAssembly there is no hardware-timer path: every clock routes through the browser's
+// performance.now(), which is deliberately coarsened as a Spectre mitigation (roughly 1ms on
+// Firefox and Safari, 0.1ms on Chrome, finer only in a cross-origin-isolated page). Stopwatch
+// .Frequency still reports a nominal frequency that does NOT reflect that clamp, so
+// MeasureResolutionMs probes the real step rather than trusting it.
 internal static class ProfileClock
 {
     private static readonly double TickToMs = 1000.0 / Stopwatch.Frequency;
 
+    // Each sample blocks until the clock ticks, so this directly bounds the probe's cost:
+    // ~10ms on a 1ms clock, microseconds on desktop. The minimum of 10 samples is plenty.
+    private const int ResolutionSampleCount = 10;
+
+    // Guards against a clock that never advances — without it the spin below would hang.
+    private const int MaxSpinsPerSample = 10_000_000;
+
     // Wall-clock milliseconds between two Stopwatch.GetTimestamp() values.
     public static double Ms(long startTicks, long endTicks) => (endTicks - startTicks) * TickToMs;
+
+    // Smallest observable step of the underlying clock, in milliseconds — the granularity every
+    // FrameProfile measurement is quantized to. Spins until the timestamp changes and takes the
+    // smallest jump seen. Returns 0 if the clock never advanced.
+    public static double MeasureResolutionMs()
+    {
+        long smallestTickJump = long.MaxValue;
+
+        for (int sample = 0; sample < ResolutionSampleCount; sample++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            long next = start;
+            for (int spin = 0; spin < MaxSpinsPerSample && next == start; spin++)
+                next = Stopwatch.GetTimestamp();
+
+            if (next == start) return 0;
+            if (next - start < smallestTickJump) smallestTickJump = next - start;
+        }
+
+        return smallestTickJump * TickToMs;
+    }
 }

--- a/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
+++ b/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
@@ -43,6 +43,22 @@ public class PerformanceMonitorTests
     }
 
     [Fact]
+    public void GenerateReport_CoarseTimerResolution_WarnsAndNamesPlatform()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true, PlatformLabel = "Firefox" };
+        monitor.TimerResolutionMs = 1.0;
+
+        monitor.Record(new FrameProfile { FrameTotalMs = 16 }, NoRelationships);
+
+        var text = monitor.GenerateReport();
+        text.ShouldContain("Platform: Firefox");
+        text.ShouldContain("timer resolution 1.00ms");
+        text.ShouldContain("per-phase timings below are unreliable");
+        // Firefox is the coarsest common target, so the report names the specific remedy.
+        text.ShouldContain("cross-origin isolated");
+    }
+
+    [Fact]
     public void GenerateReport_CollisionRelationships_OrdersBySeverityAndFlagsUnpartitioned()
     {
         var monitor = new PerformanceMonitor { IsEnabled = true };
@@ -64,6 +80,19 @@ public class PerformanceMonitorTests
         text.ShouldContain("Enemy vs Bullet: 50 deep checks [partitioned]");
         text.ShouldContain("Player vs TileShapes: 5 deep checks [NOT PARTITIONED]");
         text.IndexOf("Enemy vs Bullet").ShouldBeLessThan(text.IndexOf("Player vs TileShapes"));
+    }
+
+    [Fact]
+    public void GenerateReport_FineTimerResolution_OmitsWarning()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true, PlatformLabel = "Chrome" };
+        monitor.TimerResolutionMs = 0.1;
+
+        monitor.Record(new FrameProfile { FrameTotalMs = 16 }, NoRelationships);
+
+        var text = monitor.GenerateReport();
+        text.ShouldContain("Platform: Chrome");
+        text.ShouldNotContain("unreliable");
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Diagnostics/ProfileClockTests.cs
+++ b/tests/FlatRedBall2.Tests/Diagnostics/ProfileClockTests.cs
@@ -1,0 +1,17 @@
+using FlatRedBall2.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Diagnostics;
+
+public class ProfileClockTests
+{
+    [Fact]
+    public void MeasureResolutionMs_AnyPlatform_ReturnsPositiveValue()
+    {
+        // The probe spins until the clock ticks, so the smallest observable step is always > 0.
+        // The magnitude is platform-dependent (nanoseconds on desktop, ~1ms under a browser
+        // clamp), so only positivity is asserted here.
+        ProfileClock.MeasureResolutionMs().ShouldBeGreaterThan(0);
+    }
+}


### PR DESCRIPTION
`GenerateReport()` presented every per-phase number as equally trustworthy. On web that is wrong: browsers coarsen their clock as a Spectre mitigation (roughly 1ms on Firefox and Safari, 0.1ms on Chrome), so any phase costing less than one step reads as 0 or one full step and nothing in between. `Stopwatch.Frequency` reports a nominal frequency that does not reflect the clamp, so the real step has to be measured.

Whole-pass totals (`FrameTotal` / `UpdateTotal` / `DrawTotal`) stay accurate regardless, since their start and end errors cancel. Only the small per-phase numbers degrade, and the warning says so rather than invalidating the whole report.

New report header:

```
Platform: Firefox — timer resolution 1.00ms
[!] Clock is too coarse — per-phase timings below are unreliable. Totals
    (FrameTotal / UpdateTotal / DrawTotal) are still accurate; only the
    small per-phase numbers are dominated by quantization error.
    Firefox rounds its clock to 1ms unless the page is cross-origin isolated
    (Cross-Origin-Opener-Policy: same-origin plus Cross-Origin-Embedder-Policy:
    require-corp). Profiling in Chrome (~0.1ms) is the quicker fix.
```

Chrome gets the `Platform:` line and no warning.

## Changes

- `ProfileClock.MeasureResolutionMs()` spins until the timestamp changes, takes the smallest jump over 10 samples. Bounded so a clock that never advances cannot hang.
- `PerformanceMonitor.TimerResolutionMs` is probed lazily on first read, so nothing is paid at startup when the monitor is off.
- `PerformanceMonitor.PlatformLabel` is host-supplied. The engine targets plain `net10.0` with no `browser-wasm` TFM, so it cannot read `navigator.userAgent` itself; the game sets it via `IJSRuntime`. Firefox-specific advice keys off this.
- Fixed a stale comment in `ProfileClock` claiming RDTSC-backed timing unconditionally.

## Tests

`ProfileClockTests` (new) plus two in `PerformanceMonitorTests`, covering the coarse-clock warning with platform naming and the fine-clock case that omits it. Full suite green at 1647.

## Follow-up, not in this PR

`FrameProfile.UpdateTotalMs` is assigned rather than accumulated (`FlatRedBallService.cs:1399`). Under a fixed timestep MonoGame can run several Updates per Draw, and only the last one's cost survives into `FrameTotalMs`. That undercounts Update whenever the game is running slow, which is exactly when someone is reading this report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f7ox7doJb5HFTYocirjzT
