### PR TITLE
Fix Animation Editor: multi-track timeline scales each chain independently

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4399,9 +4399,14 @@ public partial class MainWindow : Window
     {
         _groupTimelineTracks.Clear();
 
+        // Shared across every row (#1056) so a frame of equal duration renders at equal width in
+        // every chain's row, instead of each chain scaling independently to its own shortest frame.
+        double sharedPps = TimelineBuilder.ComputeSharedEffectivePixelsPerSecond(
+            PreviewCtrl.GroupTracks.Select(t => t.Chain));
+
         foreach (var (chain, _) in PreviewCtrl.GroupTracks)
         {
-            var track = new ChainTimelineTrackVm(chain, TimelineBuilder.BuildFrameItems(chain));
+            var track = new ChainTimelineTrackVm(chain, TimelineBuilder.BuildFrameItems(chain, sharedPps));
             if (chain.Frames.Count > 0)
             {
                 var colors = EffectiveFrameColor.ResolveAll(chain.Frames);
@@ -4421,6 +4426,11 @@ public partial class MainWindow : Window
     /// </summary>
     private void RefreshGroupTimelineScrubbers()
     {
+        // Must match the shared pps RefreshGroupTimelineTracks built the frame widths with (#1056) —
+        // recomputing per-chain here would desync the sub-frame playhead offset from those widths.
+        double sharedPps = TimelineBuilder.ComputeSharedEffectivePixelsPerSecond(
+            PreviewCtrl.GroupTracks.Select(t => t.Chain));
+
         foreach (var (chain, playback) in PreviewCtrl.GroupTracks)
         {
             var track = _groupTimelineTracks.FirstOrDefault(t => ReferenceEquals(t.Chain, chain));
@@ -4430,9 +4440,8 @@ public partial class MainWindow : Window
             for (int i = 0; i < track.Frames.Count; i++)
                 track.Frames[i].IsCurrent = i == idx;
 
-            double pps = TimelineBuilder.ComputeEffectivePixelsPerSecond(chain);
             double travelWidth = Math.Max(0, track.Frames[idx].Width - TimelineFrameVm.PlayheadWidth);
-            track.Frames[idx].ScrubberOffset = Math.Min(playback.FrameElapsed * pps, travelWidth);
+            track.Frames[idx].ScrubberOffset = Math.Min(playback.FrameElapsed * sharedPps, travelWidth);
         }
     }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/ViewModels/TimelineBuilder.cs
@@ -42,6 +42,35 @@ public static class TimelineBuilder
     }
 
     /// <summary>
+    /// Returns one shared pixels-per-second rate for every chain in <paramref name="chains"/>, based
+    /// on the shortest non-zero frame across all of them combined. Use this (instead of calling
+    /// <see cref="ComputeEffectivePixelsPerSecond(AnimationChainSave?)"/> per chain) whenever multiple
+    /// chains are rendered together — e.g. the multi-track group-preview timeline — so a frame of
+    /// equal duration renders at equal width in every row instead of each chain scaling independently
+    /// to its own shortest frame.
+    /// </summary>
+    public static double ComputeSharedEffectivePixelsPerSecond(IEnumerable<AnimationChainSave?> chains)
+    {
+        double minDuration = double.MaxValue;
+        foreach (var chain in chains)
+        {
+            if (chain is null)
+                continue;
+
+            foreach (var frame in chain.Frames)
+            {
+                if (frame.FrameLength > 0)
+                    minDuration = Math.Min(minDuration, frame.FrameLength);
+            }
+        }
+
+        if (minDuration == double.MaxValue)
+            return PixelsPerSecond;
+
+        return Math.Max(PixelsPerSecond, MinCellWidth / minDuration);
+    }
+
+    /// <summary>
     /// Total play duration of <paramref name="chain"/> in seconds — the sum of every frame's
     /// <see cref="AnimationFrameSave.FrameLength"/>. FrameLength is treated as seconds (matching
     /// the editor's per-frame display) regardless of the file's <c>TimeMeasurementUnit</c>.
@@ -73,18 +102,25 @@ public static class TimelineBuilder
     /// <summary>Formats a duration in seconds for display, e.g. <c>1.5</c> → <c>"1.50s"</c>.</summary>
     public static string FormatSeconds(float seconds) => $"{seconds:0.00}s";
 
-    public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain)
+    public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain) =>
+        BuildFrameItems(chain, ComputeEffectivePixelsPerSecond(chain));
+
+    /// <summary>
+    /// Builds frame cells for <paramref name="chain"/> at an explicit <paramref name="pixelsPerSecond"/>
+    /// rate instead of one derived from this chain alone — use with
+    /// <see cref="ComputeEffectivePixelsPerSecond(IEnumerable{AnimationChainSave?})"/> so multiple
+    /// chains rendered together (e.g. group-preview timeline rows) share one time scale.
+    /// </summary>
+    public static List<TimelineFrameVm> BuildFrameItems(AnimationChainSave? chain, double pixelsPerSecond)
     {
         if (chain is null)
             return [];
-
-        double pps = ComputeEffectivePixelsPerSecond(chain);
 
         var result = new List<TimelineFrameVm>(chain.Frames.Count);
         for (int i = 0; i < chain.Frames.Count; i++)
         {
             var length = Math.Max(0f, chain.Frames[i].FrameLength);
-            var width = length > 0 ? length * pps : MinCellWidth;
+            var width = length > 0 ? length * pixelsPerSecond : MinCellWidth;
             result.Add(new TimelineFrameVm(i, width));
         }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/TimelineBuilderTests.cs
@@ -145,6 +145,40 @@ public class TimelineBuilderTests
         Assert.True(pps > TimelineBuilder.PixelsPerSecond);
     }
 
+    [Fact]
+    public void ComputeEffectivePps_MultipleChains_UsesGlobalShortestFrame()
+    {
+        // #1056: two chains shown together in the multi-track timeline must share one pps,
+        // derived from the shortest frame across ALL of them, not each chain's own shortest.
+        var chainA = new AnimationChainSave { Name = "A" };
+        chainA.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        var chainB = new AnimationChainSave { Name = "B" };
+        chainB.Frames.Add(new AnimationFrameSave { FrameLength = 0.01f });
+
+        double sharedPps = TimelineBuilder.ComputeSharedEffectivePixelsPerSecond(new[] { chainA, chainB });
+
+        Assert.Equal(TimelineBuilder.MinCellWidth / 0.01, sharedPps, precision: 3);
+    }
+
+    [Fact]
+    public void BuildFrameItems_WithExplicitPps_SameDurationGivesSameWidthAcrossChains()
+    {
+        // A 1-second frame in two different chains must render at the same width when both
+        // are built against a shared pps — this is what makes the multi-track timeline comparable.
+        var chainA = new AnimationChainSave { Name = "A" };
+        chainA.Frames.Add(new AnimationFrameSave { FrameLength = 0.1f });
+        chainA.Frames.Add(new AnimationFrameSave { FrameLength = 1.0f });
+        var chainB = new AnimationChainSave { Name = "B" };
+        chainB.Frames.Add(new AnimationFrameSave { FrameLength = 0.01f });
+        chainB.Frames.Add(new AnimationFrameSave { FrameLength = 1.0f });
+
+        double sharedPps = TimelineBuilder.ComputeSharedEffectivePixelsPerSecond(new[] { chainA, chainB });
+        var itemsA = TimelineBuilder.BuildFrameItems(chainA, sharedPps);
+        var itemsB = TimelineBuilder.BuildFrameItems(chainB, sharedPps);
+
+        Assert.Equal(itemsA[1].Width, itemsB[1].Width, precision: 6);
+    }
+
     // ── TotalSeconds & FormatSeconds ─────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- `TimelineBuilder.ComputeEffectivePixelsPerSecond` scaled pixels-per-second per chain, to that chain's own shortest frame. In the multi-track group-preview timeline, each row computed this independently, so a 1-second frame in one chain rendered at a different width than a 1-second frame in another.
- Added `ComputeSharedEffectivePixelsPerSecond(IEnumerable<AnimationChainSave?>)`, which derives one pps from the shortest frame across all given chains, and a `BuildFrameItems(chain, pixelsPerSecond)` overload that takes it explicitly.
- `MainWindow.RefreshGroupTimelineTracks`/`RefreshGroupTimelineScrubbers` now compute the shared pps once per refresh and pass it to every row, instead of each row/scrubber recomputing its own.

## Test plan
- [x] New Core tests: `ComputeEffectivePps_MultipleChains_UsesGlobalShortestFrame`, `BuildFrameItems_WithExplicitPps_SameDurationGivesSameWidthAcrossChains` — written first, confirmed failing (compile error, API didn't exist) before implementing.
- [x] `AnimationEditor.Core.Tests` — 1976 passed
- [x] `AnimationEditor.App.Tests` (includes `GroupTimelineUiTests`) — 953 passed
- [x] `AnimationEditor.Views.Tests` — 134 passed

Manual test: not needed — pure width-computation logic covered by the above headless suites (`[AvaloniaFact]` App.Tests exercises the real `MainWindow` group-timeline wiring).

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtA3SJuDguvPg8DTop1isU
