### PR TITLE
Fix Animation Editor updater: packVersion must be 3-part SemVer2

### DIFF
--- a/.github/workflows/animation-editor.yml
+++ b/.github/workflows/animation-editor.yml
@@ -27,12 +27,15 @@ jobs:
         id: meta
         shell: pwsh
         run: |
-          # Velopack package versions use SemVer, whose numeric components cannot have leading
-          # zeroes. The assembly version receives this same value. The 4th component is the
-          # workflow run number, not the date, so two releases cut on the same day still get
+          # Velopack's --packVersion requires strict 3-part SemVer2 (a 4th component, e.g.
+          # 2026.9.7.7, is rejected), so date and run number must fit into 3 components. Month+day
+          # are fused into the 2nd component (M then dd, e.g. Sept 7 -> "907") - the 100-per-month
+          # gap keeps it monotonic across month boundaries within a year. The 3rd component is the
+          # workflow run number, which never resets, so two releases cut on the same day still get
           # strictly increasing versions - otherwise the second same-day release is invisible to
           # the Velopack updater on clients already on the first one.
-          $version = (Get-Date).ToString('yyyy.M.d') + ".$($env:GITHUB_RUN_NUMBER)"
+          $date = Get-Date
+          $version = "$($date.Year).$($date.ToString('%M') + $date.ToString('dd')).$($env:GITHUB_RUN_NUMBER)"
           $kind = "${{ github.event.inputs.release_kind }}"
           switch ($kind) {
             'release'    { $prefix='Release';    $prerelease='false'; $draft='false' }


### PR DESCRIPTION
## Summary
- `windows-updater` job failed on run 34143593018: `vpk pack --packVersion 2026.9.7.7` — Velopack requires strict 3-part SemVer2, the 4th component (run number) added in ea021819 broke it.
- Fuses month+day into the 2nd version component (e.g. `2026.907.42`) instead, keeping it 3-part while staying monotonic (100-per-month gap preserves date ordering; run number never resets so same-day releases still differ).

## Test plan
- [ ] Run the `windows-updater` workflow dispatch and confirm `vpk pack` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jc565Kbmt5CMeK7L4bn6d