### PR TITLE
Animation Editor: Shift+Up/Down in ANIMATIONS tree extends range selection

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -180,6 +180,13 @@ public partial class MainWindow : Window
     private bool _suppressCompanionSave;
     private bool _suppressInterpolateSync;
     private bool _suppressGuideVisibilitySync;
+
+    // Shift+Up/Down range-select (#1023): the row a range grows from. Reset to whatever
+    // OnTreeSelectionChanged sees as the plain (non-shift-range) selection so a stale anchor
+    // never causes a surprising jump on the next Shift+Arrow. _isApplyingShiftRangeSelection
+    // guards the handler's own AnimTree.SelectedItems mutation from resetting the anchor.
+    private TreeNodeVm? _treeSelectionAnchor;
+    private bool _isApplyingShiftRangeSelection;
     private readonly AltMenuActivationSuppressor _altMenuActivationSuppressor = new();
 
     // The platform application-data root under which settings live. Injected (not read from
@@ -3056,6 +3063,15 @@ public partial class MainWindow : Window
             OnInlineRenameKeyDown,
             RoutingStrategies.Tunnel);
 
+        // Tunnel-phase Shift+Up/Down (#1023): intercept before TreeViewItem's own arrow-key
+        // handling, which otherwise just moves the single selection to the next/previous row
+        // and discards the rest. Registered after OnInlineRenameKeyDown so a rename in progress
+        // (which already swallows Up/Down via e.Handled) takes precedence.
+        AnimTree.AddHandler(
+            InputElement.KeyDownEvent,
+            OnAnimTreeShiftArrowKeyDown,
+            RoutingStrategies.Tunnel);
+
         // Bubble-phase LostFocus from the inline TextBox: commit
         AnimTree.AddHandler(
             InputElement.LostFocusEvent,
@@ -3846,6 +3862,12 @@ public partial class MainWindow : Window
     {
         if (_suppressTreeSelectionHandling) return;
         if (AnimTree.SelectedItem is not TreeNodeVm vm) return;
+
+        // Any selection change that isn't our own Shift+Arrow range mutation re-anchors
+        // range-select at the row Avalonia now reports as SelectedItem (matches Explorer:
+        // a plain click, Ctrl+click, or native arrow-key move all become the new anchor).
+        if (!_isApplyingShiftRangeSelection)
+            _treeSelectionAnchor = vm;
 
         // Sync multi-select into SelectedState
         _selectedState.SelectedNodes = AnimTree.SelectedItems
@@ -6684,6 +6706,59 @@ public partial class MainWindow : Window
             // TreeViewItem doesn't navigate to a sibling row and end the rename via focus loss.
             e.Handled = true;
         }
+    }
+
+    /// <summary>
+    /// Shift+Up/Down range-select (#1023): extends the selection by one visible row from a
+    /// fixed anchor (<see cref="_treeSelectionAnchor"/>), the far end moving with each key
+    /// press — the same semantics as Shift+Click range-select. Plain Up/Down (no Shift) is
+    /// untouched and falls through to Avalonia's native single-selection navigation.
+    /// </summary>
+    private void OnAnimTreeShiftArrowKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
+        if (e.Key is not (Key.Up or Key.Down)) return;
+        if (e.Source is TextBox) return; // inline rename owns Up/Down; see OnInlineRenameKeyDown
+
+        var visible = TreeBuilder.FlattenVisible(_treeRoots);
+        if (visible.Count == 0) return;
+
+        var anchor = _treeSelectionAnchor ?? AnimTree.SelectedItem as TreeNodeVm;
+        if (anchor is null) return;
+        int anchorIndex = visible.IndexOf(anchor);
+        if (anchorIndex < 0) return;
+
+        // The current selection's far end is whichever bound of its index range isn't the
+        // anchor — this lets the range's growth direction be read back from AnimTree.SelectedItems
+        // itself rather than tracking a second piece of state.
+        var selectedIndices = AnimTree.SelectedItems!.OfType<TreeNodeVm>()
+            .Select(n => visible.IndexOf(n))
+            .Where(i => i >= 0)
+            .ToList();
+        int lo = selectedIndices.Count > 0 ? selectedIndices.Min() : anchorIndex;
+        int hi = selectedIndices.Count > 0 ? selectedIndices.Max() : anchorIndex;
+        int farIndex = lo == anchorIndex ? hi : lo;
+
+        int newFarIndex = e.Key == Key.Down
+            ? Math.Min(visible.Count - 1, farIndex + 1)
+            : Math.Max(0, farIndex - 1);
+
+        int rangeLo = Math.Min(anchorIndex, newFarIndex);
+        int rangeHi = Math.Max(anchorIndex, newFarIndex);
+
+        _isApplyingShiftRangeSelection = true;
+        try
+        {
+            AnimTree.SelectedItems!.Clear();
+            for (int i = rangeLo; i <= rangeHi; i++)
+                AnimTree.SelectedItems.Add(visible[i]);
+        }
+        finally
+        {
+            _isApplyingShiftRangeSelection = false;
+        }
+
+        e.Handled = true;
     }
 
     // AnimTree (the TreeView itself) has Focusable=false — only its TreeViewItem containers

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TreeBuilder.cs
@@ -564,6 +564,28 @@ public static class TreeBuilder
     // ── Node search ───────────────────────────────────────────────────────────
 
     /// <summary>
+    /// Flattens <paramref name="roots"/> into the same row order the tree currently renders:
+    /// a node is included when <see cref="TreeNodeVm.PinnedVisible"/>, and its children are
+    /// walked only when it is also <see cref="TreeNodeVm.IsExpanded"/>. Used to compute
+    /// "next/previous visible row" for keyboard range-select (Shift+Up/Down).
+    /// </summary>
+    public static List<TreeNodeVm> FlattenVisible(IEnumerable<TreeNodeVm> roots)
+    {
+        var result = new List<TreeNodeVm>();
+        void Walk(TreeNodeVm node)
+        {
+            if (!node.PinnedVisible) return;
+            result.Add(node);
+            if (node.IsExpanded)
+                foreach (var child in node.Children)
+                    Walk(child);
+        }
+        foreach (var root in roots)
+            Walk(root);
+        return result;
+    }
+
+    /// <summary>
     /// Recursively searches <paramref name="roots"/> and returns the first node
     /// whose <see cref="TreeNodeVm.Data"/> is the same reference as
     /// <paramref name="target"/>.  Returns <c>null</c> when not found.

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShiftArrowMultiSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShiftArrowMultiSelectTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using AnimationEditor.Core.ViewModels;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FlatRedBall2.AnimationEditorCommon;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #1023: Shift+Down/Up in the ANIMATIONS tree must extend a contiguous range
+/// selection from an anchor row (file-explorer semantics), not just move the single
+/// selection like Avalonia's native TreeViewItem arrow-key navigation does.
+/// </summary>
+public class ShiftArrowMultiSelectTests
+{
+    private static (MainWindow Window, TestServices Ctx) CreateWindow()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName = null;
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, ctx);
+    }
+
+    private static void TriggerRefreshTreeView(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, null);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // Real MouseDown/MouseUp (not a direct model assignment) so the click's focus and
+    // selection side effects — the ones our Shift+Arrow anchor tracking depends on — actually run.
+    private static void RealSingleClick(MainWindow window, Control target)
+    {
+        var local = new Point(target.Bounds.Width / 2, target.Bounds.Height / 2);
+        var p = target.TranslatePoint(local, window)!.Value;
+        window.MouseDown(p, MouseButton.Left);
+        window.MouseUp(p, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>
+    /// Builds two chains, each with two frames, all expanded, and returns the flattened
+    /// visible-row order alongside the realized TreeViewItem for each row.
+    /// </summary>
+    private static (MainWindow Window, TestServices Ctx, List<TreeNodeVm> FlatOrder, List<TreeViewItem> Rows)
+        BuildTwoChainsTwoFramesEach()
+    {
+        var (window, ctx) = CreateWindow();
+
+        var chain0 = new AnimationChainSave { Name = "Walk" };
+        chain0.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        chain0.Frames.Add(new AnimationFrameSave { TextureName = "b.png" });
+        var chain1 = new AnimationChainSave { Name = "Run" };
+        chain1.Frames.Add(new AnimationFrameSave { TextureName = "c.png" });
+        chain1.Frames.Add(new AnimationFrameSave { TextureName = "d.png" });
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain0);
+        ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain1);
+
+        TriggerRefreshTreeView(window);
+
+        var tree = window.FindControl<TreeView>("AnimTree")!;
+        var roots = (ObservableCollection<TreeNodeVm>)tree.ItemsSource!;
+        foreach (var root in roots) root.IsExpanded = true; // default, but explicit for clarity
+        Dispatcher.UIThread.RunJobs();
+
+        var flatOrder = TreeBuilder.FlattenVisible(roots);
+        var rows = flatOrder
+            .Select(vm => tree.GetVisualDescendants().OfType<TreeViewItem>()
+                .First(t => ReferenceEquals(t.DataContext, vm)))
+            .ToList();
+
+        return (window, ctx, flatOrder, rows);
+    }
+
+    private static void ShiftKeyPress(MainWindow window, Key key) =>
+        window.KeyPress(key, RawInputModifiers.Shift, PhysicalKey.None, null);
+
+    [AvaloniaFact]
+    public void ShiftDown_FromSelectedFrame_ExtendsSelectionToNextRow()
+    {
+        var (window, _, flatOrder, rows) = BuildTwoChainsTwoFramesEach();
+        try
+        {
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            RealSingleClick(window, rows[1]); // chain0's frame0 (index 1: chain0=0, frame0=1)
+
+            ShiftKeyPress(window, Key.Down);
+
+            var selected = tree.SelectedItems!.Cast<TreeNodeVm>().ToList();
+            Assert.Equal(2, selected.Count);
+            Assert.Contains(flatOrder[1], selected); // original row stays selected
+            Assert.Contains(flatOrder[2], selected); // extended to the next row (chain0's frame1)
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ShiftDown_TwiceAcrossChainBoundary_GrowsContiguousRangeFromAnchor()
+    {
+        var (window, _, flatOrder, rows) = BuildTwoChainsTwoFramesEach();
+        try
+        {
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            // flatOrder: [0]=chain0 [1]=frame0-0 [2]=frame0-1 [3]=chain1 [4]=frame1-0 [5]=frame1-1
+            RealSingleClick(window, rows[2]); // anchor = chain0's frame1 (last row of chain0)
+
+            ShiftKeyPress(window, Key.Down); // crosses into chain1
+            ShiftKeyPress(window, Key.Down); // grows into chain1's frame0
+
+            var selected = tree.SelectedItems!.Cast<TreeNodeVm>().ToList();
+            Assert.Equal(3, selected.Count);
+            Assert.Contains(flatOrder[2], selected); // anchor
+            Assert.Contains(flatOrder[3], selected); // chain1 (crossed boundary)
+            Assert.Contains(flatOrder[4], selected); // chain1's frame0
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void ShiftUp_AfterShiftDownTwice_ShrinksRangeBackTowardAnchor()
+    {
+        var (window, _, flatOrder, rows) = BuildTwoChainsTwoFramesEach();
+        try
+        {
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            RealSingleClick(window, rows[2]); // anchor = chain0's frame1
+
+            ShiftKeyPress(window, Key.Down);
+            ShiftKeyPress(window, Key.Down); // range now [2..4]
+            ShiftKeyPress(window, Key.Up);   // shrink back to [2..3]
+
+            var selected = tree.SelectedItems!.Cast<TreeNodeVm>().ToList();
+            Assert.Equal(2, selected.Count);
+            Assert.Contains(flatOrder[2], selected); // anchor stays
+            Assert.Contains(flatOrder[3], selected); // far end shrank back to here
+            Assert.DoesNotContain(flatOrder[4], selected);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>Regression: plain (no-Shift) Down must keep switching the single selection.</summary>
+    [AvaloniaFact]
+    public void Down_NoModifier_StillReplacesSelectionWithSingleNextRow()
+    {
+        var (window, _, flatOrder, rows) = BuildTwoChainsTwoFramesEach();
+        try
+        {
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            RealSingleClick(window, rows[1]); // chain0's frame0
+
+            window.KeyPress(Key.Down, RawInputModifiers.None, PhysicalKey.None, null);
+            Dispatcher.UIThread.RunJobs();
+
+            var selected = tree.SelectedItems!.Cast<TreeNodeVm>().ToList();
+            Assert.Single(selected);
+            Assert.Same(flatOrder[2], selected[0]); // moved to chain0's frame1, old row deselected
+        }
+        finally { window.Close(); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TreeBuilderTests.cs
@@ -597,6 +597,62 @@ public class TreeBuilderPureTests
         Assert.True(roots[0].IsExpanded);                 // chain
         Assert.True(roots[0].Children[0].IsExpanded);     // parent frame
     }
+
+    // ── FlattenVisible ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FlattenVisible_ExpandedChainWithFrames_ReturnsChainThenFramesInOrder()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png" });
+        acls.AnimationChains.Add(chain);
+
+        var roots = TreeBuilder.BuildTree(acls); // defaults to expanded
+
+        var flat = TreeBuilder.FlattenVisible(roots);
+
+        Assert.Equal(3, flat.Count);
+        Assert.Same(roots[0], flat[0]);
+        Assert.Same(roots[0].Children[0], flat[1]);
+        Assert.Same(roots[0].Children[1], flat[2]);
+    }
+
+    [Fact]
+    public void FlattenVisible_CollapsedChain_ExcludesItsFrames()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        acls.AnimationChains.Add(chain);
+
+        var roots = TreeBuilder.BuildTree(acls);
+        roots[0].IsExpanded = false;
+
+        var flat = TreeBuilder.FlattenVisible(roots);
+
+        Assert.Single(flat);
+        Assert.Same(roots[0], flat[0]);
+    }
+
+    [Fact]
+    public void FlattenVisible_ChainNotPinnedVisible_IsExcluded()
+    {
+        var acls = new AnimationChainListSave();
+        var walk = new AnimationChainSave { Name = "Walk" };
+        var idle = new AnimationChainSave { Name = "Idle" };
+        acls.AnimationChains.Add(walk);
+        acls.AnimationChains.Add(idle);
+
+        var roots = TreeBuilder.BuildTree(acls);
+        roots[1].PinnedVisible = false; // e.g. filtered out by search
+
+        var flat = TreeBuilder.FlattenVisible(roots);
+
+        Assert.Single(flat);
+        Assert.Same(roots[0], flat[0]);
+    }
 }
 
 // ── SyncShapesInto tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1023

Shift+Up/Down in the ANIMATIONS tree previously fell through to Avalonia's native TreeViewItem arrow-key navigation, which just moves the single selection and discards whatever was previously selected. This adds a Tunnel-phase KeyDown handler on `AnimTree` that intercepts Shift+Up/Down and extends a contiguous range selection from a tracked anchor row (the anchor stays fixed, the far end moves with each keypress) — the same semantics as Shift+Click range-select, working across chain/frame boundaries. Plain (no-Shift) Up/Down is untouched.

- `TreeBuilder.FlattenVisible` — new pure helper computing the tree's visible row order (respects expand state and the sticky search filter), used to walk the range.
- `MainWindow`: `_treeSelectionAnchor` tracks the anchor, reset on any non-Shift-range selection change; `OnAnimTreeShiftArrowKeyDown` computes the new range from `AnimTree.SelectedItems`' current bounds (no separate far-end field needed) and rewrites the selection.

## Testing
- `ShiftArrowMultiSelectTests.cs` (new, App.Tests): drives real clicks (`window.MouseDown`/`MouseUp`) and real `window.KeyPress` Shift+Up/Down through the actual routed-event path — not reflection — covering extend-down, cross-chain-boundary growth, shrink-back-toward-anchor, and the plain-Down regression.
- `TreeBuilderTests.cs`: 3 new `FlattenVisible` Core tests (expanded chain, collapsed chain, filtered-out chain).
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/`: 886 passed.
- `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/`: 1934 passed.

Manual-test verdict: not needed — the AvaloniaFact tests drive real keyboard/mouse input end-to-end through Avalonia's routed-event dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVPxb7SLkxrTScAP1fomEL