### PR TITLE
Filter thumbnail minification instead of aliasing (#1013)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/AchxThumbnailCacheKey.cs
@@ -7,14 +7,27 @@ namespace AnimationEditor.Core.IO;
 /// <summary>
 /// Builds the disk cache file name for a project-tree thumbnail (issue #839). <paramref
 /// name="sourceIdentity"/> is hashed only to keep the file name filesystem-safe; the invalidation
-/// key is <paramref name="size"/>/<paramref name="modified"/> plainly embedded in the name -- the
-/// same <see cref="FolderEntrySnapshot"/> pair <c>FolderSnapshotDiff</c> and the hot-reload
-/// watcher already use elsewhere in this codebase, so a cache lookup is a filename match: any
-/// drift in either value produces a different name, i.e. a cache miss that regenerates the
-/// thumbnail.
+/// key is <paramref name="size"/>/<paramref name="modified"/> plus <see cref="RenderVersion"/>,
+/// plainly embedded in the name. Size/Modified are the same <see cref="FolderEntrySnapshot"/> pair
+/// <c>FolderSnapshotDiff</c> and the hot-reload watcher already use elsewhere in this codebase, and
+/// cover a changed source; <see cref="RenderVersion"/> covers a changed renderer. A cache lookup is
+/// a filename match, so drift in any of the three produces a different name, i.e. a cache miss that
+/// regenerates the thumbnail.
 /// </summary>
 public static class AchxThumbnailCacheKey
 {
+    /// <summary>
+    /// Identifies the rendering that produced a cached thumbnail. Size/Modified only invalidate the
+    /// cache when the <em>source</em> changes, so without this a build that renders thumbnails
+    /// differently keeps serving every file written by the old one -- the improvement stays
+    /// invisible until each .achx happens to be touched. <b>Bump this whenever
+    /// <c>ThumbnailService.RenderFrameThumbnail</c> changes what it draws</b> (v1: filtered
+    /// minification, issue #1013). Superseded files are cleaned up by
+    /// <c>ProjectTreeThumbnailService.TrySaveToDisk</c>'s existing same-hash glob, so a bump
+    /// replaces them rather than accumulating.
+    /// </summary>
+    public const int RenderVersion = 1;
+
     /// <param name="sourceIdentity">
     /// A string that identifies the source <c>.achx</c>. Callers pass <c>AchxFileEntry.RelativePath</c>
     /// (relative to the scanned Open Project Folder root) rather than a real absolute path --
@@ -29,6 +42,6 @@ public static class AchxThumbnailCacheKey
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..16];
         var sizePart = size?.ToString() ?? "0";
         var modifiedPart = modified?.UtcTicks.ToString() ?? "0";
-        return $"{hash}_{sizePart}_{modifiedPart}.png";
+        return $"{hash}_{sizePart}_{modifiedPart}_v{RenderVersion}.png";
     }
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
@@ -405,14 +405,33 @@ public sealed class ThumbnailService : IDisposable
             canvas.Scale(flipScaleX, flipScaleY, finalW / 2f, finalH / 2f);
         }
 
-        // Nearest-neighbour ("point") sampling: keeps sprite-sheet art crisp/pixellated
-        // instead of the blurry smear linear filtering produces on game art.
         canvas.DrawImage(region,
             SKRect.Create(0, 0, finalW, finalH),
-            new SKSamplingOptions(SKFilterMode.Nearest),
+            SelectSampling(scale),
             paint);
 
         if (anyFlip) canvas.Restore();
         return thumb;
     }
+
+    /// <summary>
+    /// Picks the sampler from the scale the crop is drawn at (issue #1013).
+    /// <para>
+    /// Magnifying keeps nearest-neighbour ("point") sampling, so a small sprite blown up to icon
+    /// size stays crisp and pixellated instead of the blurry smear filtering produces on game art.
+    /// </para>
+    /// <para>
+    /// Minifying must filter. Nearest keeps one texel per destination pixel and discards every
+    /// other one it stepped over, so a large frame squashed into a small icon aliases into noise —
+    /// a 1px checkerboard drawn at 1/8 scale comes back solid black, because every destination
+    /// pixel lands on the same phase. Skia's linear minification averages the discarded texels
+    /// (measured: the same checkerboard comes back mid-grey), so plain <see cref="SKFilterMode.Linear"/>
+    /// is enough here; a cubic resampler measured identically and mipmaps changed nothing. This also
+    /// matches what <see cref="GetFullImageThumbnail"/> already uses for the Files panel.
+    /// </para>
+    /// </summary>
+    private static SKSamplingOptions SelectSampling(float scale) =>
+        scale < 1f
+            ? new SKSamplingOptions(SKFilterMode.Linear)
+            : new SKSamplingOptions(SKFilterMode.Nearest);
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -15,8 +15,9 @@ namespace AnimationEditor.App.Tests;
 /// Issue #261: <see cref="ThumbnailService.RenderFrameThumbnail"/> crops a frame region out
 /// of a sprite sheet and scales it for the tree preview icon. It must (a) bake at the
 /// requested size so the icon is not upscaled and blurry, (b) isolate the region so the
-/// sampler does not bleed in neighbouring frames, and (c) use nearest-neighbour ("point")
-/// sampling so game art stays crisp.
+/// sampler does not bleed in neighbouring frames, and (c) pick its sampler from the scale
+/// (issue #1013): nearest-neighbour ("point") when magnifying so game art stays crisp,
+/// filtered when minifying so a large frame does not alias into noise.
 ///
 /// These tests drive the pure SkiaSharp core directly with in-memory <see cref="SKBitmap"/>
 /// sources — no file I/O, no PNG decode, no Avalonia bitmap wrapping — so they are
@@ -33,6 +34,17 @@ public class ThumbnailServiceTests
             RightCoordinate = right, BottomCoordinate = bottom,
             FlipHorizontal  = flipH, FlipVertical     = flipV,
         };
+
+    /// <summary>A sheet of alternating 1px black/white pixels — the worst case for a downscale,
+    /// since any sampler that keeps one texel per destination pixel returns a solid colour.</summary>
+    private static SKBitmap CheckerSheet(int size)
+    {
+        var bm = new SKBitmap(size, size);
+        for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
+                bm.SetPixel(x, y, (x + y) % 2 == 0 ? SKColors.Black : SKColors.White);
+        return bm;
+    }
 
     /// <summary>A sprite sheet whose left half is <paramref name="left"/> and right half <paramref name="right"/>.</summary>
     private static SKBitmap SplitSheet(int width, int height, SKColor left, SKColor right)
@@ -99,6 +111,26 @@ public class ThumbnailServiceTests
                 bool pureBlue = p is { Blue: > 200, Red: < 55 };
                 Assert.True(pureRed || pureBlue,
                     $"Pixel ({x},{y}) = {p} — point sampling should leave a hard seam, not a blended pixel.");
+            }
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_DownscalingALargeFrame_FiltersInsteadOfAliasing()
+    {
+        // Issue #1013: a 64px frame squashed into an 8px icon is drawn at 1/8 scale, so
+        // nearest-neighbour keeps one texel per destination pixel and throws the other 63
+        // away. On this checkerboard that returns solid black — every pixel lands on the
+        // same phase. Filtering must average, giving mid-grey.
+        using var source = CheckerSheet(64);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 8, 8);
+
+        Assert.NotNull(thumb);
+        for (int y = 0; y < thumb!.Height; y++)
+            for (int x = 0; x < thumb.Width; x++)
+            {
+                var p = thumb.GetPixel(x, y);
+                Assert.InRange(p.Red, 64, 191);
             }
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailCacheKeyTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AchxThumbnailCacheKeyTests.cs
@@ -43,6 +43,35 @@ public class AchxThumbnailCacheKeyTests
     }
 
     [Fact]
+    public void BuildFileName_EmbedsTheRenderVersion_SoOlderRenderersCacheFilesAreNotServed()
+    {
+        // Issue #1013 changed how a thumbnail is sampled, but an untouched .achx keeps the same
+        // Size/Modified, so every pre-fix cache file would still be a name match and keep being
+        // served -- the fix would be invisible until each file happened to change. The render
+        // version is part of the name; bump AchxThumbnailCacheKey.RenderVersion (and this literal)
+        // whenever the rendering changes.
+        var result = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Contains("_v1", result);
+    }
+
+    [Fact]
+    public void BuildFileName_KeepsTheHashAsTheFirstUnderscoreSegment()
+    {
+        // ProjectTreeThumbnailService.TrySaveToDisk deletes stale entries for the same source by
+        // globbing "{name.Split('_')[0]}_*.png", so anything appended to the name must stay after
+        // the first underscore or that cleanup silently stops matching (and a render-version bump
+        // would orphan every old file instead of replacing it).
+        var result = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var hash = result.Split('_')[0];
+        Assert.Equal(16, hash.Length);
+        Assert.Matches("^[0-9A-F]{16}$", hash);
+    }
+
+    [Fact]
     public void BuildFileName_EndsWithPngExtension()
     {
         var result = AchxThumbnailCacheKey.BuildFileName(@"C:\Content\hero.achx", 1024,


### PR DESCRIPTION
Closes #1013.

`ThumbnailService.RenderFrameThumbnail` hardcoded `SKFilterMode.Nearest`. Right when a small frame is blown up to icon size, wrong when a large one is squashed down: nearest keeps one texel per destination pixel and discards every other one it stepped over. Sampling is now picked from the scale that method already computes, `Nearest` at `scale >= 1` and `Linear` below.

Both the project-tree icons and the 22x18 timeline strip cells go through this method, so both improve.

## Why plain Linear

Probed nearest / linear / linear+mipmap / Mitchell / CatmullRom on a 64px 1px-checkerboard at 1/8 scale. Nearest returned solid black (min=max=0, total information loss, the reported "garbage"); every filtered option returned mid-grey (~127) and none beat plain `Linear`. `GetFullImageThumbnail` in the same file already uses `Linear` for the Files panel, so this matches existing precedent rather than introducing a second convention.

## Disk cache had to be versioned too

`AchxThumbnailCacheKey.BuildFileName` keys off the source `.achx`'s Size/Modified only. Neither changes when the renderer changes, so every pre-fix cache PNG would have stayed a name match and kept being served: the fix would have been invisible until each file happened to be edited, including for the manual check on this PR. `RenderVersion` is now part of the file name. `TrySaveToDisk`'s existing same-hash glob deletes superseded files, so a bump replaces rather than accumulates, and a test pins the hash to the first underscore segment that glob depends on.

## Tests

- `RenderFrameThumbnail_DownscalingALargeFrame_FiltersInsteadOfAliasing` (new, failed with `Actual: 0` before the fix).
- `RenderFrameThumbnail_UsesPointSampling_SoUpscaledArtStaysCrisp` (existing) still passes, so the magnification branch is unchanged.
- Two cache-key tests for the render version and the hash-prefix coupling.

Green: 880 App, 122 Views, 1920 Core. Solution builds with 0 warnings.

**Manual test: needed** — this is a visual-quality change, so the pixel assertions prove "not aliased" but not "looks good". Open a project folder with enemies whose frames are larger than the tree icon and compare.

Non-integer magnification below 2x (1.3x giving some pixels 1px width and some 2px) is the milder remaining case, tracked separately in #1014 with three candidate treatments to compare visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbiTjSnp2pXXQAQm3Nc3yD
