### PR TITLE
Animation Editor: hold Shift to axis-lock frame/animation offset drag

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/AxisLock.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Rendering/AxisLock.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace AnimationEditor.Core.Rendering;
+
+/// <summary>
+/// Pure Shift-constrained-drag math (#1022): given a total drag delta from the drag's
+/// starting point, zero out the axis with the smaller magnitude so the drag moves purely
+/// horizontally or vertically — the same convention as Photoshop/Figma constrained drags.
+/// </summary>
+public static class AxisLock
+{
+    /// <summary>
+    /// Applies axis locking to a world-space drag delta. When <paramref name="locked"/> is
+    /// <c>false</c>, returns <paramref name="dx"/>/<paramref name="dy"/> unchanged. When
+    /// <c>true</c>, zeroes whichever of the two has the smaller absolute magnitude; on an
+    /// exact tie both axes are left free rather than arbitrarily picking one.
+    /// </summary>
+    public static (float Dx, float Dy) Apply(float dx, float dy, bool locked)
+    {
+        if (!locked) return (dx, dy);
+
+        float absDx = MathF.Abs(dx);
+        float absDy = MathF.Abs(dy);
+
+        if (absDx > absDy) return (dx, 0f);
+        if (absDy > absDx) return (0f, dy);
+        return (dx, dy);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -924,11 +924,15 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     /// commits. Bypasses coordinate conversion, so results are independent of zoom/pan/
     /// OffsetMultiplier. No-op unless exactly one frame is selected, mirroring the gate
     /// <see cref="OnPointerPressed"/> applies before starting a live frame drag.
+    /// <paramref name="shiftHeld"/> mirrors the live Shift-axis-lock (#1022) applied in
+    /// <see cref="OnPointerMoved"/> via <see cref="AxisLock"/>.
     /// </summary>
-    internal void SimulateFrameDrag(float worldDx, float worldDy)
+    internal void SimulateFrameDrag(float worldDx, float worldDy, bool shiftHeld = false)
     {
         var frame = _selectedState!.SelectedFrame;
         if (frame is null || _selectedState!.SelectedFrames.Count > 1) return;
+
+        (worldDx, worldDy) = AxisLock.Apply(worldDx, worldDy, shiftHeld);
 
         _draggingFrame   = frame;
         _frameDragStartX = frame.RelativeX;
@@ -945,10 +949,14 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     /// coordinate conversion, so results are independent of zoom/pan/OffsetMultiplier. No-op
     /// unless <see cref="IsWholeChainDragTarget"/> holds, mirroring the gate
     /// <see cref="OnPointerPressed"/> applies before starting a live whole-animation drag.
+    /// <paramref name="shiftHeld"/> mirrors the live Shift-axis-lock (#1022) applied in
+    /// <see cref="OnPointerMoved"/> via <see cref="AxisLock"/>.
     /// </summary>
-    internal void SimulateChainDrag(float worldDx, float worldDy)
+    internal void SimulateChainDrag(float worldDx, float worldDy, bool shiftHeld = false)
     {
         if (!IsWholeChainDragTarget) return;
+
+        (worldDx, worldDy) = AxisLock.Apply(worldDx, worldDy, shiftHeld);
 
         var chain = _selectedState!.SelectedChain!;
         _draggingChainFrames = chain.Frames.ToArray();
@@ -970,10 +978,14 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
     /// No-op unless <see cref="IsMultiFrameDragTarget"/> holds, mirroring the gate
     /// <see cref="OnPointerPressed"/> applies before starting a live multi-frame drag. Mirrors
     /// <see cref="SimulateChainDrag"/>, scoped to the multi-selection instead of the whole chain.
+    /// <paramref name="shiftHeld"/> mirrors the live Shift-axis-lock (#1022) applied in
+    /// <see cref="OnPointerMoved"/> via <see cref="AxisLock"/>.
     /// </summary>
-    internal void SimulateMultiFrameDrag(float worldDx, float worldDy)
+    internal void SimulateMultiFrameDrag(float worldDx, float worldDy, bool shiftHeld = false)
     {
         if (!IsMultiFrameDragTarget) return;
+
+        (worldDx, worldDy) = AxisLock.Apply(worldDx, worldDy, shiftHeld);
 
         _draggingChainFrames = _selectedState!.SelectedFrames.ToArray();
         _chainFrameStartX    = _draggingChainFrames.Select(f => f.RelativeX).ToArray();
@@ -2124,6 +2136,7 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             float om = _appState!.OffsetMultiplier * _zoom;
             float dx = (float)(pos.X - _frameDragAnchor.X) / om;
             float dy = -(float)(pos.Y - _frameDragAnchor.Y) / om;
+            (dx, dy) = AxisLock.Apply(dx, dy, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
             _draggingFrame.RelativeX = SnapToPixel(_frameDragStartX + dx);
             _draggingFrame.RelativeY = SnapToPixel(_frameDragStartY + dy);
             InvalidateVisual();
@@ -2136,6 +2149,7 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             float om = _appState!.OffsetMultiplier * _zoom;
             float dx = (float)(pos.X - _frameDragAnchor.X) / om;
             float dy = -(float)(pos.Y - _frameDragAnchor.Y) / om;
+            (dx, dy) = AxisLock.Apply(dx, dy, e.KeyModifiers.HasFlag(KeyModifiers.Shift));
             for (int i = 0; i < _draggingChainFrames.Length; i++)
             {
                 _draggingChainFrames[i].RelativeX = SnapToPixel(_chainFrameStartX![i] + dx);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewAxisLockDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewAxisLockDragTests.cs
@@ -1,0 +1,204 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Tests for Shift-axis-locking a frame/animation offset drag (issue #1022): holding Shift
+/// constrains the drag to whichever axis (horizontal or vertical) has the larger delta, same
+/// convention as Photoshop/Figma constrained drags. The axis-lock math itself is covered by
+/// <c>AxisLockTests</c> in AnimationEditor.Core.Tests; these tests prove it is actually wired
+/// into the per-frame drag (<see cref="PreviewControl.SimulateFrameDrag"/>), the whole-chain
+/// drag (<see cref="PreviewControl.SimulateChainDrag"/>), and the multi-frame drag
+/// (<see cref="PreviewControl.SimulateMultiFrameDrag"/>), plus that live pointer input reads
+/// the real Shift key state.
+/// </summary>
+public class PreviewAxisLockDragTests
+{
+    private static AnimationFrameSave MakeFrame(float relativeX = 0f, float relativeY = 0f)
+    {
+        return new AnimationFrameSave
+        {
+            FrameLength = 0.1f,
+            RelativeX   = relativeX,
+            RelativeY   = relativeY,
+            ShapesSave  = new ShapesSave()
+        };
+    }
+
+    // ── Per-frame offset drag ──────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_ShiftHeld_HorizontalDeltaLarger_LocksToHorizontal()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var frame = MakeFrame();
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(10f, 4f, shiftHeld: true);
+
+        Assert.Equal(10f, frame.RelativeX, precision: 3);
+        Assert.Equal(0f, frame.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_ShiftHeld_VerticalDeltaLarger_LocksToVertical()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var frame = MakeFrame();
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(4f, 10f, shiftHeld: true);
+
+        Assert.Equal(0f, frame.RelativeX, precision: 3);
+        Assert.Equal(10f, frame.RelativeY, precision: 3);
+    }
+
+    [AvaloniaFact]
+    public void SimulateFrameDrag_ShiftNotHeld_MovesFreely()
+    {
+        var ctx   = TestHelpers.BuildServices();
+        var frame = MakeFrame();
+        ctx.SelectedState.SelectedFrame = frame;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateFrameDrag(10f, 4f, shiftHeld: false);
+
+        Assert.Equal(10f, frame.RelativeX, precision: 3);
+        Assert.Equal(4f, frame.RelativeY, precision: 3);
+    }
+
+    // ── Whole-animation offset drag ────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateChainDrag_ShiftHeld_LocksEveryFrameToTheSameAxis()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateChainDrag(3f, 9f, shiftHeld: true);
+
+        Assert.Equal(0f, frameA.RelativeX, precision: 3);
+        Assert.Equal(9f, frameA.RelativeY, precision: 3);
+        Assert.Equal(10f, frameB.RelativeX, precision: 3);
+        Assert.Equal(4f, frameB.RelativeY, precision: 3);
+    }
+
+    // ── Multi-frame offset drag ─────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void SimulateMultiFrameDrag_ShiftHeld_LocksSelectedFramesToTheSameAxis()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var frameA = MakeFrame(relativeX: 0f, relativeY: 0f);
+        var frameB = MakeFrame(relativeX: 10f, relativeY: -5f);
+        var chain  = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(frameA);
+        chain.Frames.Add(frameB);
+        ctx.SelectedState.SelectedChain = chain;
+        ctx.SelectedState.SelectedNodes = new List<object> { frameA, frameB };
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateMultiFrameDrag(9f, 3f, shiftHeld: true);
+
+        Assert.Equal(9f, frameA.RelativeX, precision: 3);
+        Assert.Equal(0f, frameA.RelativeY, precision: 3);
+        Assert.Equal(19f, frameB.RelativeX, precision: 3);
+        Assert.Equal(-5f, frameB.RelativeY, precision: 3);
+    }
+
+    // ── Real pointer routing: live Shift key actually reaches the drag ─────────
+
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame            = null;
+        ctx.SelectedState.SelectedNodes           = new List<object>();
+        ctx.AppCommands.DoOnUiThread              = a => a();
+        ctx.AppCommands.ConfirmAsync              = (_, _) => Task.FromResult(true);
+        ctx.AppCommands.FileDialogService         = NullFileDialogService.Instance;
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, int size = 64, string name = "sprite.png")
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(SKColors.CornflowerBlue);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void RealDrag_ShiftHeldWithLargerHorizontalMovement_LocksVerticalToStartingOffset()
+    {
+        var ctx = ResetSingletons();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var texPath = WriteSolidPng(dir);
+            var frame   = MakeFrame();
+            frame.TextureName = texPath;
+
+            var chain = new AnimationChainSave { Name = "Walk" };
+            chain.Frames.Add(frame);
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = frame;
+            // Pre-warm the bitmap cache the way a real render pass would, so the frame-drag
+            // hit-test (which requires a cached bitmap) is actually eligible to fire.
+            ctx.ThumbnailService.GetBitmap(texPath);
+
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var preview = window.FindControl<PreviewControl>("PreviewCtrl")!;
+            float centerX = (float)((preview.Bounds.Width - 20) / 2 + 20);
+            float centerY = (float)((preview.Bounds.Height - 20) / 2 + 20);
+            var localPoint  = new Point(centerX, centerY); // frame sits at world (0,0) == canvas center
+            var windowPoint = preview.TranslatePoint(localPoint, window)!.Value;
+
+            window.MouseDown(windowPoint, MouseButton.Left);
+            // Larger horizontal than vertical movement, with Shift held throughout.
+            var movedPoint = windowPoint + new Point(20, 6);
+            window.MouseMove(movedPoint, RawInputModifiers.Shift);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEqual(0f, frame.RelativeX);
+            Assert.Equal(0f, frame.RelativeY, precision: 3);
+
+            window.MouseUp(movedPoint, MouseButton.Left, RawInputModifiers.Shift);
+            Dispatcher.UIThread.RunJobs();
+
+            window.Close();
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AxisLockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AxisLockTests.cs
@@ -1,0 +1,56 @@
+using AnimationEditor.Core.Rendering;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="AxisLock"/> — the Shift-constrained-drag math behind issue #1022
+/// (hold Shift while dragging a frame/animation offset to lock to the larger-delta axis).
+/// </summary>
+public class AxisLockTests
+{
+    [Fact]
+    public void Apply_NotLocked_ReturnsDeltasUnchanged()
+    {
+        var (dx, dy) = AxisLock.Apply(3f, 9f, locked: false);
+
+        Assert.Equal(3f, dx, precision: 3);
+        Assert.Equal(9f, dy, precision: 3);
+    }
+
+    [Fact]
+    public void Apply_Locked_HorizontalDeltaLarger_ZeroesVertical()
+    {
+        var (dx, dy) = AxisLock.Apply(10f, 4f, locked: true);
+
+        Assert.Equal(10f, dx, precision: 3);
+        Assert.Equal(0f, dy, precision: 3);
+    }
+
+    [Fact]
+    public void Apply_Locked_VerticalDeltaLarger_ZeroesHorizontal()
+    {
+        var (dx, dy) = AxisLock.Apply(4f, 10f, locked: true);
+
+        Assert.Equal(0f, dx, precision: 3);
+        Assert.Equal(10f, dy, precision: 3);
+    }
+
+    [Fact]
+    public void Apply_Locked_ComparesMagnitudeNotSign()
+    {
+        var (dx, dy) = AxisLock.Apply(-10f, 4f, locked: true);
+
+        Assert.Equal(-10f, dx, precision: 3);
+        Assert.Equal(0f, dy, precision: 3);
+    }
+
+    [Fact]
+    public void Apply_Locked_EqualMagnitude_KeepsBothAxesFree()
+    {
+        var (dx, dy) = AxisLock.Apply(5f, -5f, locked: true);
+
+        Assert.Equal(5f, dx, precision: 3);
+        Assert.Equal(-5f, dy, precision: 3);
+    }
+}


### PR DESCRIPTION
Closes #1022.

Holding Shift while dragging a frame or whole-animation offset in the Preview panel now constrains the drag to whichever axis (horizontal or vertical) has the larger delta — the Photoshop/Figma constrained-drag convention.

- New pure `AxisLock.Apply(dx, dy, locked)` helper in `AnimationEditor.Core/Rendering/` (ties keep both axes free).
- Wired into `PreviewControl.OnPointerMoved`'s single-frame-drag and chain/multi-frame-drag branches via `e.KeyModifiers.HasFlag(KeyModifiers.Shift)`.
- `SimulateFrameDrag`/`SimulateChainDrag`/`SimulateMultiFrameDrag` gained an optional `shiftHeld` param so App-layer tests can drive the locked path deterministically.

Manual test: not needed — covered by `AxisLockTests` (Core, pure math) and `PreviewAxisLockDragTests` (App, including one real-pointer-routing test that drives `window.MouseMove` with `RawInputModifiers.Shift` to prove the live key state actually reaches the drag, not just the Simulate* helpers). Full `AnimationEditor.Core.Tests`, `AnimationEditor.Views.Tests`, and `AnimationEditor.App.Tests` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrdvV2W1WhJV7GaecvFUrA
