### PR TITLE
Animation Editor: add loop toggle to preview playback

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml
@@ -1579,6 +1579,18 @@
                                              CurrentColor="{DynamicResource IconInk}"
                                              VerticalAlignment="Center" HorizontalAlignment="Center" />
                                 </Button>
+                                <ToggleButton x:Name="LoopToggle"
+                                              Classes="toolbarToggle"
+                                              Height="26" Width="32"
+                                              Foreground="{DynamicResource Ink}"
+                                              VerticalAlignment="Center"
+                                              IsChecked="True"
+                                              ToolTip.Tip="Loop playback (not persisted)">
+                                    <svg:Svg Width="14" Height="14"
+                                             Path="avares://AnimationEditor.Views/Assets/icons/svg/IconLoop.svg"
+                                             CurrentColor="{DynamicResource IconInk}"
+                                             VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                </ToggleButton>
                                 <viewsControls:FlankerNumericField x:Name="SpeedInput"
                                                                     Width="92" VerticalAlignment="Center"
                                                                     ToolTip.Tip="Playback speed (1.0 = runtime speed)"

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -2898,6 +2898,9 @@ public partial class MainWindow : Window
             _suppressInterpolateSync = false;
         };
 
+        LoopToggle.IsCheckedChanged += (_, _) =>
+            PreviewCtrl.Loop = LoopToggle.IsChecked == true;
+
         TimelineStrip.ItemsSource = _timelineFrames;
         GroupTimelineTracks.ItemsSource = _groupTimelineTracks;
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PlaybackController.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/PlaybackController.cs
@@ -49,6 +49,13 @@ public class PlaybackController
     /// </summary>
     public double SpeedMultiplier { get; set; } = 1.0;
 
+    /// <summary>
+    /// When <c>true</c> (the default), <see cref="Advance"/> wraps back to the start once the
+    /// chain's total duration elapses. When <c>false</c>, playback freezes on the last frame and
+    /// pauses (firing <see cref="IsPlayingChanged"/>) instead of wrapping.
+    /// </summary>
+    public bool Loop { get; set; } = true;
+
     // ── Events ────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -81,10 +88,25 @@ public class PlaybackController
         Reset();
     }
 
-    /// <summary>Resume playback (undoes <see cref="Pause"/>).</summary>
+    /// <summary>
+    /// Resume playback (undoes <see cref="Pause"/>). When <see cref="Loop"/> is <c>false</c> and
+    /// playback had already reached the end (frozen on the last frame), restarts from the
+    /// beginning instead of resuming a no-op animation — so repeatedly pressing play/pause acts
+    /// like a replay button instead of requiring a manual seek back to the start first.
+    /// </summary>
     public void Play()
     {
         if (IsPlaying) return;
+
+        if (!Loop && _chain is not null && _chain.Frames.Count > 0)
+        {
+            double totalTime = 0;
+            foreach (var f in _chain.Frames)
+                totalTime += FrameLength(f);
+            if (totalTime > 0 && _animTime >= totalTime)
+                Reset();
+        }
+
         IsPlaying = true;
         IsPlayingChanged?.Invoke(true);
     }
@@ -151,18 +173,20 @@ public class PlaybackController
         var chain = _chain;
         if (chain is null || chain.Frames.Count <= 1) return;
 
-        _animTime += deltaSeconds * SpeedMultiplier;
-
         double totalTime = 0;
         foreach (var f in chain.Frames)
             totalTime += FrameLength(f);
         if (totalTime <= 0) return;
 
-        _animTime %= totalTime;
+        _animTime += deltaSeconds * SpeedMultiplier;
+
+        bool reachedEnd = _animTime >= totalTime;
+        if (reachedEnd)
+            _animTime = Loop ? _animTime % totalTime : totalTime;
 
         double t = 0;
         int newIdx = chain.Frames.Count - 1;
-        double newFrameStart = 0;
+        double newFrameStart = totalTime - FrameLength(chain.Frames[newIdx]);
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             double fl = FrameLength(chain.Frames[i]);
@@ -181,6 +205,10 @@ public class PlaybackController
         }
 
         PlaybackTicked?.Invoke();
+
+        // Pausing after the tick so subscribers see the final frame/time before the transport
+        // button flips to "play" — matches how a manual Pause() behaves mid-playback.
+        if (reachedEnd && !Loop) Pause();
     }
 
     // Zero/negative authored lengths fall back to 100 ms so playback still steps through them.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconLoop.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconLoop.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m17 2 4 4-4 4"/>
+  <path d="M3 11v-1a4 4 0 0 1 4-4h14"/>
+  <path d="m7 22-4-4 4-4"/>
+  <path d="M21 13v1a4 4 0 0 1-4 4H3"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -253,6 +253,20 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         }
     }
 
+    /// <summary>
+    /// Whether the preview loops back to the start when a chain finishes, or freezes/pauses on
+    /// the last frame instead. Applies to the singular preview and every active group track.
+    /// </summary>
+    public bool Loop
+    {
+        get => _playback.Loop;
+        set
+        {
+            _playback.Loop = value;
+            foreach (var c in _groupPlayback.Values) c.Loop = value;
+        }
+    }
+
     public void Play()
     {
         _playback.Play();
@@ -348,7 +362,7 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         foreach (var chain in toRemove) _groupPlayback.Remove(chain);
         foreach (var chain in toAdd)
         {
-            var controller = new PlaybackController { SpeedMultiplier = _playback.SpeedMultiplier };
+            var controller = new PlaybackController { SpeedMultiplier = _playback.SpeedMultiplier, Loop = _playback.Loop };
             controller.SetChain(chain);
             _groupPlayback[chain] = controller;
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PlaybackControllerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PlaybackControllerTests.cs
@@ -286,6 +286,107 @@ public class PlaybackControllerTests
         Assert.Equal(0, ctrl.CurrentFrameIndex);
     }
 
+    // ── Loop toggle ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Loop_DefaultsToTrue()
+    {
+        var ctrl = new PlaybackController();
+        Assert.True(ctrl.Loop);
+    }
+
+    [Fact]
+    public void Advance_StopsOnLastFrame_WhenLoopIsFalse()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f)); // total = 0.3 s
+        ctrl.Loop = false;
+
+        ctrl.Advance(0.35); // would wrap to frame 0 if looping
+
+        Assert.Equal(2, ctrl.CurrentFrameIndex);
+    }
+
+    [Fact]
+    public void Advance_PausesAtEnd_WhenLoopIsFalse()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Loop = false;
+
+        ctrl.Advance(0.35);
+
+        Assert.False(ctrl.IsPlaying);
+    }
+
+    [Fact]
+    public void Advance_DoesNotPause_WhenLoopIsTrueAndAnimationWraps()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+
+        ctrl.Advance(0.35); // wraps, Loop defaults to true
+
+        Assert.True(ctrl.IsPlaying);
+    }
+
+    [Fact]
+    public void Advance_FreezesAnimTimeAtTotalDuration_WhenLoopFalseAndOverrun()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f)); // total = 0.3 s
+        ctrl.Loop = false;
+
+        ctrl.Advance(999.0); // way past the end
+
+        Assert.Equal(0.3, ctrl.AnimTime, precision: 6);
+        Assert.Equal(2, ctrl.CurrentFrameIndex);
+    }
+
+    [Fact]
+    public void Play_RestartsFromBeginning_WhenNotLoopingAndAnimationFinished()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f)); // total = 0.3 s
+        ctrl.Loop = false;
+        ctrl.Advance(0.35); // finishes and auto-pauses on the last frame
+
+        ctrl.Play();
+
+        Assert.Equal(0, ctrl.CurrentFrameIndex);
+        Assert.Equal(0.0, ctrl.AnimTime);
+        Assert.True(ctrl.IsPlaying);
+    }
+
+    [Fact]
+    public void Play_ResumesInPlace_WhenNotLoopingButNotYetFinished()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Loop = false;
+        ctrl.Advance(0.15); // mid-animation, frame 1
+        ctrl.Pause();
+
+        ctrl.Play();
+
+        Assert.Equal(1, ctrl.CurrentFrameIndex);
+    }
+
+    [Fact]
+    public void Play_FiresFrameIndexChanged_WhenRestartingFromEnd()
+    {
+        var ctrl = new PlaybackController();
+        ctrl.SetChain(MakeChain(3, 0.1f));
+        ctrl.Loop = false;
+        ctrl.Advance(0.35); // ends on frame 2
+
+        int fired = -1;
+        ctrl.FrameIndexChanged += i => fired = i;
+        ctrl.Play();
+
+        Assert.Equal(0, fired);
+    }
+
     // ── FrameElapsed ──────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
Adds a loop toggle to the Animation Editor's preview playback transport.

- `PlaybackController.Loop` (default `true`); when `false`, `Advance()` freezes on the last frame and pauses instead of wrapping.
- Pressing Play while paused-at-the-end restarts from frame 0 — no manual seek needed to replay.
- New icon toggle (repeat-style SVG) in the preview transport strip, next to Play/Pause.
- Not persisted (in-memory preview setting only), per the request.

Manual test: not needed for the core logic — covered by unit tests. Also smoke-launched the editor to confirm the icon renders correctly and the toggle click works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVndScjYQtKszKvqCkH1FJ
