### PR TITLE
Filter thumbnail sampling in the 1.1x-1.9x magnification band

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ThumbnailService.cs
@@ -414,11 +414,25 @@ public sealed class ThumbnailService : IDisposable
         return thumb;
     }
 
+    /// <summary>Lower/upper bounds of the fractional-magnification band that gets filtered
+    /// (issue #1014). Chosen with margin around 1x and 2x so near-integer scales (e.g. 1.98x)
+    /// stay on crisp <see cref="SKFilterMode.Nearest"/> instead of picking up a needless blur.</summary>
+    private const float MagnificationFilterBandLow  = 1.1f;
+    private const float MagnificationFilterBandHigh = 1.9f;
+
     /// <summary>
-    /// Picks the sampler from the scale the crop is drawn at (issue #1013).
+    /// Picks the sampler from the scale the crop is drawn at (issue #1013, extended by #1014).
     /// <para>
     /// Magnifying keeps nearest-neighbour ("point") sampling, so a small sprite blown up to icon
     /// size stays crisp and pixellated instead of the blurry smear filtering produces on game art.
+    /// </para>
+    /// <para>
+    /// Except a fractional scale between <see cref="MagnificationFilterBandLow"/> and
+    /// <see cref="MagnificationFilterBandHigh"/> (issue #1014): nearest-neighbour there gives source
+    /// pixels uneven destination widths (e.g. at 1.3x some pixels are 1px wide, some are 2px — a 100%
+    /// size difference between neighbours), which reads as visible unevenness. The artifact shrinks as
+    /// scale grows, so only this narrow band — not every non-integer scale — is worth filtering; exact
+    /// or near-integer scale (1x, 2x, 3x, ...) stays <see cref="SKFilterMode.Nearest"/>.
     /// </para>
     /// <para>
     /// Minifying must filter. Nearest keeps one texel per destination pixel and discards every
@@ -430,8 +444,12 @@ public sealed class ThumbnailService : IDisposable
     /// matches what <see cref="GetFullImageThumbnail"/> already uses for the Files panel.
     /// </para>
     /// </summary>
-    private static SKSamplingOptions SelectSampling(float scale) =>
-        scale < 1f
+    private static SKSamplingOptions SelectSampling(float scale)
+    {
+        bool filter = scale < 1f
+            || (scale >= MagnificationFilterBandLow && scale <= MagnificationFilterBandHigh);
+        return filter
             ? new SKSamplingOptions(SKFilterMode.Linear)
             : new SKSamplingOptions(SKFilterMode.Nearest);
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ThumbnailServiceTests.cs
@@ -114,6 +114,95 @@ public class ThumbnailServiceTests
             }
     }
 
+    // -- Fractional-magnification band tests (Issue #1014) -------------------
+    //
+    // Between roughly 1.1x and 1.9x, nearest-neighbour gives source pixels uneven destination
+    // widths (some 1px, some 2px), which reads as visible unevenness. SelectSampling filters in
+    // that band while keeping exact/near-integer magnification (1x, 2x, ...) crisp.
+
+    [Fact]
+    public void RenderFrameThumbnail_FractionalMagnificationInBand_BlendsAcrossTheSeam()
+    {
+        // 40px red|blue source magnified to 60px (scale = 1.5x, inside the 1.1-1.9 band) must
+        // blend at the seam instead of leaving a hard red/blue edge like point sampling would.
+        using var source = SplitSheet(40, 2, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 60, 1000);
+
+        Assert.NotNull(thumb);
+        var middle = thumb!.GetPixel(thumb.Width / 2, 0);
+        Assert.True(middle.Red > 40 && middle.Blue > 40,
+            $"Seam pixel {middle} at 1.5x magnification should be a red/blue blend, not a hard edge.");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_MagnificationJustBelowBand_StaysCrisp()
+    {
+        // 40px source magnified to 42px (scale = 1.05x) sits below the 1.1x band floor and must
+        // stay point-sampled — no blending near 1x.
+        using var source = SplitSheet(40, 2, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 42, 1000);
+
+        Assert.NotNull(thumb);
+        AssertNoBlendedPixels(thumb!, "1.05x magnification");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_MagnificationJustAboveBand_StaysCrisp()
+    {
+        // 40px source magnified to 78px (scale = 1.95x) sits above the 1.9x band ceiling and must
+        // stay point-sampled — no needless blur just because 2x is close.
+        using var source = SplitSheet(40, 2, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 78, 1000);
+
+        Assert.NotNull(thumb);
+        AssertNoBlendedPixels(thumb!, "1.95x magnification");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_ExactDoubleMagnification_StaysCrisp()
+    {
+        // Exactly 2x is an integer magnification and must stay point-sampled even though it
+        // borders the filtered band.
+        using var source = SplitSheet(40, 2, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 80, 1000);
+
+        Assert.NotNull(thumb);
+        AssertNoBlendedPixels(thumb!, "exact 2x magnification");
+    }
+
+    [Fact]
+    public void RenderFrameThumbnail_FractionalMagnificationAboveBand_StaysCrisp()
+    {
+        // 2.3x is a non-integer magnification but outside the 1x-2x band the issue scopes this
+        // fix to (the unevenness artifact shrinks as scale grows past 2x) — must stay crisp.
+        using var source = SplitSheet(40, 2, SKColors.Red, SKColors.Blue);
+
+        using var thumb = ThumbnailService.RenderFrameThumbnail(source, Frame(), default, 92, 1000);
+
+        Assert.NotNull(thumb);
+        AssertNoBlendedPixels(thumb!, "2.3x magnification");
+    }
+
+    /// <summary>Every pixel must be purely one side's colour (Red>200/Blue&lt;55 or vice versa) —
+    /// the point-sampling hard-seam signature used by <see cref="RenderFrameThumbnail_UsesPointSampling_SoUpscaledArtStaysCrisp"/>.</summary>
+    private static void AssertNoBlendedPixels(SKBitmap thumb, string scenario)
+    {
+        for (int y = 0; y < thumb.Height; y++)
+            for (int x = 0; x < thumb.Width; x++)
+            {
+                var p = thumb.GetPixel(x, y);
+                if (p.Alpha == 0) continue;
+                bool pureRed  = p is { Red: > 200, Blue: < 55 };
+                bool pureBlue = p is { Blue: > 200, Red: < 55 };
+                Assert.True(pureRed || pureBlue,
+                    $"Pixel ({x},{y}) = {p} at {scenario} should be a hard seam, not a blended pixel.");
+            }
+    }
+
     [Fact]
     public void RenderFrameThumbnail_DownscalingALargeFrame_FiltersInsteadOfAliasing()
     {


### PR DESCRIPTION
Fixes #1014.

`ThumbnailService.SelectSampling` (extended from #1013) now filters (Linear) when the crop scale falls in [1.1x, 1.9x], on top of the existing minification filtering. Exact/near-integer magnification (1x, 2x, 3x, ...) stays `Nearest` so it doesn't blur for nothing.

Scope note: this is the plain-filter fix the issue proposes as the baseline, not the "sharp bilinear" / snap-to-integer alternatives it raises as an open visual-comparison question — those are still open for Victor to compare.

## Test plan
- [x] New tests in `ThumbnailServiceTests.cs`: in-band blend, just-below-band crisp, just-above-band crisp, exact 2x crisp, 2.3x (outside 1x-2x scope) crisp
- [x] `dotnet build tools/AnimationEditorAvalonia/AnimationEditorAvalonia.slnx` — 0 warnings, 0 errors
- [x] `dotnet test tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/` — 961/961 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161fjV3UhMoqmk3KtdZCnGC