### PR TITLE
Support cross-tab copy/cut/paste of animations

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -722,7 +722,9 @@ public partial class MainWindow : Window
     {
         if (tab == _tabManager.ActiveTab) return;
 
-        ClearPendingCut();
+        // A pending cut deliberately survives a tab switch (#1026) -- paste on a different tab
+        // completes it as a cross-tab move; ResolveCompletion decides staleness lazily at paste
+        // time, so this is no longer a "just tidy up the highlight" clear.
 
         // Save the leaving tab's undo history and in-memory model before the editor switches.
         // PNG tabs carry no model or undo stack, so only capture when leaving the achx editor.
@@ -766,7 +768,7 @@ public partial class MainWindow : Window
 
     private void ActivateUntitledTabContent(TabEntry tab)
     {
-        ClearPendingCut();
+        // See the comment in ActivateTabAsync (#1026) -- a pending cut survives this switch too.
         _projectManager.AnimationChainListSave =
             tab.CachedEditorModel ?? new AnimationChainListSave();
         _projectManager.FileName = null;
@@ -1137,7 +1139,7 @@ public partial class MainWindow : Window
         _appCommands.EditorProjectModelChanged += path =>
             LastEditorProjectModelChangedTask = Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                ClearPendingCut();
+                // A pending cut deliberately survives this (#1026) -- see ActivateTabAsync.
                 SyncTabCacheFromEditor(path);
                 await InvalidateProjectPanelThumbnailIfTrackedAsync(path);
             });
@@ -6092,6 +6094,16 @@ public partial class MainWindow : Window
     private Task HandleCutAsync()   => RunGuardedAsync(HandleCutCoreAsync,   "Cut");
     private Task HandlePasteAsync() => RunGuardedAsync(HandlePasteCoreAsync, "Paste");
 
+    /// <summary>
+    /// The directory of the currently active <c>.achx</c>, or empty for an unsaved document.
+    /// Used to make copied/cut frame texture references self-contained (#1026) so a paste into
+    /// a document in a different folder still finds the same physical texture.
+    /// </summary>
+    private string CurrentAchxFolder =>
+        string.IsNullOrEmpty(_projectManager.FileName)
+            ? string.Empty
+            : new FilePath(_projectManager.FileName).GetDirectoryContainingThis().FullPath;
+
     private async Task HandleCopyCoreAsync()
     {
         if (IsTextInputFocused()) return;
@@ -6110,7 +6122,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
+        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload, CurrentAchxFolder));
         _pendingCutState.Clear();
         SyncPendingCutHighlights();
     }
@@ -6133,8 +6145,8 @@ public partial class MainWindow : Window
             return;
         }
 
-        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
-        _pendingCutState.Set(payload);
+        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload, CurrentAchxFolder));
+        _pendingCutState.Set(payload, _projectManager.AnimationChainListSave!);
         SyncPendingCutHighlights();
     }
 
@@ -6155,19 +6167,25 @@ public partial class MainWindow : Window
         if (acls is null) return;
 
         var selectedData = SelectedData;
-        bool completingCut = _pendingCutState.IsActive;
-        if (completingCut && !_pendingCutState.SourcesBelongToProject(acls, _objectFinder))
+        var cutCompletion = _pendingCutState.ResolveCompletion(acls);
+        bool completingCut = cutCompletion is CutCompletion.SameDocument or CutCompletion.CrossDocument;
+        bool completingCutAcrossDocuments = cutCompletion == CutCompletion.CrossDocument;
+        if (cutCompletion == CutCompletion.Stale)
         {
             _pendingCutState.Clear();
             SyncPendingCutHighlights();
-            completingCut = false;
         }
 
         if (chains is { Count: > 0 })
         {
             if (completingCut && _pendingCutState.Kind != CopySelectionKind.Chain) return;
             QueuePastedChainExpandFromSources(chains, chains);
-            if (completingCut)
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands.PasteChains(chains);
+                _pendingCutState.RemoveSourcesFrom(_pendingCutState.SourceDocument!);
+            }
+            else if (completingCut)
                 _appCommands.PasteChainsCut(chains, _pendingCutState.Chains);
             else
                 _appCommands.PasteChains(chains);
@@ -6179,7 +6197,12 @@ public partial class MainWindow : Window
                 acls, selectedData, _objectFinder, _selectedState);
             if (targetChain is null) return;
 
-            if (completingCut)
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands.PasteFrames(targetChain, frames, insertIndex);
+                _pendingCutState.RemoveSourcesFrom(_pendingCutState.SourceDocument!);
+            }
+            else if (completingCut)
                 _appCommands.PasteFramesCut(targetChain, frames, insertIndex, _pendingCutState.Frames);
             else
                 _appCommands.PasteFrames(targetChain, frames, insertIndex);
@@ -6193,7 +6216,12 @@ public partial class MainWindow : Window
             var frame = _selectedState.SelectedFrame;
             if (frame is null) return;
 
-            if (completingCut)
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands.PasteShapes(frame, rectangles ?? [], circles ?? []);
+                _pendingCutState.RemoveSourcesFrom(_pendingCutState.SourceDocument!);
+            }
+            else if (completingCut)
             {
                 var sourceFrame = _pendingCutState.Shapes[0] switch
                 {
@@ -6232,13 +6260,6 @@ public partial class MainWindow : Window
             Walk(root);
         WireframeCtrl.InvalidateVisual();
         PreviewCtrl.InvalidateVisual();
-    }
-
-    private void ClearPendingCut()
-    {
-        if (!_pendingCutState.IsActive) return;
-        _pendingCutState.Clear();
-        SyncPendingCutHighlights();
     }
 
     private bool TreeMultiSelectionAlreadySynced(IReadOnlyList<object> dataObjects)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ClipboardPayload.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/ClipboardPayload.cs
@@ -54,10 +54,21 @@ public static class ClipboardPayload
     public static string Serialize(CircleSave circle)
         => Encode(circle);
 
-  public static string SerializeFromPayload(CopySelectionPayload payload) => payload.Kind switch
+    /// <param name="payload">The items to serialize.</param>
+    /// <param name="sourceAchxFolder">
+    /// The directory of the <c>.achx</c> the copy/cut originated from. When given, every copied
+    /// frame's <c>TextureName</c> is resolved to an absolute path before being embedded, so the
+    /// same physical texture is still found after a paste into a document that lives in a
+    /// different folder (#1026) -- relative-to-source paths would otherwise resolve against the
+    /// destination folder instead. Pass <see langword="null"/> (e.g. an unsaved document with no
+    /// folder yet) to embed <c>TextureName</c> unchanged.
+    /// </param>
+    public static string SerializeFromPayload(CopySelectionPayload payload, string? sourceAchxFolder = null) => payload.Kind switch
     {
-        CopySelectionKind.Chain => Serialize(payload.Chains.Select(AnimationCloneHelper.CloneChain).ToList()),
-        CopySelectionKind.Frame => Serialize(payload.Frames.Select(AnimationCloneHelper.CloneFrame).ToList()),
+        CopySelectionKind.Chain => Serialize(ResolveChainTextures(
+            payload.Chains.Select(AnimationCloneHelper.CloneChain).ToList(), sourceAchxFolder)),
+        CopySelectionKind.Frame => Serialize(ResolveFrameTextures(
+            payload.Frames.Select(AnimationCloneHelper.CloneFrame).ToList(), sourceAchxFolder)),
         CopySelectionKind.Shape => payload.Shapes.Count == 1 && payload.Shapes[0] is AARectSave r
             ? Serialize((AARectSave)AnimationCloneHelper.CloneShape(r)!)
             : payload.Shapes.Count == 1 && payload.Shapes[0] is CircleSave c
@@ -67,6 +78,25 @@ public static class ClipboardPayload
                 .ToList()),
         _ => throw new System.ArgumentOutOfRangeException(nameof(payload)),
     };
+
+    private static List<AnimationChainSave> ResolveChainTextures(
+        List<AnimationChainSave> chains, string? sourceAchxFolder)
+    {
+        if (!string.IsNullOrEmpty(sourceAchxFolder))
+            foreach (var chain in chains)
+                ResolveFrameTextures(chain.Frames, sourceAchxFolder);
+        return chains;
+    }
+
+    private static List<AnimationFrameSave> ResolveFrameTextures(
+        List<AnimationFrameSave> frames, string? sourceAchxFolder)
+    {
+        if (!string.IsNullOrEmpty(sourceAchxFolder))
+            foreach (var frame in frames)
+                if (!string.IsNullOrEmpty(frame.TextureName))
+                    frame.TextureName = TexturePathHelper.ResolveDisplayPath(frame.TextureName, sourceAchxFolder);
+        return frames;
+    }
 
     // ── Deserialization ───────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/PendingCutState.cs
@@ -7,6 +7,30 @@ using System.Linq;
 namespace AnimationEditor.Core;
 
 /// <summary>
+/// How a paste should treat an active pending cut, from <see cref="IPendingCutState.ResolveCompletion"/>.
+/// </summary>
+public enum CutCompletion
+{
+    /// <summary>No cut is pending; paste this as a plain copy.</summary>
+    None,
+
+    /// <summary>The cut's sources are still in the active document -- delete them there, undoably.</summary>
+    SameDocument,
+
+    /// <summary>
+    /// The cut's sources are in a different, still-open document (a cross-tab cut, #1026) --
+    /// paste into the active document, then remove the sources from the other document directly.
+    /// </summary>
+    CrossDocument,
+
+    /// <summary>
+    /// The cut's sources are gone from both the active and the original document (e.g. the source
+    /// tab/file closed since) -- treat this paste as a plain copy.
+    /// </summary>
+    Stale,
+}
+
+/// <summary>
 /// Tracks animation items cut to the clipboard that remain in the project until paste completes.
 /// </summary>
 public interface IPendingCutState
@@ -19,7 +43,14 @@ public interface IPendingCutState
     IReadOnlyList<AnimationFrameSave> Frames { get; }
     IReadOnlyList<object> Shapes { get; }
 
-    void Set(CopySelectionPayload payload);
+    /// <summary>
+    /// The document the pending cut's sources live in, captured at <see cref="Set"/> time (#1026).
+    /// Lets paste tell a stale cut (source tab/file closed) apart from a cut whose source is a
+    /// different, still-open document (a cross-tab cut) once the active document has moved on.
+    /// </summary>
+    AnimationChainListSave? SourceDocument { get; }
+
+    void Set(CopySelectionPayload payload, AnimationChainListSave sourceDocument);
     void Clear();
     bool Contains(object data);
 
@@ -30,7 +61,21 @@ public interface IPendingCutState
     IReadOnlyList<object> WireframeShapes { get; }
 
     /// <summary>True when every pending-cut source still lives in <paramref name="acls"/>.</summary>
-    bool SourcesBelongToProject(AnimationChainListSave? acls, IObjectFinder finder);
+    bool SourcesBelongToProject(AnimationChainListSave? acls);
+
+    /// <summary>
+    /// Directly removes the pending cut's source chains/frames/shapes from <paramref name="acls"/>,
+    /// bypassing the undo manager entirely (#1026). Use only when <paramref name="acls"/> is a
+    /// document other than the currently active one -- the undo stack only ever tracks the active
+    /// document, so a cross-document delete can never be made undoable the normal way.
+    /// </summary>
+    bool RemoveSourcesFrom(AnimationChainListSave acls);
+
+    /// <summary>
+    /// Classifies how a paste against <paramref name="activeAcls"/> should treat this pending cut.
+    /// Centralizes the decision so the desktop and browser paste handlers don't each re-derive it.
+    /// </summary>
+    CutCompletion ResolveCompletion(AnimationChainListSave? activeAcls);
 }
 
 public sealed class PendingCutState : IPendingCutState
@@ -44,6 +89,7 @@ public sealed class PendingCutState : IPendingCutState
     public IReadOnlyList<AnimationChainSave> Chains => _payload?.Chains ?? [];
     public IReadOnlyList<AnimationFrameSave> Frames => _payload?.Frames ?? [];
     public IReadOnlyList<object> Shapes => _payload?.Shapes ?? [];
+    public AnimationChainListSave? SourceDocument { get; private set; }
 
     public IReadOnlyList<AnimationFrameSave> WireframeFrames =>
         _payload?.Kind switch
@@ -56,9 +102,10 @@ public sealed class PendingCutState : IPendingCutState
     public IReadOnlyList<object> WireframeShapes =>
         _payload?.Kind == CopySelectionKind.Shape ? _payload.Shapes : [];
 
-    public void Set(CopySelectionPayload payload)
+    public void Set(CopySelectionPayload payload, AnimationChainListSave sourceDocument)
     {
         _payload = payload;
+        SourceDocument = sourceDocument;
         Changed?.Invoke();
     }
 
@@ -66,6 +113,7 @@ public sealed class PendingCutState : IPendingCutState
     {
         if (_payload is null) return;
         _payload = null;
+        SourceDocument = null;
         Changed?.Invoke();
     }
 
@@ -78,24 +126,64 @@ public sealed class PendingCutState : IPendingCutState
             _ => false,
         };
 
-    public bool SourcesBelongToProject(AnimationChainListSave? acls, IObjectFinder finder)
+    public bool SourcesBelongToProject(AnimationChainListSave? acls)
     {
         if (_payload is null || acls is null) return false;
         return _payload.Kind switch
         {
             CopySelectionKind.Chain => _payload.Chains.All(acls.AnimationChains.Contains),
-            CopySelectionKind.Frame => _payload.Frames.All(f =>
-                acls.AnimationChains.Any(c => c.Frames.Contains(f))),
-            CopySelectionKind.Shape => _payload.Shapes.All(s => s switch
-            {
-                AARectSave r => BelongsToProject(finder.GetAnimationFrameContaining(r), acls),
-                CircleSave c => BelongsToProject(finder.GetAnimationFrameContaining(c), acls),
-                _ => false,
-            }),
+            CopySelectionKind.Frame => _payload.Frames.All(f => ChainContaining(acls, f) is not null),
+            CopySelectionKind.Shape => _payload.Shapes.All(s => FrameContaining(acls, s) is not null),
             _ => false,
         };
     }
 
-    private static bool BelongsToProject(AnimationFrameSave? frame, AnimationChainListSave acls) =>
-        frame is not null && acls.AnimationChains.Any(c => c.Frames.Contains(frame));
+    public bool RemoveSourcesFrom(AnimationChainListSave acls)
+    {
+        if (_payload is null) return false;
+        switch (_payload.Kind)
+        {
+            case CopySelectionKind.Chain:
+                return acls.AnimationChains.RemoveAll(_payload.Chains.Contains) > 0;
+
+            case CopySelectionKind.Frame:
+                bool removedAnyFrame = false;
+                foreach (var frame in _payload.Frames)
+                {
+                    if (ChainContaining(acls, frame) is { } chain && chain.Frames.Remove(frame))
+                        removedAnyFrame = true;
+                }
+                return removedAnyFrame;
+
+            case CopySelectionKind.Shape:
+                bool removedAnyShape = false;
+                foreach (var shape in _payload.Shapes)
+                {
+                    if (FrameContaining(acls, shape) is { ShapesSave: { } shapes } &&
+                        shapes.Shapes.Remove(shape))
+                        removedAnyShape = true;
+                }
+                return removedAnyShape;
+
+            default:
+                return false;
+        }
+    }
+
+    public CutCompletion ResolveCompletion(AnimationChainListSave? activeAcls)
+    {
+        if (_payload is null) return CutCompletion.None;
+        if (SourcesBelongToProject(activeAcls)) return CutCompletion.SameDocument;
+        if (SourceDocument is { } src && !ReferenceEquals(src, activeAcls) && SourcesBelongToProject(src))
+            return CutCompletion.CrossDocument;
+        return CutCompletion.Stale;
+    }
+
+    private static AnimationChainSave? ChainContaining(AnimationChainListSave acls, AnimationFrameSave frame) =>
+        acls.AnimationChains.FirstOrDefault(c => c.Frames.Contains(frame));
+
+    private static AnimationFrameSave? FrameContaining(AnimationChainListSave acls, object shape) =>
+        acls.AnimationChains
+            .SelectMany(c => c.Frames)
+            .FirstOrDefault(f => f.ShapesSave?.Shapes.Contains(shape) == true);
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
@@ -4,6 +4,7 @@ using AnimationEditor.Core;
 using AnimationEditor.Core.CommandsAndState;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
+using AnimationEditor.Core.Paths;
 using AnimationEditor.Core.ViewModels;
 using AnimationEditor.Views.Dialogs;
 using Avalonia.Controls;
@@ -490,6 +491,12 @@ public partial class AnimationTreeControl : UserControl
     // (#757), SelectedNodes is kept in sync so SelectedChains/SelectedFrames/etc. cover the
     // whole multi-selection (singular Selected* remains the fallback when the bag is empty).
 
+    /// <summary>Mirrors <c>MainWindow.CurrentAchxFolder</c> -- see #1026.</summary>
+    private string CurrentAchxFolder =>
+        string.IsNullOrEmpty(_projectManager!.FileName)
+            ? string.Empty
+            : new FilePath(_projectManager.FileName).GetDirectoryContainingThis().FullPath;
+
     private async Task HandleCopyAsync()
     {
         var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
@@ -497,7 +504,7 @@ public partial class AnimationTreeControl : UserControl
         if (!SelectionCopyContext.TryGet(_selectedState!, _objectFinder!, _projectManager!.AnimationChainListSave, out var payload, out _))
             return;
 
-        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
+        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload, CurrentAchxFolder));
         _pendingCutState!.Clear();
     }
 
@@ -508,8 +515,8 @@ public partial class AnimationTreeControl : UserControl
         if (!SelectionCopyContext.TryGet(_selectedState!, _objectFinder!, _projectManager!.AnimationChainListSave, out var payload, out _))
             return;
 
-        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload));
-        _pendingCutState!.Set(payload);
+        await clipboard.SetTextAsync(ClipboardPayload.SerializeFromPayload(payload, CurrentAchxFolder));
+        _pendingCutState!.Set(payload, _projectManager!.AnimationChainListSave!);
     }
 
     private async Task HandlePasteAsync(object? nodeData)
@@ -526,17 +533,21 @@ public partial class AnimationTreeControl : UserControl
         if (acls is null) return;
 
         var pendingCut = _pendingCutState!;
-        bool completingCut = pendingCut.IsActive;
-        if (completingCut && !pendingCut.SourcesBelongToProject(acls, _objectFinder!))
-        {
+        var cutCompletion = pendingCut.ResolveCompletion(acls);
+        bool completingCut = cutCompletion is CutCompletion.SameDocument or CutCompletion.CrossDocument;
+        bool completingCutAcrossDocuments = cutCompletion == CutCompletion.CrossDocument;
+        if (cutCompletion == CutCompletion.Stale)
             pendingCut.Clear();
-            completingCut = false;
-        }
 
         if (chains is { Count: > 0 })
         {
             if (completingCut && pendingCut.Kind != CopySelectionKind.Chain) return;
-            if (completingCut) _appCommands!.PasteChainsCut(chains, pendingCut.Chains);
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands!.PasteChains(chains);
+                pendingCut.RemoveSourcesFrom(pendingCut.SourceDocument!);
+            }
+            else if (completingCut) _appCommands!.PasteChainsCut(chains, pendingCut.Chains);
             else _appCommands!.PasteChains(chains);
         }
         else if (frames is { Count: > 0 })
@@ -546,7 +557,12 @@ public partial class AnimationTreeControl : UserControl
                 PastePlacementLogic.ResolveFramePasteTarget(acls, nodeData, _objectFinder!, _selectedState);
             if (targetChain is null) return;
 
-            if (completingCut) _appCommands!.PasteFramesCut(targetChain, frames, insertIndex, pendingCut.Frames);
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands!.PasteFrames(targetChain, frames, insertIndex);
+                pendingCut.RemoveSourcesFrom(pendingCut.SourceDocument!);
+            }
+            else if (completingCut) _appCommands!.PasteFramesCut(targetChain, frames, insertIndex, pendingCut.Frames);
             else _appCommands!.PasteFrames(targetChain, frames, insertIndex);
         }
         else if (rectangles is { Count: > 0 } || circles is { Count: > 0 })
@@ -555,7 +571,12 @@ public partial class AnimationTreeControl : UserControl
             var frame = _selectedState!.SelectedFrame;
             if (frame is null) return;
 
-            if (completingCut)
+            if (completingCutAcrossDocuments)
+            {
+                _appCommands!.PasteShapes(frame, rectangles ?? new List<AARectSave>(), circles ?? new List<CircleSave>());
+                pendingCut.RemoveSourcesFrom(pendingCut.SourceDocument!);
+            }
+            else if (completingCut)
             {
                 var sourceFrame = pendingCut.Shapes[0] switch
                 {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CrossTabCutPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/CrossTabCutPasteTests.cs
@@ -1,0 +1,132 @@
+using AnimationEditor.Core;
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.ViewModels;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input.Platform;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// End-to-end coverage for issue #1026: copying/cutting an animation from one open tab into
+/// another tab in the same project, where the two <c>.achx</c> files live in different folders.
+/// </summary>
+public class CrossTabCutPasteTests
+{
+    private static string WriteAchx(string dir, string fileName, string chainName, string textureName)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, fileName);
+        var acls = new AnimationChainListSave { CoordinateType = TextureCoordinateType.Pixel };
+        var chain = new AnimationChainSave { Name = chainName };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = textureName, FrameLength = 0.1f });
+        acls.AnimationChains.Add(chain);
+        acls.Save(path);
+        return path;
+    }
+
+    private static async Task InvokePrivateAsync(MainWindow window, string methodName)
+    {
+        var method = typeof(MainWindow).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await (Task)method.Invoke(window, null)!;
+    }
+
+    private static void FlushUi()
+    {
+        Dispatcher.UIThread.RunJobs();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static void RebuildTree(MainWindow window)
+    {
+        typeof(MainWindow).GetMethod("RebuildTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, new object[] { Array.Empty<string>() });
+        FlushUi();
+    }
+
+    [AvaloniaFact]
+    public async Task CutChain_FromOtherOpenTab_MovesItAndResolvesTextureToOriginalFolder()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var folderA = Path.Combine(root, "FolderA");
+        var folderB = Path.Combine(root, "FolderB");
+        try
+        {
+            var pathA = WriteAchx(folderA, "a.achx", "Walk", "hero.png");
+            var pathB = WriteAchx(folderB, "b.achx", "Run", "enemy.png");
+
+            var ctx = TestHelpers.BuildServices();
+            ctx.AppCommands.ConfirmAsync = (_, _) => Task.FromResult(true);
+            ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+            var window = ctx.CreateMainWindow();
+            window.Show();
+            try
+            {
+                // Open tab A and cut its "Walk" chain.
+                await window.OpenFileAsTab(pathA);
+                FlushUi();
+                RebuildTree(window);
+                var tree = window.FindControl<TreeView>("AnimTree")!;
+                var walkNode = tree.ItemsSource!.Cast<TreeNodeVm>().First();
+                tree.SelectedItems!.Clear();
+                tree.SelectedItems.Add(walkNode);
+                FlushUi();
+
+                await InvokePrivateAsync(window, "HandleCutCoreAsync");
+
+                // The clipboard payload is self-contained: the texture reference was resolved to
+                // an absolute path at cut time, before the folder it's relative to (FolderA) goes
+                // out of scope by switching tabs.
+                var clipTextAfterCut = await window.Clipboard!.TryGetTextAsync();
+                var absoluteHeroPath = TexturePathHelper.ResolveDisplayPath("hero.png", folderA);
+                Assert.Contains(absoluteHeroPath.Replace("\\", "/"), clipTextAfterCut!.Replace("\\", "/"));
+
+                // The document the cut's sources live in, captured at cut time -- this is the
+                // exact object a cross-tab paste must later remove "Walk" from directly (#1026),
+                // since it stops being the active document (and the undo stack moves on to
+                // whichever tab is pasted into) the moment a different tab is opened.
+                var sourceDoc = ctx.PendingCutState.SourceDocument!;
+                Assert.Contains(sourceDoc.AnimationChains, c => c.Name == "Walk");
+
+                // Switch to tab B -- this is what makes the cut "cross-tab".
+                await window.OpenFileAsTab(pathB);
+                FlushUi();
+                RebuildTree(window);
+
+                Assert.Equal(CutCompletion.CrossDocument,
+                    ctx.PendingCutState.ResolveCompletion(ctx.ProjectManager.AnimationChainListSave));
+
+                await InvokePrivateAsync(window, "HandlePasteCoreAsync");
+                FlushUi();
+
+                // The chain landed in B's document with its texture reference re-relativized
+                // (by the paste command's own auto-save) against FolderB, pointing back at the
+                // same physical file in FolderA -- not "hero.png" relative to FolderB, which
+                // would silently point at a texture that doesn't exist there.
+                var bAcls = ctx.ProjectManager.AnimationChainListSave!;
+                var pastedChain = Assert.Single(bAcls.AnimationChains, c => c.Name == "Walk");
+                var expectedTexturePath = TexturePathHelper.ComputeStorePath(absoluteHeroPath, folderB);
+                Assert.Equal(expectedTexturePath, pastedChain.Frames[0].TextureName);
+
+                // The source chain was actually moved, not merely copied.
+                Assert.DoesNotContain(sourceDoc.AnimationChains, c => c.Name == "Walk");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ClipboardPayloadCrossFolderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/ClipboardPayloadCrossFolderTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.Core.IO;
+using FlatRedBall2.AnimationEditorCommon;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.Core.Tests;
+
+/// <summary>
+/// Cross-tab/cross-folder copy-paste (#1026): a frame's <c>TextureName</c> is stored relative to
+/// its own <c>.achx</c> folder, so copying it as-is into a document that lives in a different
+/// folder would resolve against the wrong base and silently break the reference.
+/// <see cref="ClipboardPayload.SerializeFromPayload(CopySelectionPayload, string?)"/> resolves
+/// <c>TextureName</c> to an absolute path at copy time so the same physical file is still found
+/// regardless of which folder it ends up pasted into.
+/// </summary>
+public class ClipboardPayloadCrossFolderTests
+{
+    [Fact]
+    public void SerializeFromPayload_Chain_WithSourceFolder_ResolvesEveryFrameTextureNameToAbsolute()
+    {
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "a.png" });
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "b.png" });
+        var payload = new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } };
+        string sourceFolder = TestPaths.AbsDir("Project", "Animations", "Player");
+
+        var text = ClipboardPayload.SerializeFromPayload(payload, sourceFolder);
+        ClipboardPayload.TryDeserialize(text, out var chains, out _, out _, out _);
+
+        var expected = new[]
+        {
+            TexturePathHelper.ResolveDisplayPath("a.png", sourceFolder),
+            TexturePathHelper.ResolveDisplayPath("b.png", sourceFolder),
+        };
+        Assert.Equal(expected, chains!.Single().Frames.Select(f => f.TextureName));
+    }
+
+    [Fact]
+    public void SerializeFromPayload_Frame_WithSourceFolder_ResolvesRelativeTextureNameToAbsolute()
+    {
+        var frame = new AnimationFrameSave { TextureName = "sheet.png" };
+        var payload = new CopySelectionPayload { Kind = CopySelectionKind.Frame, Frames = new[] { frame } };
+        string sourceFolder = TestPaths.AbsDir("Project", "Animations", "Player");
+
+        var text = ClipboardPayload.SerializeFromPayload(payload, sourceFolder);
+        ClipboardPayload.TryDeserialize(text, out _, out var frames, out _, out _);
+
+        Assert.Equal(TexturePathHelper.ResolveDisplayPath("sheet.png", sourceFolder), frames!.Single().TextureName);
+    }
+
+    [Fact]
+    public void SerializeFromPayload_Frame_WithoutSourceFolder_LeavesTextureNameUnchanged()
+    {
+        var frame = new AnimationFrameSave { TextureName = "sheet.png" };
+        var payload = new CopySelectionPayload { Kind = CopySelectionKind.Frame, Frames = new[] { frame } };
+
+        var text = ClipboardPayload.SerializeFromPayload(payload);
+        ClipboardPayload.TryDeserialize(text, out _, out var frames, out _, out _);
+
+        Assert.Equal("sheet.png", frames!.Single().TextureName);
+    }
+
+    [Fact]
+    public void SerializeFromPayload_Frame_AlreadyAbsoluteTextureName_UnaffectedBySourceFolder()
+    {
+        var absolutePath = TestPaths.Abs("Project", "Animations", "Enemy", "sheet.png");
+        var frame = new AnimationFrameSave { TextureName = absolutePath };
+        var payload = new CopySelectionPayload { Kind = CopySelectionKind.Frame, Frames = new[] { frame } };
+
+        var text = ClipboardPayload.SerializeFromPayload(payload, TestPaths.AbsDir("Project", "Animations", "Player"));
+        ClipboardPayload.TryDeserialize(text, out _, out var frames, out _, out _);
+
+        Assert.Equal(absolutePath, frames!.Single().TextureName);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/CutPasteTests.cs
@@ -18,6 +18,7 @@ public class CutPasteTests
     public void PendingCutState_SetClearAndContains()
     {
         var cut = new PendingCutState();
+        var acls = new AnimationChainListSave();
         var chain = new AnimationChainSave { Name = "Walk" };
         var payload = new CopySelectionPayload
         {
@@ -25,14 +26,16 @@ public class CutPasteTests
             Chains = new[] { chain },
         };
 
-        cut.Set(payload);
+        cut.Set(payload, acls);
         Assert.True(cut.IsActive);
         Assert.Equal(CopySelectionKind.Chain, cut.Kind);
+        Assert.Same(acls, cut.SourceDocument);
         Assert.True(cut.Contains(chain));
         Assert.False(cut.Contains(new AnimationChainSave { Name = "Other" }));
 
         cut.Clear();
         Assert.False(cut.IsActive);
+        Assert.Null(cut.SourceDocument);
         Assert.False(cut.Contains(chain));
     }
 
@@ -40,10 +43,11 @@ public class CutPasteTests
     public void PendingCutState_NewCutReplacesPrevious()
     {
         var cut = new PendingCutState();
+        var acls = new AnimationChainListSave();
         var c1 = new AnimationChainSave { Name = "A" };
         var c2 = new AnimationChainSave { Name = "B" };
-        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c1 } });
-        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c2 } });
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c1 } }, acls);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { c2 } }, acls);
 
         Assert.False(cut.Contains(c1));
         Assert.True(cut.Contains(c2));
@@ -53,8 +57,9 @@ public class CutPasteTests
     public void PendingCutState_WireframeFrames_IncludesChainChildren()
     {
         var cut = new PendingCutState();
-        var chain = TestHelpers.MakeChain(new AnimationChainListSave(), "Walk", 2);
-        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } });
+        var acls = new AnimationChainListSave();
+        var chain = TestHelpers.MakeChain(acls, "Walk", 2);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, acls);
 
         Assert.Equal(2, cut.WireframeFrames.Count);
         Assert.Contains(chain.Frames[0], cut.WireframeFrames);
@@ -155,15 +160,92 @@ public class CutPasteTests
     }
 
     [Fact]
+    public void ResolveCompletion_SourceInDifferentOpenDocument_ReturnsCrossDocument()
+    {
+        // Cut happened while tab A was active; the user then switched to tab B and pastes there.
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var ctxB = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 1);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, ctxA.Acls);
+
+        Assert.Equal(CutCompletion.CrossDocument, cut.ResolveCompletion(ctxB.Acls));
+    }
+
+    [Fact]
+    public void ResolveCompletion_SourceInActiveDocument_ReturnsSameDocument()
+    {
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 1);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, ctxA.Acls);
+
+        Assert.Equal(CutCompletion.SameDocument, cut.ResolveCompletion(ctxA.Acls));
+    }
+
+    [Fact]
+    public void ResolveCompletion_SourceGoneFromBothDocuments_ReturnsStale()
+    {
+        // Simulates the source tab having been closed (and its document discarded) since the cut.
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var ctxB = TestHelpers.SetupFreshAcls();
+        var chain = new AnimationChainSave { Name = "Walk" }; // never added to any acls
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, ctxA.Acls);
+
+        Assert.Equal(CutCompletion.Stale, cut.ResolveCompletion(ctxB.Acls));
+    }
+
+    [Fact]
+    public void ResolveCompletion_NoCutPending_ReturnsNone()
+    {
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+
+        Assert.Equal(CutCompletion.None, cut.ResolveCompletion(ctxA.Acls));
+    }
+
+    [Fact]
+    public void RemoveSourcesFrom_Chain_RemovesFromGivenDocumentEvenWhenNotActive()
+    {
+        // Simulates a cut made in tab A while tab B is now the active document (#1026):
+        // the source chain lives in A's document, not the currently active one.
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 1);
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, ctxA.Acls);
+
+        bool removed = cut.RemoveSourcesFrom(cut.SourceDocument!);
+
+        Assert.True(removed);
+        Assert.DoesNotContain(chain, ctxA.Acls.AnimationChains);
+    }
+
+    [Fact]
+    public void RemoveSourcesFrom_Frame_RemovesFromChainInGivenDocument()
+    {
+        var cut = new PendingCutState();
+        var ctxA = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 2);
+        var frame = chain.Frames[0];
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Frame, Frames = new[] { frame } }, ctxA.Acls);
+
+        bool removed = cut.RemoveSourcesFrom(cut.SourceDocument!);
+
+        Assert.True(removed);
+        Assert.DoesNotContain(frame, chain.Frames);
+    }
+
+    [Fact]
     public void SourcesBelongToProject_FalseWhenSourceFromOtherAcls()
     {
         var cut = new PendingCutState();
         var ctxA = TestHelpers.SetupFreshAcls();
         var ctxB = TestHelpers.SetupFreshAcls();
         var chain = TestHelpers.MakeChain(ctxA.Acls, "Walk", 1);
-        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } });
+        cut.Set(new CopySelectionPayload { Kind = CopySelectionKind.Chain, Chains = new[] { chain } }, ctxA.Acls);
 
-        Assert.True(cut.SourcesBelongToProject(ctxA.Acls, ctxA.ObjectFinder));
-        Assert.False(cut.SourcesBelongToProject(ctxB.Acls, ctxB.ObjectFinder));
+        Assert.True(cut.SourcesBelongToProject(ctxA.Acls));
+        Assert.False(cut.SourcesBelongToProject(ctxB.Acls));
     }
 }


### PR DESCRIPTION
Closes #1026

## Summary
- Copying/cutting a chain or frame now resolves its texture reference to an absolute path at copy time, so pasting into a document in a different folder still finds the same physical file. The destination's own auto-save (every paste triggers one) re-relativizes it against the new folder immediately.
- Cross-tab cut/paste previously silently degraded to a copy: switching tabs eagerly cleared the pending-cut state (dead weight from before cross-tab paste was possible), so nothing was left to complete as a move by the time you pasted. Replaced the scattered same-document-only checks with `PendingCutState.ResolveCompletion` (`None`/`SameDocument`/`CrossDocument`/`Stale`), which tracks the cut's source document so a cross-tab paste removes the source directly from it — non-undoable, since the undo stack only ever tracks the active document.
- Also fixed a latent bug in `PendingCutState.SourcesBelongToProject`'s shape branch: it resolved shape-containment through `IObjectFinder`, which is bound to the *active* document only, so it could never correctly check membership in any other document.

## Test plan
- [x] Core.Tests (1949), Views.Tests (127), App.Tests (883) all green
- [x] New `ClipboardPayloadCrossFolderTests` covers the texture-path resolution at the clipboard-serialization layer
- [x] New `CutPasteTests` cases cover `ResolveCompletion`/`RemoveSourcesFrom` for chains and frames
- [x] New end-to-end `CrossTabCutPasteTests` opens two tabs backed by files in different folders, cuts a chain from tab A, pastes into tab B, and verifies both the texture reference and that the source was actually removed (not duplicated)
- Manual test: not needed — covered by the headless Avalonia integration test driving the real `MainWindow` cut/paste handlers end-to-end (no rendering involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCvTKwgbTqF6X4St6yh6T6