### PR TITLE
Fix Animation Editor: window maximize state not persisted

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -247,6 +247,7 @@ public partial class MainWindow : Window
         ApplyPersistedTheme();
         ApplyPersistedCanvasColors();
         ApplyPersistedPreviewPaneHeight();
+        ApplyPersistedWindowState();
         WireMenuEvents();
         WireWireframeToolbar();
         WireWireframeControl();
@@ -323,6 +324,7 @@ public partial class MainWindow : Window
         {
             // Piggyback on SaveTabsToSettings' write rather than a separate SaveSettingsFile call.
             _appSettings.PreviewPaneHeight = AchxEditorPane.RowDefinitions[3].Height.Value;
+            _appSettings.WindowMaximized = WindowState == WindowState.Maximized;
             SaveTabsToSettings();
             _appCommands.HotReloadWatcher.Dispose();
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
@@ -5710,6 +5712,13 @@ public partial class MainWindow : Window
         var resolved = PreviewPaneHeightValidator.Resolve(
             _appSettings.PreviewPaneHeight, MinPreviewPaneHeight, MaxPreviewPaneHeight, DefaultPreviewPaneHeight);
         AchxEditorPane.RowDefinitions[3].Height = new GridLength(resolved, GridUnitType.Pixel);
+    }
+
+    /// <summary>Restores the maximized/restored window state from the last session (#1045).</summary>
+    private void ApplyPersistedWindowState()
+    {
+        if (_appSettings.WindowMaximized)
+            WindowState = WindowState.Maximized;
     }
 
     private static uint ToArgb(SKColor color) =>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/Models/AppSettingsModel.cs
@@ -71,6 +71,12 @@ namespace AnimationEditor.Core.Models
         /// </summary>
         public double? PreviewPaneHeight { get; set; }
 
+        /// <summary>
+        /// Whether the window was maximized when the editor last closed (#1045). Applied on the
+        /// next launch so the window reopens in the same maximized/restored state it was left in.
+        /// </summary>
+        public bool WindowMaximized { get; set; }
+
         public void AddFile(FilePath filePath)
         {
             RecentFiles.RemoveAll(item => new FilePath(item) == filePath);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WindowMaximizedPersistenceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/WindowMaximizedPersistenceTests.cs
@@ -1,0 +1,71 @@
+using AnimationEditor.Core.IO;
+using AnimationEditor.Core.Models;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #1045: the window's maximized state must survive a restart. Previously nothing
+/// persisted <see cref="WindowState"/> at all, so un-maximizing before close (or closing
+/// while maximized) both reopened the window in its default restored size.
+/// </summary>
+public class WindowMaximizedPersistenceTests
+{
+    [AvaloniaFact]
+    public void Startup_PersistedWindowMaximized_AppliesMaximizedState()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        Directory.CreateDirectory(settingsFile.GetDirectoryContainingThis().FullPath);
+        File.WriteAllText(settingsFile.FullPath,
+            JsonSerializer.Serialize(new AppSettingsModel { WindowMaximized = true }));
+
+        var window = ctx.CreateMainWindow();
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(WindowState.Maximized, window.WindowState);
+        }
+        finally { window.Close(); }
+    }
+
+    [AvaloniaFact]
+    public void Closing_WhileMaximized_PersistsWindowMaximizedTrue()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.WindowState = WindowState.Maximized;
+        window.Close();
+
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        var settings = JsonSerializer.Deserialize<AppSettingsModel>(File.ReadAllText(settingsFile.FullPath))!;
+        Assert.True(settings.WindowMaximized);
+    }
+
+    [AvaloniaFact]
+    public void Closing_AfterUnMaximizing_PersistsWindowMaximizedFalse()
+    {
+        var ctx = TestHelpers.BuildServices();
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.WindowState = WindowState.Maximized;
+        window.WindowState = WindowState.Normal;
+        window.Close();
+
+        var settingsFile = AppSettingsLocation.ForApplicationDataRoot(ctx.SettingsRoot);
+        var settings = JsonSerializer.Deserialize<AppSettingsModel>(File.ReadAllText(settingsFile.FullPath))!;
+        Assert.False(settings.WindowMaximized);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppSettingsModelTests.cs
@@ -205,4 +205,23 @@ public class AppSettingsModelTests
 
         Assert.True(restored!.SuppressDefaultHandlerPrompt);
     }
+
+    [Fact]
+    public void WindowMaximized_DefaultsToFalse()
+    {
+        var model = new AppSettingsModel();
+
+        Assert.False(model.WindowMaximized);
+    }
+
+    [Fact]
+    public void WindowMaximized_SurvivesJsonRoundTrip()
+    {
+        var model = new AppSettingsModel { WindowMaximized = true };
+
+        var json = JsonSerializer.Serialize(model);
+        var restored = JsonSerializer.Deserialize<AppSettingsModel>(json);
+
+        Assert.True(restored!.WindowMaximized);
+    }
 }


### PR DESCRIPTION
Closes #1045.

Nothing persisted `WindowState` at all — the window always reopened restored regardless of how it was left before close. Added `AppSettingsModel.WindowMaximized`, saved on `Closed` alongside the existing tab/preview-pane settings, and applied before the window is shown.

Manual test: not needed — headless `[AvaloniaFact]` tests construct/close/reopen `MainWindow` for real (`WindowMaximizedPersistenceTests.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
