### PR TITLE
Fix Animation Editor dialogs having a fixed guessed height instead of auto-sizing

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Dialogs/EditorDialogs.cs
@@ -32,7 +32,7 @@ public static class EditorDialogs
         panel.Children.Add(new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap });
 
         var dialog = new EditorDialog<bool>(
-            new EditorDialogOptions(title, 420, 160), panel, cancelResult: false);
+            new EditorDialogOptions(title, 420, SizeToContentHeight: true), panel, cancelResult: false);
         dialog.Confirm = () => dialog.Complete(true);
         dialog.Cancel = () => dialog.Complete(false);
         panel.Children.Add(BuildButtonRow(
@@ -53,7 +53,7 @@ public static class EditorDialogs
         panel.Children.Add(new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap });
 
         var dialog = new EditorDialog<SaveDiscardCancelChoice>(
-            new EditorDialogOptions(title, 420, 160), panel, cancelResult: SaveDiscardCancelChoice.Cancel);
+            new EditorDialogOptions(title, 420, SizeToContentHeight: true), panel, cancelResult: SaveDiscardCancelChoice.Cancel);
         dialog.Confirm = () => dialog.Complete(SaveDiscardCancelChoice.Save);
         dialog.Cancel = () => dialog.Complete(SaveDiscardCancelChoice.Cancel);
         panel.Children.Add(BuildButtonRow(
@@ -72,7 +72,7 @@ public static class EditorDialogs
         panel.Children.Add(input);
 
         var dialog = new EditorDialog<string?>(
-            new EditorDialogOptions(title, 380, 155), panel, cancelResult: null);
+            new EditorDialogOptions(title, 380, SizeToContentHeight: true), panel, cancelResult: null);
         dialog.Confirm = () => dialog.Complete(input.Text);
         dialog.Cancel = () => dialog.Complete(null);
         panel.Children.Add(BuildButtonRow(
@@ -200,7 +200,7 @@ public static class EditorDialogs
         panel.Children.Add(incrementToggle);
 
         var dialog = new EditorDialog<AddFramesChoice?>(
-            new EditorDialogOptions("Add Multiple Frames", 320, 200), panel, cancelResult: null);
+            new EditorDialogOptions("Add Multiple Frames", 320, SizeToContentHeight: true), panel, cancelResult: null);
         dialog.Confirm = () => dialog.Complete(new AddFramesChoice(
             (int)(countInput.Value ?? 0), incrementToggle.IsChecked == true));
         dialog.Cancel = () => dialog.Complete(null);
@@ -259,7 +259,7 @@ public static class EditorDialogs
         panel.Children.Add(offsetModeRow);
 
         var dialog = new EditorDialog<OffsetChoice?>(
-            new EditorDialogOptions("Adjust Offsets", 340, 265), panel, cancelResult: null);
+            new EditorDialogOptions("Adjust Offsets", 340, SizeToContentHeight: true), panel, cancelResult: null);
         dialog.Confirm = () => dialog.Complete(new OffsetChoice(
             justifyBottom.IsChecked == true,
             (float)(xInput.Value ?? 0),

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/EditorDialogSizingTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Views.Tests/EditorDialogSizingTests.cs
@@ -1,0 +1,79 @@
+using AnimationEditor.Core.CommandsAndState;
+using AnimationEditor.Views.Dialogs;
+using Avalonia.Headless.XUnit;
+using FlatRedBall2.AnimationEditorCommon;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.Views.Tests;
+
+/// <summary>
+/// #1037: several <see cref="EditorDialogs"/> factories built their window with a guessed fixed
+/// <see cref="EditorDialogOptions.Height"/> instead of <see cref="EditorDialogOptions.SizeToContentHeight"/>,
+/// leaving a large empty gap whenever the real content was shorter than the guess (most visibly the
+/// Save/Don't Save/Cancel "Unsaved Changes" prompt). Every dialog should auto-size to its content instead.
+/// </summary>
+public class EditorDialogSizingTests
+{
+    private sealed class OptionsCapturingDialogHost : IEditorDialogHost
+    {
+        public EditorDialogOptions? CapturedOptions { get; private set; }
+
+        public async Task<T> ShowAsync<T>(EditorDialog<T> dialog)
+        {
+            CapturedOptions = dialog.Options;
+            dialog.Cancel();
+            return await dialog.Result;
+        }
+    }
+
+    private static void AssertAutoSized(EditorDialogOptions? options)
+    {
+        Assert.NotNull(options);
+        Assert.True(options!.SizeToContentHeight);
+        Assert.Null(options.Height);
+    }
+
+    [AvaloniaFact]
+    public async Task ConfirmAsync_AutoSizesToContent()
+    {
+        var host = new OptionsCapturingDialogHost();
+        await EditorDialogs.ConfirmAsync(host, "Continue?", "Confirm");
+        AssertAutoSized(host.CapturedOptions);
+    }
+
+    [AvaloniaFact]
+    public async Task ConfirmSaveDiscardCancelAsync_AutoSizesToContent()
+    {
+        var host = new OptionsCapturingDialogHost();
+        await EditorDialogs.ConfirmSaveDiscardCancelAsync(
+            host, "\"Untitled\" has unsaved changes. Save before closing?", "Unsaved Changes");
+        AssertAutoSized(host.CapturedOptions);
+    }
+
+    [AvaloniaFact]
+    public async Task PromptStringAsync_AutoSizesToContent()
+    {
+        var host = new OptionsCapturingDialogHost();
+        await EditorDialogs.PromptStringAsync(host, "Rename", "New name:", "Walk");
+        AssertAutoSized(host.CapturedOptions);
+    }
+
+    [AvaloniaFact]
+    public async Task ShowAddMultipleFramesAsync_AutoSizesToContent()
+    {
+        var host = new OptionsCapturingDialogHost();
+        await EditorDialogs.ShowAddMultipleFramesAsync(
+            host, appCommands: null!, chain: new AnimationChainSave());
+        AssertAutoSized(host.CapturedOptions);
+    }
+
+    [AvaloniaFact]
+    public async Task ShowAdjustOffsetsAsync_AutoSizesToContent()
+    {
+        var host = new OptionsCapturingDialogHost();
+        await EditorDialogs.ShowAdjustOffsetsAsync(
+            host, appCommands: null!, chain: new AnimationChainSave(), getTextureHeight: _ => null);
+        AssertAutoSized(host.CapturedOptions);
+    }
+}


### PR DESCRIPTION
## Summary
- Several `EditorDialogs.cs` factories (Confirm, Save/Don't Save/Cancel "Unsaved Changes", PromptString, Add Multiple Frames, Adjust Offsets) built their window with a hard-coded `Height` guess instead of `SizeToContentHeight: true`, leaving an empty gap below the buttons whenever real content was shorter than the guess.
- Switched all of them to auto-size, matching the pattern `ShowAdjustFrameTimeAsync` already used correctly, so this can't be reintroduced dialog-by-dialog.

## Test plan
- [x] New `EditorDialogSizingTests.cs`: fails against the old fixed-height code (verified red), asserts each factory's `EditorDialogOptions` has `SizeToContentHeight == true` and `Height == null`.
- [x] `dotnet test tests/AnimationEditor.Views.Tests/` — 132/132 passed.
- [x] `dotnet test tests/AnimationEditor.Core.Tests/` — 1957/1957 passed.
- [x] `dotnet test tests/AnimationEditor.App.Tests/` — 895/895 passed.

Manual test: not needed — auto-sizing is a boolean flag on `EditorDialogOptions`, fully covered by the new headless test.

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9yudPJbQnfD3eVPNAt7p8
