### PR TITLE
Add a prose-style rule to skills-writer and apply it

### DIFF
--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -31,6 +31,33 @@ A skill is rarely written whole; it grows as **pulls** act on it — and a pull 
 
 **Signpost quality bar.** A nudge must name *where to look* — a file, class, or relationship — not merely assert that something exists. "Frame color interacts with the preview" raises a question without reducing search cost; "see the tint path in `<Control>.cs` — per-frame RGB multiplies because `<reason>`" reduces it. A vague signpost is worse than none: it costs context and resolves nothing.
 
+## Prose Style — Clarity Beats Brevity
+
+Cut length that adds *reading*, never length that adds *understanding*. Density and clarity are
+separate axes: a longer sentence that lands the first time beats a compressed one the reader has to
+decode. The damping rules above govern which *facts* earn a line, not how tightly the sentence
+carrying them gets compressed.
+
+Three habits that buy density with clarity:
+
+- **Em-dash restatement.** `<claim> — <same claim, negated>` is one fact in two coats. Keep the
+  positive half and delete the rest.
+- **Algorithm name in place of observable effect.** Say what changes for the reader and point at an
+  API member they can inspect, not at the technique's academic name.
+- **Imperative that hides the subject.** "Set X to Y to do Z" makes the reader the subject and the
+  API an object. Make the API the subject so the line reads as documentation, not a command.
+
+**Read-aloud test.** If a clause after a dash repeats the clause before it, or the sentence runs out
+of breath, rewrite it. Do not shorten it.
+
+❌ "Set `Factory<T>.PartitionAxis = Axis.X` (or `Axis.Y`) to replace the default O(n×m) pairwise
+check with sweep-and-prune broad-phase culling. It engages automatically — nothing to opt into on
+the relationship itself."
+
+✅ "Setting `Factory<T>.PartitionAxis` to either `Axis.X` or `Axis.Y` enables axis-based
+partitioning, which reduces the deep collision count. Once the `PartitionAxis` is set, partitioning
+happens automatically."
+
 ## Authoritative Sources (do not duplicate)
 
 Before writing anything, identify where the ground truth already lives:

--- a/frb-skills/collision-relationships/SKILL.md
+++ b/frb-skills/collision-relationships/SKILL.md
@@ -296,24 +296,30 @@ Concave `Polygon` shapes are fully supported: the engine automatically decompose
 
 ## Broad-Phase Partitioning (Performance)
 
-Set `Factory<T>.PartitionAxis = Axis.X` (or `Axis.Y`) to replace the default O(n×m) pairwise
-check with sweep-and-prune broad-phase culling. It engages automatically — nothing to opt into
-on the relationship itself.
+Setting `Factory<T>.PartitionAxis` to either `Axis.X` or `Axis.Y` enables axis-based partitioning,
+which reduces the deep collision count. Once the `PartitionAxis` is set, partitioning happens
+automatically.
 
-**Eligibility**: both sides must be a `Factory<T>` with the *same* non-null `PartitionAxis`. A
-plain `List<T>`, a single entity, or a `TileShapes` is not a factory and never partitions.
+Partitioning requires a `Factory<T>` on both sides of the relationship, and both factories must use
+the same axis. A relationship built from a plain `List<T>`, a single entity, or a `TileShapes`
+always checks every pair, because none of those is a factory and none has a `PartitionAxis` to set.
 
 ```csharp
 _bulletFactory.PartitionAxis = Axis.X;
-_enemyFactory.PartitionAxis  = Axis.X;   // mismatched or null silently falls back to O(n×m)
+_enemyFactory.PartitionAxis = Axis.X;
 AddCollisionRelationship<Bullet, Enemy>(_bulletFactory, _enemyFactory);
 ```
 
-- **Self-collision**: only that one factory needs `PartitionAxis` set.
-- Verify via `relationship.DeepCollisionCount` (should sit well below n×m), or
-  `PerformanceMonitor.GetCollisionReport()` (see `performance` skill), whose `PartitionStatus`
-  flags only the fixable `Unpartitioned` case — a non-factory side reports `NotApplicable`.
-- Pick the axis your entities spread out along most — e.g. `Axis.X` for a wide side-scroller level.
+If the two axes differ, or either one is left null, the relationship silently falls back to checking
+every pair.
+
+- A self-collision relationship uses a single factory, so only that factory needs a `PartitionAxis`.
+- To confirm partitioning is working, read `relationship.DeepCollisionCount`. It drops well below
+  n×m once the sweep engages. `PerformanceMonitor.GetCollisionReport()` (see the `performance`
+  skill) also reports a `PartitionStatus` for every relationship, and `Unpartitioned` is the only
+  value that means something you can fix.
+- Choose the axis your entities spread out along most. A wide side-scrolling level partitions best
+  on `Axis.X`.
 
 ### Object Size (`BroadPhaseRadius`)
 

--- a/frb-skills/performance/SKILL.md
+++ b/frb-skills/performance/SKILL.md
@@ -16,7 +16,7 @@ FlatRedBallService.Default.Performance.IsEnabled = true;
 var perf = FlatRedBallService.Default.Performance;
 Console.WriteLine(perf.GenerateReport());   // FPS + phase timing + collision severity, as a string
 var fps = perf.Fps;                         // .Current / .Average / .Min / .Max
-var worst = perf.GetCollisionReport();      // ordered most-expensive first, with a PartitionStatus each
+var worst = perf.GetCollisionReport();      // most expensive first; each row carries a PartitionStatus
 ```
 
 `GenerateReport()` only builds a string — it does no I/O itself, so printing/logging/writing it is on the caller.
@@ -29,6 +29,6 @@ var worst = perf.GetCollisionReport();      // ordered most-expensive first, wit
 
 Set `PlatformLabel` from the host — the engine targets `net10.0` and cannot read `navigator.userAgent` itself.
 
-Each row carries a `PartitionStatus`: only `Unpartitioned` is worth acting on (set a matching `Factory<T>.PartitionAxis` on both sides). `NotApplicable` means a non-factory side — `TileShapes`, a single entity, a plain `List<T>` — where no axis setting applies; see the `collision-relationships` skill.
+Every row in the collision report carries a `PartitionStatus`. `Unpartitioned` is the only value worth acting on, and the fix is to set the same `Factory<T>.PartitionAxis` on both sides of the relationship. `NotApplicable` means one side is not a factory, such as a `TileShapes`, a single entity, or a plain `List<T>`, so no axis setting would change it. See the `collision-relationships` skill.
 
 See `src/Diagnostics/FrameProfile.cs` for the underlying per-frame timing struct.


### PR DESCRIPTION
`skills-writer` governed which *facts* earn a line but said nothing about how the sentence carrying them should read, so skill prose drifted into compressed jargon.

## The rule

New "Clarity Beats Brevity" section naming three habits that buy density with clarity:

- **Em-dash restatement** — `<claim> — <same claim, negated>` is one fact in two coats.
- **Algorithm name in place of observable effect** — say what changes for the reader and point at an API member they can inspect.
- **Imperative that hides the subject** — "Set X to Y to do Z" makes the reader the subject and the API an object.

Plus a read-aloud test and a worked before/after.

## Applied to the two sections it was written from

Before:

> Set `Factory<T>.PartitionAxis = Axis.X` (or `Axis.Y`) to replace the default O(n×m) pairwise check with sweep-and-prune broad-phase culling. It engages automatically — nothing to opt into on the relationship itself.

After:

> Setting `Factory<T>.PartitionAxis` to either `Axis.X` or `Axis.Y` enables axis-based partitioning, which reduces the deep collision count. Once the `PartitionAxis` is set, partitioning happens automatically.

The rewritten broad-phase section is **longer** than what it replaces (+17/-11). That's the point — brevity was never the constraint; the old version paid for density with clarity.

Same treatment for the `PartitionStatus` paragraph in `performance`, which had packed three clauses behind a colon and an em-dash aside.

## Scope

Only the sections written in #998 are rewritten. The neighbouring `Object Size (BroadPhaseRadius)` subsection is left untouched on purpose, so the diff shows old voice against new. If this reads right, the same pass over the other ~30 `frb-skills/` files is the obvious follow-up.

The identical section is already pushed to PersonalAiFiles (`b74b6e2`) so it applies outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZxXCGuQhgk2koMdKdjomN