### PR TITLE
Don't prompt to copy a texture that's already in the open project

### DIFF
--- a/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
+++ b/tools/AnimationEditorAvalonia/docs/FEATURE_COVERAGE_REPORT.md
@@ -123,7 +123,7 @@
 | AS02 | Wireframe zoom level | `WireframeZoomValue` (default 100); changing fires `AfterZoomChange` |
 | AS03 | Snap-to-grid toggle | `IsSnapToGridChecked` boolean |
 | AS04 | Grid size setting | `GridSize` integer (default 16) |
-| AS05 | Project folder | `ProjectFolder` string used to suppress file-copy prompts |
+| AS05 | Project folder | `ProjectManager.ProjectFolderPath` used to suppress file-copy prompts |
 | AS06 | `CurrentFrame` alias | Delegates to `SelectedState.Self.SelectedFrame` |
 
 ### 1.8 Application Events

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -3281,8 +3281,7 @@ public partial class MainWindow : Window
             ? string.Empty
             : (Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty);
 
-        if (!string.IsNullOrEmpty(achxFolder) &&
-            TextureCopyDecider.ShouldPromptToCopy(droppedFilePath, achxFolder, _appState.ProjectFolder))
+        if (TextureCopyDecider.ShouldPromptToCopyForProject(_projectManager, droppedFilePath))
         {
             var choice = await ShowTextureCopyDialogAsync(droppedFilePath);
             if (choice == TextureCopyChoice.Cancel) return false;
@@ -4743,38 +4742,35 @@ public partial class MainWindow : Window
         // resolvedAbsPath tracks the actual file we will use (may change if user copies it)
         string resolvedAbsPath = pickedPath;
 
-        if (!string.IsNullOrEmpty(achxFolder))
+        if (TextureCopyDecider.ShouldPromptToCopyForProject(_projectManager, pickedPath))
         {
-            if (TextureCopyDecider.ShouldPromptToCopy(pickedPath, achxFolder, _appState.ProjectFolder))
-            {
-                var choice = await ShowTextureCopyDialogAsync(pickedPath);
-                if (choice == TextureCopyChoice.Cancel) return;
+            var choice = await ShowTextureCopyDialogAsync(pickedPath);
+            if (choice == TextureCopyChoice.Cancel) return;
 
-                if (choice == TextureCopyChoice.Copy)
+            if (choice == TextureCopyChoice.Copy)
+            {
+                string destination = Path.Combine(achxFolder, Path.GetFileName(pickedPath));
+                try
                 {
-                    string destination = Path.Combine(achxFolder, Path.GetFileName(pickedPath));
-                    try
+                    File.Copy(pickedPath, destination, overwrite: true);
+                    resolvedAbsPath = destination;
+                }
+                catch (Exception ex)
+                {
+                    var capturedSource = pickedPath;
+                    var capturedDest   = destination;
+                    ShowToast($"Could not copy: {ex.Message}", retryAction: () =>
                     {
-                        File.Copy(pickedPath, destination, overwrite: true);
-                        resolvedAbsPath = destination;
-                    }
-                    catch (Exception ex)
-                    {
-                        var capturedSource = pickedPath;
-                        var capturedDest   = destination;
-                        ShowToast($"Could not copy: {ex.Message}", retryAction: () =>
+                        try
                         {
-                            try
-                            {
-                                File.Copy(capturedSource, capturedDest, overwrite: true);
-                                CommitFrameTexture(new[] { frame }, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
-                            }
-                            catch (Exception retryEx)
-                            {
-                                ShowToast($"Retry failed: {retryEx.Message}");
-                            }
-                        });
-                    }
+                            File.Copy(capturedSource, capturedDest, overwrite: true);
+                            CommitFrameTexture(new[] { frame }, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
+                        }
+                        catch (Exception retryEx)
+                        {
+                            ShowToast($"Retry failed: {retryEx.Message}");
+                        }
+                    });
                 }
             }
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppState.cs
@@ -18,12 +18,6 @@ namespace AnimationEditor.Core.CommandsAndState
             _events = events;
             _selectedState = selectedState;
         }
-        /// <summary>
-        /// The absolute path of the project (.gluj/.glux) that this .achx belongs to.
-        /// When set, the tool won't prompt the user to copy files that are part of the project.
-        /// </summary>
-        public string? ProjectFolder { get; set; }
-
         private int _wireframeZoomValue = 100;
         public int WireframeZoomValue
         {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppState.cs
@@ -5,7 +5,6 @@ namespace AnimationEditor.Core.CommandsAndState
 {
     public interface IAppState
     {
-        string? ProjectFolder { get; set; }
         int WireframeZoomValue { get; set; }
         bool IsSnapToGridChecked { get; set; }
         int GridSize { get; set; }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TextureCopyDecider.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/TextureCopyDecider.cs
@@ -1,42 +1,74 @@
+using FilePath = AnimationEditor.Core.Paths.FilePath;
+
 namespace AnimationEditor.Core.IO;
 
 /// <summary>
-/// Determines whether the user should be prompted to copy a texture file into
-/// the project folder.  Mirrors the "ask to copy" dialog logic from the WinForms
-/// AnimationEditor (see <c>AppState.ProjectFolder</c> doc comment in AS05).
+/// Determines whether the user should be prompted to copy a texture file next to the
+/// loaded .achx.  Mirrors the "ask to copy" dialog logic from the WinForms
+/// AnimationEditor.
 /// </summary>
 public static class TextureCopyDecider
 {
     /// <summary>
+    /// Returns <see langword="true"/> when assigning <paramref name="texturePath"/> should show the
+    /// "copy file?" dialog, given the editor's current project state. No prompt when the .achx has
+    /// never been saved (nowhere to copy to yet), when the texture already sits under the .achx's
+    /// own folder, or when the .achx and the texture are both under the open project folder — a
+    /// project is shared as a whole, so a path relative to it is already portable.
+    /// </summary>
+    public static bool ShouldPromptToCopyForProject(IProjectManager projectManager, string? texturePath)
+    {
+        if (string.IsNullOrEmpty(projectManager.FileName)) return false;
+
+        var achxFolder = new FilePath(projectManager.FileName).GetDirectoryContainingThis().FullPath;
+        return ShouldPromptToCopy(texturePath, achxFolder, projectManager.ProjectFolderPath);
+    }
+
+    /// <summary>
     /// Returns <see langword="true"/> when the user should be shown a "copy file?"
-    /// dialog — i.e., the texture lives outside the project folder.
+    /// dialog — i.e., the texture lives outside <paramref name="folder"/>.
     /// </summary>
     /// <param name="texturePath">
     /// Absolute or relative path of the texture the user selected.
     /// If null or empty the texture has not been set, so no copy is needed.
     /// </param>
-    /// <param name="projectFolder">
-    /// Absolute path of the project folder.  If null or empty, no project context
-    /// is available and the prompt should always be shown.
+    /// <param name="folder">
+    /// Absolute path of the folder the texture may already live in.  If null or empty,
+    /// no folder context is available and the prompt should always be shown.
     /// </param>
-    public static bool ShouldPromptToCopy(string? texturePath, string? projectFolder)
+    public static bool ShouldPromptToCopy(string? texturePath, string? folder)
     {
         if (string.IsNullOrEmpty(texturePath)) return false;
-        if (string.IsNullOrEmpty(projectFolder)) return true;
+        if (string.IsNullOrEmpty(folder)) return true;
 
-        // Normalise separators so forward- and back-slash variants compare equally.
-        char sep = Path.DirectorySeparatorChar;
-        string normTexture = texturePath.Replace('/', sep).Replace('\\', sep);
-        string normFolder  = projectFolder.TrimEnd('/', '\\').Replace('/', sep).Replace('\\', sep)
-                             + sep;
-
-        return !normTexture.StartsWith(normFolder, StringComparison.OrdinalIgnoreCase);
+        return !IsInside(texturePath, folder);
     }
 
     /// <summary>
-    /// Overload for callers with two candidate "already inside" folders — e.g. the .achx
-    /// folder and the broader project folder. Prompts only when the texture is outside both.
+    /// Overload that also lets <paramref name="projectFolder"/> suppress the prompt — but only when
+    /// <paramref name="achxFolder"/> is inside it too. An .achx outside the project would store a
+    /// "../.." climb to reach the project's textures, which is what the prompt exists to avoid.
     /// </summary>
-    public static bool ShouldPromptToCopy(string? texturePath, string? primaryFolder, string? secondaryFolder)
-        => ShouldPromptToCopy(texturePath, primaryFolder) && ShouldPromptToCopy(texturePath, secondaryFolder);
+    public static bool ShouldPromptToCopy(string? texturePath, string? achxFolder, string? projectFolder)
+    {
+        if (!ShouldPromptToCopy(texturePath, achxFolder)) return false;
+        if (string.IsNullOrEmpty(achxFolder) || string.IsNullOrEmpty(projectFolder)) return true;
+
+        return !(IsInside(texturePath!, projectFolder) && IsInside(achxFolder, projectFolder));
+    }
+
+    /// <summary>
+    /// Path-prefix containment, tolerant of mixed separators, casing, and trailing separators.
+    /// A path equal to the folder counts as inside so a folder can be tested against itself.
+    /// </summary>
+    private static bool IsInside(string path, string folder)
+    {
+        // Normalise separators so forward- and back-slash variants compare equally.
+        char sep = Path.DirectorySeparatorChar;
+        string normPath   = path.Replace('/', sep).Replace('\\', sep).TrimEnd(sep);
+        string normFolder = folder.Replace('/', sep).Replace('\\', sep).TrimEnd(sep);
+
+        return normPath.Equals(normFolder, StringComparison.OrdinalIgnoreCase)
+            || normPath.StartsWith(normFolder + sep, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppStateTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppStateTests.cs
@@ -91,14 +91,4 @@ public class AppStateTests
 
         Assert.Null(ctx.AppState.CurrentFrame);
     }
-
-    [Fact]
-    public void ProjectFolder_WhenSet_StoresValue()
-    {
-        var ctx = TestHelpers.SetupFreshAcls();
-
-        ctx.AppState.ProjectFolder = "C:/MyGame/Content";
-
-        Assert.Equal("C:/MyGame/Content", ctx.AppState.ProjectFolder);
-    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TestHelpers.cs
@@ -58,7 +58,6 @@ internal sealed class TestServices
         AppState.GridSize           = 16;
         AppState.IsSnapToGridChecked = false;
         AppState.WireframeZoomValue = 100;
-        AppState.ProjectFolder      = null;
     }
 }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureCopyDeciderTests.cs
@@ -112,4 +112,45 @@ public class TextureCopyDeciderTests
     [Fact]
     public void ShouldPromptToCopy_TwoFolders_TextureNullOrEmpty_ReturnsFalse()
         => Assert.False(TextureCopyDecider.ShouldPromptToCopy(null, Folder, Folder));
+
+    [Fact]
+    public void ShouldPromptToCopy_TwoFolders_AchxOutsideProjectFolder_ReturnsTrue()
+    {
+        // The texture is in the project but the .achx is not, so the stored path would be a
+        // "../.." climb out of the .achx's folder, which is what the prompt exists to avoid.
+        string projectFolder   = TestPaths.Abs("project");
+        string looseAchxFolder = TestPaths.AltAbs("scratch");
+        Assert.True(TextureCopyDecider.ShouldPromptToCopy(Inside, looseAchxFolder, projectFolder));
+    }
+
+    // ── ShouldPromptToCopyForProject (what the call sites actually use) ──────
+
+    [Fact]
+    public void ShouldPromptToCopyForProject_AchxAndTextureInOpenProjectFolder_ReturnsFalse()
+    {
+        var projectManager = new ProjectManager
+        {
+            FileName          = TestPaths.Abs("project", "Animations", "hero.achx"),
+            ProjectFolderPath = TestPaths.Abs("project")
+        };
+        Assert.False(TextureCopyDecider.ShouldPromptToCopyForProject(projectManager, Inside));
+    }
+
+    [Fact]
+    public void ShouldPromptToCopyForProject_NoProjectFolderOpen_ReturnsTrue()
+    {
+        var projectManager = new ProjectManager
+        {
+            FileName = TestPaths.Abs("project", "Animations", "hero.achx")
+        };
+        Assert.True(TextureCopyDecider.ShouldPromptToCopyForProject(projectManager, Inside));
+    }
+
+    [Fact]
+    public void ShouldPromptToCopyForProject_UnsavedAchx_ReturnsFalse()
+    {
+        // Nowhere to copy the texture to until the .achx has a folder of its own.
+        var projectManager = new ProjectManager { ProjectFolderPath = TestPaths.Abs("project") };
+        Assert.False(TextureCopyDecider.ShouldPromptToCopyForProject(projectManager, Outside));
+    }
 }


### PR DESCRIPTION
Closes #1016.

The "copy this file?" prompt keeps a loose .achx portable by pulling outside textures next to it. It's wrong when the .achx belongs to a project that gets shared as a whole, since a path relative to the project is already portable.

`TextureCopyDecider` already had a two-folder overload for this and `AppState.ProjectFolder`'s doc comment already promised it, but nothing in production ever assigned `AppState.ProjectFolder`, so both call sites passed null and the prompt fired unconditionally. The decision now runs off `ProjectManager.ProjectFolderPath` (File > Open Project Folder) through a new `ShouldPromptToCopyForProject(IProjectManager, texturePath)`, and the dead `AppState.ProjectFolder` is gone.

The project folder only suppresses the prompt when the **.achx is inside it too**. An .achx outside the project would store a `../..` climb to reach the project's textures, which is what the prompt guards against.

Both MainWindow call sites lost their own `string.IsNullOrEmpty(achxFolder)` guard, now folded into the decider (an unsaved .achx has nowhere to copy to, so it never prompts).

Tests: 4 added to `TextureCopyDeciderTests`. `ShouldPromptToCopy_TwoFolders_AchxOutsideProjectFolder_ReturnsTrue` was confirmed red against the old one-liner before the fix. Core 1923, Views 122, App 880 all green.

Manual test: needed. Open a project folder, open an .achx inside it, drag a PNG from another folder of that same project onto a frame: no prompt. Same drag from outside the project still prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nn57gNWBoqGWZJsDfAT6F
