### PR TITLE
Add IsEnabled to CollisionRelationship

### DIFF
--- a/frb-skills/collision-relationships/SKILL.md
+++ b/frb-skills/collision-relationships/SKILL.md
@@ -105,6 +105,15 @@ rel.CollisionEnded   += (_, _)    => _player.ResetMovementProfile();
 - **Tunneling:** if an entity moves so fast it overlaps for zero frames, neither event fires. Same limitation as `CollisionOccurred`.
 - **Zero-overhead when unused** — no tracking runs if neither event has a subscriber.
 
+## Turning a Relationship Off — `IsEnabled`
+
+`rel.IsEnabled = false` stops the automatic per-frame run. `rel.RunCollisions()` is public and
+still works while disabled, so game code can drive collision on its own schedule.
+
+**Landmine**: disabling fires `CollisionEnded` immediately for every pair overlapping at that
+moment, and re-enabling refires `CollisionStarted` for pairs still overlapping — an enter/exit
+counter sees one extra pair of events per toggle.
+
 ## Execution Order
 
 Collision runs after physics and before `CustomActivity` — by the time game logic runs, entities are already separated from any overlapping collision partner. See `engine-overview` for the full frame loop.

--- a/src/Collision/CollisionRelationship.cs
+++ b/src/Collision/CollisionRelationship.cs
@@ -18,7 +18,8 @@ namespace FlatRedBall2.Collision;
 /// Created by
 /// <see cref="Screen.AddCollisionRelationship{A,B}(System.Collections.Generic.IReadOnlyList{A}, System.Collections.Generic.IReadOnlyList{B})"/>
 /// — game code does not construct these directly. Once added, the screen calls
-/// <c>RunCollisions</c> on each registered relationship every frame.
+/// <see cref="RunCollisions"/> on each registered relationship every frame, unless
+/// <see cref="IsEnabled"/> has been set to <c>false</c>.
 /// </para>
 /// <para>
 /// Performance: when both lists come from a <see cref="Factory{T}"/> sharing the same
@@ -240,9 +241,11 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
     // Tracked in a set to avoid double-subscribing across frames. HashSet<object> because A or B
     // may be Entity, shape, or TileShapes; only Entity has _onDestroy.
     private HashSet<object>? _hookedEntities;
-    // Reused scratch set when a destroy hook fires, to dedupe pairs across current+previous before
-    // firing Ended once per unique pair.
-    private HashSet<(A, B)>? _scratchDestroyedPairs;
+    // Reused scratch set when a destroy hook fires or the relationship is disabled, to dedupe pairs
+    // across current+previous before firing Ended once per unique pair.
+    private HashSet<(A, B)>? _scratchUniqueEndedPairs;
+
+    private bool _isEnabled = true;
 
     internal CollisionRelationship(IReadOnlyList<A> listA, IReadOnlyList<B> listB)
     {
@@ -395,19 +398,19 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
         // Fire CollisionEnded exactly once for each unique pair that referenced the destroyed
         // entity — whether the pair was in _current, _previous, or both. Removing from both sets
         // prevents the end-of-frame diff from double-firing.
-        _scratchDestroyedPairs ??= new HashSet<(A, B)>();
-        _scratchDestroyedPairs.Clear();
+        _scratchUniqueEndedPairs ??= new HashSet<(A, B)>();
+        _scratchUniqueEndedPairs.Clear();
 
         if (_currentContacts != null)
             foreach (var p in _currentContacts)
                 if (ReferenceEquals(p.Item1, destroyed) || ReferenceEquals(p.Item2, destroyed))
-                    _scratchDestroyedPairs.Add(p);
+                    _scratchUniqueEndedPairs.Add(p);
         if (_previousContacts != null)
             foreach (var p in _previousContacts)
                 if (ReferenceEquals(p.Item1, destroyed) || ReferenceEquals(p.Item2, destroyed))
-                    _scratchDestroyedPairs.Add(p);
+                    _scratchUniqueEndedPairs.Add(p);
 
-        foreach (var p in _scratchDestroyedPairs)
+        foreach (var p in _scratchUniqueEndedPairs)
         {
             _currentContacts?.Remove(p);
             _previousContacts?.Remove(p);
@@ -416,9 +419,61 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
         _hookedEntities?.Remove(destroyed);
     }
 
-    void ICollisionRelationship.RunCollisions() => RunCollisions();
+    // Fires CollisionEnded once per unique tracked pair, then drops all tracking. Called when the
+    // relationship is disabled so no pair is left dangling in the "started" state.
+    private void FireEndedForAllContacts()
+    {
+        if (!IsTrackingContacts) return;
+        _scratchUniqueEndedPairs ??= new HashSet<(A, B)>();
+        _scratchUniqueEndedPairs.Clear();
 
-    internal void RunCollisions()
+        if (_currentContacts != null)
+            foreach (var p in _currentContacts) _scratchUniqueEndedPairs.Add(p);
+        if (_previousContacts != null)
+            foreach (var p in _previousContacts) _scratchUniqueEndedPairs.Add(p);
+
+        // Clear before invoking so a handler that re-enables the relationship starts from a clean
+        // slate rather than seeing pairs that are about to be reported as ended.
+        _currentContacts?.Clear();
+        _previousContacts?.Clear();
+
+        foreach (var p in _scratchUniqueEndedPairs)
+            CollisionEnded?.Invoke(p.Item1, p.Item2);
+    }
+
+    /// <summary>
+    /// When <c>false</c>, the screen stops running this relationship each frame. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Setting this to <c>false</c> fires <see cref="CollisionEnded"/> immediately for every pair
+    /// currently overlapping, so a disable mid-overlap never strands a pair in the "started" state.
+    /// Re-enabling refires <see cref="CollisionStarted"/> for pairs that are still overlapping.
+    /// <para>
+    /// Disabling only opts out of the automatic per-frame call. <see cref="RunCollisions"/> still
+    /// works while disabled, so game code can drive collision on its own schedule.
+    /// </para>
+    /// </remarks>
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (_isEnabled == value) return;
+            _isEnabled = value;
+            if (!value)
+            {
+                DeepCollisionCount = 0;
+                FireEndedForAllContacts();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs this relationship's collision detection and response once. The screen calls this every
+    /// frame while <see cref="IsEnabled"/> is <c>true</c>; call it yourself to drive collision on a
+    /// custom schedule — it works whether or not the relationship is enabled.
+    /// </summary>
+    public void RunCollisions()
     {
         DeepCollisionCount = 0;
         bool forward = _sweepForward;

--- a/src/Collision/CollisionSystem.cs
+++ b/src/Collision/CollisionSystem.cs
@@ -21,10 +21,16 @@ internal sealed class CollisionSystem
     /// <summary>Clears all collision relationships.</summary>
     internal void Clear() => _relationships.Clear();
 
-    /// <summary>Runs all registered collision relationships. Called once per frame after physics.</summary>
+    /// <summary>
+    /// Runs every enabled collision relationship. Called once per frame after physics; relationships
+    /// with <see cref="ICollisionRelationship.IsEnabled"/> set to <c>false</c> are skipped.
+    /// </summary>
     internal void RunAllCollisions()
     {
         for (int i = 0; i < _relationships.Count; i++)
-            _relationships[i].RunCollisions();
+        {
+            if (_relationships[i].IsEnabled)
+                _relationships[i].RunCollisions();
+        }
     }
 }

--- a/src/Collision/ICollisionRelationship.cs
+++ b/src/Collision/ICollisionRelationship.cs
@@ -6,6 +6,12 @@ internal interface ICollisionRelationship
     int DeepCollisionCount { get; }
 
     /// <summary>
+    /// When <c>false</c>, <see cref="CollisionSystem.RunAllCollisions"/> skips this relationship and
+    /// <see cref="FlatRedBall2.Diagnostics.PerformanceMonitor"/> omits it from the collision report.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
     /// <c>false</c> when this relationship falls back to the O(n×m) check because its lists don't
     /// share a matching <see cref="Factory{T}.PartitionAxis"/>. Read by
     /// <see cref="FlatRedBall2.Diagnostics.PerformanceMonitor"/> for its collision severity report.

--- a/src/Diagnostics/PerformanceMonitor.cs
+++ b/src/Diagnostics/PerformanceMonitor.cs
@@ -127,6 +127,7 @@ public class PerformanceMonitor
         var report = new List<CollisionRelationshipReport>(_relationships.Count);
         foreach (var r in _relationships)
         {
+            if (!r.IsEnabled) continue;    // costs nothing to run, so flagging it as expensive is noise
             report.Add(new CollisionRelationshipReport
             {
                 Name = r.DisplayName,

--- a/tests/FlatRedBall2.Tests/Collision/CollisionRelationshipIsEnabledTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/CollisionRelationshipIsEnabledTests.cs
@@ -1,0 +1,109 @@
+using FlatRedBall2.Collision;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Collision;
+
+public class CollisionRelationshipIsEnabledTests
+{
+    private static AARect Rect(float x, float y = 0f, float size = 32f) =>
+        new() { Width = size, Height = size, X = x, Y = y };
+
+    [Fact]
+    public void IsEnabled_DefaultsToTrue()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(20f) });
+
+        rel.IsEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_SetToFalseTwiceWhileOverlapping_FiresCollisionEndedOnce()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(20f) });
+        int ended = 0;
+        rel.CollisionEnded += (_, _) => ended++;
+        rel.RunCollisions();
+
+        rel.IsEnabled = false;
+        rel.IsEnabled = false;
+
+        ended.ShouldBe(1);
+    }
+
+    [Fact]
+    public void IsEnabled_SetToFalseWhileNotOverlapping_DoesNotFireCollisionEnded()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(200f) });
+        int ended = 0;
+        rel.CollisionEnded += (_, _) => ended++;
+        rel.RunCollisions();
+
+        rel.IsEnabled = false;
+
+        ended.ShouldBe(0);
+    }
+
+    [Fact]
+    public void IsEnabled_SetToFalseWhileOverlapping_FiresCollisionEnded()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(20f) });
+        int ended = 0;
+        rel.CollisionEnded += (_, _) => ended++;
+        rel.RunCollisions();           // overlapping — Ended not yet fired
+        ended.ShouldBe(0);
+
+        rel.IsEnabled = false;
+
+        ended.ShouldBe(1);
+    }
+
+    [Fact]
+    public void IsEnabled_SetToFalse_ZeroesDeepCollisionCount()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(20f) });
+        rel.RunCollisions();
+        rel.DeepCollisionCount.ShouldBe(1);
+
+        rel.IsEnabled = false;
+
+        rel.DeepCollisionCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void IsEnabled_ReEnabledWhileStillOverlapping_FiresCollisionStartedAgain()
+    {
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { Rect(0f) }, new[] { Rect(20f) });
+        int started = 0;
+        rel.CollisionStarted += (_, _) => started++;
+        rel.RunCollisions();           // started #1
+        started.ShouldBe(1);
+
+        rel.IsEnabled = false;
+        rel.IsEnabled = true;
+        rel.RunCollisions();
+
+        started.ShouldBe(2);
+    }
+
+    [Fact]
+    public void RunCollisions_CalledManuallyWhileDisabled_StillCollidesAndTracksContacts()
+    {
+        var a = Rect(0f);
+        var b = Rect(20f);
+        var rel = new CollisionRelationship<AARect, AARect>(new[] { a }, new[] { b });
+        int started = 0, ended = 0;
+        rel.CollisionStarted += (_, _) => started++;
+        rel.CollisionEnded += (_, _) => ended++;
+        rel.IsEnabled = false;
+
+        rel.RunCollisions();           // manual run while disabled — overlapping
+        started.ShouldBe(1);
+        rel.DeepCollisionCount.ShouldBe(1);
+
+        b.X = 200f;
+        rel.RunCollisions();
+
+        ended.ShouldBe(1);
+    }
+}

--- a/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
@@ -13,6 +13,7 @@ public class CollisionSystemTests
         public int DeepCollisionCount => 0;
         public bool IsPartitioned => false;
         public string DisplayName => "CallCountRelationship";
+        public bool IsEnabled { get; set; } = true;
         public void RunCollisions() => CallCount++;
     }
 
@@ -26,6 +27,18 @@ public class CollisionSystemTests
         system.RunAllCollisions();
 
         rel.CallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RunAllCollisions_WithDisabledRelationship_DoesNotInvokeRunCollisions()
+    {
+        var system = new CollisionSystem();
+        var rel = new CallCountRelationship { IsEnabled = false };
+        system.Add(rel);
+
+        system.RunAllCollisions();
+
+        rel.CallCount.ShouldBe(0);
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
+++ b/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
@@ -10,16 +10,18 @@ public class PerformanceMonitorTests
 {
     private sealed class FakeRelationship : ICollisionRelationship
     {
-        public FakeRelationship(string name, int deepCollisionCount, bool isPartitioned)
+        public FakeRelationship(string name, int deepCollisionCount, bool isPartitioned, bool isEnabled = true)
         {
             DisplayName = name;
             DeepCollisionCount = deepCollisionCount;
             IsPartitioned = isPartitioned;
+            IsEnabled = isEnabled;
         }
 
         public string DisplayName { get; }
         public int DeepCollisionCount { get; }
         public bool IsPartitioned { get; }
+        public bool IsEnabled { get; set; }
         public void RunCollisions() { }
     }
 
@@ -80,6 +82,24 @@ public class PerformanceMonitorTests
         text.ShouldContain("Enemy vs Bullet: 50 deep checks [partitioned]");
         text.ShouldContain("Player vs TileShapes: 5 deep checks [NOT PARTITIONED]");
         text.IndexOf("Enemy vs Bullet").ShouldBeLessThan(text.IndexOf("Player vs TileShapes"));
+    }
+
+    [Fact]
+    public void GenerateReport_DisabledRelationship_IsOmittedFromCollisionReport()
+    {
+        var monitor = new PerformanceMonitor { IsEnabled = true };
+        var relationships = new List<ICollisionRelationship>
+        {
+            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, isPartitioned: true),
+            new FakeRelationship("Player vs Door", deepCollisionCount: 5, isPartitioned: false, isEnabled: false)
+        };
+
+        monitor.Record(new FrameProfile { FrameTotalMs = 16 }, relationships);
+
+        var report = monitor.GetCollisionReport();
+        report.Count.ShouldBe(1);
+        report[0].Name.ShouldBe("Enemy vs Bullet");
+        monitor.GenerateReport().ShouldNotContain("Player vs Door");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #987.

`IsEnabled = false` opts a relationship out of the automatic per-frame run. `RunCollisions()` is now public so game code can still drive it on its own schedule while disabled.

Naming: went with `RunCollisions()` over FRB1's `DoCollisions()` to match the existing internal name and this repo's `Run*` vocabulary.

Started/Ended across the boundary, per the decision in the issue: disabling fires `CollisionEnded` for every currently-overlapping pair and clears contact tracking, so a disable mid-overlap never strands a pair in the "started" state. Re-enabling refires `CollisionStarted` for pairs still overlapping. Nothing fires if no pairs were overlapping or if neither event has a subscriber (tracking is already gated on that).

Also: `PerformanceMonitor` omits disabled relationships from the collision report, since a relationship that costs nothing to run doesn't deserve a NOT PARTITIONED warning.

Tests: 8 new, covering default value, disable while overlapping, disable while apart, idempotent disable, re-enable refires Started, `DeepCollisionCount` zeroing, manual `RunCollisions()` while disabled, and the `CollisionSystem` skip. Full suite 1656/1656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkJYBLrJ7AHhbCBUMmN79f
