### PR TITLE
Replace the Restore Recovery File modal with a restored tab and a banner (#1020)

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -271,6 +271,45 @@
             </DockPanel>
         </Border>
 
+        <!-- ── Recovered-document banner (issue #1020): a crash-recovery file is restored into
+             a tab automatically on startup, and this announces it instead of the old blocking
+             Restore/Delete modal — the user can look at the content before deciding, and
+             discards it by closing the tab rather than from memory. ── -->
+        <Border x:Name="RecoveredDocumentBanner"
+                DockPanel.Dock="Top"
+                IsVisible="False"
+                Background="{DynamicResource InfoBannerBg}"
+                BorderBrush="{DynamicResource LineBrush}"
+                BorderThickness="0,0,0,1">
+            <DockPanel>
+                <Border DockPanel.Dock="Left"
+                        Width="3"
+                        Background="{DynamicResource AccentCool}" />
+                <DockPanel Margin="12,6">
+                    <Button x:Name="DismissRecoveredDocumentBtn"
+                            DockPanel.Dock="Right"
+                            Content="OK"
+                            Padding="10,3"
+                            FontSize="12"
+                            VerticalAlignment="Center" />
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                        <Path Width="16"
+                              Height="16"
+                              VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource AccentCool}"
+                              Data="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+                        <TextBlock Text="This file was unsaved when the editor last closed. It has been restored into this tab. Save it to keep it."
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource Ink}" />
+                    </StackPanel>
+                </DockPanel>
+            </DockPanel>
+        </Border>
+
         <!-- ── Automatic-update banner (issue #982) ── only shown while a managed install
              downloads an update, waits for an explicit restart, or needs a safe retry. ── -->
         <Border x:Name="UpdateAvailableBanner"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -259,6 +259,7 @@ public partial class MainWindow : Window
         WireKeyboard();
         WireTabBar();
         WireDefaultHandlerBanner();
+        WireRecoveredDocumentBanner();
         WireUpdateAvailableBanner();
 
         WireframeCtrl.InitializeServices(_selectedState, _appState, _appCommands, _events, _projectManager, _undoManager, _pendingCutState, _objectFinder, msg => ShowStatusMessage(msg, isError: true));
@@ -959,22 +960,31 @@ public partial class MainWindow : Window
 
     private async Task HandleStartupAsync()
     {
-        if (!await TryRestoreRecoveryFileAsync())
+        // Consume any crash-recovery file up front, but open it *after* the normal startup
+        // branches below (#1020). Restoring it used to early-out of this whole block, so
+        // accepting the old Restore/Delete prompt silently dropped every other open tab.
+        var recovered = TakeRecoveryFileContent();
+
+        var args = Environment.GetCommandLineArgs();
+        if (args.Length >= 2 && File.Exists(args[1]))
         {
-            var args = Environment.GetCommandLineArgs();
-            if (args.Length >= 2 && File.Exists(args[1]))
-            {
-                _ = LoadAnimationFileAsync(args[1]);
-            }
-            else if (_appSettings.OpenTabPaths.Count > 0)
-            {
-                _ = RestoreTabsAsync();
-            }
-            else
-            {
-                _projectManager.AnimationChainListSave =
-                    new AnimationChainListSave();
-            }
+            await LoadAnimationFileAsync(args[1]);
+        }
+        else if (_appSettings.OpenTabPaths.Count > 0)
+        {
+            await RestoreTabsAsync();
+        }
+        else if (recovered is null)
+        {
+            _projectManager.AnimationChainListSave =
+                new AnimationChainListSave();
+        }
+
+        if (recovered is not null)
+        {
+            // Awaited above, so nothing is still in flight to clobber the restored document.
+            OpenAsNewUnsavedDocument(recovered, recovered.AnimationChains.FirstOrDefault());
+            RecoveredDocumentBanner.IsVisible = true;
         }
 
         // Independent of which branch above ran -- the Project tab tree isn't tied to which
@@ -982,11 +992,10 @@ public partial class MainWindow : Window
         if (_appSettings.LastProjectFolderPath is { } lastProjectFolder && Directory.Exists(lastProjectFolder))
             await LoadProjectFolderAsync(lastProjectFolder);
 
-        // Whichever branch above set the active tab (RestoreTabsAsync, the CLI-arg open, or
-        // neither) did so directly rather than through ActivateTabAsync, so it never synced the
-        // Project list's own selection (#910 follow-up) -- do it once here, now the tree is
-        // populated. TabManager.ActiveTab is set synchronously by those paths even though their
-        // content load may still be in flight, so this doesn't need to wait on them.
+        // Whichever branch above set the active tab (RestoreTabsAsync, the CLI-arg open, the
+        // recovered document, or none of them) did so directly rather than through
+        // ActivateTabAsync, so it never synced the Project list's own selection (#910
+        // follow-up) -- do it once here, now the tree is populated.
         if (_tabManager.ActiveTab is { } activeTab)
             SyncProjectPanelSelectionTo(activeTab);
 
@@ -1000,45 +1009,43 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Checks for a crash-recovery file left by <see cref="IIoManager.WriteRecoveryFile"/> after
-    /// an unclean shutdown of an unsaved document (see <see cref="AppCommands.SaveCurrentAnimationChainList"/>).
-    /// When found, asks the user via <see cref="IAppCommands.ConfirmAsync"/> whether to restore it.
-    /// Returns <c>true</c> when recovered content was loaded as the active document (still
-    /// unsaved — <see cref="ProjectManager.FileName"/> stays null, matching the pre-crash state),
-    /// so the caller should skip its normal open-file / restore-tabs / blank-document startup.
-    /// Returns <c>false</c> when there was nothing to restore, the user declined, or the file
-    /// could not be parsed — in the latter two cases the stale recovery file is deleted first.
+    /// Reads and deletes any crash-recovery file left by <see cref="IIoManager.WriteRecoveryFile"/>
+    /// after an unclean shutdown of an unsaved document (see
+    /// <see cref="AppCommands.SaveCurrentAnimationChainList"/>), returning its content for the
+    /// caller to open as an unsaved document. Returns null when there was nothing to recover or
+    /// the file could not be parsed; the unparseable file is deleted rather than re-offered on
+    /// every subsequent launch.
     /// </summary>
-    private async Task<bool> TryRestoreRecoveryFileAsync()
+    /// <remarks>
+    /// Deleting on read is safe because the content lives in the restored tab from here on, and
+    /// closing that tab is what the user does to discard it (<see cref="CloseTabCore"/>). There is
+    /// deliberately no "delete permanently?" prompt: the old modal made that call from memory,
+    /// before the user could see what was in the file (#1020).
+    /// </remarks>
+    private AnimationChainListSave? TakeRecoveryFileContent()
     {
-        if (!_ioManager.RecoveryFileExists()) return false;
-
-        bool restore = await ShowTwoButtonDialogAsync(
-            "The editor closed unexpectedly last time with unsaved changes. Restore them into a new unsaved tab, or delete them permanently?",
-            "Restore Recovery File", "Restore", "Delete");
-
-        if (!restore)
-        {
-            _ioManager.DeleteRecoveryFile();
-            return false;
-        }
+        if (!_ioManager.RecoveryFileExists()) return null;
 
         var recovered = _ioManager.TryReadRecoveryFile();
-        if (recovered is null)
-        {
-            _ioManager.DeleteRecoveryFile();
-            return false;
-        }
-
         _ioManager.DeleteRecoveryFile();
-        OpenAsNewUnsavedDocument(recovered, recovered.AnimationChains.FirstOrDefault());
-        return true;
+        return recovered;
     }
+
+    // ── Recovered-document banner ─────────────────────────────────────────────
+
+    /// <summary>
+    /// The banner is informational only, so dismissing it just hides it (#1020). It carries no
+    /// "don't show again" setting: it appears exactly when a document was recovered, which is
+    /// never routine noise the user would want suppressed permanently.
+    /// </summary>
+    private void WireRecoveredDocumentBanner() =>
+        DismissRecoveredDocumentBtn.Click += (_, _) => RecoveredDocumentBanner.IsVisible = false;
 
     // ── Default-handler prompt banner ─────────────────────────────────────────
 
     private void WireDefaultHandlerBanner()
     {
+
         MakeDefaultBtn.Click += (_, _) => RegisterAsDefaultAchxHandler(hideBanner: true);
 
         DismissDefaultHandlerBtn.Click += (_, _) =>
@@ -1116,7 +1123,6 @@ public partial class MainWindow : Window
         _appCommands.DoOnUiThread = action => Dispatcher.UIThread.InvokeAsync(action);
         _appCommands.ConfirmAsync = ShowConfirmDialogAsync;
         _appCommands.PromptStringAsync = ShowStringInputDialogAsync;
-        ShowTwoButtonDialogAsync = ShowTwoButtonDialogAsyncCore;
         ShowSaveDiscardCancelDialogAsync = ShowSaveDiscardCancelDialogAsyncCore;
 
         // File dialog service
@@ -1147,23 +1153,31 @@ public partial class MainWindow : Window
         _appCommands.RefreshAnimationFrameDisplayRequested += () => PreviewCtrl.InvalidateVisual();
         // RefreshWireframeRequested is handled by WireframeControl directly
 
-        _events.CurrentFileChanged     += path => Dispatcher.UIThread.InvokeAsync(() =>
+        _events.CurrentFileChanged     += path =>
         {
-            _appSettings.AddFile(new FilePath(path));
-            SaveSettingsFile();
-            RefreshRecentFiles();
-            UpdateTitle();
-            UpdateStatusBar();
-            RefreshFilesPanel();
-
-            // If the active tab was an Untitled sentinel, promote it to the real file path.
-            var active = _tabManager.ActiveTab;
-            if (active != null && IsUntitledTab(active))
+            // Capture the promotion candidate synchronously, at raise time. The continuation
+            // below is queued, and whichever tab is active by the time it runs is not
+            // necessarily the one this file was loaded into -- startup opens a crash-recovered
+            // document immediately after a restored tab's load raises this, and the queued
+            // continuation would otherwise rename the recovered tab to the restored file.
+            var toPromote = _tabManager.ActiveTab;
+            Dispatcher.UIThread.InvokeAsync(() =>
             {
-                _tabManager.Rename(active.Path, new FilePath(path));
-                RebuildTabStrip();
-            }
-        });
+                _appSettings.AddFile(new FilePath(path));
+                SaveSettingsFile();
+                RefreshRecentFiles();
+                UpdateTitle();
+                UpdateStatusBar();
+                RefreshFilesPanel();
+
+                // If that tab was an Untitled sentinel, promote it to the real file path.
+                if (toPromote != null && IsUntitledTab(toPromote))
+                {
+                    _tabManager.Rename(toPromote.Path, new FilePath(path));
+                    RebuildTabStrip();
+                }
+            });
+        };
         _events.AvailableTexturesChanged += () => Dispatcher.UIThread.InvokeAsync(RefreshTextureCombo);
 
         _undoManager.StackChanged         += () => Dispatcher.UIThread.InvokeAsync(UpdateStatusBar);
@@ -2384,7 +2398,7 @@ public partial class MainWindow : Window
     /// <summary>
     /// Replaces the in-memory document with <paramref name="content"/> as a new, unsaved
     /// (Untitled) document, resets selection/undo/tree state, and opens/activates a tab for it.
-    /// Shared by <see cref="OnNewClick"/> and <see cref="TryRestoreRecoveryFileAsync"/> so both
+    /// Shared by <see cref="OnNewClick"/> and the startup crash-recovery path so both
     /// "start editing from a fresh in-memory document" paths can't drift apart again — #892 was
     /// exactly that: the recovery path duplicated everything except the tab-opening step.
     /// </summary>
@@ -5657,28 +5671,10 @@ public partial class MainWindow : Window
         EditorDialogs.ConfirmAsync(_dialogHost, message, title);
 
     /// <summary>
-    /// Test seam for <see cref="ShowTwoButtonDialogAsyncCore"/> -- assigned to the real dialog in
-    /// <see cref="WireAppCommands"/>, mirroring <c>IAppCommands.ConfirmAsync</c>'s pattern. Not a
-    /// property on <c>IAppCommands</c> itself: that delegate is shared by ~20 test stubs across
-    /// unrelated tests, and this is UI-layer-only (used by exactly one caller,
-    /// <see cref="TryRestoreRecoveryFileAsync"/>) so it doesn't need that shared indirection.
-    /// </summary>
-    internal Func<string, string, string, string, Task<bool>> ShowTwoButtonDialogAsync { get; set; } = null!;
-
-    /// <summary>
-    /// Same as <see cref="ShowConfirmDialogAsync"/> but with caller-chosen button text instead of
-    /// generic Yes/No, for prompts where "Yes"/"No" would force the user to mentally map a named
-    /// choice (e.g. Restore/Delete) back onto Yes/No.
-    /// </summary>
-    private Task<bool> ShowTwoButtonDialogAsyncCore(
-        string message, string title, string confirmLabel, string cancelLabel) =>
-        EditorDialogs.ConfirmAsync(_dialogHost, message, title, confirmLabel, cancelLabel);
-
-    /// <summary>
     /// Test seam for the Save / Don't Save / Cancel prompt shown by
-    /// <see cref="CloseTabAsync"/> when closing an untitled tab that has content. Same
-    /// reasoning as <see cref="ShowTwoButtonDialogAsync"/> for living here instead of on the
-    /// shared <c>IAppCommands</c> delegate surface.
+    /// <see cref="CloseTabAsync"/> when closing an untitled tab that has content. Lives here
+    /// rather than on the shared <c>IAppCommands</c> delegate surface: that delegate is stubbed
+    /// by ~20 tests across unrelated fixtures, and this prompt is UI-layer-only.
     /// </summary>
     internal Func<string, string, Task<SaveDiscardCancelChoice>> ShowSaveDiscardCancelDialogAsync { get; set; } = null!;
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/StartupRecoveryTests.cs
@@ -1,9 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using FlatRedBall2.AnimationEditorCommon;
 using Xunit;
@@ -11,11 +18,11 @@ using Xunit;
 namespace AnimationEditor.App.Tests;
 
 /// <summary>
-/// Covers the crash-recovery restore-on-launch path wired through <c>MainWindow.OnOpened</c>
-/// (issue #754 Phase 0): a recovery file written by <see cref="IIoManager.WriteRecoveryFile"/>
-/// after an unclean shutdown must be offered back to the user on the next launch. The prompt
-/// itself goes through <c>MainWindow.ShowTwoButtonDialogAsync</c> (custom Restore/Delete button
-/// labels, #772 follow-up), not the shared <c>IAppCommands.ConfirmAsync</c> Yes/No dialog.
+/// Covers the crash-recovery restore-on-launch path wired through <c>MainWindow.OnOpened</c>.
+/// A recovery file written by <see cref="IIoManager.WriteRecoveryFile"/> after an unclean
+/// shutdown is restored into a tab automatically and announced with a dismissable banner
+/// (issue #1020) — it used to be a blocking Restore/Delete modal that forced the user to
+/// decide from memory, with no way to see the content first.
 /// </summary>
 public class StartupRecoveryTests
 {
@@ -24,22 +31,24 @@ public class StartupRecoveryTests
             .GetField("_tabManager", BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(window)!;
 
+    private static void SeedRecoveryFile(TestServices ctx, string chainName)
+    {
+        var seed = new AnimationChainListSave();
+        seed.AnimationChains.Add(new AnimationChainSave { Name = chainName });
+        ctx.IoManager.WriteRecoveryFile(seed);
+    }
+
     [AvaloniaFact]
-    public void NoRecoveryFile_StartsNormally_NeverPrompts()
+    public void NoRecoveryFile_StartsNormally_ShowsNoBanner()
     {
         var ctx = TestHelpers.BuildServices();
         var window = ctx.CreateMainWindow();
-        int confirmCalls = 0;
-        // Must be set AFTER CreateMainWindow: the constructor's WireAppCommands wires this to
-        // the real dialog, so a mock set beforehand gets overwritten. Setting it here (before
-        // Show, which fires Opened) is what actually takes effect.
-        window.ShowTwoButtonDialogAsync = (_, _, _, _) => { confirmCalls++; return Task.FromResult(true); };
 
         window.Show();
         Dispatcher.UIThread.RunJobs();
         try
         {
-            Assert.Equal(0, confirmCalls);
+            Assert.False(window.FindControl<Border>("RecoveredDocumentBanner")!.IsVisible);
             Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
             Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
         }
@@ -47,117 +56,126 @@ public class StartupRecoveryTests
     }
 
     [AvaloniaFact]
-    public void RecoveryFilePresent_UserConfirms_RestoresContentAsUnsavedDocument()
+    public void RecoveryFilePresent_BannerDismissed_HidesBanner()
     {
         var ctx = TestHelpers.BuildServices();
-        var seed = new AnimationChainListSave();
-        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
-        ctx.IoManager.WriteRecoveryFile(seed);
+        SeedRecoveryFile(ctx, "Recovered");
 
         var window = ctx.CreateMainWindow();
-        window.ShowTwoButtonDialogAsync = (_, _, _, _) => Task.FromResult(true);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            var banner = window.FindControl<Border>("RecoveredDocumentBanner")!;
+            Assert.True(banner.IsVisible);
 
+            window.FindControl<Button>("DismissRecoveredDocumentBtn")!
+                  .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(banner.IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_DeletesRecoveryFileAfterRestore()
+    {
+        // Otherwise the same recovery file re-announces itself on every subsequent launch,
+        // whether or not the user goes on to Save As the restored content.
+        var ctx = TestHelpers.BuildServices();
+        SeedRecoveryFile(ctx, "Recovered");
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            Assert.False(ctx.IoManager.RecoveryFileExists());
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_KeepsTabsFromPreviousSession()
+    {
+        // The old modal path early-returned out of HandleStartupAsync on a successful restore,
+        // so accepting the recovery silently dropped every other tab the session had open.
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var previousTabPath = Path.Combine(dir, "previous.achx");
+        new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel }.Save(previousTabPath);
+
+        var ctx = TestHelpers.BuildServices();
+        SeedRecoveryFile(ctx, "Recovered");
+
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        Directory.CreateDirectory(settingsFile.GetDirectoryContainingThis().FullPath);
+        File.WriteAllText(settingsFile.FullPath, JsonSerializer.Serialize(new AppSettingsModel
+        {
+            OpenTabPaths = new List<string> { previousTabPath },
+            ActiveTabPath = previousTabPath,
+        }));
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            var tabManager = GetTabManager(window);
+            Assert.Equal(2, tabManager.Tabs.Count);
+            Assert.Contains(tabManager.Tabs, t => t.Path == new FilePath(previousTabPath));
+            // The recovered document is what the banner points at, so it wins the activation.
+            // Compare against Path.Original: FullPath rewrites the untitled sentinel as a path.
+            Assert.True(TabManager.IsUntitledSentinel(tabManager.ActiveTab!.Path.Original));
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryFilePresent_RestoresContentIntoActiveTabWithoutPrompting()
+    {
+        // No dialog is stubbed anywhere in this class on purpose: a modal on the startup path
+        // blocks the headless UI thread with nothing to close it, so this test reaching its
+        // asserts at all is the proof that recovery no longer prompts.
+        var ctx = TestHelpers.BuildServices();
+        SeedRecoveryFile(ctx, "Recovered");
+
+        var window = ctx.CreateMainWindow();
         window.Show();
         Dispatcher.UIThread.RunJobs();
         try
         {
             Assert.Contains(ctx.ProjectManager.AnimationChainListSave!.AnimationChains, c => c.Name == "Recovered");
             Assert.Null(ctx.ProjectManager.FileName);
-        }
-        finally { window.Close(); }
-    }
 
-    [AvaloniaFact]
-    public void RecoveryFilePresent_UserConfirms_OpensRestoredContentInATab()
-    {
-        // Issue #892: restoring loaded the content into the model/tree but never registered a
-        // tab for it, so the restored document was invisible/unreachable once you switched away.
-        var ctx = TestHelpers.BuildServices();
-        var seed = new AnimationChainListSave();
-        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
-        ctx.IoManager.WriteRecoveryFile(seed);
-
-        var window = ctx.CreateMainWindow();
-        window.ShowTwoButtonDialogAsync = (_, _, _, _) => Task.FromResult(true);
-
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        try
-        {
             var tabManager = GetTabManager(window);
             Assert.Single(tabManager.Tabs);
             Assert.Same(tabManager.Tabs[0], tabManager.ActiveTab);
+            Assert.True(window.FindControl<Border>("RecoveredDocumentBanner")!.IsVisible);
         }
         finally { window.Close(); }
     }
 
     [AvaloniaFact]
-    public void RecoveryFilePresent_UserConfirms_DeletesRecoveryFileAfterRestore()
+    public void RecoveryFilePresent_UnparseableContent_DeletesFileAndShowsNoBanner()
     {
-        // Otherwise the same recovery file re-prompts on every subsequent launch, whether or
-        // not the user goes on to Save As the restored content.
         var ctx = TestHelpers.BuildServices();
-        var seed = new AnimationChainListSave();
-        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
-        ctx.IoManager.WriteRecoveryFile(seed);
+        Directory.CreateDirectory(new FilePath(ctx.IoManager.RecoveryFilePath).GetDirectoryContainingThis().FullPath);
+        File.WriteAllText(ctx.IoManager.RecoveryFilePath, "not an animation chain list");
 
         var window = ctx.CreateMainWindow();
-        window.ShowTwoButtonDialogAsync = (_, _, _, _) => Task.FromResult(true);
-
         window.Show();
         Dispatcher.UIThread.RunJobs();
         try
         {
             Assert.False(ctx.IoManager.RecoveryFileExists());
-        }
-        finally { window.Close(); }
-    }
-
-    [AvaloniaFact]
-    public void RecoveryFilePresent_UserDeclines_DeletesFileAndStartsNormally()
-    {
-        var ctx = TestHelpers.BuildServices();
-        var seed = new AnimationChainListSave();
-        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
-        ctx.IoManager.WriteRecoveryFile(seed);
-
-        var window = ctx.CreateMainWindow();
-        window.ShowTwoButtonDialogAsync = (_, _, _, _) => Task.FromResult(false);
-
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        try
-        {
-            Assert.False(ctx.IoManager.RecoveryFileExists());
-            Assert.NotNull(ctx.ProjectManager.AnimationChainListSave);
+            Assert.False(window.FindControl<Border>("RecoveredDocumentBanner")!.IsVisible);
             Assert.Empty(ctx.ProjectManager.AnimationChainListSave!.AnimationChains);
-        }
-        finally { window.Close(); }
-    }
-
-    [AvaloniaFact]
-    public void RecoveryFilePresent_PromptsWithRestoreDeleteLabels_NotYesNo()
-    {
-        var ctx = TestHelpers.BuildServices();
-        var seed = new AnimationChainListSave();
-        seed.AnimationChains.Add(new AnimationChainSave { Name = "Recovered" });
-        ctx.IoManager.WriteRecoveryFile(seed);
-
-        var window = ctx.CreateMainWindow();
-        string? confirmLabel = null, cancelLabel = null;
-        window.ShowTwoButtonDialogAsync = (_, _, confirm, cancel) =>
-        {
-            confirmLabel = confirm;
-            cancelLabel = cancel;
-            return Task.FromResult(true);
-        };
-
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        try
-        {
-            Assert.Equal("Restore", confirmLabel);
-            Assert.Equal("Delete", cancelLabel);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
Closes #1020.

The startup "Restore Recovery File" modal made the user choose Restore or Delete from memory: it named no file, showed no content, and Delete was permanent. It also blocked the editor from opening, and a successful restore early-returned out of `HandleStartupAsync`, so accepting it silently dropped every other tab from the last session.

Now the recovery file is read, deleted, and opened as an unsaved tab alongside the normally-restored tabs, announced by a dismissable `RecoveredDocumentBanner` styled like the existing default-handler and update banners. Discarding it is closing the tab, which already clears the recovery file.

Two things fell out of this:

- **Tab-promotion race.** `CurrentFileChanged` queued its work through `InvokeAsync` and then renamed whichever tab was active when that continuation ran, not the tab the file loaded into. Startup opens the recovered document immediately after a restored tab's load raises the event, so the recovered tab got renamed to the restored file. The promotion candidate is now captured at raise time.
- **Dead code.** `ShowTwoButtonDialogAsync` and its core had no caller left once the recovery prompt went away; removed.

Deliberately not fixed here: the prompt fires far more often than actual crashes because nothing deletes the recovery file on a clean shutdown (there is no window-closing handler at all, and the file is written on every edit to a document with no filename). Fixing that first would make the banner path rare and untested in real use. Issue #1020 has the detail.

Tests: 6 in `StartupRecoveryTests`, rewritten for the new behavior (banner shown/dismissed, content restored into the active tab, previous session's tabs kept, recovery file deleted, unparseable file discarded silently). No dialog is stubbed anywhere in the class on purpose, so a modal reappearing on this path would hang the headless run rather than pass. Full AE suite green: 1931 Core, 127 Views, 882 App, clean build with 0 warnings.

Manual test: needed, for the banner's appearance and the real launch path. A recovery file is already planted at `%TEMP%\AnimationEditor_Recovery.achx`, so opening `AnimationEditorAvalonia.slnx` and running the editor shows the banner on first launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qy3N8F2cXvFpS9FSsv3kC
