### PR TITLE
Fix AutomationMode.Stop() to block until the reader thread actually exits

### DIFF
--- a/src/Automation/AutomationMode.cs
+++ b/src/Automation/AutomationMode.cs
@@ -67,14 +67,30 @@ internal class AutomationMode
     internal Thread? ReaderThread { get; private set; }
 
     /// <summary>
-    /// Ends <see cref="ReaderLoop"/> at its next EOF retry. Idempotent; safe from any thread.
+    /// Ends <see cref="ReaderLoop"/> and blocks until the reader thread has actually exited (bounded
+    /// — see remarks). Idempotent; safe from any thread.
     /// </summary>
     /// <remarks>
-    /// A loop currently blocked inside <c>ReadLine()</c> on a real stdin handle stays blocked until
-    /// that read returns — the stop is observed on the next pass, not the instant it is signalled.
-    /// That is acceptable precisely because the thread is background: nothing waits on it.
+    /// Setting the signal alone leaves a window, up to one <see cref="EofRetryDelayMs"/> retry
+    /// cycle wide, where the reader thread is still alive after <see cref="Stop"/> returns. That is
+    /// fine for the one reader thread a real running game has, torn down with the whole process at
+    /// exit — but a test host runs hundreds of these across a single process, each leaving its own
+    /// transient window; if the process's own exit teardown lands inside one, it can corrupt the
+    /// native heap (issue #1054, seen as an intermittent <c>malloc_consolidate</c> crash in CI,
+    /// always after every test had already reported passing). Joining here closes that window for
+    /// every caller at once instead of relying on each one to wait it out separately.
+    ///
+    /// The bounded timeout preserves the one case where the loop legitimately can't respond
+    /// promptly: a loop blocked inside <c>ReadLine()</c> on a real stdin handle stays blocked until
+    /// that read returns, however long that takes. <see cref="Stop"/> gives up waiting after that
+    /// timeout rather than hanging the caller — the thread is still background, so the CLR tears it
+    /// down at process exit exactly as before.
     /// </remarks>
-    internal void Stop() => _stopSignal.Set();
+    internal void Stop()
+    {
+        _stopSignal.Set();
+        ReaderThread?.Join(TimeSpan.FromMilliseconds(EofRetryDelayMs * 8));
+    }
 
     /// <summary>
     /// Reads stdin as a raw stream rather than through <see cref="Console.In"/>.

--- a/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
+++ b/tests/FlatRedBall2.Tests/Automation/AutomationModeTests.cs
@@ -638,6 +638,30 @@ public class AutomationModeReaderLoopTests
         mode.ReaderThread!.IsBackground.ShouldBeTrue();
         mode.Stop();
     }
+
+    // Issue #1054: every call site treats Stop() as "the reader thread is gone now" (tests skip
+    // straight to asserting side effects, production's Shutdown() does nothing further), but Stop()
+    // only sets a signal — the thread can still be alive, mid retry-sleep, for up to one
+    // EofRetryDelayMs cycle after Stop() returns. With enough of these transient windows open at
+    // once across a full test run, one can coincide with the test host's own process-exit teardown
+    // and corrupt the native heap (observed as an intermittent malloc_consolidate crash in CI,
+    // always after every test already reported passing). Stop() must not return until the reader
+    // thread has actually exited.
+    [Fact]
+    public void Stop_ReturnsOnlyAfterReaderThreadHasActuallyExited()
+    {
+        for (int i = 0; i < 50; i++)
+        {
+            var reader = new AlwaysNullReader();
+            var mode = new AutomationMode(new FlatRedBallService(), new StringWriter(), log: _ => { });
+            mode.Start(reader);
+            SpinWait.SpinUntil(() => reader.ReadCount >= 2, TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+            mode.Stop();
+
+            mode.ReaderThread!.IsAlive.ShouldBeFalse();
+        }
+    }
 }
 
 // --- AutomationMode screenshot ---


### PR DESCRIPTION
Closes #1054.

Seen as an intermittent `malloc_consolidate` native heap crash in CI's `Engine and AnimationEditor tests (ubuntu)` job, always occurring after every test already reported passing (surfaced on PR #1053, whose own diff never touches this code).

`AutomationMode.Stop()` only set a signal — the reader thread could stay alive for up to one `EofRetryDelayMs` (25ms) retry cycle after `Stop()` returned. A real running game only ever has one such thread, torn down with the whole process at exit, so this was invisible there. A test host runs hundreds of `AutomationMode` instances across a single process; if the host's own exit teardown lands inside one of these transient windows, it can corrupt the native heap.

Fix: `Stop()` now joins the reader thread (bounded — a genuinely blocked real-stdin read still can't hang the caller) before returning, so no caller is left with a "probably stopped" thread.

Manual test: not needed — the race itself is proven headlessly (see below); no display/graphics device involved.

Test added (`AutomationModeTests.cs`): `Stop_ReturnsOnlyAfterReaderThreadHasActuallyExited` asserts `ReaderThread.IsAlive` is `false` immediately after `Stop()` returns, looped 50x to make the race reliably observable — this failed within the loop against the old `Stop()` (confirmed locally on Windows before the fix), and is green after.

Full engine suite green: 1690/1690, no aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCWTZtWJhnghfxWixR1MW8
