### PR TITLE
Fix Animation Editor: empty chains lose their default texture

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1331,6 +1331,13 @@ public partial class MainWindow : Window
         WireframeCtrl.FrameCreatedFromRegion += OnFrameCreatedFromRegion;
         // Same apply path the ANIMATIONS tree's PNG drop uses (issue #560).
         WireframeCtrl.HandlePngDrop          = HandlePngDropAsync;
+        // "Add Frame" (menu/button, no explicit texture) falls back to whatever the canvas is
+        // currently showing when the document has nothing else to offer (#1011).
+        _appCommands.CanvasDefaultTexturePath = () =>
+        {
+            var texPath = WireframeCtrl.LoadedTexturePathCasePreserved;
+            return string.IsNullOrEmpty(texPath) ? null : RelativizeTexturePath(texPath);
+        };
         // WireframeZoom follows the live zoom itself (ZoomControl.Attach subscribes ZoomChanged);
         // this handler only persists the settled state — once the smooth wheel-zoom (#425) stops
         // animating (IsZoomAnimating == false), not on every frame.
@@ -1746,11 +1753,7 @@ public partial class MainWindow : Window
         var (bitmapW, bitmapH) = WireframeCtrl.BitmapSize;
         if (bitmapW == 0 || bitmapH == 0) return;
 
-        string relPath = !string.IsNullOrEmpty(_projectManager.FileName)
-            ? Path.GetRelativePath(
-                Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty,
-                texPath).Replace('\\', '/')
-            : texPath;
+        string relPath = RelativizeTexturePath(texPath);
 
         var chainsToAddTo = selectedChains.Count > 1 ? selectedChains : new List<AnimationChainSave> { primaryChain };
 
@@ -1768,6 +1771,14 @@ public partial class MainWindow : Window
             _selectedState.SelectedFrame = priorFrame;
         }
     }
+
+    /// <summary>Converts an absolute texture path to .achx-relative form (unsaved project: verbatim).</summary>
+    private string RelativizeTexturePath(string absolutePath) =>
+        !string.IsNullOrEmpty(_projectManager.FileName)
+            ? Path.GetRelativePath(
+                Path.GetDirectoryName(_projectManager.FileName) ?? string.Empty,
+                absolutePath).Replace('\\', '/')
+            : absolutePath;
 
     // ── Core event handlers ───────────────────────────────────────────────────
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -1332,7 +1332,7 @@ public partial class MainWindow : Window
         // Same apply path the ANIMATIONS tree's PNG drop uses (issue #560).
         WireframeCtrl.HandlePngDrop          = HandlePngDropAsync;
         // "Add Frame" (menu/button, no explicit texture) falls back to whatever the canvas is
-        // currently showing when the document has nothing else to offer (#1011).
+        // currently showing when the document has nothing else to offer.
         _appCommands.CanvasDefaultTexturePath = () =>
         {
             var texPath = WireframeCtrl.LoadedTexturePathCasePreserved;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1,4 +1,5 @@
 ﻿using AnimationEditor.Core.CommandsAndState.Commands;
+using AnimationEditor.Core.Data;
 using AnimationEditor.Core.HotReload;
 using AnimationEditor.Core.IO;
 using AnimationEditor.Core.Models;
@@ -835,15 +836,7 @@ namespace AnimationEditor.Core.CommandsAndState
             if (chain.Frames.Count > 0)
                 return chain.Frames[^1];
 
-            if (chainList is not null)
-            {
-                foreach (var otherChain in chainList.AnimationChains)
-                    foreach (var frame in otherChain.Frames)
-                        if (!string.IsNullOrEmpty(frame.TextureName))
-                            return frame;
-            }
-
-            return null;
+            return TextureListBuilder.FindFirstTexturedFrame(chainList);
         }
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -804,8 +804,8 @@ namespace AnimationEditor.Core.CommandsAndState
                 : null;
 
             // Nothing in the document to inherit from (a brand-new document, or a chain-less
-            // selection) -- fall back to whatever the wireframe canvas is already showing (#1011)
-            // rather than leaving the new frame textureless.
+            // selection) -- fall back to whatever the wireframe canvas is already showing rather
+            // than leaving the new frame textureless.
             var resolvedTextureName = textureName ?? source?.TextureName;
             if (string.IsNullOrEmpty(resolvedTextureName))
                 resolvedTextureName = CanvasDefaultTexturePath?.Invoke();

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -788,6 +788,8 @@ namespace AnimationEditor.Core.CommandsAndState
             return true;
         }
 
+        public Func<string?>? CanvasDefaultTexturePath { get; set; }
+
         public void AddFrame(AnimationChainSave chain, string? textureName = null)
         {
             if (IsChainLocked(chain)) return;
@@ -800,9 +802,16 @@ namespace AnimationEditor.Core.CommandsAndState
                 ? ResolveInheritedFrame(chain, _pm.AnimationChainListSave)
                 : null;
 
+            // Nothing in the document to inherit from (a brand-new document, or a chain-less
+            // selection) -- fall back to whatever the wireframe canvas is already showing (#1011)
+            // rather than leaving the new frame textureless.
+            var resolvedTextureName = textureName ?? source?.TextureName;
+            if (string.IsNullOrEmpty(resolvedTextureName))
+                resolvedTextureName = CanvasDefaultTexturePath?.Invoke();
+
             var frame = new AnimationFrameSave
             {
-                TextureName  = textureName ?? source?.TextureName ?? string.Empty,
+                TextureName  = resolvedTextureName ?? string.Empty,
                 LeftCoordinate   = source?.LeftCoordinate   ?? 0f,
                 RightCoordinate  = source?.RightCoordinate  ?? 1f,
                 TopCoordinate    = source?.TopCoordinate    ?? 0f,

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -146,6 +146,17 @@ namespace AnimationEditor.Core.CommandsAndState
         /// </summary>
         void SetChainLocked(AnimationChainSave chain, bool locked);
         void AddFrame(AnimationChainSave chain, string? textureName = null);
+
+        /// <summary>
+        /// Last-resort texture for <see cref="AddFrame"/> when the target chain has no frames and
+        /// no other chain in the document has a texture to borrow (a brand-new document or a
+        /// chain-less selection). The host wires this to whatever the wireframe canvas is
+        /// currently showing -- see <c>WireframeControl.RefreshAll</c> -- so a frame added via the
+        /// "Add Frame" menu/button uses the same default the canvas already displays, instead of
+        /// coming up textureless. Left <c>null</c> in headless/Core-only contexts.
+        /// </summary>
+        Func<string?>? CanvasDefaultTexturePath { get; set; }
+
         void MoveChain(AnimationChainSave chain, int delta);
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
@@ -42,7 +42,7 @@ public static class TextureListBuilder
     /// truth behind both <see cref="GetFirstTextureName"/> (the wireframe/combo fallback) and
     /// <c>AppCommands.ResolveInheritedFrame</c>'s cross-chain borrow (which also needs the frame's
     /// region, not just its texture name) — kept as one scan so "first available texture in this
-    /// document" can't drift between the two call sites (#1011).
+    /// document" can't drift between the two call sites.
     /// </summary>
     /// <param name="acls">The animation chain list; may be <c>null</c>.</param>
     public static AnimationFrameSave? FindFirstTexturedFrame(AnimationChainListSave? acls) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Data/TextureListBuilder.cs
@@ -37,16 +37,26 @@ public static class TextureListBuilder
     }
 
     /// <summary>
-    /// Returns the <c>TextureName</c> of the first frame — in chain-then-frame list order —
-    /// that references a non-empty texture, or <c>null</c> when nothing in
-    /// <paramref name="acls"/> does. Used to borrow a texture for a chain that has no frames
-    /// of its own, so the wireframe shows something the user can Ctrl+click to seed the first
-    /// frame, and so the +Add button can inherit a texture (issues #618 / #617).
+    /// Returns the first frame — in chain-then-frame list order — that references a non-empty
+    /// texture, or <c>null</c> when nothing in <paramref name="acls"/> does. The single source of
+    /// truth behind both <see cref="GetFirstTextureName"/> (the wireframe/combo fallback) and
+    /// <c>AppCommands.ResolveInheritedFrame</c>'s cross-chain borrow (which also needs the frame's
+    /// region, not just its texture name) — kept as one scan so "first available texture in this
+    /// document" can't drift between the two call sites (#1011).
+    /// </summary>
+    /// <param name="acls">The animation chain list; may be <c>null</c>.</param>
+    public static AnimationFrameSave? FindFirstTexturedFrame(AnimationChainListSave? acls) =>
+        acls?.AnimationChains
+            .SelectMany(c => c.Frames)
+            .FirstOrDefault(f => !string.IsNullOrWhiteSpace(f.TextureName));
+
+    /// <summary>
+    /// Returns the <c>TextureName</c> of <see cref="FindFirstTexturedFrame"/>, or <c>null</c> when
+    /// nothing in <paramref name="acls"/> has one. Used to borrow a texture for a chain that has no
+    /// frames of its own, so the wireframe shows something the user can Ctrl+click to seed the
+    /// first frame, and so the +Add button can inherit a texture (issues #618 / #617).
     /// </summary>
     /// <param name="acls">The animation chain list; may be <c>null</c>.</param>
     public static string? GetFirstTextureName(AnimationChainListSave? acls) =>
-        acls?.AnimationChains
-            .SelectMany(c => c.Frames)
-            .Select(f => f.TextureName)
-            .FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+        FindFirstTexturedFrame(acls)?.TextureName;
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/WireframeControl.cs
@@ -775,6 +775,16 @@ public class WireframeControl : TextureViewport
     {
         var path = DetermineTexturePath();
 
+        // Nothing to show for the current selection: no frame selected, and nothing anywhere in
+        // this document to borrow (an empty chain, or a chain-less document). Keep whatever
+        // texture is already loaded instead of blanking it, so the #618 "seed the first frame"
+        // texture survives selecting a brand-new empty chain instead of vanishing the instant it's
+        // created. A frame that IS selected but has no texture is a different case -- that must
+        // still blank so the canvas doesn't imply a texture the frame doesn't have (#616) -- so
+        // this substitution only applies when no frame is selected at all.
+        if (path is null && _selectedState?.SelectedFrame is null)
+            path = LoadedTexturePathCasePreserved;
+
         SKBitmap? known = null;
         if (_thumbnailService != null)
         {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
@@ -1,0 +1,119 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.Core.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System;
+using System.IO;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// The "borrow a texture to seed the first frame" fallback (#618) only fired while an empty
+/// *chain* was selected in an otherwise-textured document. It did nothing for a chain-less
+/// document (nothing to select, so RefreshAll never ran) and, worse, actively blanked the
+/// canvas the moment that document's first empty chain was selected — RefreshAll found no
+/// texture anywhere in the new document and cleared whatever was already showing. This left
+/// users staring at a blank canvas right after creating their first chain, with no way to seed
+/// a frame by Ctrl+clicking. The fix: when there's nothing to borrow, RefreshAll leaves the
+/// currently-loaded texture in place instead of clearing it, so the same "default" texture
+/// carries through an empty document, an empty chain, and into that chain's first frame.
+/// </summary>
+public class WireframeDefaultTexturePersistsTests
+{
+    private static TestServices ResetSingletons()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.FileName               = null;
+        ctx.SelectedState.SelectedChain           = null;
+        ctx.SelectedState.SelectedFrame           = null;
+        ctx.SelectedState.SelectedNodes           = new System.Collections.Generic.List<object>();
+        return ctx;
+    }
+
+    private static string WriteSolidPng(string dir, string name, int size = 64)
+    {
+        var path = Path.Combine(dir, name);
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(SKColors.Red);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+        return path;
+    }
+
+    [AvaloniaFact]
+    public void SelectingEmptyChainInDocumentWithNoTextureAnywhere_KeepsPreviouslyLoadedTexture()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var png = WriteSolidPng(dir, "sheet.png");
+            var ctx = ResetSingletons();
+            var ctrl = ctx.CreateWireframeControl();
+
+            // A texture is already showing, e.g. carried over from the previously active tab.
+            ctrl.LoadTexture(png);
+            Assert.Equal((64, 64), ctrl.BitmapSize);
+
+            // Switch to a brand-new, entirely empty document (0 chains -- nothing anywhere in it
+            // to borrow a texture from) with nothing selected. Mirrors opening a new .achx.
+            ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+            ctx.SelectedState.SelectedChain = null;
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal((64, 64), ctrl.BitmapSize);
+
+            // Add the document's first chain (still zero frames) and select it -- this is what
+            // actually fires SelectionChanged/RefreshAll for the first time in the new document.
+            var emptyChain = new AnimationChainSave { Name = "NewAnimation" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(emptyChain);
+            ctx.SelectedState.SelectedChain = emptyChain;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal((64, 64), ctrl.BitmapSize);
+            Assert.EndsWith("sheet.png", ctrl.LoadedTexturePathCasePreserved);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [AvaloniaFact]
+    public void CtrlClick_OnDefaultTextureCarriedIntoEmptyChain_SeedsFirstFrameWithIt()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var png = WriteSolidPng(dir, "Items.png");
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")
+                ?? throw new InvalidOperationException("WireframeCtrl not found");
+            wireframe.LoadTexture(png);
+            wireframe.SetCamera(0f, 0f, 1f);
+
+            var chain = new AnimationChainSave { Name = "NewAnimation" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal((64, 64), wireframe.BitmapSize);   // default survived selecting the empty chain
+
+            wireframe.SimulatePlainCtrlClick(32, 32);
+
+            Assert.Single(chain.Frames);
+            Assert.EndsWith("Items.png", chain.Frames[0].TextureName);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
@@ -120,9 +120,9 @@ public class WireframeDefaultTexturePersistsTests
     /// <summary>
     /// The tree's "Add Frame" menu/button (<c>AppCommands.AddFrame</c>, no explicit texture) is a
     /// second, independent entry point from Ctrl+click -- it resolves its own texture from the
-    /// document instead of reading the wireframe canvas directly. #1011's manual repro used this
-    /// path (right-click the chain -> Add Frame) and still got a textureless frame after the
-    /// RefreshAll fix, because AddFrame never consulted the canvas at all.
+    /// document instead of reading the wireframe canvas directly. The manual repro that surfaced
+    /// this used this exact path (right-click the chain -> Add Frame) and still got a textureless
+    /// frame after the RefreshAll fix, because AddFrame never consulted the canvas at all.
     /// </summary>
     [AvaloniaFact]
     public void AddFrameButton_OnEmptyChainWithDefaultTextureShowing_UsesTheDefaultTexture()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WireframeDefaultTexturePersistsTests.cs
@@ -116,4 +116,47 @@ public class WireframeDefaultTexturePersistsTests
             Directory.Delete(dir, true);
         }
     }
+
+    /// <summary>
+    /// The tree's "Add Frame" menu/button (<c>AppCommands.AddFrame</c>, no explicit texture) is a
+    /// second, independent entry point from Ctrl+click -- it resolves its own texture from the
+    /// document instead of reading the wireframe canvas directly. #1011's manual repro used this
+    /// path (right-click the chain -> Add Frame) and still got a textureless frame after the
+    /// RefreshAll fix, because AddFrame never consulted the canvas at all.
+    /// </summary>
+    [AvaloniaFact]
+    public void AddFrameButton_OnEmptyChainWithDefaultTextureShowing_UsesTheDefaultTexture()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var ctx = ResetSingletons();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        try
+        {
+            var png = WriteSolidPng(dir, "Items.png");
+            ctx.ProjectManager.FileName = Path.Combine(dir, "test.achx");
+
+            var wireframe = window.FindControl<WireframeControl>("WireframeCtrl")
+                ?? throw new InvalidOperationException("WireframeCtrl not found");
+            wireframe.LoadTexture(png);
+
+            var chain = new AnimationChainSave { Name = "NewAnimation" };
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            ctx.SelectedState.SelectedChain = chain;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal((64, 64), wireframe.BitmapSize);   // default survived selecting the empty chain
+
+            ctx.AppCommands.AddFrame(chain);   // the "Add Frame" tree menu item's exact call
+
+            Assert.Single(chain.Frames);
+            Assert.EndsWith("Items.png", chain.Frames[0].TextureName);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
@@ -74,10 +74,10 @@ public class AppCommandsFrameTests
         Assert.Equal(string.Empty, chain.Frames[0].TextureName);
     }
 
-    // #1011: a brand-new document has nothing in its ACLS to inherit from, but the wireframe
-    // canvas may already be showing a "default" texture (borrowed from a previous document, or
-    // kept alive when an empty chain is selected -- see WireframeControl.RefreshAll). AddFrame
-    // must fall through to that canvas default rather than leaving the new frame textureless.
+    // A brand-new document has nothing in its ACLS to inherit from, but the wireframe canvas may
+    // already be showing a "default" texture (borrowed from a previous document, or kept alive
+    // when an empty chain is selected -- see WireframeControl.RefreshAll). AddFrame must fall
+    // through to that canvas default rather than leaving the new frame textureless.
     [Fact]
     public void AddFrame_NothingToInherit_FallsBackToCanvasDefaultTexturePath()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsFrameTests.cs
@@ -74,6 +74,51 @@ public class AppCommandsFrameTests
         Assert.Equal(string.Empty, chain.Frames[0].TextureName);
     }
 
+    // #1011: a brand-new document has nothing in its ACLS to inherit from, but the wireframe
+    // canvas may already be showing a "default" texture (borrowed from a previous document, or
+    // kept alive when an empty chain is selected -- see WireframeControl.RefreshAll). AddFrame
+    // must fall through to that canvas default rather than leaving the new frame textureless.
+    [Fact]
+    public void AddFrame_NothingToInherit_FallsBackToCanvasDefaultTexturePath()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "NewAnimation"); // empty document, empty chain
+        ctx.AppCommands.CanvasDefaultTexturePath = () => "sheet.png";
+
+        ctx.AppCommands.AddFrame(chain);
+
+        Assert.Equal("sheet.png", chain.Frames[0].TextureName);
+    }
+
+    [Fact]
+    public void AddFrame_ChainHasFrames_IgnoresCanvasDefaultTexturePath()
+    {
+        // The chain's own last frame always wins over the canvas fallback.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run");
+        ctx.AppCommands.AddFrame(chain, "first.png");
+        ctx.AppCommands.CanvasDefaultTexturePath = () => "sheet.png";
+
+        ctx.AppCommands.AddFrame(chain);
+
+        Assert.Equal("first.png", chain.Frames[^1].TextureName);
+    }
+
+    [Fact]
+    public void AddFrame_OtherChainHasTexture_IgnoresCanvasDefaultTexturePath()
+    {
+        // Borrowing from another chain in the same document always wins over the canvas fallback.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var withTexture = TestHelpers.MakeChain(ctx.Acls, "Walk");
+        ctx.AppCommands.AddFrame(withTexture, "hero.png");
+        var empty = TestHelpers.MakeChain(ctx.Acls, "Idle");
+        ctx.AppCommands.CanvasDefaultTexturePath = () => "sheet.png";
+
+        ctx.AppCommands.AddFrame(empty);
+
+        Assert.Equal("hero.png", empty.Frames[0].TextureName);
+    }
+
     [Fact]
     public void AddFrame_LeavesShapesSaveNull()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
@@ -159,4 +159,68 @@ public class TextureListBuilderTests
 
         Assert.Equal("hero.png", TextureListBuilder.GetFirstTextureName(acls));
     }
+
+    // ── FindFirstTexturedFrame (shared primitive behind GetFirstTextureName and
+    //    AppCommands.ResolveInheritedFrame's cross-chain borrow — #1011) ──────
+
+    [Fact]
+    public void FindFirstTexturedFrame_NullAcls_ReturnsNull()
+    {
+        Assert.Null(TextureListBuilder.FindFirstTexturedFrame(null));
+    }
+
+    [Fact]
+    public void FindFirstTexturedFrame_NoTexturedFrames_ReturnsNull()
+    {
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+        acls.AnimationChains.Add(AclsWithTextures("", " ").AnimationChains[0]);
+
+        Assert.Null(TextureListBuilder.FindFirstTexturedFrame(acls));
+    }
+
+    [Fact]
+    public void FindFirstTexturedFrame_ReturnsTheFrameItself_NotJustItsTextureName()
+    {
+        // Callers that need the region too (AppCommands.ResolveInheritedFrame) rely on
+        // getting the actual frame back, not a re-derived name.
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        var frame = new AnimationFrameSave
+        {
+            TextureName = "hero.png",
+            LeftCoordinate = 0.25f, RightCoordinate = 0.5f,
+        };
+        chain.Frames.Add(frame);
+        acls.AnimationChains.Add(chain);
+
+        Assert.Same(frame, TextureListBuilder.FindFirstTexturedFrame(acls));
+    }
+
+    [Fact]
+    public void FindFirstTexturedFrame_ScansChainsInListOrder()
+    {
+        var acls = new AnimationChainListSave();
+        acls.AnimationChains.Add(new AnimationChainSave { Name = "Empty" });
+        var textured = new AnimationChainSave { Name = "Walk" };
+        var first = new AnimationFrameSave { TextureName = "hero.png" };
+        textured.Frames.Add(first);
+        textured.Frames.Add(new AnimationFrameSave { TextureName = "later.png" });
+        acls.AnimationChains.Add(textured);
+
+        Assert.Same(first, TextureListBuilder.FindFirstTexturedFrame(acls));
+    }
+
+    [Fact]
+    public void GetFirstTextureName_IsConsistentWithFindFirstTexturedFrame()
+    {
+        var acls = new AnimationChainListSave();
+        var chain = new AnimationChainSave { Name = "Walk" };
+        chain.Frames.Add(new AnimationFrameSave { TextureName = "hero.png" });
+        acls.AnimationChains.Add(chain);
+
+        Assert.Equal(
+            TextureListBuilder.FindFirstTexturedFrame(acls)?.TextureName,
+            TextureListBuilder.GetFirstTextureName(acls));
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TextureListBuilderTests.cs
@@ -161,7 +161,7 @@ public class TextureListBuilderTests
     }
 
     // ── FindFirstTexturedFrame (shared primitive behind GetFirstTextureName and
-    //    AppCommands.ResolveInheritedFrame's cross-chain borrow — #1011) ──────
+    //    AppCommands.ResolveInheritedFrame's cross-chain borrow) ──────────────
 
     [Fact]
     public void FindFirstTexturedFrame_NullAcls_ReturnsNull()


### PR DESCRIPTION
## Summary
- `RefreshAll` blanked the wireframe canvas the moment an empty chain/document was selected, even when a texture was already showing — wiping the #618 "seed the first frame" default. Now it keeps the currently-loaded texture when there's nothing to borrow.
- The tree's "Add Frame" button/menu (`AppCommands.AddFrame`) is a second, independent entry point that never consulted the canvas at all — added `IAppCommands.CanvasDefaultTexturePath`, a host-supplied fallback it uses only when the document has nothing to inherit. Left unwired in the Browser host (its wireframe path is a synthetic identity — see code comment on `FrameCreatedFromRegion` there).
- Merged two independent "first texture in this document" scans (`TextureListBuilder.GetFirstTextureName` and `AppCommands.ResolveInheritedFrame`'s cross-chain borrow) into one shared primitive, `TextureListBuilder.FindFirstTexturedFrame`.

## Test plan
- [x] New TDD tests reproduce both bugs (fail before fix, pass after) — `WireframeDefaultTexturePersistsTests.cs`, `AppCommandsFrameTests.cs`
- [x] `TextureListBuilderTests.cs` covers the shared scan directly
- [x] Full `AnimationEditor.Core.Tests` suite green (1972/1972)
- [x] Full `AnimationEditor.App.Tests` suite green (942/942)
- [x] Whole solution (incl. Browser/WASM) builds clean
- [x] Manually verified against the reported repro (open a boss's .achx, add a new animation, add a frame — texture now carries through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S18MpVuKieVtdoe7B6TCRL