### PR TITLE
Fix Animation Editor updater missing same-day second release

### DIFF
--- a/.github/workflows/animation-editor.yml
+++ b/.github/workflows/animation-editor.yml
@@ -28,8 +28,11 @@ jobs:
         shell: pwsh
         run: |
           # Velopack package versions use SemVer, whose numeric components cannot have leading
-          # zeroes. The assembly version receives this same three-part date value.
-          $version = (Get-Date).ToString('yyyy.M.d')
+          # zeroes. The assembly version receives this same value. The 4th component is the
+          # workflow run number, not the date, so two releases cut on the same day still get
+          # strictly increasing versions - otherwise the second same-day release is invisible to
+          # the Velopack updater on clients already on the first one.
+          $version = (Get-Date).ToString('yyyy.M.d') + ".$($env:GITHUB_RUN_NUMBER)"
           $kind = "${{ github.event.inputs.release_kind }}"
           switch ($kind) {
             'release'    { $prefix='Release';    $prerelease='false'; $draft='false' }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/AnimationEditor.App.csproj
@@ -18,9 +18,10 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- MainWindow is DI-only; runtime XAML instantiation is intentionally not supported -->
     <NoWarn>$(NoWarn);AVLN3001</NoWarn>
-    <!-- Release CI stamps -p:Version=yyyy.M.d (animation-editor.yml), which wins here as an
-         MSBuild global property. Local builds keep a zero-padded display date so the About
-         dialog's "Version" line and the Velopack release manifest always see a real value. -->
+    <!-- Release CI stamps -p:Version=yyyy.M.d.<run_number> (animation-editor.yml), which wins here
+         as an MSBuild global property - the run number makes same-day releases still compare
+         greater for the Velopack updater. Local builds keep a zero-padded display date so the
+         About dialog's "Version" line and the Velopack release manifest always see a real value. -->
     <Version Condition="'$(Version)' == ''">$([System.DateTime]::Now.ToString('yyyy.MM.dd'))</Version>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem
Animation Editor's release version was date-only (`yyyy.M.d`). Two releases cut on the same day got identical versions, so Velopack's updater saw no update for the second one.

## Fix
`meta` job in `.github/workflows/animation-editor.yml` appends `$env:GITHUB_RUN_NUMBER` as a 4th version component (`yyyy.M.d.<run_number>`), guaranteeing same-day releases still compare strictly greater. Updated a stale csproj comment that referenced the old 3-part format.

Manual test: not needed — CI workflow script; verified the version string builds correctly locally via PowerShell. No testable core exists outside the GitHub Actions runner.

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ngm2CJvctTWCdNU1H9s3eT
