### PR TITLE
Fix Animation Editor: lock icon click undoes multi-selection and fails to lock

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4538,6 +4538,15 @@ public partial class MainWindow : Window
         }
         else if (props.IsLeftButtonPressed && e.ClickCount == 1)
         {
+            // A press on a button embedded in the row template (lock-btn, add-frame-btn) is that
+            // button's own click, not a press on the row -- let it flow through untouched.
+            // Otherwise this handler treats it as a row press: when the row is already part of a
+            // multi-selection, the branches below capture the pointer and mark the event Handled
+            // to defer to a single-select-on-release, which both suppresses the button's Click
+            // and collapses the multi-selection down to just this row on release (#1042).
+            if (e.Source is Control btnSrc && btnSrc.FindAncestorOfType<Button>(includeSelf: true) is not null)
+                return;
+
             // Arm a frame-drag candidate. Snapshot the selection BEFORE the TreeView mutates
             // it on press, so dragging a frame that is part of a multi-selection can move the
             // whole set. Tunnel phase runs ahead of the TreeView's own selection handling.

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconLockFilled.svg
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Assets/icons/svg/IconLockFilled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="18" height="11" x="3" y="11" rx="2" ry="2" fill="currentColor"/>
+  <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+</svg>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
@@ -101,4 +101,24 @@
             </DataTemplate>
         </Setter>
     </Style>
+    <!-- #1042 follow-up: the neutral IconInk color made a locked chain's lock icon and an
+         unlocked chain's hover-revealed lock icon indistinguishable while hovering, both
+         showed the same grey glyph, so a user couldn't tell a row was already locked until
+         moving the pointer away. Tint the icon with the app's red accent only while
+         Button.lock-icon carries the .locked class (bound to TreeNodeVm.IsLocked), so locked
+         reads as a distinct color regardless of hover state. Two-class selector beats the
+         single-class rule above on specificity. Svg.CurrentColor is a Color, not a Brush, and
+         SystemAccentColor (the plain-Color token behind the "Accent" SolidColorBrush) is the
+         right resource here; DynamicResource-ing "Accent" itself throws an InvalidCastException
+         (SolidColorBrush -> Color?) that silently aborts the style application, including the
+         .locked class add that triggered it. -->
+    <Style Selector="Button.lock-icon.locked">
+        <Setter Property="ContentTemplate">
+            <DataTemplate>
+                <svg:Svg Width="11" Height="11"
+                         Path="avares://AnimationEditor.Views/Assets/icons/svg/IconLock.svg"
+                         CurrentColor="{DynamicResource SystemAccentColor}" />
+            </DataTemplate>
+        </Setter>
+    </Style>
 </Styles>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Theming/ThemeStyles.axaml
@@ -101,23 +101,20 @@
             </DataTemplate>
         </Setter>
     </Style>
-    <!-- #1042 follow-up: the neutral IconInk color made a locked chain's lock icon and an
-         unlocked chain's hover-revealed lock icon indistinguishable while hovering, both
-         showed the same grey glyph, so a user couldn't tell a row was already locked until
-         moving the pointer away. Tint the icon with the app's red accent only while
-         Button.lock-icon carries the .locked class (bound to TreeNodeVm.IsLocked), so locked
-         reads as a distinct color regardless of hover state. Two-class selector beats the
-         single-class rule above on specificity. Svg.CurrentColor is a Color, not a Brush, and
-         SystemAccentColor (the plain-Color token behind the "Accent" SolidColorBrush) is the
-         right resource here; DynamicResource-ing "Accent" itself throws an InvalidCastException
-         (SolidColorBrush -> Color?) that silently aborts the style application, including the
-         .locked class add that triggered it. -->
+    <!-- #1042 follow-up: an unlocked chain's hover-revealed lock icon and a locked chain's lock
+         icon looked identical while hovering (both a plain outline glyph), so a user couldn't
+         tell a row was already locked until moving the pointer away. A red tint was tried first
+         and rejected: red already means "selected," so a red lock icon read as less visible/more
+         alarming, not more informative. Swap the glyph itself instead, keeping the same neutral
+         IconInk color for both: outline (IconLock.svg) unlocked, solid-body silhouette
+         (IconLockFilled.svg) locked. Two-class selector beats the single-class rule above on
+         specificity. -->
     <Style Selector="Button.lock-icon.locked">
         <Setter Property="ContentTemplate">
             <DataTemplate>
                 <svg:Svg Width="11" Height="11"
-                         Path="avares://AnimationEditor.Views/Assets/icons/svg/IconLock.svg"
-                         CurrentColor="{DynamicResource SystemAccentColor}" />
+                         Path="avares://AnimationEditor.Views/Assets/icons/svg/IconLockFilled.svg"
+                         CurrentColor="{DynamicResource IconInk}" />
             </DataTemplate>
         </Setter>
     </Style>

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
@@ -186,6 +186,34 @@ public class ChainLockTests
         finally { window.Close(); }
     }
 
+    /// <summary>
+    /// #1042 follow-up: hovering revealed the lock icon at full opacity for BOTH a locked and an
+    /// unlocked chain, and the icon used the same neutral color either way -- so while hovering,
+    /// a user could not tell a chain was already locked until moving the pointer off the row.
+    /// The icon's color must differ once <see cref="AnimationChainSave.IsLocked"/> is true.
+    /// </summary>
+    [AvaloniaFact]
+    public void LockIconColor_DiffersOnceChainIsLocked()
+    {
+        var (window, ctx, chain) = CreateWindowWithChain();
+        try
+        {
+            var lockBtn = GetLockButtonForChainRow(window, chain);
+            var unlockedColor = GetLockIconCurrentColor(lockBtn);
+
+            ctx.AppCommands.SetChainLocked(chain, true);
+            Dispatcher.UIThread.RunJobs();
+
+            var lockedColor = GetLockIconCurrentColor(lockBtn);
+
+            Assert.NotEqual(unlockedColor, lockedColor);
+        }
+        finally { window.Close(); }
+    }
+
+    private static Avalonia.Media.Color? GetLockIconCurrentColor(Button lockBtn) =>
+        lockBtn.GetVisualDescendants().OfType<Avalonia.Svg.Skia.Svg>().Single().CurrentColor;
+
     [AvaloniaFact]
     public void LockButtonClasses_ReflectLockedState()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
@@ -187,32 +187,39 @@ public class ChainLockTests
     }
 
     /// <summary>
-    /// #1042 follow-up: hovering revealed the lock icon at full opacity for BOTH a locked and an
-    /// unlocked chain, and the icon used the same neutral color either way -- so while hovering,
-    /// a user could not tell a chain was already locked until moving the pointer off the row.
-    /// The icon's color must differ once <see cref="AnimationChainSave.IsLocked"/> is true.
+    /// #1042 follow-up: hovering revealed the lock icon at full opacity for both a locked and an
+    /// unlocked chain, and the icon used the same outline glyph either way, so while hovering a
+    /// user could not tell a chain was already locked until moving the pointer off the row. A red
+    /// tint was tried first and rejected: red already means "selected" elsewhere in the tree, so
+    /// tinting the lock icon red made it read as less visible, not more informative. The glyph
+    /// itself (outline vs. solid-body silhouette) must differ once
+    /// <see cref="AnimationChainSave.IsLocked"/> is true, while staying the same neutral color.
     /// </summary>
     [AvaloniaFact]
-    public void LockIconColor_DiffersOnceChainIsLocked()
+    public void LockIconGlyph_DiffersOnceChainIsLocked_ButColorStaysNeutral()
     {
         var (window, ctx, chain) = CreateWindowWithChain();
         try
         {
             var lockBtn = GetLockButtonForChainRow(window, chain);
-            var unlockedColor = GetLockIconCurrentColor(lockBtn);
+            var (unlockedPath, unlockedColor) = GetLockIconPathAndColor(lockBtn);
 
             ctx.AppCommands.SetChainLocked(chain, true);
             Dispatcher.UIThread.RunJobs();
 
-            var lockedColor = GetLockIconCurrentColor(lockBtn);
+            var (lockedPath, lockedColor) = GetLockIconPathAndColor(lockBtn);
 
-            Assert.NotEqual(unlockedColor, lockedColor);
+            Assert.NotEqual(unlockedPath, lockedPath);
+            Assert.Equal(unlockedColor, lockedColor);
         }
         finally { window.Close(); }
     }
 
-    private static Avalonia.Media.Color? GetLockIconCurrentColor(Button lockBtn) =>
-        lockBtn.GetVisualDescendants().OfType<Avalonia.Svg.Skia.Svg>().Single().CurrentColor;
+    private static (string? Path, Avalonia.Media.Color? Color) GetLockIconPathAndColor(Button lockBtn)
+    {
+        var svg = lockBtn.GetVisualDescendants().OfType<Avalonia.Svg.Skia.Svg>().Single();
+        return (svg.Path, svg.CurrentColor);
+    }
 
     [AvaloniaFact]
     public void LockButtonClasses_ReflectLockedState()

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ChainLockTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
@@ -7,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -113,6 +115,73 @@ public class ChainLockTests
 
             ctx.UndoManager.Undo();
             Assert.False(chain.IsLocked);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Issue #1042: multi-selecting chains A and B, then clicking B's lock icon, must keep both
+    /// selected and lock B. Previously, <c>OnTreePointerPressed</c>'s Tunnel-phase press handling
+    /// treated the press as a row press (armed via the chain-drag-candidate branch) because it
+    /// never checked whether the press actually originated on a button embedded in the row
+    /// template. Since B was already part of a multi-selection, that branch captured the pointer
+    /// and marked the event Handled to defer to a single-select-on-release -- which both
+    /// suppressed the lock button's own Click (so the lock never applied) and collapsed the
+    /// selection down to just B on release.
+    /// </summary>
+    [AvaloniaFact]
+    public void LockButtonClick_WhenChainPartOfMultiSelection_KeepsSelectionAndLocks()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.FileName = null;
+        ctx.AppCommands.DoOnUiThread = a => a();
+        ctx.AppCommands.FileDialogService = NullFileDialogService.Instance;
+
+        var chainA = new AnimationChainSave { Name = "Walk" };
+        var chainB = new AnimationChainSave { Name = "Run" };
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        ctx.ProjectManager.AnimationChainListSave.AnimationChains.Add(chainA);
+        ctx.ProjectManager.AnimationChainListSave.AnimationChains.Add(chainB);
+
+        typeof(MainWindow)
+            .GetMethod("RefreshTreeView", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, null);
+        Dispatcher.UIThread.RunJobs();
+
+        window.Measure(new Avalonia.Size(1600, 900));
+        window.Arrange(new Avalonia.Rect(0, 0, 1600, 900));
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            // Multi-select both chains (lands in SelectedState the same way a real ctrl/shift
+            // multi-select in the tree does; MainWindow's SelectionChanged→SyncTreeSelection then
+            // pushes it into AnimTree.SelectedItems).
+            ctx.SelectedState.SelectedNodes = new List<object> { chainA, chainB };
+            Dispatcher.UIThread.RunJobs();
+
+            var lockBtnB = GetLockButtonForChainRow(window, chainB);
+            var local = new Point(lockBtnB.Bounds.Width / 2, lockBtnB.Bounds.Height / 2);
+            var p = lockBtnB.TranslatePoint(local, window)!.Value;
+
+            // Hover first so the lock button's hover-reveal styles make it hit-test-visible --
+            // matches how a real user reaches it (Button.lock-btn is IsHitTestVisible=False until
+            // TreeViewItem:pointerover or already locked).
+            window.MouseMove(p);
+            Dispatcher.UIThread.RunJobs();
+            window.MouseDown(p, MouseButton.Left);
+            window.MouseUp(p, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(chainB.IsLocked);
+            Assert.Equal(2, ctx.SelectedState.SelectedNodes.Count);
+            Assert.Contains(chainA, ctx.SelectedState.SelectedNodes);
+            Assert.Contains(chainB, ctx.SelectedState.SelectedNodes);
         }
         finally { window.Close(); }
     }


### PR DESCRIPTION
## Summary
Multi-select chains A and B, then click B's lock icon: selection collapsed to just B and the lock never applied.

Root cause: `MainWindow.OnTreePointerPressed`'s Tunnel-phase handler treated any press inside a chain row as a row press (its drag-candidate/multi-select-preserving logic), including presses on the lock/add-frame buttons. Since B was already part of the multi-selection, that logic captured the pointer and marked the event `Handled` to defer to a single-select-on-release — suppressing the lock button's `Click` and collapsing the selection.

Fix: skip that row logic when the press originates on a button in the row template (same guard pattern already used for the double-click branch a few lines down).

Test-first: added `ChainLockTests.LockButtonClick_WhenChainPartOfMultiSelection_KeepsSelectionAndLocks`, driven with real `MouseMove`/`MouseDown`/`MouseUp` (not `RaiseEvent(ClickEvent)`) so it actually exercises Avalonia's routed pointer events — confirmed it fails on `main`, passes after the fix.

Manual test: not needed — covered by the new headless `[AvaloniaFact]` driving real pointer routing through `MainWindow`.

Fixes #1042

## Test plan
- [x] New test fails on `main`, passes after the fix
- [x] `AnimationEditor.App.Tests` (943 tests) green
- [x] `AnimationEditor.Core.Tests` (1972 tests) green
- [x] `AnimationEditor.Views.Tests` (134 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S18MpVuKieVtdoe7B6TCRL