### PR TITLE
Recover from a frozen Animation Editor instance on relaunch

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/App.axaml.cs
@@ -38,36 +38,114 @@ public partial class App : Application
         // through the dispatcher). The background-thread handlers are installed in Program.Main.
         Services.CrashLogging.InstallDispatcherHandler();
 
-        var services = BuildServices();
-
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            var window = services.GetRequiredService<MainWindow>();
-            window.Icon = LoadAppIcon();
-            desktop.MainWindow = window;
-            RegisterNativeMenu(window);
-
-            // Wire single-instance IPC: file paths received from a second process open as tabs
-            // and bring the window forward (#1009) -- otherwise it opens behind whatever else
-            // currently has focus.
-            if (SingleInstance != null)
-            {
-                SingleInstance.FileOpenRequested += path =>
-                    Dispatcher.UIThread.InvokeAsync(async () =>
-                    {
-                        await window.OpenFileAsTab(path);
-                        window.BringToForeground();
-                    });
-            }
-
-            // Post the Dock icon update to the next UI tick. Avalonia's macOS backend
-            // may clear NSApplication.applicationIconImage during window assignment
-            // (when WindowDecorations="None" bypasses the native title-bar path), so
-            // we set it AFTER Avalonia's own initialisation has finished.
-            Dispatcher.UIThread.Post(SetMacOSDockIcon);
+            // Program.Main only reaches here as a non-owner when its pipe hand-off to the
+            // primary instance failed (#1049) — show a recovery dialog instead of the normal
+            // MainWindow/DI graph, which would be overkill for a two-button prompt.
+            if (SingleInstance is { IsOwner: false })
+                HandleUnreachablePrimary(desktop);
+            else
+                StartAsOwner(desktop);
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    /// <summary>
+    /// Classifies why the primary was unreachable and shows the matching recovery dialog. Called
+    /// only when <see cref="SingleInstance"/> is not the mutex owner and its pipe hand-off
+    /// already failed in <see cref="Program.Main"/>.
+    /// </summary>
+    private void HandleUnreachablePrimary(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        var hangResult = PrimaryInstanceHangChecker.Check();
+        var action = SingleInstanceRecoveryDecision.Decide(reachedPrimary: false, hangResult);
+
+        switch (action)
+        {
+            case SingleInstanceRecoveryAction.ShowBusyMessage:
+                ShowRecoveryDialog(desktop, SingleInstanceRecoveryWindow.CreateBusyDialog(), onRestartConfirmed: null);
+                break;
+
+            case SingleInstanceRecoveryAction.OfferRestart:
+                ShowRecoveryDialog(desktop, SingleInstanceRecoveryWindow.CreateHungDialog(),
+                    onRestartConfirmed: () => RestartAndTakeOver(desktop));
+                break;
+
+            default:
+                // SilentExit only happens when reachedPrimary is true, which can't be the case
+                // here — Program.Main already returned in that branch without booting Avalonia.
+                desktop.Shutdown(0);
+                break;
+        }
+    }
+
+    private static void ShowRecoveryDialog(
+        IClassicDesktopStyleApplicationLifetime desktop,
+        SingleInstanceRecoveryWindow window,
+        Action? onRestartConfirmed)
+    {
+        desktop.MainWindow = window;
+        window.Closed += (_, _) =>
+        {
+            if (window.RestartRequested && onRestartConfirmed != null)
+                onRestartConfirmed();
+            else
+                desktop.Shutdown(0);
+        };
+        window.Show();
+    }
+
+    /// <summary>
+    /// Kills the frozen primary, reacquires the single-instance mutex, and falls through into
+    /// the normal owner startup — all within this process, without a second Avalonia boot.
+    /// </summary>
+    private void RestartAndTakeOver(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        PrimaryInstanceHangChecker.KillOtherInstance();
+
+        SingleInstance?.Dispose();
+        SingleInstance = new SingleInstanceServer();
+
+        if (!SingleInstance.IsOwner)
+        {
+            // Race: something else still holds the mutex — give up cleanly rather than looping.
+            desktop.Shutdown(0);
+            return;
+        }
+
+        SingleInstance.StartListening();
+        StartAsOwner(desktop);
+    }
+
+    private void StartAsOwner(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        var services = BuildServices();
+        var window = services.GetRequiredService<MainWindow>();
+        window.Icon = LoadAppIcon();
+        desktop.MainWindow = window;
+        RegisterNativeMenu(window);
+
+        // Wire single-instance IPC: file paths received from a second process open as tabs
+        // and bring the window forward (#1009) -- otherwise it opens behind whatever else
+        // currently has focus.
+        if (SingleInstance != null)
+        {
+            SingleInstance.FileOpenRequested += path =>
+                Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await window.OpenFileAsTab(path);
+                    window.BringToForeground();
+                });
+        }
+
+        // Post the Dock icon update to the next UI tick. Avalonia's macOS backend
+        // may clear NSApplication.applicationIconImage during window assignment
+        // (when WindowDecorations="None" bypasses the native title-bar path), so
+        // we set it AFTER Avalonia's own initialisation has finished.
+        Dispatcher.UIThread.Post(SetMacOSDockIcon);
+        window.Show();
     }
 
     private static void SetMacOSDockIcon()

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Program.cs
@@ -28,16 +28,24 @@ class Program
         var singleInstance = new SingleInstanceServer();
         if (!singleInstance.IsOwner)
         {
-            // Another instance is running — forward the file path and exit.
-            if (fileArg != null)
-                SingleInstanceServer.SendToRunningInstanceAsync(fileArg).GetAwaiter().GetResult();
-            singleInstance.Dispose();
-            return;
+            // Another instance is running. A successful hand-off means it's alive and well, so
+            // exit immediately without paying Avalonia's startup cost, same as before (#1049).
+            // A failed hand-off is ambiguous — could be a slow-but-fine primary, could be a
+            // frozen one — so it falls through into the Avalonia boot below, which shows a
+            // recovery dialog instead of the normal MainWindow (see App.OnFrameworkInitializationCompleted).
+            bool reachedPrimary = SingleInstanceServer.SendToRunningInstanceAsync(fileArg).GetAwaiter().GetResult();
+            if (reachedPrimary)
+            {
+                singleInstance.Dispose();
+                return;
+            }
         }
-
-        // We are the primary instance. Start the pipe listener before Avalonia so requests
-        // that arrive during startup are queued in the server.
-        singleInstance.StartListening();
+        else
+        {
+            // We are (immediately) the primary instance. Start the pipe listener before Avalonia
+            // so requests that arrive during startup are queued in the server.
+            singleInstance.StartListening();
+        }
 
         // Set the Dock label BEFORE Avalonia calls [NSApplication sharedApplication]
         // (inside UsePlatformDetect). The Dock caches the process name at that point;
@@ -60,7 +68,10 @@ class Program
         }
         finally
         {
-            singleInstance.Dispose();
+            // App.SingleInstance may have been replaced with a freshly-acquired instance if the
+            // user restarted a frozen primary (App.RestartAndTakeOver) — dispose whichever one
+            // is current, not the local var captured before that could have happened.
+            App.SingleInstance?.Dispose();
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PrimaryInstanceHangChecker.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/PrimaryInstanceHangChecker.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// OS-specific wiring that classifies why the primary instance's IPC pipe was unreachable, and
+/// kills it when the user confirms a restart. Thin P/Invoke + <see cref="Process"/> lookup layer
+/// around the pure <see cref="SingleInstanceRecoveryDecision"/> — not unit tested, since there is
+/// no way to manufacture a real hung window (or a second real process under the same mutex) in a
+/// test. See PR for issue #1049 for the full TDD-exception rationale.
+/// </summary>
+internal static class PrimaryInstanceHangChecker
+{
+    // Task Manager's own "Not Responding" check — a window that hasn't pumped a message in
+    // ~5 seconds. This is the strong signal the pipe-connect timeout alone can't provide, since
+    // the pipe listener runs on a background thread independent of the UI thread (see
+    // SingleInstanceServer.SendToRunningInstanceAsync's doc comment).
+    [DllImport("user32.dll")]
+    private static extern bool IsHungAppWindow(IntPtr hWnd);
+
+    public static PrimaryInstanceHangResult Check()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            // No IsHungAppWindow equivalent off Windows. A wedged pipe listener means the whole
+            // process is stuck (not just its UI thread), so treat unreachable as sufficient
+            // evidence on its own.
+            return PrimaryInstanceHangResult.Hung;
+        }
+
+        var other = FindOtherInstanceProcess();
+        var handle = other?.MainWindowHandle ?? IntPtr.Zero;
+        if (handle != IntPtr.Zero && IsHungAppWindow(handle))
+            return PrimaryInstanceHangResult.Hung;
+
+        // Either no other process was found, or its window isn't reporting hung — don't offer
+        // to kill a process that might just be busy.
+        return PrimaryInstanceHangResult.BusyNotHung;
+    }
+
+    /// <summary>Kills the other Animation Editor process and waits (best-effort) for it to exit.
+    /// Failures are swallowed — the caller re-checks mutex ownership afterward and gives up
+    /// cleanly if it still isn't available.</summary>
+    public static void KillOtherInstance()
+    {
+        using var other = FindOtherInstanceProcess();
+        if (other == null) return;
+
+        try
+        {
+            other.Kill();
+            other.WaitForExit(5000);
+        }
+        catch
+        {
+            // Already exited, access denied, etc. — nothing more we can do here.
+        }
+    }
+
+    /// <summary>Finds the other running Animation Editor process (excluding this one). Only one
+    /// other should exist under the single-instance mutex.</summary>
+    private static Process? FindOtherInstanceProcess()
+    {
+        var current = Process.GetCurrentProcess();
+        return Process.GetProcessesByName(current.ProcessName)
+            .FirstOrDefault(p => p.Id != current.Id);
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceRecoveryDecision.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceRecoveryDecision.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Why the primary instance's IPC pipe was unreachable, as classified by an OS-specific check
+/// (<c>PrimaryInstanceHangChecker</c>). Off Windows there is no window-responsiveness API, so an
+/// unreachable pipe is itself treated as sufficient evidence of <see cref="Hung"/>.
+/// </summary>
+internal enum PrimaryInstanceHangResult
+{
+    /// <summary>Windows only: the pipe was unreachable, but the other process's main window is
+    /// still responding — likely just busy, not frozen. Never produced off Windows.</summary>
+    BusyNotHung,
+
+    /// <summary>The primary is confirmed (Windows) or assumed (macOS/Linux) to be frozen.</summary>
+    Hung,
+}
+
+/// <summary>What a second launch should do once it knows whether it reached the primary.</summary>
+internal enum SingleInstanceRecoveryAction
+{
+    /// <summary>The primary is alive and reachable — exit quietly, as before.</summary>
+    SilentExit,
+
+    /// <summary>Windows only: tell the user the primary looks busy and to try again. No restart
+    /// offered — killing a merely-busy process would lose their work.</summary>
+    ShowBusyMessage,
+
+    /// <summary>The primary is frozen — offer to kill it and take over as the new instance.</summary>
+    OfferRestart,
+}
+
+/// <summary>
+/// Pure decision table for a second launch: given whether it reached the primary over the IPC
+/// pipe and, if not, why, decide what to show the user. Deliberately free of
+/// <c>Process</c>/P-Invoke/Avalonia so this is unit-testable without a real hung process.
+/// </summary>
+internal static class SingleInstanceRecoveryDecision
+{
+    public static SingleInstanceRecoveryAction Decide(bool reachedPrimary, PrimaryInstanceHangResult hangResult)
+    {
+        if (reachedPrimary)
+            return SingleInstanceRecoveryAction.SilentExit;
+
+        return hangResult switch
+        {
+            PrimaryInstanceHangResult.Hung => SingleInstanceRecoveryAction.OfferRestart,
+            PrimaryInstanceHangResult.BusyNotHung => SingleInstanceRecoveryAction.ShowBusyMessage,
+            _ => throw new ArgumentOutOfRangeException(nameof(hangResult), hangResult, null),
+        };
+    }
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceRecoveryWindow.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceRecoveryWindow.cs
@@ -1,0 +1,71 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace AnimationEditor.App.Services;
+
+/// <summary>
+/// Minimal top-level window shown when a second launch can't reach the primary instance over
+/// IPC. Built entirely in code (no XAML, no DI) since <c>App.OnFrameworkInitializationCompleted</c>
+/// may need to show this before the full <c>MainWindow</c>/service graph is built at all.
+/// </summary>
+internal sealed class SingleInstanceRecoveryWindow : Window
+{
+    /// <summary>True once the user has clicked "Restart Animation Editor".</summary>
+    public bool RestartRequested { get; private set; }
+
+    private SingleInstanceRecoveryWindow(string message, bool offerRestart)
+    {
+        Title = "Animation Editor";
+        Width = 380;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        Content = BuildContent(message, offerRestart);
+    }
+
+    public static SingleInstanceRecoveryWindow CreateHungDialog() =>
+        new("A previous instance of Animation Editor is frozen.", offerRestart: true);
+
+    public static SingleInstanceRecoveryWindow CreateBusyDialog() =>
+        new("Animation Editor appears to be busy. Please wait and try again.", offerRestart: false);
+
+    private Control BuildContent(string message, bool offerRestart)
+    {
+        var panel = new StackPanel { Margin = new Thickness(16), Spacing = 12 };
+        panel.Children.Add(new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap });
+
+        var buttonRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+
+        if (offerRestart)
+        {
+            var restart = new Button { Content = "Restart Animation Editor" };
+            restart.Click += (_, _) => ConfirmRestart();
+            buttonRow.Children.Add(restart);
+        }
+
+        var dismiss = new Button { Content = offerRestart ? "Exit" : "OK" };
+        dismiss.Click += (_, _) => Dismiss();
+        buttonRow.Children.Add(dismiss);
+
+        panel.Children.Add(buttonRow);
+        return panel;
+    }
+
+    /// <summary>Handles "Restart Animation Editor". Internal (not private) so tests can invoke it
+    /// directly instead of simulating a real pointer click on the button.</summary>
+    internal void ConfirmRestart()
+    {
+        RestartRequested = true;
+        Close();
+    }
+
+    /// <summary>Handles "Exit"/"OK" — exposed for the same reason as <see cref="ConfirmRestart"/>.</summary>
+    internal void Dismiss() => Close();
+}

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceServer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Services/SingleInstanceServer.cs
@@ -91,10 +91,17 @@ public sealed class SingleInstanceServer : IDisposable
     }
 
     /// <summary>
-    /// Sends <paramref name="filePath"/> to the running instance via the named pipe.
-    /// Called by the second process before it exits.
+    /// Attempts to reach the running instance via the named pipe and, if <paramref name="filePath"/>
+    /// is non-null, forwards it to be opened as a tab. Called by the second process before it exits.
+    ///
+    /// <para>Returns whether the pipe connection itself succeeded. This is a reachability signal
+    /// only, not proof the primary's UI is responsive: <see cref="ListenLoopAsync"/> runs on a
+    /// background thread independent of the UI thread, so a wedged UI thread can still leave the
+    /// pipe listener accepting connections fine. A caller that gets <c>false</c> back needs a
+    /// second, OS-level signal (see <c>PrimaryInstanceHangChecker</c> in the App layer) before
+    /// concluding the primary is actually hung.</para>
     /// </summary>
-    public static async Task SendToRunningInstanceAsync(string filePath)
+    public static async Task<bool> SendToRunningInstanceAsync(string? filePath)
     {
         try
         {
@@ -104,12 +111,18 @@ public sealed class SingleInstanceServer : IDisposable
             // 2-second timeout — if the server isn't listening yet, give up gracefully.
             await client.ConnectAsync(2000);
 
-            using var writer = new StreamWriter(client) { AutoFlush = true };
-            await writer.WriteLineAsync(filePath);
+            if (filePath != null)
+            {
+                using var writer = new StreamWriter(client) { AutoFlush = true };
+                await writer.WriteLineAsync(filePath);
+            }
+
+            return true;
         }
         catch
         {
-            // Could not reach the running instance — silently ignore.
+            // Could not reach the running instance.
+            return false;
         }
     }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SingleInstanceRecoveryDecisionTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SingleInstanceRecoveryDecisionTests.cs
@@ -1,0 +1,40 @@
+using AnimationEditor.App.Services;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Covers the pure decision table a second launch uses once it knows whether it reached the
+/// primary instance's IPC pipe (#1049). The OS-specific classification that produces
+/// <see cref="PrimaryInstanceHangResult"/> (P/Invoke <c>IsHungAppWindow</c>, process lookup) is
+/// thin wiring tested separately/manually — see <c>PrimaryInstanceHangChecker</c>'s doc comment.
+/// </summary>
+public class SingleInstanceRecoveryDecisionTests
+{
+    [Fact]
+    public void Decide_PipeReached_ReturnsSilentExit()
+    {
+        var action = SingleInstanceRecoveryDecision.Decide(
+            reachedPrimary: true, hangResult: PrimaryInstanceHangResult.Hung);
+
+        Assert.Equal(SingleInstanceRecoveryAction.SilentExit, action);
+    }
+
+    [Fact]
+    public void Decide_PipeUnreachableAndBusyNotHung_ReturnsShowBusyMessage()
+    {
+        var action = SingleInstanceRecoveryDecision.Decide(
+            reachedPrimary: false, hangResult: PrimaryInstanceHangResult.BusyNotHung);
+
+        Assert.Equal(SingleInstanceRecoveryAction.ShowBusyMessage, action);
+    }
+
+    [Fact]
+    public void Decide_PipeUnreachableAndHung_ReturnsOfferRestart()
+    {
+        var action = SingleInstanceRecoveryDecision.Decide(
+            reachedPrimary: false, hangResult: PrimaryInstanceHangResult.Hung);
+
+        Assert.Equal(SingleInstanceRecoveryAction.OfferRestart, action);
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SingleInstanceRecoveryWindowTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/SingleInstanceRecoveryWindowTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using AnimationEditor.App.Services;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Regression tests for the frozen/busy-primary recovery dialog (#1049). Button wiring is thin
+/// enough to verify by invoking the handler methods directly (per animation-editor-testing's
+/// last-resort guidance) rather than simulating a real pointer click.
+/// </summary>
+public class SingleInstanceRecoveryWindowTests
+{
+    [AvaloniaFact]
+    public void ConfirmRestart_HungDialog_SetsRestartRequestedTrue()
+    {
+        var window = SingleInstanceRecoveryWindow.CreateHungDialog();
+        window.Show();
+
+        window.ConfirmRestart();
+
+        Assert.True(window.RestartRequested);
+    }
+
+    [AvaloniaFact]
+    public void CreateBusyDialog_HasNoRestartButton()
+    {
+        var window = SingleInstanceRecoveryWindow.CreateBusyDialog();
+
+        var buttonRow = (StackPanel)((StackPanel)window.Content!).Children[1];
+        var hasRestartButton = buttonRow.Children.OfType<Button>()
+            .Any(b => b.Content as string == "Restart Animation Editor");
+
+        Assert.False(hasRestartButton);
+    }
+
+    [AvaloniaFact]
+    public void Dismiss_BusyDialog_LeavesRestartRequestedFalse()
+    {
+        var window = SingleInstanceRecoveryWindow.CreateBusyDialog();
+        window.Show();
+
+        window.Dismiss();
+
+        Assert.False(window.RestartRequested);
+    }
+}


### PR DESCRIPTION
Closes #1049

## Summary
A second launch used to swallow a failed pipe hand-off and silently exit — even when the primary was genuinely UI-thread-frozen (mutex held by a process that Task Manager can end but not actually kill in an uninterruptible wait). Every relaunch after that did nothing, with no window and no error.

- `SingleInstanceServer.SendToRunningInstanceAsync` now returns whether the pipe hand-off succeeded, instead of swallowing failure silently.
- On failure, `PrimaryInstanceHangChecker` classifies why: Windows checks `IsHungAppWindow` against the *other* process's main window handle (the same check Task Manager uses) — pipe reachability alone under-detects, since the listener runs on a background thread independent of a wedged UI thread. Off Windows (no equivalent API), an unreachable pipe is itself treated as sufficient evidence of a hang.
- `SingleInstanceRecoveryDecision.Decide` (pure) maps `(reachedPrimary, hangResult)` to `SilentExit` / `ShowBusyMessage` / `OfferRestart`.
- A small code-only Avalonia window (`SingleInstanceRecoveryWindow`) shows the matching dialog: hung → "A previous instance of Animation Editor is frozen." with Restart/Exit; Windows busy-not-hung → a plain wait-and-retry message, no restart offered (don't kill a merely-busy process).
- `App.axaml.cs` restructured so a failed hand-off falls through into the same Avalonia boot to host this dialog, and a confirmed restart kills the frozen process, reacquires the mutex, and falls through into normal owner startup — all in one process, one Avalonia lifetime. A successful hand-off still exits before Avalonia boots at all, so the common case pays no extra startup cost.

## Untested-wiring justification
`PrimaryInstanceHangChecker`'s `IsHungAppWindow` P/Invoke and `Process.GetProcessesByName` lookup are not unit tested — there's no way to manufacture a real hung window, or a second real OS process under the same named mutex, inside a test. The pure decision table it feeds (`SingleInstanceRecoveryDecision.Decide`) is fully covered by `SingleInstanceRecoveryDecisionTests` (all three reachable/hung/busy-not-hung outcomes). The recovery dialog's button wiring is covered by `SingleInstanceRecoveryWindowTests`, invoking the handler methods directly rather than simulating a pointer click (per the `animation-editor-testing` skill's last-resort guidance).

## Test plan
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 953 passed
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/` — 1974 passed
- Manual test: not needed for the decision/dialog logic (fully unit tested); a human should still verify end-to-end on Windows at least once — freeze a real primary, relaunch, confirm the dialog shows and Restart actually recovers the app — since that flow can't be exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)