### PR TITLE
Report a three-state PartitionStatus, and fix the skills that described the old boolean

### DIFF
--- a/frb-skills/collision-relationships/SKILL.md
+++ b/frb-skills/collision-relationships/SKILL.md
@@ -297,15 +297,22 @@ Concave `Polygon` shapes are fully supported: the engine automatically decompose
 ## Broad-Phase Partitioning (Performance)
 
 Set `Factory<T>.PartitionAxis = Axis.X` (or `Axis.Y`) to replace the default O(n×m) pairwise
-check with sweep-and-prune broad-phase culling. It engages automatically for any relationship
-built from partitioned factories — nothing to opt into on the relationship itself.
+check with sweep-and-prune broad-phase culling. It engages automatically — nothing to opt into
+on the relationship itself.
+
+**Eligibility**: both sides must be a `Factory<T>` with the *same* non-null `PartitionAxis`. A
+plain `List<T>`, a single entity, or a `TileShapes` is not a factory and never partitions.
+
+```csharp
+_bulletFactory.PartitionAxis = Axis.X;
+_enemyFactory.PartitionAxis  = Axis.X;   // mismatched or null silently falls back to O(n×m)
+AddCollisionRelationship<Bullet, Enemy>(_bulletFactory, _enemyFactory);
+```
 
 - **Self-collision**: only that one factory needs `PartitionAxis` set.
-- **Two-list relationship**: both factories must share the *same* axis. One set to `X` and the
-  other `Y` (or left `null`) silently falls back to O(n×m) — no warning.
-- Verify it actually engaged via `relationship.DeepCollisionCount` (should sit well below n×m),
-  or `PerformanceMonitor.GetCollisionReport()` (see `performance` skill), which flags
-  unpartitioned relationships.
+- Verify via `relationship.DeepCollisionCount` (should sit well below n×m), or
+  `PerformanceMonitor.GetCollisionReport()` (see `performance` skill), whose `PartitionStatus`
+  flags only the fixable `Unpartitioned` case — a non-factory side reports `NotApplicable`.
 - Pick the axis your entities spread out along most — e.g. `Axis.X` for a wide side-scroller level.
 
 ### Object Size (`BroadPhaseRadius`)

--- a/frb-skills/performance/SKILL.md
+++ b/frb-skills/performance/SKILL.md
@@ -16,7 +16,7 @@ FlatRedBallService.Default.Performance.IsEnabled = true;
 var perf = FlatRedBallService.Default.Performance;
 Console.WriteLine(perf.GenerateReport());   // FPS + phase timing + collision severity, as a string
 var fps = perf.Fps;                         // .Current / .Average / .Min / .Max
-var worst = perf.GetCollisionReport();      // ordered most-expensive first, flags unpartitioned relationships
+var worst = perf.GetCollisionReport();      // ordered most-expensive first, with a PartitionStatus each
 ```
 
 `GenerateReport()` only builds a string — it does no I/O itself, so printing/logging/writing it is on the caller.
@@ -29,4 +29,6 @@ var worst = perf.GetCollisionReport();      // ordered most-expensive first, fla
 
 Set `PlatformLabel` from the host — the engine targets `net10.0` and cannot read `navigator.userAgent` itself.
 
-See `src/Diagnostics/FrameProfile.cs` for the underlying per-frame timing struct, and `Factory<T>.PartitionAxis` for what "unpartitioned" in the collision report means.
+Each row carries a `PartitionStatus`: only `Unpartitioned` is worth acting on (set a matching `Factory<T>.PartitionAxis` on both sides). `NotApplicable` means a non-factory side — `TileShapes`, a single entity, a plain `List<T>` — where no axis setting applies; see the `collision-relationships` skill.
+
+See `src/Diagnostics/FrameProfile.cs` for the underlying per-frame timing struct.

--- a/src/Collision/CollisionRelationship.cs
+++ b/src/Collision/CollisionRelationship.cs
@@ -165,18 +165,25 @@ public class CollisionRelationship<A, B> : ICollisionRelationship
     /// </summary>
     public int DeepCollisionCount { get; private set; }
 
-    // Mirrors the partitioning gate in RunCollisions — true only when the broad phase actually
-    // engaged sweep-and-prune, not merely when a Factory has PartitionAxis set on one side.
-    bool ICollisionRelationship.IsPartitioned
+    // Mirrors the partitioning gate in RunCollisions. Distinguishes "could partition but doesn't"
+    // (both sides are factories — actionable) from "can't partition at all" (a non-factory side,
+    // where no PartitionAxis setting would change anything).
+    PartitionStatus ICollisionRelationship.PartitionStatus
     {
         get
         {
             if (ReferenceEquals(_listA, _listB))
-                return (_listA is IFactory fa) && fa.PartitionAxis != null;
+            {
+                if (_listA is not IFactory self) return PartitionStatus.NotApplicable;
+                return self.PartitionAxis != null ? PartitionStatus.Partitioned : PartitionStatus.Unpartitioned;
+            }
 
-            Axis? axisA = (_listA is IFactory fa2) ? fa2.PartitionAxis : null;
-            Axis? axisB = (_listB is IFactory fb) ? fb.PartitionAxis : null;
-            return axisA != null && axisA == axisB;
+            if (_listA is not IFactory fa || _listB is not IFactory fb)
+                return PartitionStatus.NotApplicable;
+
+            return fa.PartitionAxis != null && fa.PartitionAxis == fb.PartitionAxis
+                ? PartitionStatus.Partitioned
+                : PartitionStatus.Unpartitioned;
         }
     }
 

--- a/src/Collision/ICollisionRelationship.cs
+++ b/src/Collision/ICollisionRelationship.cs
@@ -12,11 +12,11 @@ internal interface ICollisionRelationship
     bool IsEnabled { get; }
 
     /// <summary>
-    /// <c>false</c> when this relationship falls back to the O(n×m) check because its lists don't
-    /// share a matching <see cref="Factory{T}.PartitionAxis"/>. Read by
+    /// Whether the sweep-and-prune broad phase engaged, and when it did not, whether a matching
+    /// <see cref="Factory{T}.PartitionAxis"/> could make it. Read by
     /// <see cref="FlatRedBall2.Diagnostics.PerformanceMonitor"/> for its collision severity report.
     /// </summary>
-    bool IsPartitioned { get; }
+    PartitionStatus PartitionStatus { get; }
 
     /// <summary>Human-readable label for diagnostics, e.g. "Enemy vs PlayerBullet".</summary>
     string DisplayName { get; }

--- a/src/Collision/PartitionStatus.cs
+++ b/src/Collision/PartitionStatus.cs
@@ -1,0 +1,31 @@
+namespace FlatRedBall2.Collision;
+
+/// <summary>
+/// Whether a collision relationship is using the sweep-and-prune broad phase, and when it is not,
+/// whether that is something the game can act on. Reported per relationship by
+/// <see cref="FlatRedBall2.Diagnostics.PerformanceMonitor.GetCollisionReport"/>.
+/// </summary>
+public enum PartitionStatus
+{
+    /// <summary>
+    /// Both lists are a <see cref="Factory{T}"/> sharing the same non-null
+    /// <see cref="Factory{T}.PartitionAxis"/>, so sweep-and-prune culls candidate pairs.
+    /// </summary>
+    Partitioned,
+
+    /// <summary>
+    /// Both lists are a <see cref="Factory{T}"/> and so <em>could</em> partition, but their
+    /// <see cref="Factory{T}.PartitionAxis"/> values are unset or don't match, leaving the full
+    /// O(n×m) pass. The only status worth acting on — set a matching axis on both factories.
+    /// </summary>
+    Unpartitioned,
+
+    /// <summary>
+    /// At least one list is not a <see cref="Factory{T}"/>, so sweep-and-prune cannot apply no
+    /// matter how <see cref="Factory{T}.PartitionAxis"/> is set. Usually not a problem: the
+    /// <c>staticGeometry</c> and single-entity overloads wrap their side in a one-element list, and
+    /// <see cref="TileShapes"/> does its own cell-range lookup. A large plain <c>List&lt;T&gt;</c>
+    /// is the exception — move it to a <see cref="Factory{T}"/> to make partitioning available.
+    /// </summary>
+    NotApplicable,
+}

--- a/src/Diagnostics/CollisionRelationshipReport.cs
+++ b/src/Diagnostics/CollisionRelationshipReport.cs
@@ -1,3 +1,5 @@
+using FlatRedBall2.Collision;
+
 namespace FlatRedBall2.Diagnostics;
 
 /// <summary>
@@ -14,9 +16,9 @@ public readonly struct CollisionRelationshipReport
     public int DeepCollisionCount { get; init; }
 
     /// <summary>
-    /// <c>false</c> when this relationship is not benefiting from the sweep-and-prune broad phase
-    /// — its lists don't share a matching <c>Factory&lt;T&gt;.PartitionAxis</c> — so every check
-    /// runs the full O(n×m) pass. Mirrors FRB1's "NOT PARTITIONED" collision debugger warning.
+    /// Whether the sweep-and-prune broad phase engaged. Only
+    /// <see cref="Collision.PartitionStatus.Unpartitioned"/> is worth acting on — see that enum
+    /// for why <see cref="Collision.PartitionStatus.NotApplicable"/> is not a defect.
     /// </summary>
-    public bool IsPartitioned { get; init; }
+    public PartitionStatus PartitionStatus { get; init; }
 }

--- a/src/Diagnostics/PerformanceMonitor.cs
+++ b/src/Diagnostics/PerformanceMonitor.cs
@@ -132,7 +132,7 @@ public class PerformanceMonitor
             {
                 Name = r.DisplayName,
                 DeepCollisionCount = r.DeepCollisionCount,
-                IsPartitioned = r.IsPartitioned
+                PartitionStatus = r.PartitionStatus
             });
         }
         report.Sort((a, b) => b.DeepCollisionCount.CompareTo(a.DeepCollisionCount));
@@ -169,7 +169,12 @@ public class PerformanceMonitor
             sb.AppendLine("Collision relationships (most expensive first):");
             foreach (var r in collisionReport)
             {
-                var partitionNote = r.IsPartitioned ? "partitioned" : "NOT PARTITIONED";
+                var partitionNote = r.PartitionStatus switch
+                {
+                    PartitionStatus.Partitioned => "partitioned",
+                    PartitionStatus.Unpartitioned => "NOT PARTITIONED — set a matching PartitionAxis on both factories",
+                    _ => "partitioning n/a — non-factory side",
+                };
                 sb.AppendLine(FormattableString.Invariant(
                     $"  {r.Name}: {r.DeepCollisionCount} deep checks [{partitionNote}]"));
             }

--- a/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/CollisionSystemTests.cs
@@ -11,7 +11,7 @@ public class CollisionSystemTests
     {
         public int CallCount { get; private set; }
         public int DeepCollisionCount => 0;
-        public bool IsPartitioned => false;
+        public PartitionStatus PartitionStatus => PartitionStatus.NotApplicable;
         public string DisplayName => "CallCountRelationship";
         public bool IsEnabled { get; set; } = true;
         public void RunCollisions() => CallCount++;

--- a/tests/FlatRedBall2.Tests/Collision/SweepAndPruneTests.cs
+++ b/tests/FlatRedBall2.Tests/Collision/SweepAndPruneTests.cs
@@ -316,4 +316,45 @@ public class SweepAndPruneTests
         var firstPairFrame2 = frame2Pairs.First();
         firstPairFrame1.ShouldNotBe(firstPairFrame2);
     }
+
+    [Fact]
+    public void PartitionStatus_FactoriesWithMatchingAxis_ReturnsPartitioned()
+    {
+        var (factory, _) = CreateFactory();
+        factory.PartitionAxis = Axis.X;
+        var rel = new CollisionRelationship<BallEntity, BallEntity>(factory, factory);
+
+        ((ICollisionRelationship)rel).PartitionStatus.ShouldBe(PartitionStatus.Partitioned);
+    }
+
+    [Fact]
+    public void PartitionStatus_FactoriesWithMismatchedAxis_ReturnsUnpartitioned()
+    {
+        // Both sides are factories, so a matching axis WOULD engage the sweep — the one case a
+        // perf report should actually flag.
+        var screenA = new TestScreen();
+        screenA.Engine = new FlatRedBallService();
+        var screenB = new TestScreen();
+        screenB.Engine = new FlatRedBallService();
+        var factoryA = new Factory<BallEntity>(screenA) { PartitionAxis = Axis.X };
+        var factoryB = new Factory<BallEntity>(screenB) { PartitionAxis = Axis.Y };
+
+        var rel = new CollisionRelationship<BallEntity, BallEntity>(factoryA, factoryB);
+
+        ((ICollisionRelationship)rel).PartitionStatus.ShouldBe(PartitionStatus.Unpartitioned);
+    }
+
+    [Fact]
+    public void PartitionStatus_TileShapesSide_ReturnsNotApplicable()
+    {
+        // TileShapes is not a Factory<T> and is wrapped in a one-element array, so sweep-and-prune
+        // can never apply — reporting it as unpartitioned is a false alarm with no remedy.
+        var (factory, _) = CreateFactory();
+        factory.PartitionAxis = Axis.X;
+        var tiles = new TileShapes { GridSize = 16f };
+
+        var rel = new CollisionRelationship<BallEntity, TileShapes>(factory, new[] { tiles });
+
+        ((ICollisionRelationship)rel).PartitionStatus.ShouldBe(PartitionStatus.NotApplicable);
+    }
 }

--- a/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
+++ b/tests/FlatRedBall2.Tests/Diagnostics/PerformanceMonitorTests.cs
@@ -10,17 +10,17 @@ public class PerformanceMonitorTests
 {
     private sealed class FakeRelationship : ICollisionRelationship
     {
-        public FakeRelationship(string name, int deepCollisionCount, bool isPartitioned, bool isEnabled = true)
+        public FakeRelationship(string name, int deepCollisionCount, PartitionStatus partitionStatus, bool isEnabled = true)
         {
             DisplayName = name;
             DeepCollisionCount = deepCollisionCount;
-            IsPartitioned = isPartitioned;
+            PartitionStatus = partitionStatus;
             IsEnabled = isEnabled;
         }
 
         public string DisplayName { get; }
         public int DeepCollisionCount { get; }
-        public bool IsPartitioned { get; }
+        public PartitionStatus PartitionStatus { get; }
         public bool IsEnabled { get; set; }
         public void RunCollisions() { }
     }
@@ -61,13 +61,15 @@ public class PerformanceMonitorTests
     }
 
     [Fact]
-    public void GenerateReport_CollisionRelationships_OrdersBySeverityAndFlagsUnpartitioned()
+    public void GenerateReport_CollisionRelationships_OrdersBySeverityAndWarnsOnlyOnTheFixableRow()
     {
         var monitor = new PerformanceMonitor { IsEnabled = true };
         var relationships = new List<ICollisionRelationship>
         {
-            new FakeRelationship("Player vs TileShapes", deepCollisionCount: 5, isPartitioned: false),
-            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, isPartitioned: true)
+            // NotApplicable — a non-factory side, so no PartitionAxis can ever engage the sweep.
+            new FakeRelationship("Player vs TileShapes", deepCollisionCount: 5, partitionStatus: PartitionStatus.NotApplicable),
+            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, partitionStatus: PartitionStatus.Partitioned),
+            new FakeRelationship("Enemy vs Pickup", deepCollisionCount: 20, partitionStatus: PartitionStatus.Unpartitioned)
         };
 
         monitor.Record(new FrameProfile { FrameTotalMs = 16 }, relationships);
@@ -75,13 +77,14 @@ public class PerformanceMonitorTests
         var report = monitor.GetCollisionReport();
         report[0].Name.ShouldBe("Enemy vs Bullet");
         report[0].DeepCollisionCount.ShouldBe(50);
-        report[1].Name.ShouldBe("Player vs TileShapes");
-        report[1].IsPartitioned.ShouldBeFalse();
+        report[2].Name.ShouldBe("Player vs TileShapes");
+        report[2].PartitionStatus.ShouldBe(PartitionStatus.NotApplicable);
 
         var text = monitor.GenerateReport();
         text.ShouldContain("Enemy vs Bullet: 50 deep checks [partitioned]");
-        text.ShouldContain("Player vs TileShapes: 5 deep checks [NOT PARTITIONED]");
-        text.IndexOf("Enemy vs Bullet").ShouldBeLessThan(text.IndexOf("Player vs TileShapes"));
+        text.ShouldContain("Enemy vs Pickup: 20 deep checks [NOT PARTITIONED");
+        text.ShouldContain("Player vs TileShapes: 5 deep checks [partitioning n/a");
+        text.IndexOf("Enemy vs Bullet").ShouldBeLessThan(text.IndexOf("Enemy vs Pickup"));
     }
 
     [Fact]
@@ -90,8 +93,8 @@ public class PerformanceMonitorTests
         var monitor = new PerformanceMonitor { IsEnabled = true };
         var relationships = new List<ICollisionRelationship>
         {
-            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, isPartitioned: true),
-            new FakeRelationship("Player vs Door", deepCollisionCount: 5, isPartitioned: false, isEnabled: false)
+            new FakeRelationship("Enemy vs Bullet", deepCollisionCount: 50, partitionStatus: PartitionStatus.Partitioned),
+            new FakeRelationship("Player vs Door", deepCollisionCount: 5, partitionStatus: PartitionStatus.Unpartitioned, isEnabled: false)
         };
 
         monitor.Record(new FrameProfile { FrameTotalMs = 16 }, relationships);


### PR DESCRIPTION
Closes #993.

## Engine

`GetCollisionReport()` printed `NOT PARTITIONED` for every relationship not using sweep-and-prune — including the ones where it can never apply. The `staticGeometry` and single-entity overloads wrap their side in a one-element list, and `TileShapes` does its own cell-range lookup in `GetSeparationFor`, so those rows were permanent false alarms with no available fix.

`IsPartitioned` (on `ICollisionRelationship` and `CollisionRelationshipReport`) becomes `PartitionStatus`:

| Status | Prints | Meaning |
|---|---|---|
| `Partitioned` | `[partitioned]` | Sweep engaged. |
| `Unpartitioned` | `[NOT PARTITIONED — set a matching PartitionAxis on both factories]` | Both sides are factories, axes unset or mismatched. **The only actionable one.** |
| `NotApplicable` | `[partitioning n/a — non-factory side]` | No `PartitionAxis` setting would help. |

Note `NotApplicable` isn't always free: a large plain `List<T>` lands there too, and the fix is to move it to a `Factory<T>`. Called out in the enum's XML docs rather than in the printed string, which stays short.

## Skills (#993)

`collision-relationships` never stated that **both** sides must be a `Factory<T>` — only that the axes must match — and the section had no code at all for what is a two-line setup. Adds the eligibility rule, both `PartitionAxis` assignments, and the `PartitionStatus` semantics. `performance` said the report "flags unpartitioned relationships", which predates the enum.

Rejected from the issue's suggestions: the 4-row collection-type table (two of its rows restate one rule), the `IsSolidGrid` disclaimer (that skill never claims it's a broad phase — denying it would create the association), the `entities-and-factories` cross-link, and the claim that tile collision is O(n×m) — it isn't, m = 1.

## Tests

4: three for the enum contract in `SweepAndPruneTests`, one for the printing in `PerformanceMonitorTests` (replacing the test that asserted the old string). 1673 pass, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZxXCGuQhgk2koMdKdjomN