### PR TITLE
Ship the SIL OFL license alongside Solitaire's bundled Liberation Sans

### DIFF
--- a/samples/Solitaire/Solitaire.Common/Content/GumProject/Fonts/LiberationSans-LICENSE.txt
+++ b/samples/Solitaire/Solitaire.Common/Content/GumProject/Fonts/LiberationSans-LICENSE.txt
@@ -1,0 +1,102 @@
+Digitized data copyright (c) 2010 Google Corporation
+	with Reserved Font Arimo, Tinos and Cousine.
+Copyright (c) 2012 Red Hat, Inc.
+	with Reserved Font Name Liberation.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE The goals of the Open Font License (OFL) are to stimulate
+worldwide development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to provide
+a free and open framework in which fonts may be shared and improved in
+partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves.
+The fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works.  The fonts and derivatives,
+however, cannot be released under any other type of license.  The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+ 
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such.
+This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting ? in part or in whole ?
+any of the components of the Original Version, by changing formats or
+by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,in
+   Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+   redistributed and/or sold with any software, provided that each copy
+   contains the above copyright notice and this license. These can be
+   included either as stand-alone text files, human-readable headers or
+   in the appropriate machine-readable metadata fields within text or
+   binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+   Name(s) unless explicit written permission is granted by the
+   corresponding Copyright Holder. This restriction only applies to the
+   primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+   Software shall not be used to promote, endorse or advertise any
+   Modified Version, except to acknowledge the contribution(s) of the
+   Copyright Holder(s) and the Author(s) or with their explicit written
+   permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must
+   be distributed entirely under this license, and must not be distributed
+   under any other license. The requirement for fonts to remain under
+   this license does not apply to any document created using the Font
+   Software.
+
+
+ 
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+ 
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+

--- a/samples/Solitaire/Solitaire.Common/Kni/Solitaire.Common.Kni.csproj
+++ b/samples/Solitaire/Solitaire.Common/Kni/Solitaire.Common.Kni.csproj
@@ -51,6 +51,11 @@
     <Content Include="..\Content\GumProject\GumProject.gumpkg"
              Link="Content\GumProject\GumProject.gumpkg"
              CopyToOutputDirectory="PreserveNewest" />
+    <!-- SIL OFL 1.1 license, mirroring the MonoGame sibling. See that project for why bundle mode
+         has to name it explicitly. -->
+    <Content Include="..\Content\GumProject\Fonts\LiberationSans-LICENSE.txt"
+             Link="Content\GumProject\Fonts\LiberationSans-LICENSE.txt"
+             CopyToOutputDirectory="PreserveNewest" />
     <None Remove="..\Content\GumProject\**\*.*" />
   </ItemGroup>
 </Project>

--- a/samples/Solitaire/Solitaire.Common/Solitaire.Common.csproj
+++ b/samples/Solitaire/Solitaire.Common/Solitaire.Common.csproj
@@ -42,6 +42,11 @@
   <ItemGroup Condition="'$(UseGumPackage)' == 'true'">
     <Content Include="Content\GumProject\GumProject.gumpkg"
              CopyToOutputDirectory="PreserveNewest" />
+    <!-- Liberation Sans is SIL OFL 1.1, which requires the license to travel with the font. Loose
+         mode's glob above already copies it; bundle mode has to name it, since `gumcli pack` only
+         bundles files the Gum project references and nothing references a license. -->
+    <Content Include="Content\GumProject\Fonts\LiberationSans-LICENSE.txt"
+             CopyToOutputDirectory="PreserveNewest" />
     <None Remove="Content\GumProject\**\*.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#1001 checked in `LiberationSans-Regular.ttf` with no license text. Liberation Sans is SIL OFL 1.1, which requires the copyright notice and license to accompany the font wherever it's redistributed, so the sample was out of compliance in both the repo and its build output.

Adds the license next to the `.ttf`. Loose mode's Content glob picks it up for free; bundle mode has to name it explicitly, because `gumcli pack` only bundles files the Gum project references and nothing references a license.

## No test

1. What this changes is which files MSBuild copies to the output directory in each of the two Gum deployment modes. No test in this repo can observe that without shelling out to a build.
2. No testable core to extract: there's no code here, just a content file and two `Content` items.
3. Verified by hand instead, which beats a proxy assertion here. Built `Solitaire.Common` both ways, 0 errors each, and confirmed `Content/GumProject/Fonts/LiberationSans-LICENSE.txt` lands in `bin` in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3dPG4jweJMg7fMXC7PW45