### PR TITLE
Fix AnimationEditor: Files panel folder rows get "View in Explorer"

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/Controls/FilesPanelControl.cs
@@ -159,7 +159,7 @@ public partial class FilesPanelControl : UserControl
         }
 
         SetEmptyMessage(null, visible: false);
-        foreach (var node in PngFolderTreeBuilder.Build(files))
+        foreach (var node in PngFolderTreeBuilder.Build(files, _filesRoot))
             TreeRoots.Add(PngFilesTreeNodeVm.FromNode(node, _thumbnailService, ThumbnailSize));
     }
 
@@ -194,11 +194,13 @@ public partial class FilesPanelControl : UserControl
 
         FilesTree.ContextMenu.Items.Clear();
 
-        if (_contextNode is not { IsFile: true, AbsolutePath: { } path })
+        // Issue #1059: folder rows carry an AbsolutePath too now, so they get "View in Explorer"
+        // the same as file rows -- just opening the folder rather than selecting a file in it.
+        if (_contextNode is not { AbsolutePath: { } path } node)
             return;
 
         var revealItem = new MenuItem { Header = "View in Explorer" };
-        revealItem.Click += (_, _) => RevealInExplorer(path);
+        revealItem.Click += (_, _) => RevealInExplorer(path, node.IsFolder);
         FilesTree.ContextMenu.Items.Add(revealItem);
     }
 
@@ -301,9 +303,9 @@ public partial class FilesPanelControl : UserControl
         _dragPath = null;
     }
 
-    private void RevealInExplorer(string absolutePath)
+    private void RevealInExplorer(string absolutePath, bool isFolder)
     {
-        var error = ShellExplorer.RevealFile(absolutePath);
+        var error = isFolder ? ShellExplorer.OpenFolder(absolutePath) : ShellExplorer.RevealFile(absolutePath);
         if (error is not null)
             _showError?.Invoke(error);
     }
@@ -315,11 +317,11 @@ public sealed class PngFilesTreeNodeVm : INotifyPropertyChanged
     private bool _isDragging;
 
     public string Name { get; }
+    public bool IsFolder { get; }
+    public bool IsFile => !IsFolder;
     public string? AbsolutePath { get; }
     public string? PathHint { get; }
     public bool ShowPathHint => !string.IsNullOrEmpty(PathHint);
-    public bool IsFolder => AbsolutePath is null;
-    public bool IsFile => AbsolutePath is not null;
     public Bitmap? Thumbnail { get; }
     public ObservableCollection<PngFilesTreeNodeVm> Children { get; } = new();
 
@@ -348,9 +350,10 @@ public sealed class PngFilesTreeNodeVm : INotifyPropertyChanged
         }
     }
 
-    private PngFilesTreeNodeVm(string name, string? absolutePath, string? pathHint, Bitmap? thumbnail)
+    private PngFilesTreeNodeVm(string name, bool isFolder, string? absolutePath, string? pathHint, Bitmap? thumbnail)
     {
         Name = name;
+        IsFolder = isFolder;
         AbsolutePath = absolutePath;
         PathHint = pathHint;
         Thumbnail = thumbnail;
@@ -370,7 +373,7 @@ public sealed class PngFilesTreeNodeVm : INotifyPropertyChanged
                 pathHint = node.RelativePath[..slash].Replace("/", " › ");
         }
 
-        var vm = new PngFilesTreeNodeVm(node.Name, node.AbsolutePath, pathHint, bitmap);
+        var vm = new PngFilesTreeNodeVm(node.Name, node.IsFolder, node.AbsolutePath, pathHint, bitmap);
         foreach (var child in node.Children)
             vm.Children.Add(FromNode(child, thumbnails, thumbSize));
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderTreeBuilder.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/IO/PngFolderTreeBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace AnimationEditor.Core.IO;
@@ -9,7 +10,13 @@ namespace AnimationEditor.Core.IO;
 /// </summary>
 public static class PngFolderTreeBuilder
 {
-    public static IReadOnlyList<PngFilesTreeNode> Build(IReadOnlyList<PngFileEntry> files)
+    /// <param name="filesRoot">
+    /// Absolute root the scan started from -- combined with each folder's path to give folder
+    /// nodes an <see cref="PngFilesTreeNode.AbsolutePath"/> too (issue #1059: needed so "View in
+    /// Explorer" works on a folder row, not just a file row). Pass null/empty only when no
+    /// filesystem reveal will ever be attempted (e.g. a test that only checks names/hierarchy).
+    /// </param>
+    public static IReadOnlyList<PngFilesTreeNode> Build(IReadOnlyList<PngFileEntry> files, string? filesRoot = null)
     {
         var root = new BuilderNode();
         foreach (var file in files)
@@ -18,7 +25,7 @@ public static class PngFolderTreeBuilder
             root.Insert(parts, file);
         }
 
-        return root.ToSortedNodes();
+        return root.ToSortedNodes(filesRoot);
     }
 
     private sealed class BuilderNode
@@ -45,17 +52,19 @@ public static class PngFolderTreeBuilder
             child.Insert(remaining, file);
         }
 
-        public List<PngFilesTreeNode> ToSortedNodes()
+        public List<PngFilesTreeNode> ToSortedNodes(string? folderAbsolutePath)
         {
             var nodes = new List<PngFilesTreeNode>();
 
             foreach (var (name, folder) in _folders.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
             {
+                var childAbsolutePath = folderAbsolutePath is null ? null : Path.Combine(folderAbsolutePath, name);
                 nodes.Add(new PngFilesTreeNode
                 {
                     Name = name,
-                    AbsolutePath = null,
-                    Children = folder.ToSortedNodes(),
+                    IsFolder = true,
+                    AbsolutePath = childAbsolutePath,
+                    Children = folder.ToSortedNodes(childAbsolutePath),
                 });
             }
 
@@ -64,6 +73,7 @@ public static class PngFolderTreeBuilder
                 nodes.Add(new PngFilesTreeNode
                 {
                     Name = file.FileName,
+                    IsFolder = false,
                     AbsolutePath = file.AbsolutePath,
                     RelativePath = file.RelativePath,
                     Children = Array.Empty<PngFilesTreeNode>(),
@@ -76,14 +86,15 @@ public static class PngFolderTreeBuilder
 }
 
 /// <summary>
-/// A folder or PNG file node in the files-panel tree. Folders have a null
-/// <see cref="AbsolutePath"/>; file nodes carry the on-disk path for drag/reveal.
+/// A folder or PNG file node in the files-panel tree. <see cref="AbsolutePath"/> is populated for
+/// both -- use <see cref="IsFolder"/>, not its nullability, to tell them apart (issue #1059: a
+/// folder's path is needed too, for "View in Explorer").
 /// </summary>
 public sealed class PngFilesTreeNode
 {
     public required string Name { get; init; }
+    public required bool IsFolder { get; init; }
     public string? AbsolutePath { get; init; }
     public string? RelativePath { get; init; }
     public IReadOnlyList<PngFilesTreeNode> Children { get; init; } = Array.Empty<PngFilesTreeNode>();
-    public bool IsFolder => AbsolutePath is null;
 }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ShellExplorer.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Services/ShellExplorer.cs
@@ -65,6 +65,30 @@ public static class ShellExplorer
     }
 
     /// <summary>
+    /// Opens <paramref name="absolutePath"/> (a directory) in the system file manager -- no
+    /// selection, unlike <see cref="RevealFile"/>. Returns <c>null</c> on success, or an error
+    /// message when the folder is missing or the shell command fails.
+    /// </summary>
+    public static string? OpenFolder(string absolutePath)
+    {
+        if (string.IsNullOrEmpty(absolutePath))
+            return "No folder path was provided.";
+
+        if (!Directory.Exists(absolutePath))
+            return $"Folder not found: {absolutePath}";
+
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = absolutePath, UseShellExecute = true });
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"Could not open file manager: {ex.Message}";
+        }
+    }
+
+    /// <summary>
     /// explorer.exe's <c>/select,</c> switch mis-parses forward slashes as extra switch
     /// separators, silently ignoring the target and opening a default folder instead of
     /// selecting the file. Callers may pass either separator (e.g. a path built from

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FilesPanelControlTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/FilesPanelControlTests.cs
@@ -1,0 +1,76 @@
+using AnimationEditor.App.Controls;
+using AnimationEditor.App.Services;
+using AnimationEditor.Core;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using SkiaSharp;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #1059: right-clicking a folder row in the Files panel showed an empty context menu --
+/// only file rows got "View in Explorer" because folder nodes carried no <c>AbsolutePath</c>.
+/// </summary>
+public class FilesPanelControlTests
+{
+    private static void WritePng(string dir, string fileName, SKColor color)
+    {
+        using var bm = new SKBitmap(8, 8);
+        bm.Erase(color);
+        using var img = SKImage.FromBitmap(bm);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(Path.Combine(dir, fileName), data.ToArray());
+    }
+
+    [AvaloniaFact]
+    public void RightClickingFolderRow_ShowsViewInExplorerItem()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(dir, "Sprites"));
+        WritePng(Path.Combine(dir, "Sprites"), "hero.png", SKColors.Red);
+
+        var control = new FilesPanelControl();
+        var window = new Window { Content = control, Width = 400, Height = 400 };
+        control.Initialize(new ThumbnailService(new ProjectManager()), window);
+        window.Show();
+
+        try
+        {
+            control.Refresh(dir, Array.Empty<string>(), null);
+            window.Measure(new Size(400, 400));
+            window.Arrange(new Rect(0, 0, 400, 400));
+            Dispatcher.UIThread.RunJobs();
+
+            RightClick(window, control, control.TreeRoots[0]); // "Sprites" folder
+
+            var headers = control.FilesTree.ContextMenu!.Items.OfType<MenuItem>()
+                .Select(i => i.Header).ToArray();
+            Assert.Equal(new object?[] { "View in Explorer" }, headers);
+        }
+        finally
+        {
+            window.Close();
+            Directory.Delete(dir, true);
+        }
+    }
+
+    private static void RightClick(Window window, FilesPanelControl control, PngFilesTreeNodeVm node)
+    {
+        var tvi = control.FilesTree.GetVisualDescendants().OfType<TreeViewItem>()
+            .First(t => ReferenceEquals(t.DataContext, node));
+        var local = new Point(tvi.Bounds.Width / 2, 8);
+        var p = tvi.TranslatePoint(local, window)!.Value;
+        window.MouseDown(p, MouseButton.Right);
+        window.MouseUp(p, MouseButton.Right);
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShellExplorerTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/ShellExplorerTests.cs
@@ -28,4 +28,20 @@ public class ShellExplorerTests
     {
         Assert.Equal(@"C:\proj\textures\hero.png", ShellExplorer.ToWindowsSelectPath(@"C:/proj\textures/hero.png"));
     }
+
+    // Issue #1059: OpenFolder backs "View in Explorer" on a folder row. Only the guard clauses
+    // are unit-testable without actually launching the shell.
+    [Fact]
+    public void OpenFolder_MissingFolder_ReturnsError()
+    {
+        var missing = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+
+        Assert.Equal($"Folder not found: {missing}", ShellExplorer.OpenFolder(missing));
+    }
+
+    [Fact]
+    public void OpenFolder_EmptyPath_ReturnsError()
+    {
+        Assert.Equal("No folder path was provided.", ShellExplorer.OpenFolder(string.Empty));
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
@@ -41,6 +41,22 @@ public class PngFolderTreeBuilderTests
         Assert.Equal("root.png", tree[1].Name);
     }
 
+    // Issue #1059: a folder row needs its own AbsolutePath so "View in Explorer" can open it --
+    // previously only file nodes carried one.
+    [Fact]
+    public void Build_WithFilesRoot_GivesFolderNodesAbsolutePaths()
+    {
+        var files = new[]
+        {
+            new PngFileEntry(@"C:\proj\Sprites\Enemies\goblin.png", "Sprites/Enemies/goblin.png"),
+        };
+
+        var tree = PngFolderTreeBuilder.Build(files, @"C:\proj");
+
+        Assert.Equal(@"C:\proj\Sprites", tree[0].AbsolutePath);
+        Assert.Equal(@"C:\proj\Sprites\Enemies", tree[0].Children[0].AbsolutePath);
+    }
+
     [Fact]
     public void Build_EmptyInput_ReturnsEmpty()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/PngFolderTreeBuilderTests.cs
@@ -1,4 +1,5 @@
 using AnimationEditor.Core.IO;
+using System.IO;
 using Xunit;
 
 namespace AnimationEditor.Core.Tests;
@@ -51,10 +52,14 @@ public class PngFolderTreeBuilderTests
             new PngFileEntry(@"C:\proj\Sprites\Enemies\goblin.png", "Sprites/Enemies/goblin.png"),
         };
 
-        var tree = PngFolderTreeBuilder.Build(files, @"C:\proj");
+        const string root = @"C:\proj";
+        var tree = PngFolderTreeBuilder.Build(files, root);
 
-        Assert.Equal(@"C:\proj\Sprites", tree[0].AbsolutePath);
-        Assert.Equal(@"C:\proj\Sprites\Enemies", tree[0].Children[0].AbsolutePath);
+        // Path.Combine (matching production) rather than a hardcoded separator -- the CI runner
+        // is Linux, where combining with '/' still leaves the Windows-style literal root's own
+        // backslashes untouched.
+        Assert.Equal(Path.Combine(root, "Sprites"), tree[0].AbsolutePath);
+        Assert.Equal(Path.Combine(root, "Sprites", "Enemies"), tree[0].Children[0].AbsolutePath);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Right-clicking a folder row in the AnimationEditor's Files panel showed an empty context menu — only file rows got "View in Explorer". Root cause: folder tree nodes had a null `AbsolutePath` by design, and the context-menu builder required a non-null path to show the item at all.

- `PngFilesTreeNode`/`PngFilesTreeNodeVm` now carry an explicit `IsFolder` flag instead of inferring it from `AbsolutePath` nullability, freeing folder nodes to carry their own absolute path.
- `PngFolderTreeBuilder.Build` takes the scan root and stamps each folder node's absolute path.
- `ShellExplorer.OpenFolder` opens a directory directly (mirrors `MainWindow.RevealProjectFolderInExplorer`'s existing pattern for the Project panel); `FilesPanelControl` routes folder clicks there and file clicks to the existing `RevealFile`.

Manual test: not needed — headless Avalonia test drives a real right-click through the pointer pipeline and asserts the menu item appears; `ShellExplorer.OpenFolder`'s guard clauses are unit tested directly (its `Process.Start` call, like `RevealFile`'s, isn't exercised in tests).

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lmhf86KvagYzPUGn7iAxzH
