### PR TITLE
Bring Animation Editor to foreground on single-instance file open

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -48,11 +48,17 @@ public partial class App : Application
             desktop.MainWindow = window;
             RegisterNativeMenu(window);
 
-            // Wire single-instance IPC: file paths received from a second process open as tabs.
+            // Wire single-instance IPC: file paths received from a second process open as tabs
+            // and bring the window forward (#1009) -- otherwise it opens behind whatever else
+            // currently has focus.
             if (SingleInstance != null)
             {
                 SingleInstance.FileOpenRequested += path =>
-                    Dispatcher.UIThread.InvokeAsync(() => window.OpenFileAsTab(path));
+                    Dispatcher.UIThread.InvokeAsync(async () =>
+                    {
+                        await window.OpenFileAsTab(path);
+                        window.BringToForeground();
+                    });
             }
 
             // Post the Dock icon update to the next UI tick. Avalonia's macOS backend

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -794,6 +794,19 @@ public partial class MainWindow : Window
     public async Task OpenFileAsTab(string filePath) => await LoadAnimationFileAsync(filePath);
 
     /// <summary>
+    /// Restores the window if minimized and requests OS focus. Called from <see cref="App"/>
+    /// alongside <see cref="OpenFileAsTab"/> when a second process hands off a file path over
+    /// the single-instance pipe (issue #1009) -- without this, the file opens as a new tab but
+    /// the window stays behind whatever else has focus.
+    /// </summary>
+    public void BringToForeground()
+    {
+        if (WindowState == WindowState.Minimized)
+            WindowState = WindowState.Normal;
+        Activate();
+    }
+
+    /// <summary>
     /// Closes <paramref name="tab"/>, prompting to save first when it is an untitled tab that
     /// has actual content (issue #928) -- an untitled tab that was never edited (or was edited
     /// back to empty) closes silently, same as before. "Save" runs the normal Save-As flow;

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowForegroundTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MainWindowForegroundTests.cs
@@ -1,0 +1,52 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for issue #1009: opening a file via the single-instance pipe (a second
+/// process handing its .achx path to the already-running instance) must bring the window
+/// forward, not just open the tab behind whatever else has focus.
+/// </summary>
+public class MainWindowForegroundTests
+{
+    [AvaloniaFact]
+    public void BringToForeground_WhenMinimized_RestoresToNormal()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            window.WindowState = WindowState.Minimized;
+
+            window.BringToForeground();
+
+            Assert.Equal(WindowState.Normal, window.WindowState);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void BringToForeground_WhenAlreadyNormal_DoesNotThrowAndStaysNormal()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var ex = Record.Exception(() => window.BringToForeground());
+
+            Assert.Null(ex);
+            Assert.Equal(WindowState.Normal, window.WindowState);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Double-clicking a `.achx`/`.achj` while the editor is already running opened the file as a new tab but left the window behind whatever else had focus.

`App.axaml.cs`'s single-instance pipe handler only called `window.OpenFileAsTab(path)` — nothing ever activated the window. Added `MainWindow.BringToForeground()` (restores from minimized, then `Activate()`s) and call it after the tab opens.

## Test plan
- [x] New `MainWindowForegroundTests` (`BringToForeground_WhenMinimized_RestoresToNormal`, `BringToForeground_WhenAlreadyNormal_DoesNotThrowAndStaysNormal`) — confirmed the minimized-restore test fails without the fix, passes with it.
- [x] Full `AnimationEditor.App.Tests` suite: 879 passed.
- [x] `dotnet build AnimationEditorAvalonia.slnx`: clean, 0 warnings.

Closes #1009
