### PR TITLE
Add "New Animation File" to Project-tree folder right-click (#1018)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -277,6 +277,7 @@ public partial class MainWindow : Window
         // Right-clicking blank space in the tree offers "New Animation" (#908) -- same flow as
         // File > New.
         ProjectPanel.NewAnimationRequested += () => OnNewClick(null, null!);
+        ProjectPanel.NewAnimationFileRequested += request => _ = CreateNewAnimationFileAsync(request);
         // On scope toggle, re-supply the current referenced-texture set so "This File" reflects
         // the live .achx instead of the snapshot cached at the last refresh.
         FilesPanel.ScopeChanged += (_, _) => RefreshFilesPanel();
@@ -2189,6 +2190,35 @@ public partial class MainWindow : Window
     /// about it.
     /// </summary>
     internal Func<string, string?> DeleteToRecycleBin { get; set; } = RecycleBin.Delete;
+
+    /// <summary>
+    /// Issue #1018: right-click "New Animation File" on a Project-tree folder row, after the user
+    /// named it inline. The panel has already rejected a name colliding with anything it can see,
+    /// but the scan behind the tree can be stale (an external <c>git pull</c>, another editor), so
+    /// this writes with <see cref="FileMode.CreateNew"/> and reports rather than overwriting. No
+    /// explicit tree refresh -- the project folder watcher rescans on any create under the watched
+    /// folder, same as <see cref="DeleteProjectFileAsync"/> relies on for a delete. Internal
+    /// (not private) so tests can drive it without a real context menu.
+    /// </summary>
+    internal async Task CreateNewAnimationFileAsync(NewAnimationFileRequest request)
+    {
+        var folder = ResolveProjectFolderAbsolutePath(request.FolderRelativePath);
+        if (folder is null) return;
+
+        var absolutePath = Path.Combine(folder, request.FileName);
+        try
+        {
+            using (var stream = new FileStream(absolutePath, FileMode.CreateNew, FileAccess.Write))
+                NewAnimationFileWriter.WriteEmpty(stream, request.FileName);
+        }
+        catch (Exception ex)
+        {
+            ShowStatusMessage($"⚠ Could not create {request.FileName}: {ex.Message}", isError: true);
+            return;
+        }
+
+        await LoadAnimationFileAsync(absolutePath);
+    }
 
     private void OnTitleFileCopyPathClick(object? sender, RoutedEventArgs e)
     {

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -1597,6 +1597,10 @@ public partial class App : Application
         // Set by openButton.Click, read by a later Project-tree click -- see its assignment site.
         string lastOpenFolderWriteState = "";
 
+        // The picked project folder's own handle, kept so "New Animation File" (#1018) can walk
+        // down to the right subfolder later; a Project-tree node carries only a relative path.
+        JSObject? lastOpenFolderNativeDir = null;
+
         // #763 fallback: directory enumeration (dirHandle.entries(), used by
         // folder.GetItemsAsync() below) can throw NotFoundError on some environments even though
         // named lookups (getFileHandle) on the identical handle keep working -- confirmed live on
@@ -1763,6 +1767,7 @@ public partial class App : Application
             // populated) can finish the load with the same write-permission suffix in the status
             // text, without re-running EnsureReadWriteAsync.
             lastOpenFolderWriteState = writeState;
+            lastOpenFolderNativeDir = nativeDir;
 
             // Directory reads (enumeration, file access) can fail for reasons outside this app's
             // control -- confirmed live: a valid, correctly-permissioned handle can still throw
@@ -1786,6 +1791,48 @@ public partial class App : Application
         };
 
         projectPanel.FileSelected += entry => _ = LoadAchxEntryAsync(entry, lastOpenFolderWriteState);
+
+        // #1018: right-click a Project-tree folder -> "New Animation File". Works here as well as
+        // on desktop -- the picked folder handle is writable (EnsureReadWriteAsync ran at pick
+        // time), it just can't be revealed in an OS shell.
+        async Task CreateNewAnimationFileAsync(NewAnimationFileRequest request)
+        {
+            if (lastOpenFolderNativeDir is null) return;
+
+            var relativePath = request.FolderRelativePath.Length == 0
+                ? request.FileName
+                : request.FolderRelativePath + "/" + request.FileName;
+            try
+            {
+                var dirHandle = lastOpenFolderNativeDir;
+                foreach (var segment in request.FolderRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries))
+                    dirHandle = await NativeFolderInterop.GetDirectoryHandleAsync(dirHandle, segment);
+
+                // The tree's scan can be stale, so re-check before writing -- there's no
+                // create-only mode here to lean on the way desktop's FileMode.CreateNew does.
+                var folder = new NativeReadWriteFolder(dirHandle);
+                if (await folder.GetFileAsync(request.FileName) is not null)
+                {
+                    notifications.ShowErrorBanner($"\"{request.FileName}\" already exists in that folder.");
+                    return;
+                }
+
+                await using (var stream = await new NativeReadWriteFile(dirHandle, request.FileName).OpenWriteAsync())
+                    NewAnimationFileWriter.WriteEmpty(stream, request.FileName);
+
+                var entries = await AchxFolderScanner.ScanAsync(new NativeReadWriteFolder(lastOpenFolderNativeDir));
+                projectPanel.SetEntries(entries);
+
+                if (entries.FirstOrDefault(e => e.RelativePath == relativePath) is { } created)
+                    await LoadAchxEntryAsync(created, lastOpenFolderWriteState);
+            }
+            catch (JSException ex)
+            {
+                notifications.ShowErrorBanner($"Could not create {relativePath}: {ex.Message}");
+            }
+        }
+
+        projectPanel.NewAnimationFileRequested += request => _ = CreateNewAnimationFileAsync(request);
 
         // Prompts for a new save location (the OS-level save dialog) and writes there --
         // shared by Save As (always) and Save's first-time fallback (no known location yet).

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NewAnimationFileNaming.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NewAnimationFileNaming.cs
@@ -1,0 +1,112 @@
+using AnimationEditor.Core.Paths;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Naming rules for "New Animation File" on a Project-tree folder row (issue #1018): which
+/// extension a new file gets, what name it starts out with, and whether a typed name is legal.
+/// Pure string logic so both hosts share it and neither needs a filesystem to test it.
+/// </summary>
+public static class NewAnimationFileNaming
+{
+    /// <summary>Extension used when a project has no existing animation files, or an equal
+    /// number of each (issue #872 made JSON the going-forward default).</summary>
+    public const string JsonExtension = "achj";
+
+    public const string XmlExtension = "achx";
+
+    private const string DefaultStem = "NewAnimation";
+
+    /// <summary>Outcome of <see cref="Resolve"/>: exactly one of the two is non-null.</summary>
+    /// <param name="FileName">The file name to create, extension included.</param>
+    /// <param name="Error">User-facing reason the typed name was rejected.</param>
+    public readonly record struct NameResult(string? FileName, string? Error);
+
+    /// <summary>
+    /// The extension a new file in this project should get: whichever of <c>.achx</c>/<c>.achj</c>
+    /// the project already uses more of, with <c>.achj</c> winning a tie or an empty project.
+    /// Pass every animation file in the project, not just the target folder's -- the convention is
+    /// a project-wide property, and the folder being right-clicked is often empty.
+    /// </summary>
+    public static string ResolveExtension(IEnumerable<string> projectFileNames)
+    {
+        int achx = 0, achj = 0;
+        foreach (var name in projectFileNames)
+        {
+            if (HasExtension(name, XmlExtension)) achx++;
+            else if (HasExtension(name, JsonExtension)) achj++;
+        }
+
+        return achx > achj ? XmlExtension : JsonExtension;
+    }
+
+    /// <summary>
+    /// Name the inline editor starts on: "NewAnimation", or the first numbered variant whose stem
+    /// isn't already taken in <paramref name="siblingFileNames"/>. Suffixing is only ever applied
+    /// to this suggestion -- a name the user actually types is rejected on collision rather than
+    /// silently renamed.
+    /// </summary>
+    public static string SuggestFileName(IEnumerable<string> siblingFileNames, string extension)
+    {
+        var taken = StemSet(siblingFileNames);
+
+        if (!taken.Contains(DefaultStem)) return DefaultStem + "." + extension;
+
+        for (int suffix = 2; ; suffix++)
+        {
+            var candidate = DefaultStem + suffix;
+            if (!taken.Contains(candidate)) return candidate + "." + extension;
+        }
+    }
+
+    /// <summary>
+    /// Validates a name typed into the inline editor and turns it into a file name.
+    /// <paramref name="typedName"/> may include an <c>.achx</c>/<c>.achj</c> extension, which wins
+    /// over <paramref name="projectExtension"/>; anything else is treated as the stem. A stem
+    /// already used by a sibling is rejected whichever extension it carries, so <c>Player.achj</c>
+    /// collides with an existing <c>Player.achx</c>.
+    /// </summary>
+    public static NameResult Resolve(
+        string typedName, IEnumerable<string> siblingFileNames, string projectExtension)
+    {
+        var trimmed = (typedName ?? string.Empty).Trim();
+        if (trimmed.Length == 0)
+            return new NameResult(null, "Enter a name.");
+
+        var extension = projectExtension;
+        if (HasExtension(trimmed, XmlExtension) || HasExtension(trimmed, JsonExtension))
+        {
+            extension = trimmed[(trimmed.LastIndexOf('.') + 1)..].ToLowerInvariant();
+            trimmed = trimmed[..trimmed.LastIndexOf('.')];
+        }
+
+        if (trimmed.Length == 0)
+            return new NameResult(null, "Enter a name.");
+
+        if (trimmed.IndexOfAny(InvalidNameChars) >= 0)
+            return new NameResult(null, "Name contains invalid characters.");
+
+        if (StemSet(siblingFileNames).Contains(trimmed))
+            return new NameResult(null, $"\"{trimmed}\" already exists in this folder.");
+
+        return new NameResult(trimmed + "." + extension, null);
+    }
+
+    // Path.GetInvalidFileNameChars() is the host OS's list, so a name legal on Linux but not on
+    // Windows would pass here and produce a project other contributors can't check out. The set
+    // below is the union both platforms have to live with.
+    private static readonly char[] InvalidNameChars = "\\/:*?\"<>|".ToCharArray();
+
+    private static HashSet<string> StemSet(IEnumerable<string> fileNames) =>
+        fileNames
+            .Where(AchxFolderScanner.IsAchxPath)
+            .Select(name => new FilePath(name).NoPathNoExtension)
+            .Where(stem => !string.IsNullOrEmpty(stem))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static bool HasExtension(string fileName, string extension) =>
+        fileName.EndsWith("." + extension, StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NewAnimationFileWriter.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/NewAnimationFileWriter.cs
@@ -1,0 +1,31 @@
+using AnimationEditor.Core.Paths;
+using FlatRedBall2.AnimationEditorCommon;
+using System;
+using System.IO;
+
+namespace AnimationEditor.Core.IO;
+
+/// <summary>
+/// Writes the empty animation chain list that "New Animation File" creates (issue #1018). Stream-
+/// based so desktop and the browser share it -- one writes a <c>FileStream</c>, the other an
+/// <see cref="IEditorFile"/> stream.
+/// </summary>
+public static class NewAnimationFileWriter
+{
+    /// <summary>
+    /// Writes an empty chain list to <paramref name="stream"/>, XML or JSON per
+    /// <paramref name="fileName"/>'s extension. The stream is left open for the caller to dispose.
+    /// </summary>
+    public static void WriteEmpty(Stream stream, string fileName)
+    {
+        // Pixel, not the AnimationChainListSave default of UV: opening a UV file runs the
+        // convert-to-pixel prompt, which is nonsense for a file the editor just created empty.
+        var save = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+
+        if (string.Equals(new FilePath(fileName).Extension, NewAnimationFileNaming.JsonExtension,
+                StringComparison.OrdinalIgnoreCase))
+            save.SaveJson(stream);
+        else
+            save.Save(stream);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
@@ -65,9 +65,26 @@
                                Stretch="Uniform"
                                VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Name}"
+                                   IsVisible="{Binding IsNotEditing}"
                                    FontSize="11"
                                    VerticalAlignment="Center"
                                    TextTrimming="CharacterEllipsis" />
+                        <!-- Inline rename for a not-yet-created file (#1018). The extension is
+                             neither shown nor edited here; the project's convention picks it. -->
+                        <TextBox Text="{Binding EditText, Mode=TwoWay}"
+                                 IsVisible="{Binding IsEditing}"
+                                 MinWidth="120"
+                                 FontSize="11"
+                                 Padding="2,0"
+                                 VerticalAlignment="Center"
+                                 AttachedToVisualTree="OnPendingNameAttached"
+                                 KeyDown="OnPendingNameKeyDown"
+                                 LostFocus="OnPendingNameLostFocus" />
+                        <TextBlock Text="{Binding ErrorMessage}"
+                                   IsVisible="{Binding HasError}"
+                                   FontSize="11"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource Accent}" />
                     </StackPanel>
                 </TreeDataTemplate>
             </TreeView.ItemTemplate>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml
@@ -46,6 +46,28 @@
                             Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="MinHeight" Value="24" />
                 </Style>
+                <!-- FluentTheme's TextBox is 32px tall with a 2px accent underline on focus, both
+                     of which overflow a 24px tree row. Size it to the row and give it a quiet
+                     border so it reads as the row being edited, not as an error. -->
+                <Style Selector="TextBox.inline-rename">
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="Height" Value="20" />
+                    <Setter Property="MinWidth" Value="0" />
+                    <Setter Property="Padding" Value="4,0" />
+                    <Setter Property="FontSize" Value="11" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                </Style>
+                <Style Selector="TextBox.inline-rename /template/ Border#PART_BorderElement">
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="CornerRadius" Value="2" />
+                    <Setter Property="BorderThickness" Value="1" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource LineStrong}" />
+                    <Setter Property="Background" Value="{DynamicResource BgApp}" />
+                </Style>
+                <Style Selector="TextBox.inline-rename:focus /template/ Border#PART_BorderElement">
+                    <Setter Property="BorderThickness" Value="1" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource AccentCool}" />
+                </Style>
             </TreeView.Styles>
             <TreeView.ItemTemplate>
                 <TreeDataTemplate DataType="controls:AchxTreeNodeVm"
@@ -71,11 +93,10 @@
                                    TextTrimming="CharacterEllipsis" />
                         <!-- Inline rename for a not-yet-created file (#1018). The extension is
                              neither shown nor edited here; the project's convention picks it. -->
-                        <TextBox Text="{Binding EditText, Mode=TwoWay}"
+                        <TextBox Classes="inline-rename"
+                                 Text="{Binding EditText, Mode=TwoWay}"
                                  IsVisible="{Binding IsEditing}"
-                                 MinWidth="120"
-                                 FontSize="11"
-                                 Padding="2,0"
+                                 Width="140"
                                  VerticalAlignment="Center"
                                  AttachedToVisualTree="OnPendingNameAttached"
                                  KeyDown="OnPendingNameKeyDown"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/ProjectPanelControl.axaml.cs
@@ -1,5 +1,7 @@
 using AnimationEditor.App.Services;
 using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Paths;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -33,6 +35,11 @@ public partial class ProjectPanelControl : UserControl
     private ProjectTreeThumbnailService? _thumbnailService;
     private CancellationTokenSource? _thumbnailLoadCts;
     private AchxTreeNodeVm? _contextNode;
+
+    // The un-committed "New Animation File" row and the folder it sits under (issue #1018). Both
+    // null whenever no inline edit is in progress; a Rebuild drops the row with the rest of the tree.
+    private AchxTreeNodeVm? _pendingNode;
+    private AchxTreeNodeVm? _pendingParent;
 
     // Guards against re-entrant SelectionChanged while a selection change is programmatic rather
     // than a real user click -- ClearSearchAndReveal restoring post-rebuild, or SyncSelectionToActiveFile
@@ -99,6 +106,14 @@ public partial class ProjectPanelControl : UserControl
     public event Action? NewAnimationRequested;
 
     /// <summary>
+    /// Raised when the user commits a name for "New Animation File" on a folder row (issue
+    /// #1018). The host creates the file and opens it -- this control only picks the name and the
+    /// extension, and has no way to write anything itself. Never raised for a name that collides
+    /// with a sibling: the inline editor stays open showing the error instead.
+    /// </summary>
+    public event Action<NewAnimationFileRequest>? NewAnimationFileRequested;
+
+    /// <summary>
     /// Completes once every thumbnail from the most recent <see cref="Rebuild"/> has finished
     /// loading (or been cancelled by a newer one). Test seam for awaiting the async thumbnail
     /// load -- production code never needs to await this.
@@ -146,6 +161,8 @@ public partial class ProjectPanelControl : UserControl
 
     private void Rebuild()
     {
+        _pendingNode = null;
+        _pendingParent = null;
         TreeRoots.Clear();
 
         var excludeBinObj = ExcludeBinObjCheck.IsChecked == true;
@@ -348,15 +365,23 @@ public partial class ProjectPanelControl : UserControl
             return;
         }
 
-        if (!SupportsRevealInExplorer) return;
-
         if (_contextNode is { IsFolder: true } folderNode)
         {
+            // Not gated on SupportsRevealInExplorer: creating a file works on both hosts, only
+            // the OS-shell reveal below is desktop-only (issue #1018).
+            var newFileItem = new MenuItem { Header = "New Animation File" };
+            newFileItem.Click += (_, _) => BeginNewAnimationFile(folderNode);
+            ProjectTree.ContextMenu.Items.Add(newFileItem);
+
+            if (!SupportsRevealInExplorer) return;
+
             var revealItem = new MenuItem { Header = "View in Explorer" };
             revealItem.Click += (_, _) => FolderRevealRequested?.Invoke(folderNode.RelativePath);
             ProjectTree.ContextMenu.Items.Add(revealItem);
             return;
         }
+
+        if (!SupportsRevealInExplorer) return;
 
         if (_contextNode is { IsFile: true } fileNode)
         {
@@ -378,6 +403,81 @@ public partial class ProjectPanelControl : UserControl
         }
     }
 
+    /// <summary>
+    /// Adds a placeholder row under <paramref name="folderNode"/> and puts it straight into inline
+    /// edit mode (issue #1018). Nothing is written until the name is committed -- an abandoned edit
+    /// leaves no file behind, so Escape only has to drop the row.
+    /// </summary>
+    private void BeginNewAnimationFile(AchxTreeNodeVm folderNode)
+    {
+        CancelPendingNewAnimationFile();
+
+        var extension = NewAnimationFileNaming.ResolveExtension(
+            _allEntries
+                .Where(f => ExcludeBinObjCheck.IsChecked != true || !BinObjPathFilter.IsExcluded(f.RelativePath))
+                .Select(f => f.FileName));
+        var suggested = NewAnimationFileNaming.SuggestFileName(SiblingFileNames(folderNode), extension);
+
+        _pendingNode = AchxTreeNodeVm.CreatePending(suggested, folderNode.RelativePath);
+        _pendingParent = folderNode;
+        folderNode.IsExpanded = true;
+        folderNode.Children.Add(_pendingNode);
+    }
+
+    private void OnPendingNameKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter) { CommitPendingNewAnimationFile(); e.Handled = true; }
+        else if (e.Key == Key.Escape) { CancelPendingNewAnimationFile(); e.Handled = true; }
+    }
+
+    // Clicking away abandons the new file rather than committing it -- a half-typed name is far
+    // more likely than a deliberate commit-by-defocus, and the row is trivially re-created.
+    private void OnPendingNameLostFocus(object? sender, RoutedEventArgs e) =>
+        CancelPendingNewAnimationFile();
+
+    // Every row's template carries this TextBox, collapsed -- an unguarded Focus() here would let
+    // any newly-realized row steal focus (from the search box, say), not just the pending one.
+    private void OnPendingNameAttached(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (sender is not TextBox { DataContext: AchxTreeNodeVm { IsEditing: true } } textBox) return;
+
+        textBox.Focus();
+        textBox.SelectAll();
+    }
+
+    private void CommitPendingNewAnimationFile()
+    {
+        if (_pendingNode is null || _pendingParent is null) return;
+
+        var extension = new FilePath(_pendingNode.Name).Extension;
+        var result = NewAnimationFileNaming.Resolve(
+            _pendingNode.EditText, SiblingFileNames(_pendingParent), extension);
+
+        if (result.Error is not null)
+        {
+            _pendingNode.ErrorMessage = result.Error;
+            return;
+        }
+
+        var request = new NewAnimationFileRequest(_pendingParent.RelativePath, result.FileName!);
+        CancelPendingNewAnimationFile();
+        NewAnimationFileRequested?.Invoke(request);
+    }
+
+    private void CancelPendingNewAnimationFile()
+    {
+        if (_pendingNode is not null && _pendingParent is not null)
+            _pendingParent.Children.Remove(_pendingNode);
+
+        _pendingNode = null;
+        _pendingParent = null;
+    }
+
+    // Only files directly inside the folder -- the collision that matters is a name clash on disk,
+    // which is per-directory.
+    private static IEnumerable<string> SiblingFileNames(AchxTreeNodeVm folderNode) =>
+        folderNode.Children.Where(n => n.IsFile).Select(n => n.Name);
+
     private void OnFolderExpanderToggled(object? sender, EventArgs e)
     {
         if (sender is not Control control) return;
@@ -388,16 +488,74 @@ public partial class ProjectPanelControl : UserControl
     }
 }
 
+/// <summary>
+/// A committed "New Animation File" name (issue #1018): the file to create, and the folder to
+/// create it in as a project-root-relative, forward-slash-separated path (empty for the root).
+/// </summary>
+public readonly record struct NewAnimationFileRequest(string FolderRelativePath, string FileName);
+
 /// <summary>Tree node view-model for <see cref="ProjectPanelControl"/>'s <c>TreeView</c>.</summary>
 public sealed class AchxTreeNodeVm : INotifyPropertyChanged
 {
     private bool _isExpanded = true;
     private Bitmap? _thumbnail;
+    private bool _isEditing;
+    private string _editText = string.Empty;
+    private string? _errorMessage;
 
     public string Name { get; }
     public AchxFileEntry? Entry { get; }
-    public bool IsFolder => Entry is null;
+
+    /// <summary>
+    /// True for the placeholder row a "New Animation File" edit adds (issue #1018). It has no
+    /// <see cref="Entry"/> because nothing exists on disk yet, so it would otherwise read as a
+    /// folder -- hence this flag rather than inferring from <see cref="Entry"/> alone.
+    /// </summary>
+    public bool IsPending { get; private init; }
+
+    public bool IsFolder => Entry is null && !IsPending;
     public bool IsFile => Entry is not null;
+
+    /// <summary>Name shown in the inline editor, without the extension.</summary>
+    public string EditText
+    {
+        get => _editText;
+        set
+        {
+            if (_editText == value) return;
+            _editText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsEditing
+    {
+        get => _isEditing;
+        set
+        {
+            if (_isEditing == value) return;
+            _isEditing = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsNotEditing));
+        }
+    }
+
+    public bool IsNotEditing => !_isEditing;
+
+    /// <summary>Why the typed name was rejected, shown beside the inline editor; null when valid.</summary>
+    public string? ErrorMessage
+    {
+        get => _errorMessage;
+        set
+        {
+            if (_errorMessage == value) return;
+            _errorMessage = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasError));
+        }
+    }
+
+    public bool HasError => _errorMessage is not null;
 
     /// <summary>Path from the project root, forward-slash separated -- see
     /// <see cref="AchxTreeNode.RelativePath"/>. Used to resolve a folder row's absolute path for
@@ -445,6 +603,19 @@ public sealed class AchxTreeNodeVm : INotifyPropertyChanged
         Entry = entry;
         RelativePath = relativePath;
     }
+
+    /// <summary>
+    /// The un-committed row a "New Animation File" edit starts on (issue #1018).
+    /// <paramref name="suggestedFileName"/> carries the extension the project's convention
+    /// resolved to; the editor itself only shows the stem.
+    /// </summary>
+    public static AchxTreeNodeVm CreatePending(string suggestedFileName, string folderRelativePath) =>
+        new(suggestedFileName, entry: null, folderRelativePath)
+        {
+            IsPending = true,
+            EditText = new FilePath(suggestedFileName).NoPathNoExtension,
+            IsEditing = true,
+        };
 
     public static AchxTreeNodeVm FromNode(AchxTreeNode node)
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAnimationFileTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/NewAnimationFileTests.cs
@@ -1,0 +1,71 @@
+using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using AnimationEditor.Views.Controls;
+using Avalonia.Headless.XUnit;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #1018 -- "New Animation File" on a Project-tree folder row. <c>ProjectPanelControlTests</c>
+/// (Views.Tests) covers the context menu, the inline editor and the naming rules; these cover
+/// MainWindow's half: writing the file into the right folder and opening it as a tab.
+/// </summary>
+public class NewAnimationFileTests
+{
+    private static TabManager GetTabManager(MainWindow window) =>
+        (TabManager)typeof(MainWindow)
+            .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(window)!;
+
+    [AvaloniaFact]
+    public async Task CreateNewAnimationFileAsync_WritesFileIntoFolderAndOpensItAsTab()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Directory.CreateDirectory(Path.Combine(dir, "Sprites"));
+        var expected = Path.Combine(dir, "Sprites", "Enemy.achj");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            await window.CreateNewAnimationFileAsync(new NewAnimationFileRequest("Sprites", "Enemy.achj"));
+
+            Assert.True(File.Exists(expected));
+            Assert.Contains(GetTabManager(window).Tabs, t => t.Path == new FilePath(expected));
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+
+    // The tree's scan can be stale (an external git pull, another editor), so the panel's own
+    // collision check isn't the last word -- creating must never clobber a file already there.
+    [AvaloniaFact]
+    public async Task CreateNewAnimationFileAsync_FileAlreadyExists_LeavesItAloneAndShowsError()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var existing = Path.Combine(dir, "Enemy.achj");
+        File.WriteAllText(existing, "original contents");
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            await window.OpenProjectFolderForTestAsync(dir);
+
+            await window.CreateNewAnimationFileAsync(new NewAnimationFileRequest("", "Enemy.achj"));
+
+            Assert.Equal("original contents", File.ReadAllText(existing));
+            Assert.True(window.Notifications.ErrorBanner.IsVisible);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NewAnimationFileNamingTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NewAnimationFileNamingTests.cs
@@ -1,0 +1,65 @@
+using AnimationEditor.Core.IO;
+using System;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class NewAnimationFileNamingTests
+{
+    [Fact]
+    public void Resolve_NameTakenByOtherExtension_ReturnsError()
+    {
+        // A .achj project that already has Player.achx: the stem is taken regardless of which
+        // extension the new file would get, so this must be rejected rather than suffixed (#1018).
+        var result = NewAnimationFileNaming.Resolve("Player", new[] { "Player.achx" }, "achj");
+
+        Assert.Null(result.FileName);
+        Assert.Equal("\"Player\" already exists in this folder.", result.Error);
+    }
+
+    [Fact]
+    public void Resolve_NameWithAnimationExtensionTyped_HonorsTypedExtension()
+    {
+        var result = NewAnimationFileNaming.Resolve("Player.achx", Array.Empty<string>(), "achj");
+
+        Assert.Equal("Player.achx", result.FileName);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Resolve_ValidName_AppendsProjectExtension()
+    {
+        var result = NewAnimationFileNaming.Resolve("Player", new[] { "Enemy.achj" }, "achj");
+
+        Assert.Equal("Player.achj", result.FileName);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void ResolveExtension_AchxOutnumbersAchj_ReturnsAchx()
+    {
+        var extension = NewAnimationFileNaming.ResolveExtension(
+            new[] { "Player.achx", "Enemy.achx", "Boss.achj" });
+
+        Assert.Equal("achx", extension);
+    }
+
+    [Fact]
+    public void ResolveExtension_EqualCounts_ReturnsAchj()
+    {
+        // .achj is the tiebreaker, so a tie (and an empty project) lands on JSON.
+        var extension = NewAnimationFileNaming.ResolveExtension(
+            new[] { "Player.achx", "Enemy.achj" });
+
+        Assert.Equal("achj", extension);
+    }
+
+    [Fact]
+    public void SuggestFileName_DefaultNameTaken_UsesNextFreeNumber()
+    {
+        var suggested = NewAnimationFileNaming.SuggestFileName(
+            new[] { "NewAnimation.achj", "NewAnimation2.achx" }, "achj");
+
+        Assert.Equal("NewAnimation3.achj", suggested);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NewAnimationFileWriterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/NewAnimationFileWriterTests.cs
@@ -1,0 +1,36 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.AnimationEditorCommon;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+public class NewAnimationFileWriterTests
+{
+    [Fact]
+    public void WriteEmpty_AchjFileName_WritesJsonWithPixelCoordinates()
+    {
+        using var stream = new MemoryStream();
+
+        NewAnimationFileWriter.WriteEmpty(stream, "Player.achj");
+
+        stream.Position = 0;
+        // AnimationChainListSave defaults to UV; a new file written that way would make the very
+        // next open prompt the user to convert to pixel coordinates (#1018).
+        var reloaded = AnimationChainListSave.FromJsonStream(stream);
+        Assert.Equal(TextureCoordinateType.Pixel, reloaded.CoordinateType);
+        Assert.Empty(reloaded.AnimationChains);
+    }
+
+    [Fact]
+    public void WriteEmpty_AchxFileName_WritesXml()
+    {
+        using var stream = new MemoryStream();
+
+        NewAnimationFileWriter.WriteEmpty(stream, "Player.achx");
+
+        stream.Position = 0;
+        var text = new StreamReader(stream).ReadToEnd();
+        Assert.StartsWith("<?xml", text);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -575,6 +575,39 @@ public class ProjectPanelControlTests
         finally { window.Close(); }
     }
 
+    // The inline editor must fit the 24px tree row (see the TreeViewItem MinHeight setter in the
+    // XAML). Fluent's default TextBox is far taller than that, which left the box overflowing the
+    // row with its text stranded at the top.
+    [AvaloniaFact]
+    public void PendingRowEditor_FitsWithinTreeRowHeight()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            BeginNewAnimationFile(window, control, control.TreeRoots[0]);
+            window.Measure(new Size(400, 400));
+            window.Arrange(new Rect(0, 0, 400, 400));
+            Dispatcher.UIThread.RunJobs();
+
+            var pending = control.TreeRoots[0].Children.Single(n => n.IsPending);
+            var textBox = control.ProjectTree.GetVisualDescendants().OfType<TextBox>()
+                .First(t => ReferenceEquals(t.DataContext, pending));
+
+            Assert.True(textBox.Bounds.Height <= 24, $"editor is {textBox.Bounds.Height}px tall");
+            // The height above comes from the TextBox's own setters, but the border/background
+            // setters target PART_BorderElement inside the template -- a rename there is a silent
+            // no-op, so confirm that selector actually matched something.
+            var border = textBox.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Name == "PART_BorderElement");
+            Assert.Equal(new Thickness(1), border.BorderThickness);
+        }
+        finally { window.Close(); }
+    }
+
     private static MenuItem NewAnimationFileMenuItem(Controls.ProjectPanelControl control) =>
         control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
             .Single(i => (string)i.Header! == "New Animation File");

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/ProjectPanelControlTests.cs
@@ -200,8 +200,9 @@ public class ProjectPanelControlTests
         {
             RightClick(window, control, control.TreeRoots[0]); // "Sprites" folder
 
-            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>().Single();
-            Assert.Equal("View in Explorer", item.Header);
+            var headers = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Select(i => i.Header).ToArray();
+            Assert.Equal(new object?[] { "New Animation File", "View in Explorer" }, headers);
         }
         finally { window.Close(); }
     }
@@ -220,7 +221,8 @@ public class ProjectPanelControlTests
             string? requested = null;
             control.FolderRevealRequested += path => requested = path;
 
-            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>().Single();
+            var item = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Single(i => (string)i.Header! == "View in Explorer");
             item.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
 
             Assert.Equal("Sprites", requested);
@@ -330,23 +332,6 @@ public class ProjectPanelControlTests
         try
         {
             RightClick(window, control, control.TreeRoots[0]); // "hero.achx" file
-
-            Assert.Empty(control.ProjectTree.ContextMenu!.Items);
-        }
-        finally { window.Close(); }
-    }
-
-    [AvaloniaFact]
-    public void RightClickingFolderRow_WithRevealNotSupported_ShowsNoItems()
-    {
-        var control = new Controls.ProjectPanelControl(); // SupportsRevealInExplorer defaults false
-        var root = new FakeFolder("Content");
-        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
-
-        var window = ShowInWindow(control);
-        try
-        {
-            RightClick(window, control, control.TreeRoots[0]); // "Sprites" folder
 
             Assert.Empty(control.ProjectTree.ContextMenu!.Items);
         }
@@ -472,6 +457,145 @@ public class ProjectPanelControlTests
         await control.ThumbnailLoadTask;
 
         Assert.True(control.TreeRoots[0].HasThumbnail);
+    }
+
+    // Issue #1018: right-click a folder row -> "New Animation File", named inline in the tree.
+    // Shown regardless of SupportsRevealInExplorer -- the browser build has real folder access
+    // via NativeReadWriteFolder, it just can't reveal in an OS shell.
+    [AvaloniaFact]
+    public void ClickingNewAnimationFile_AddsPendingRowInEditModeWithSuggestedName()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            BeginNewAnimationFile(window, control, control.TreeRoots[0]); // "Sprites" folder
+
+            var pending = control.TreeRoots[0].Children.Single(n => n.IsPending);
+            Assert.True(pending.IsEditing);
+            // Project is all-.achx, so the convention resolves to .achx rather than the .achj default.
+            Assert.Equal("NewAnimation.achx", pending.Name);
+            Assert.Equal("NewAnimation", pending.EditText);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CommittingPendingName_RaisesNewAnimationFileRequestedWithFolderAndFileName()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achj"), root, "Sprites/hero.achj") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            BeginNewAnimationFile(window, control, control.TreeRoots[0]); // "Sprites"
+            Controls.NewAnimationFileRequest? requested = null;
+            control.NewAnimationFileRequested += r => requested = r;
+
+            var pending = control.TreeRoots[0].Children.Single(n => n.IsPending);
+            pending.EditText = "Enemy";
+            PressKey(control, pending, Key.Enter);
+
+            Assert.Equal("Sprites", requested!.Value.FolderRelativePath);
+            Assert.Equal("Enemy.achj", requested!.Value.FileName);
+            Assert.DoesNotContain(control.TreeRoots[0].Children, n => n.IsPending);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CommittingPendingName_CollidingWithOtherExtension_ShowsErrorAndStaysInEditMode()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            BeginNewAnimationFile(window, control, control.TreeRoots[0]); // "Sprites"
+            var raised = false;
+            control.NewAnimationFileRequested += _ => raised = true;
+
+            var pending = control.TreeRoots[0].Children.Single(n => n.IsPending);
+            pending.EditText = "hero"; // hero.achx already exists, so hero.achj collides too
+            PressKey(control, pending, Key.Enter);
+
+            Assert.False(raised);
+            Assert.True(pending.IsEditing);
+            Assert.Equal("\"hero\" already exists in this folder.", pending.ErrorMessage);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void CancellingPendingName_RemovesRowWithoutRequestingAFile()
+    {
+        var control = new Controls.ProjectPanelControl();
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            BeginNewAnimationFile(window, control, control.TreeRoots[0]); // "Sprites"
+            var raised = false;
+            control.NewAnimationFileRequested += _ => raised = true;
+
+            var pending = control.TreeRoots[0].Children.Single(n => n.IsPending);
+            PressKey(control, pending, Key.Escape);
+
+            Assert.False(raised);
+            Assert.DoesNotContain(control.TreeRoots[0].Children, n => n.IsPending);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RightClickingFolderRow_WithRevealNotSupported_StillShowsNewAnimationFileItem()
+    {
+        var control = new Controls.ProjectPanelControl(); // browser build leaves this false
+        var root = new FakeFolder("Content");
+        control.SetEntries(new[] { new AchxFileEntry(new FakeFile("hero.achx"), root, "Sprites/hero.achx") });
+
+        var window = ShowInWindow(control);
+        try
+        {
+            RightClick(window, control, control.TreeRoots[0]); // "Sprites" folder
+
+            var headers = control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Select(i => i.Header).ToArray();
+            Assert.Equal(new object?[] { "New Animation File" }, headers);
+        }
+        finally { window.Close(); }
+    }
+
+    private static MenuItem NewAnimationFileMenuItem(Controls.ProjectPanelControl control) =>
+        control.ProjectTree.ContextMenu!.Items.OfType<MenuItem>()
+            .Single(i => (string)i.Header! == "New Animation File");
+
+    private static void BeginNewAnimationFile(
+        Window window, Controls.ProjectPanelControl control, Controls.AchxTreeNodeVm folderNode)
+    {
+        RightClick(window, control, folderNode);
+        NewAnimationFileMenuItem(control).RaiseEvent(
+            new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // Drives the real TextBox in the pending row rather than calling a commit method directly, so
+    // the Enter/Escape key wiring is part of what's under test.
+    private static void PressKey(Controls.ProjectPanelControl control, Controls.AchxTreeNodeVm pending, Key key)
+    {
+        var textBox = control.ProjectTree.GetVisualDescendants().OfType<TextBox>()
+            .First(t => ReferenceEquals(t.DataContext, pending));
+        textBox.RaiseEvent(new KeyEventArgs { Key = key, RoutedEvent = InputElement.KeyDownEvent });
+        Dispatcher.UIThread.RunJobs();
     }
 
     private sealed class FakeFile : IEditorFile


### PR DESCRIPTION
Right-clicking a folder in the Animations tab now offers "New Animation File", which adds a placeholder row in inline edit mode. Enter creates the file and opens it as a tab; Escape drops the row. Nothing is written until commit, so an abandoned edit leaves no file behind.

Extension follows the project's convention: whichever of `.achx`/`.achj` the project uses more of, `.achj` on a tie or an empty project. A colliding name is rejected inline (either extension counts, so `Player.achj` collides with an existing `Player.achx`) rather than suffixed; only the suggestion the editor starts on gets numbered.

Wired on both hosts. The browser build's picked folder handle is already writable from `EnsureReadWriteAsync` at pick time, so it only lacked the OS-shell reveal, not the ability to create.

## Tests

Naming rules and the empty-file writer in Core.Tests; the context menu, inline editor and Enter/Escape keys in Views.Tests; MainWindow's write-and-open, including the `FileMode.CreateNew` guard against a stale scan, in App.Tests.

The browser's equivalent wiring is untested: it is a thin layer over `JSImport` calls that need a real File System Access handle, with no headless seam. Everything it does beyond those calls (naming, file contents) is covered by the Core tests it shares with desktop.

## Manual test: needed

Headless can't cover two things. Open `tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx`, File → Open Project Folder, right-click a folder:

- the inline TextBox takes focus with the name selected (the tests drive its key events directly, they don't prove focus lands)
- the row and its error text look right at 24px row height

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWHtGnuhq7Vs4oAQ2DrEAt
