### PR TITLE
Rotate attached children's position offset with parent rotation (lever-arm)

### DIFF
--- a/src/AttachmentMath.cs
+++ b/src/AttachmentMath.cs
@@ -1,0 +1,26 @@
+namespace FlatRedBall2;
+
+/// <summary>
+/// Shared math for composing a child's world-space position from a parent <see cref="Entity"/>.
+/// Every <see cref="ISpatialAttachable"/> implementation (<see cref="Entity"/>, shapes, <c>Sprite</c>)
+/// calls this from its <c>AbsoluteX</c>/<c>AbsoluteY</c> getters so the rigid-2D-transform formula
+/// exists in exactly one place.
+/// </summary>
+internal static class AttachmentMath
+{
+    /// <summary>
+    /// Rotates the local offset (<paramref name="localX"/>, <paramref name="localY"/>) by
+    /// <paramref name="parent"/>'s <see cref="Entity.AbsoluteRotation"/> and adds it to the
+    /// parent's absolute position — the lever-arm transform that makes an attached child orbit
+    /// around its parent's origin as the parent rotates, matching the parent's own visible facing.
+    /// </summary>
+    public static (float X, float Y) ComposeAbsolute(Entity parent, float localX, float localY)
+    {
+        float angle = parent.AbsoluteRotation.Radians;
+        float cos = System.MathF.Cos(angle);
+        float sin = System.MathF.Sin(angle);
+        float rotatedX = localX * cos - localY * sin;
+        float rotatedY = localX * sin + localY * cos;
+        return (parent.AbsoluteX + rotatedX, parent.AbsoluteY + rotatedY);
+    }
+}

--- a/src/Collision/AARect.cs
+++ b/src/Collision/AARect.cs
@@ -72,9 +72,9 @@ public class AARect : IAttachable, IRenderable, ICollidable
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>
-    public float AbsoluteX => Parent != null ? Parent.AbsoluteX + X : X;
+    public float AbsoluteX => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).X : X;
     /// <inheritdoc/>
-    public float AbsoluteY => Parent != null ? Parent.AbsoluteY + Y : Y;
+    public float AbsoluteY => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).Y : Y;
     /// <summary>Final Z after walking the parent chain.</summary>
     public float AbsoluteZ => Parent != null ? Parent.AbsoluteZ + Z : Z;
     /// <inheritdoc/>

--- a/src/Collision/Circle.cs
+++ b/src/Collision/Circle.cs
@@ -43,9 +43,9 @@ public class Circle : IAttachable, IRenderable, ICollidable
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>
-    public float AbsoluteX => Parent != null ? Parent.AbsoluteX + X : X;
+    public float AbsoluteX => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).X : X;
     /// <inheritdoc/>
-    public float AbsoluteY => Parent != null ? Parent.AbsoluteY + Y : Y;
+    public float AbsoluteY => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).Y : Y;
     /// <summary>Final Z after walking the parent chain.</summary>
     public float AbsoluteZ => Parent != null ? Parent.AbsoluteZ + Z : Z;
     /// <inheritdoc/>

--- a/src/Collision/Polygon.cs
+++ b/src/Collision/Polygon.cs
@@ -141,9 +141,9 @@ public class Polygon : IAttachable, IRenderable, ICollidable
     /// <summary>Z value. See <see cref="Entity.Z"/> for draw-order semantics.</summary>
     public float Z { get; set; }
     /// <inheritdoc/>
-    public float AbsoluteX => Parent != null ? Parent.AbsoluteX + X : X;
+    public float AbsoluteX => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).X : X;
     /// <inheritdoc/>
-    public float AbsoluteY => Parent != null ? Parent.AbsoluteY + Y : Y;
+    public float AbsoluteY => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).Y : Y;
     /// <summary>Final Z after walking the parent chain.</summary>
     public float AbsoluteZ => Parent != null ? Parent.AbsoluteZ + Z : Z;
 

--- a/src/Entity.cs
+++ b/src/Entity.cs
@@ -113,15 +113,18 @@ public class Entity : ICollidable, IAttachable, ILifecycleEvents
 
     /// <summary>
     /// Final world-space X after walking the parent chain. Equal to <see cref="X"/> when this
-    /// entity is a root; otherwise <c>Parent.AbsoluteX + X</c>.
+    /// entity is a root; otherwise <see cref="X"/>/<see cref="Y"/> rotated by
+    /// <c>Parent.AbsoluteRotation</c> and added to <c>Parent.AbsoluteX</c> — an attached child
+    /// orbits its parent's origin as the parent rotates (lever-arm), it does not keep a fixed
+    /// world offset.
     /// </summary>
-    public float AbsoluteX => Parent != null ? Parent.AbsoluteX + X : X;
+    public float AbsoluteX => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).X : X;
 
     /// <summary>
     /// Final world-space Y after walking the parent chain. Equal to <see cref="Y"/> when this
-    /// entity is a root; otherwise <c>Parent.AbsoluteY + Y</c>.
+    /// entity is a root; otherwise see <see cref="AbsoluteX"/> for the rotation-composed formula.
     /// </summary>
-    public float AbsoluteY => Parent != null ? Parent.AbsoluteY + Y : Y;
+    public float AbsoluteY => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).Y : Y;
 
     /// <summary>
     /// Final Z after walking the parent chain. Equal to <see cref="Z"/> when this entity is a

--- a/src/Rendering/Sprite.cs
+++ b/src/Rendering/Sprite.cs
@@ -72,11 +72,16 @@ public class Sprite : IRenderable, IAttachable
     /// <summary>Per-sprite draw order within its <see cref="Layer"/>. See <see cref="IRenderable.Z"/> for sorting semantics.</summary>
     public float Z { get; set; }
 
-    /// <summary>Final world-space X after walking the parent chain.</summary>
-    public float AbsoluteX => Parent != null ? Parent.AbsoluteX + X : X;
+    /// <summary>
+    /// Final world-space X after walking the parent chain. When attached, <see cref="X"/>/<see cref="Y"/>
+    /// are rotated by the parent's <see cref="AbsoluteRotation"/> before being added to the
+    /// parent's absolute position — an attached sprite orbits its parent's origin as the parent
+    /// rotates (lever-arm), it does not keep a fixed world offset.
+    /// </summary>
+    public float AbsoluteX => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).X : X;
 
-    /// <summary>Final world-space Y after walking the parent chain.</summary>
-    public float AbsoluteY => Parent != null ? Parent.AbsoluteY + Y : Y;
+    /// <summary>Final world-space Y after walking the parent chain. See <see cref="AbsoluteX"/> for the rotation-composed formula.</summary>
+    public float AbsoluteY => Parent != null ? AttachmentMath.ComposeAbsolute(Parent, X, Y).Y : Y;
 
     /// <summary>Final Z after walking the parent chain. Used for sort order; see <see cref="Z"/>.</summary>
     public float AbsoluteZ => Parent != null ? Parent.AbsoluteZ + Z : Z;

--- a/tests/FlatRedBall2.Tests/Collision/ShapeAttachmentTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/ShapeAttachmentTests.cs
@@ -1,0 +1,62 @@
+using FlatRedBall2.Collision;
+using FlatRedBall2.Math;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Collision;
+
+// Issue #991: a shape's local offset must rotate with the parent's AbsoluteRotation (lever-arm
+// orbit), not stay at a fixed world offset. One test per shape type since each implements its
+// own AbsoluteX/AbsoluteY rather than sharing Entity's.
+public class ShapeAttachmentTests
+{
+    [Fact]
+    public void AbsoluteX_AARectWithRotatedParent_OrbitsAroundParent()
+    {
+        var parentRotation = Angle.FromDegrees(90f);
+        float childX = 10f, childY = 0f;
+        float expectedAbsoluteX = 0f;
+        float expectedAbsoluteY = 10f;
+
+        var parent = new Entity { Rotation = parentRotation };
+        var rect = new AARect { X = childX, Y = childY };
+        parent.Add(rect);
+
+        rect.AbsoluteX.ShouldBe(expectedAbsoluteX, tolerance: 0.001f);
+        rect.AbsoluteY.ShouldBe(expectedAbsoluteY, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void AbsoluteX_CircleWithRotatedParent_OrbitsAroundParent()
+    {
+        var parentRotation = Angle.FromDegrees(90f);
+        float childX = 10f, childY = 0f;
+        float expectedAbsoluteX = 0f;
+        float expectedAbsoluteY = 10f;
+
+        var parent = new Entity { Rotation = parentRotation };
+        var circle = new Circle { X = childX, Y = childY };
+        parent.Add(circle);
+
+        circle.AbsoluteX.ShouldBe(expectedAbsoluteX, tolerance: 0.001f);
+        circle.AbsoluteY.ShouldBe(expectedAbsoluteY, tolerance: 0.001f);
+    }
+
+    [Fact]
+    public void AbsoluteX_PolygonWithRotatedParent_OrbitsAroundParent()
+    {
+        var parentRotation = Angle.FromDegrees(90f);
+        float childX = 10f, childY = 0f;
+        float expectedAbsoluteX = 0f;
+        float expectedAbsoluteY = 10f;
+
+        var parent = new Entity { Rotation = parentRotation };
+        var polygon = Polygon.CreateRectangle(4f, 4f);
+        polygon.X = childX;
+        polygon.Y = childY;
+        parent.Add(polygon);
+
+        polygon.AbsoluteX.ShouldBe(expectedAbsoluteX, tolerance: 0.001f);
+        polygon.AbsoluteY.ShouldBe(expectedAbsoluteY, tolerance: 0.001f);
+    }
+}

--- a/tests/FlatRedBall2.Tests/EntityTests.cs
+++ b/tests/FlatRedBall2.Tests/EntityTests.cs
@@ -26,6 +26,25 @@ public class EntityTests
     }
 
     [Fact]
+    public void AbsolutePosition_ParentRotated_OffsetOrbitsAroundParent()
+    {
+        // Parent rotated 90 degrees CCW: a child offset directly along the parent's local
+        // +X axis should swing to point along world +Y, not stay at its unrotated world offset.
+        var parentRotation = Angle.FromDegrees(90f);
+        float parentX = 0f, parentY = 0f;
+        float childX = 10f, childY = 0f;
+        float expectedAbsoluteX = 0f;
+        float expectedAbsoluteY = 10f;
+
+        var parent = new Entity { X = parentX, Y = parentY, Rotation = parentRotation };
+        var child = new Entity { X = childX, Y = childY };
+        parent.Add(child);
+
+        child.AbsoluteX.ShouldBe(expectedAbsoluteX, tolerance: 0.001f);
+        child.AbsoluteY.ShouldBe(expectedAbsoluteY, tolerance: 0.001f);
+    }
+
+    [Fact]
     public void PauseMode_NewEntity_DefaultsToPausable()
     {
         var entity = new Entity();

--- a/tests/FlatRedBall2.Tests/Rendering/SpriteRotationTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/SpriteRotationTests.cs
@@ -39,6 +39,24 @@ public class SpriteRotationTests
         return XVec2.Transform(preMatrix, camera.GetTransformMatrix()).Y;
     }
 
+    // Issue #991: a sprite's local offset must rotate with the parent's AbsoluteRotation
+    // (lever-arm orbit), not stay at a fixed world offset.
+    [Fact]
+    public void AbsoluteX_ParentRotated_OrbitsAroundParent()
+    {
+        var parentRotation = Angle.FromDegrees(90f);
+        float childX = 10f, childY = 0f;
+        float expectedAbsoluteX = 0f;
+        float expectedAbsoluteY = 10f;
+
+        var parent = new Entity { Rotation = parentRotation };
+        var sprite = new Sprite { X = childX, Y = childY };
+        parent.Add(sprite);
+
+        sprite.AbsoluteX.ShouldBe(expectedAbsoluteX, tolerance: 0.001f);
+        sprite.AbsoluteY.ShouldBe(expectedAbsoluteY, tolerance: 0.001f);
+    }
+
     [Fact]
     public void Sprite_PositiveRotation_RotatesCounterclockwise_LikePolygon()
     {


### PR DESCRIPTION
Closes #991.

## Fix

`AbsoluteX`/`AbsoluteY` on `Entity`, `AARect`, `Circle`, `Polygon`, and `Sprite` all added
`Parent.AbsoluteX/Y + X/Y` with no rotation applied to the local offset — an attached child's
position stayed fixed in world space regardless of parent rotation (it spun in place via
`AbsoluteRotation`, which does compose, but never orbited). Turret guns, wheels, orbiting
shields, etc. never swung to track parent facing.

Fix: rotate the local `(X, Y)` offset by `Parent.AbsoluteRotation` before adding it to
`Parent.AbsoluteX/Y` (standard rigid 2D transform), extracted into a single
`AttachmentMath.ComposeAbsolute` helper all five call sites share so the formula can't drift
apart again.

## Resolving the issue's open questions

- **Is fixed-offset-with-independent-orientation intended, or should offsets rotate?** Checked
  FRB1's `PositionedObject.ForceUpdateDependencies` as the reference point: it rotates the offset
  by the parent's rotation matrix by default (`ParentRotationChangesPosition = true`). This PR
  matches that default. FRB1 also exposes an opt-out flag (`ParentRotationChangesPosition = false`)
  to keep the old fixed-offset behavior per-instance — deliberately not porting that flag here;
  no current FRB2 use case needs it, and it's easy to add later against a real use case.
- **Should this apply uniformly to every position-composing type?** Yes — fixed all five
  (`Entity`, `AARect`, `Circle`, `Polygon`, `Sprite`), matching the issue's own point that there's
  no split between "looks right, physics wrong."
- **FRB1 reference behavior**: confirmed above.

## Tests

One test per type (5 total) reproduces the bug: a parent rotated 90° with a child offset along
local +X must land at world (0, +offset), not stay at unrotated (+offset, 0). All failed before
the fix, pass after. Full suite: 1661/1661 passing, no regressions.

Manual test: not needed — pure position/rotation math covered by the headless unit tests above;
no rendering or GraphicsDevice involved.
