### PR TITLE
Fix stale BroadPhaseRadius cache and per-factory sweep bound

### DIFF
--- a/frb-skills/collision-relationships/SKILL.md
+++ b/frb-skills/collision-relationships/SKILL.md
@@ -302,13 +302,15 @@ built from partitioned factories — nothing to opt into on the relationship its
 ### Object Size (`BroadPhaseRadius`)
 
 Each entity's own `BroadPhaseRadius` (farthest shape edge from center, aggregated across attached
-shapes, cached) is used as its sweep edge — no manual size configuration needed, mixed sizes in
-one factory partition correctly automatically. `ICollidable.BroadPhaseRadius` has no default body;
+shapes) grows and shrinks automatically as shapes are added, removed, resized, moved, or
+reparented — no manual invalidation needed. `ICollidable.BroadPhaseRadius` has no default body;
 `Entity` supplies the aggregation itself, so every game entity gets it for free.
 
-**Landmine**: the cache is only invalidated on `Add`/`Remove`/`SetDefaultCollision` — resizing a
-shape's `Width`/`Height`/`Radius` after attaching it does not update it, so a growing entity can
-silently miss collisions under partitioning. Tracked in issue #989.
+The sweep itself never reads an individual entity's radius — it uses one shared upper bound per
+factory (`Factory<T>.PartitionMaxRadius`, internal), the largest `BroadPhaseRadius` any entity in
+that factory has ever reached. A single per-factory bound keeps the sweep's edge order valid even
+when entities in the same factory have very different sizes; the tradeoff is a slightly wider (but
+still correct) candidate window when sizes vary a lot.
 
 See `Factory<T>.PartitionAxis`/`SortForPartition` in `src/Factory.cs` and the broad-phase gate in
 `src/Collision/CollisionRelationship.cs`.

--- a/src/Collision/AARect.cs
+++ b/src/Collision/AARect.cs
@@ -19,10 +19,16 @@ namespace FlatRedBall2.Collision;
 /// </remarks>
 public class AARect : IAttachable, IRenderable, ICollidable
 {
+    private float _width = 32f;
+    private float _height = 32f;
+    private float _x;
+    private float _y;
+    private Entity? _parent;
+
     /// <summary>Width in world units. Defaults to 32. Centered on <see cref="X"/>.</summary>
-    public float Width { get; set; } = 32f;
+    public float Width { get => _width; set { _width = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Height in world units. Defaults to 32. Centered on <see cref="Y"/>.</summary>
-    public float Height { get; set; } = 32f;
+    public float Height { get => _height; set { _height = value; _parent?.InvalidateBroadPhaseRadius(); } }
 
     /// <summary>
     /// Controls which directions this rectangle may reposition overlapping objects.
@@ -47,11 +53,22 @@ public class AARect : IAttachable, IRenderable, ICollidable
 
     // IAttachable
     /// <inheritdoc/>
-    public Entity? Parent { get; set; }
+    public Entity? Parent
+    {
+        get => _parent;
+        set
+        {
+            if (ReferenceEquals(_parent, value)) return;
+            var old = _parent;
+            _parent = value;
+            old?.InvalidateBroadPhaseRadius();
+            value?.InvalidateBroadPhaseRadius();
+        }
+    }
     /// <summary>Center X. Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float X { get; set; }
+    public float X { get => _x; set { _x = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Center Y (Y+ up). Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float Y { get; set; }
+    public float Y { get => _y; set { _y = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>

--- a/src/Collision/Circle.cs
+++ b/src/Collision/Circle.cs
@@ -14,16 +14,32 @@ namespace FlatRedBall2.Collision;
 /// </summary>
 public class Circle : IAttachable, IRenderable, ICollidable
 {
+    private float _radius = 16f;
+    private float _x;
+    private float _y;
+    private Entity? _parent;
+
     /// <summary>Radius in world units. Defaults to 16. Used for both rendering and collision.</summary>
-    public float Radius { get; set; } = 16f;
+    public float Radius { get => _radius; set { _radius = value; _parent?.InvalidateBroadPhaseRadius(); } }
 
     // IAttachable
     /// <inheritdoc/>
-    public Entity? Parent { get; set; }
+    public Entity? Parent
+    {
+        get => _parent;
+        set
+        {
+            if (ReferenceEquals(_parent, value)) return;
+            var old = _parent;
+            _parent = value;
+            old?.InvalidateBroadPhaseRadius();
+            value?.InvalidateBroadPhaseRadius();
+        }
+    }
     /// <summary>X position. Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float X { get; set; }
+    public float X { get => _x; set { _x = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Y position (Y+ up). Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float Y { get; set; }
+    public float Y { get => _y; set { _y = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>

--- a/src/Collision/CollisionRelationship.cs
+++ b/src/Collision/CollisionRelationship.cs
@@ -426,18 +426,21 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
 
         if (ReferenceEquals(_listA, _listB))
         {
-            var axis = (_listA is IFactory fa) ? fa.PartitionAxis : null;
+            var fa = _listA as IFactory;
+            var axis = fa?.PartitionAxis;
             if (axis != null)
-                RunSameListCollisionsSweep(axis.Value, forward);
+                RunSameListCollisionsSweep(axis.Value, forward, fa!.PartitionMaxRadius);
             else
                 RunSameListCollisions(forward);
         }
         else
         {
-            Axis? axisA = (_listA is IFactory fa2) ? fa2.PartitionAxis : null;
-            Axis? axisB = (_listB is IFactory fb) ? fb.PartitionAxis : null;
+            var fa2 = _listA as IFactory;
+            var fb = _listB as IFactory;
+            Axis? axisA = fa2?.PartitionAxis;
+            Axis? axisB = fb?.PartitionAxis;
             if (axisA != null && axisA == axisB)
-                RunCrossListCollisionsSweep(axisA.Value);
+                RunCrossListCollisionsSweep(axisA.Value, fa2!.PartitionMaxRadius, fb!.PartitionMaxRadius);
             else
             {
                 for (int i = 0; i < _listA.Count; i++)
@@ -576,8 +579,11 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
         TryOfferGroundSnap(a, b);
     }
 
-    // Both lists are already sorted by their respective factories.
-    private void RunCrossListCollisionsSweep(Axis axis)
+    // Both lists are already sorted by their respective factories. radiusA/radiusB are each
+    // factory's shared IFactory.PartitionMaxRadius — a single bound per side, not each entity's
+    // own BroadPhaseRadius, so the sweep edges stay monotonic in sort order regardless of
+    // per-instance radius variance (see #992).
+    private void RunCrossListCollisionsSweep(Axis axis, float radiusA, float radiusB)
     {
         var listA = _listA;
         var listB = _listB;
@@ -589,16 +595,15 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
             var a = listA[i];
             var effectiveA = GetEffectiveA(a);
             float aPos = axis == Axis.X ? effectiveA.AbsoluteX : effectiveA.AbsoluteY;
-            float aR = effectiveA.BroadPhaseRadius;
-            float aLeft = aPos - aR;
-            float aRight = aPos + aR;
+            float aLeft = aPos - radiusA;
+            float aRight = aPos + radiusA;
 
             // Advance startB past items whose far edge is behind aLeft
             while (startB < listB.Count)
             {
                 var testB = GetEffectiveB(listB[startB]);
                 float testPos = axis == Axis.X ? testB.AbsoluteX : testB.AbsoluteY;
-                if (testPos + testB.BroadPhaseRadius >= aLeft) break;
+                if (testPos + radiusB >= aLeft) break;
                 startB++;
             }
 
@@ -607,7 +612,7 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
                 var b = listB[j];
                 var effectiveB = GetEffectiveB(b);
                 float bPos = axis == Axis.X ? effectiveB.AbsoluteX : effectiveB.AbsoluteY;
-                float bLeft = bPos - effectiveB.BroadPhaseRadius;
+                float bLeft = bPos - radiusB;
                 if (bLeft > aRight) break; // too far; all remaining are also too far
 
                 DeepCollisionCount++;
@@ -635,8 +640,10 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
     }
 
     // List is already sorted ascending by factory. Alternates sweep direction each frame
-    // to cancel the bias where the leftmost entity is always pushed left first.
-    private void RunSameListCollisionsSweep(Axis axis, bool forward)
+    // to cancel the bias where the leftmost entity is always pushed left first. radius is the
+    // factory's shared IFactory.PartitionMaxRadius — see RunCrossListCollisionsSweep for why a
+    // single per-factory bound (not each entity's own BroadPhaseRadius) is required here.
+    private void RunSameListCollisionsSweep(Axis axis, bool forward, float radius)
     {
         var list = _listA;
 
@@ -647,14 +654,14 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
                 var a = list[i];
                 var effectiveA = GetEffectiveA(a);
                 float aPos = axis == Axis.X ? effectiveA.AbsoluteX : effectiveA.AbsoluteY;
-                float aRight = aPos + effectiveA.BroadPhaseRadius;
+                float aRight = aPos + radius;
 
                 for (int j = i + 1; j < list.Count; j++)
                 {
                     var b = list[j];
                     var effectiveB = GetEffectiveB((B)(object)b);
                     float bPos = axis == Axis.X ? effectiveB.AbsoluteX : effectiveB.AbsoluteY;
-                    float bLeft = bPos - effectiveB.BroadPhaseRadius;
+                    float bLeft = bPos - radius;
                     if (bLeft > aRight) break;
 
                     RunSameListPair(a, b);
@@ -668,14 +675,14 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
                 var a = list[i];
                 var effectiveA = GetEffectiveA(a);
                 float aPos = axis == Axis.X ? effectiveA.AbsoluteX : effectiveA.AbsoluteY;
-                float aLeft = aPos - effectiveA.BroadPhaseRadius;
+                float aLeft = aPos - radius;
 
                 for (int j = i - 1; j >= 0; j--)
                 {
                     var b = list[j];
                     var effectiveB = GetEffectiveB((B)(object)b);
                     float bPos = axis == Axis.X ? effectiveB.AbsoluteX : effectiveB.AbsoluteY;
-                    float bRight = bPos + effectiveB.BroadPhaseRadius;
+                    float bRight = bPos + radius;
                     if (bRight < aLeft) break;
 
                     RunSameListPair(a, b);

--- a/src/Collision/Line.cs
+++ b/src/Collision/Line.cs
@@ -19,19 +19,35 @@ namespace FlatRedBall2.Collision;
 /// </remarks>
 public class Line : IAttachable, IRenderable, ICollidable
 {
+    private Vector2 _endPoint = new Vector2(32f, 0f);
+    private float _x;
+    private float _y;
+    private Entity? _parent;
+
     /// <summary>
     /// Offset from the first endpoint to the second, in world units.
     /// Added to <see cref="AbsolutePoint1"/> to produce <see cref="AbsolutePoint2"/>.
     /// </summary>
-    public Vector2 EndPoint { get; set; } = new Vector2(32f, 0f);
+    public Vector2 EndPoint { get => _endPoint; set { _endPoint = value; _parent?.InvalidateBroadPhaseRadius(); } }
 
     // IAttachable
     /// <inheritdoc/>
-    public Entity? Parent { get; set; }
+    public Entity? Parent
+    {
+        get => _parent;
+        set
+        {
+            if (ReferenceEquals(_parent, value)) return;
+            var old = _parent;
+            _parent = value;
+            old?.InvalidateBroadPhaseRadius();
+            value?.InvalidateBroadPhaseRadius();
+        }
+    }
     /// <summary>X of the first endpoint. Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float X { get; set; }
+    public float X { get => _x; set { _x = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Y of the first endpoint (Y+ up). Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float Y { get; set; }
+    public float Y { get => _y; set { _y = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>

--- a/src/Collision/Polygon.cs
+++ b/src/Collision/Polygon.cs
@@ -29,6 +29,9 @@ public class Polygon : IAttachable, IRenderable, ICollidable
 {
     private readonly List<Vector2> _points = new();
     private List<IReadOnlyList<Vector2>> _convexParts = new();
+    private float _x;
+    private float _y;
+    private Entity? _parent;
 
     /// <summary>
     /// The polygon's vertices in local (unrotated, unpositioned) space. Read-only — call
@@ -114,15 +117,27 @@ public class Polygon : IAttachable, IRenderable, ICollidable
         _points.Clear();
         _points.AddRange(points);
         BuildConvexParts();
+        _parent?.InvalidateBroadPhaseRadius();
     }
 
     // IAttachable
     /// <inheritdoc/>
-    public Entity? Parent { get; set; }
+    public Entity? Parent
+    {
+        get => _parent;
+        set
+        {
+            if (ReferenceEquals(_parent, value)) return;
+            var old = _parent;
+            _parent = value;
+            old?.InvalidateBroadPhaseRadius();
+            value?.InvalidateBroadPhaseRadius();
+        }
+    }
     /// <summary>X position. Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float X { get; set; }
+    public float X { get => _x; set { _x = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Y position (Y+ up). Relative to <see cref="Parent"/> when attached, world when root.</summary>
-    public float Y { get; set; }
+    public float Y { get => _y; set { _y = value; _parent?.InvalidateBroadPhaseRadius(); } }
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>

--- a/src/Entity.cs
+++ b/src/Entity.cs
@@ -43,6 +43,7 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
     private float _cachedBroadPhaseRadius;
     private bool _broadPhaseRadiusDirty = true;
     private readonly List<GraphicalUiElement> _gumChildren = new();
+    private Entity? _parent;
 
     /// <summary>
     /// Optional logical name for diagnostics, snapshots, and game-specific lookup.
@@ -132,7 +133,9 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
     /// <summary>
     /// Maximum distance from <see cref="AbsoluteX"/>/<see cref="AbsoluteY"/> to the far edge of
     /// any attached collision shape, used by the broad phase to cull entity pairs before
-    /// per-shape collision checks. Cached and invalidated when shapes are added or removed.
+    /// per-shape collision checks. Cached and invalidated whenever a shape is added, removed,
+    /// resized, moved (local offset), or reparented — including nested entities attached as
+    /// another entity's shape.
     /// </summary>
     public float BroadPhaseRadius
     {
@@ -154,6 +157,28 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
             }
             return _cachedBroadPhaseRadius;
         }
+    }
+
+    // Set by Factory<T>.CreateCore on the entities it creates — mirrors the _onDestroy closure
+    // convention (no stored back-reference to the generic Factory<T>). Invoked with this entity's
+    // freshly recomputed BroadPhaseRadius whenever it may have grown, so the factory's shared
+    // partitioning bound (Factory<T>.PartitionMaxRadius) can grow with it.
+    internal Action<float>? _onBroadPhaseRadiusGrew;
+
+    // Marks the cached BroadPhaseRadius dirty and eagerly recomputes it — this only runs on the
+    // rare write path (shape add/remove/resize/reparent), never per-frame movement, so eager
+    // recompute here is cheap. If the recompute grew the radius, notifies the owning factory (if
+    // any) and propagates up the Parent chain, since a nested entity's growth can grow its
+    // parent's aggregate too. Shrinking never needs to propagate — a stale-too-large bound stays
+    // safe, only a stale-too-small one is a correctness bug.
+    internal void InvalidateBroadPhaseRadius()
+    {
+        float previous = _cachedBroadPhaseRadius;
+        _broadPhaseRadiusDirty = true;
+        float current = BroadPhaseRadius;
+        if (current > previous)
+            _onBroadPhaseRadiusGrew?.Invoke(current);
+        Parent?.InvalidateBroadPhaseRadius();
     }
 
     /// <summary>
@@ -225,7 +250,22 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
     /// automatically by <see cref="Add(IAttachable, Layer?)"/> / <see cref="Remove(IAttachable)"/>; manual
     /// assignment is permitted but bypasses child-list bookkeeping and is rarely correct.
     /// </summary>
-    public Entity? Parent { get; set; }
+    public Entity? Parent
+    {
+        get => _parent;
+        set
+        {
+            if (ReferenceEquals(_parent, value)) return;
+            // Invalidate both sides *after* the pointer changes — this entity may be attached as
+            // another entity's shape (Entity implements ICollidable), so reparenting can change
+            // either side's aggregate, and the old side must recompute using this entity's new
+            // (post-reassignment) AbsoluteX/Y, not its pre-reassignment position.
+            var old = _parent;
+            _parent = value;
+            old?.InvalidateBroadPhaseRadius();
+            value?.InvalidateBroadPhaseRadius();
+        }
+    }
 
     /// <summary>
     /// All attached children (shapes, sprites, Gum visuals, sub-entities). Populated by
@@ -352,7 +392,7 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
         if (child is ICollidable collidable)
         {
             _shapes.Add(collidable);
-            _broadPhaseRadiusDirty = true;
+            InvalidateBroadPhaseRadius();
         }
 
         if (child is IRenderable renderable && _engine?.CurrentScreen != null)
@@ -381,7 +421,7 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
         if (isDefaultCollision)
         {
             _shapes.Add(child);
-            _broadPhaseRadiusDirty = true;
+            InvalidateBroadPhaseRadius();
         }
 
         if (child is IRenderable renderable && _engine?.CurrentScreen != null)
@@ -418,13 +458,13 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
             if (!_shapes.Contains(shape))
             {
                 _shapes.Add(shape);
-                _broadPhaseRadiusDirty = true;
+                InvalidateBroadPhaseRadius();
             }
         }
         else
         {
             if (_shapes.Remove(shape))
-                _broadPhaseRadiusDirty = true;
+                InvalidateBroadPhaseRadius();
         }
     }
 
@@ -439,7 +479,7 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
         child.Parent = null;
 
         if (child is ICollidable collidable && _shapes.Remove(collidable))
-            _broadPhaseRadiusDirty = true;
+            InvalidateBroadPhaseRadius();
 
         if (child is IRenderable renderable)
             _engine?.CurrentScreen?.Remove(renderable);

--- a/src/Factory.cs
+++ b/src/Factory.cs
@@ -14,6 +14,15 @@ internal interface IFactory
     void SortForPartition();
     System.Type EntityType { get; }
     System.Collections.Generic.IReadOnlyList<Entity> EntityInstances { get; }
+
+    /// <summary>
+    /// Upper bound on <see cref="Entity.BroadPhaseRadius"/> across every entity this factory has
+    /// ever created. Used as a single shared sweep-edge bound by the broad-phase partitioner
+    /// instead of each entity's own radius, so the sweep's monotonic-edge assumption holds
+    /// regardless of per-instance radius variance. Grows as entities are created or grow; never
+    /// shrinks (a stale-too-large bound is safe, just less tight).
+    /// </summary>
+    float PartitionMaxRadius { get; }
 }
 
 /// <summary>
@@ -43,6 +52,7 @@ public class Factory<T> : IEnumerable<T>, IReadOnlyList<T>, IFactory where T : E
 {
     private readonly Screen _screen;
     private readonly List<T> _instances = new();
+    private float _partitionMaxRadius;
 
     // Pooling state — only populated while pooling is enabled.
     private bool _poolingEnabled;
@@ -188,6 +198,8 @@ public class Factory<T> : IEnumerable<T>, IReadOnlyList<T>, IFactory where T : E
     /// </summary>
     public Axis? PartitionAxis { get; set; }
 
+    float IFactory.PartitionMaxRadius => _partitionMaxRadius;
+
     /// <summary>
     /// Controls SNES-style lazy-spawn behavior when this factory is the target of
     /// <see cref="Tiled.TileMap.CreateEntities{T}"/>. Default <see cref="LazySpawnMode.Disabled"/>
@@ -292,6 +304,11 @@ public class Factory<T> : IEnumerable<T>, IReadOnlyList<T>, IFactory where T : E
             entity._isPooled = true;
         _screen.AddEntity(entity);
         _instances.Add(entity);
+        entity._onBroadPhaseRadiusGrew = r =>
+        {
+            if (r > _partitionMaxRadius)
+                _partitionMaxRadius = r;
+        };
         entity._onDestroy = () =>
         {
             _instances.Remove(entity);

--- a/tests/FlatRedBall2.Tests/Collision/SweepAndPruneTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/SweepAndPruneTests.cs
@@ -231,6 +231,57 @@ public class SweepAndPruneTests
     }
 
     [Fact]
+    public void PartitionMaxRadius_GrowsWhenEntityRadiusGrowsAfterCreation()
+    {
+        // #992 — the factory-level bound must track growth, not just the radius at creation.
+        var (factory, _) = CreateFactory();
+        var a = factory.Create(); // default Circle radius 16
+        ((IFactory)factory).PartitionMaxRadius.ShouldBe(16f);
+
+        a.Circle.Radius = 60f;
+
+        ((IFactory)factory).PartitionMaxRadius.ShouldBe(60f);
+    }
+
+    [Fact]
+    public void PartitionAxis_EntityGrowsAfterCreation_SweepStillDetectsCollisionAgainstOtherFactory()
+    {
+        // Regression for #992: Factory<T>.SortForPartition() sorts by center position, and the
+        // sweep's two-pointer "startB" only ever advances forward across the outer loop. That's
+        // only safe if the per-entity radius is uniform — if a *later* entity in sort order has
+        // a much larger radius than an *earlier* one, the earlier entity's (smaller) radius can
+        // advance startB past a B-side candidate that the later entity actually overlaps, and
+        // that candidate is never tested again. The fix is a single shared per-factory bound
+        // (Factory<T>.PartitionMaxRadius) used for every entity's edge test, restoring the
+        // sweep's monotonic-edge invariant regardless of per-instance radius variance.
+        var screenA = new TestScreen();
+        screenA.Engine = new FlatRedBallService();
+        var screenB = new TestScreen();
+        screenB.Engine = new FlatRedBallService();
+        var factoryA = new Factory<BallEntity>(screenA);
+        var factoryB = new Factory<BallEntity>(screenB);
+        factoryA.PartitionAxis = Axis.X;
+        factoryB.PartitionAxis = Axis.X;
+
+        var a0 = factoryA.Create(); a0.X = 100f; a0.Name = "a0"; // default radius 16
+        var a1 = factoryA.Create(); a1.X = 110f; a1.Name = "a1";
+        a1.Circle.Radius = 60f; // grows well after creation — sorted after a0, much larger radius
+
+        var b0 = factoryB.Create(); b0.X = 65f; b0.Name = "b0"; // default radius 16 — overlaps only a1
+
+        ((IFactory)factoryA).SortForPartition();
+        ((IFactory)factoryB).SortForPartition();
+
+        var rel = new CollisionRelationship<BallEntity, BallEntity>(factoryA, factoryB);
+        (string, string)? firedPair = null;
+        rel.CollisionOccurred += (x, y) => firedPair = (x.Name!, y.Name!);
+
+        rel.RunCollisions();
+
+        firedPair.ShouldBe(("a1", "b0"));
+    }
+
+    [Fact]
     public void RunSameListCollisionsSweep_AlternatesSweepDirection_PairOrderReversesOnSecondFrame()
     {
         // Three overlapping balls in a line. On the first frame the sweep processes pairs

--- a/tests/FlatRedBall2.Tests/EntityTests.cs
+++ b/tests/FlatRedBall2.Tests/EntityTests.cs
@@ -278,6 +278,113 @@ public class EntityTests
         entity.BroadPhaseRadius.ShouldBe(0f);
     }
 
+    // #989 — BroadPhaseRadius goes stale when a shape resizes after Add.
+    [Fact]
+    public void BroadPhaseRadius_AfterCircleRadiusGrows_ReflectsNewRadius()
+    {
+        var entity = new Entity();
+        var circle = new Circle { Radius = 8f };
+        entity.Add(circle);
+        entity.BroadPhaseRadius.ShouldBe(8f);
+
+        circle.Radius = 64f;
+
+        entity.BroadPhaseRadius.ShouldBe(64f);
+    }
+
+    [Fact]
+    public void BroadPhaseRadius_AfterAARectWidthGrows_ReflectsNewRadius()
+    {
+        var entity = new Entity();
+        var rect = new AARect { Width = 10f, Height = 10f };
+        entity.Add(rect);
+        entity.BroadPhaseRadius.ShouldBe(5f);
+
+        rect.Width = 200f;
+
+        entity.BroadPhaseRadius.ShouldBe(100f);
+    }
+
+    [Fact]
+    public void BroadPhaseRadius_AfterPolygonSetPointsGrows_ReflectsNewRadius()
+    {
+        var entity = new Entity();
+        var poly = Polygon.CreateRectangle(10f, 10f);
+        entity.Add(poly);
+        var smallRadius = entity.BroadPhaseRadius;
+
+        poly.SetPoints(new System.Numerics.Vector2[]
+        {
+            new(-100f, -100f), new(100f, -100f), new(100f, 100f), new(-100f, 100f)
+        });
+
+        entity.BroadPhaseRadius.ShouldBeGreaterThan(smallRadius);
+    }
+
+    [Fact]
+    public void BroadPhaseRadius_AfterLineEndPointGrows_ReflectsNewRadius()
+    {
+        var entity = new Entity();
+        var line = new Line { EndPoint = new System.Numerics.Vector2(4f, 0f) };
+        entity.Add(line);
+        entity.BroadPhaseRadius.ShouldBe(4f);
+
+        line.EndPoint = new System.Numerics.Vector2(100f, 0f);
+
+        entity.BroadPhaseRadius.ShouldBe(100f);
+    }
+
+    [Fact]
+    public void BroadPhaseRadius_AfterShapeLocalOffsetGrows_ReflectsNewOffset()
+    {
+        var entity = new Entity();
+        var circle = new Circle { Radius = 4f, X = 0f };
+        entity.Add(circle);
+        entity.BroadPhaseRadius.ShouldBe(4f);
+
+        circle.X = 50f;
+
+        entity.BroadPhaseRadius.ShouldBe(54f);
+    }
+
+    // #989 — direct Parent reassignment bypasses Add()/Remove() shape-list bookkeeping
+    // entirely (a pre-existing, documented limitation of manual Parent assignment — it does
+    // not move the shape between _shapes lists). What must not happen is the *cache* going
+    // stale: oldParent still nominally owns the shape, so once the shape's absolute position
+    // jumps because its Parent changed, oldParent's cached BroadPhaseRadius must grow to
+    // match — a stale-small cache here is the actual bug (broad-phase would wrongly cull a
+    // real overlap).
+    [Fact]
+    public void BroadPhaseRadius_DirectParentReassignment_InvalidatesOldOwnersCache()
+    {
+        var oldParent = new Entity { X = 0f };
+        var farParent = new Entity { X = 1000f };
+        var circle = new Circle { Radius = 5f };
+        oldParent.Add(circle);
+        oldParent.BroadPhaseRadius.ShouldBe(5f);
+
+        circle.Parent = farParent; // bypasses Remove()/Add() — oldParent._shapes still has circle
+
+        oldParent.BroadPhaseRadius.ShouldBe(1005f);
+    }
+
+    // #989 — a nested Entity attached as another entity's shape must propagate growth up
+    // through the Parent chain, since the outer entity's cache aggregates the inner one's.
+    [Fact]
+    public void BroadPhaseRadius_NestedEntityShapeGrows_PropagatesToGrandparent()
+    {
+        var outer = new Entity();
+        var inner = new Entity();
+        var circle = new Circle { Radius = 4f };
+        inner.Add(circle);
+        outer.Add(inner);
+        var smallRadius = outer.BroadPhaseRadius;
+
+        circle.Radius = 100f;
+
+        outer.BroadPhaseRadius.ShouldBeGreaterThan(smallRadius);
+    }
+
     private class DestroyTrackingEntity : Entity
     {
         public bool WasDestroyed { get; private set; }


### PR DESCRIPTION
## Summary
- **#989**: `Entity.BroadPhaseRadius` only invalidated on Add/Remove/SetDefaultCollision. Shape resize (`Width`/`Height`/`Radius`/`SetPoints`/`EndPoint`), local-offset change, and direct `Parent` reassignment (bypassing Add/Remove) now all invalidate and eagerly recompute, propagating growth up through nested-entity `Parent` chains.
- **#992**: `Factory<T>.SortForPartition()` sorts by center position; the sweep's two-pointer break assumed roughly uniform per-entity radius. Variable `BroadPhaseRadius` could break that monotonic-edge assumption and silently miss real overlaps. The sweep now uses one shared bound per factory (`Factory<T>.PartitionMaxRadius`, internal) instead of each entity's own radius, restoring the invariant regardless of size variance. The bound grows via a closure set on each entity at creation (mirrors the existing `_onDestroy` decoupling convention) and never shrinks — a stale-too-large bound is safe, only stale-too-small is a correctness bug.
- Updated the `collision-relationships` skill's now-stale landmine note to describe the fixed, timeless behavior.

Combined into one PR per the dependency: #992's design requires the invalidation hooks #989 adds.

## Test plan
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1656 passed, 0 failed
- [x] New regression test (`SweepAndPruneTests.PartitionAxis_EntityGrowsAfterCreation_SweepStillDetectsCollisionAgainstOtherFactory`) reproduces the exact startB-never-rewinds bug: an entity that grows after creation, sorted before a smaller entity that already advanced the two-pointer past a real overlap — confirmed failing before the fix, passing after.
- [x] New `EntityTests` cases cover resize-after-add for every shape type, local-offset change, direct-Parent-reassignment cache staleness, and nested-entity growth propagation.
- Manual test: not needed — fully covered by the headless `Factory<T>`/`Screen` boot pattern already used throughout `tests/FlatRedBall2.Tests`.

Closes #989, closes #992.
