### PR TITLE
Add docs for loading and drawing .achx/.achj animations in MonoGame

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: docs-writing
+description: Writing FlatRedBall2 user docs in this repo's own docs/ folder (GitBook-synced). Triggers: new FlatRedBall2 tutorial/how-to pages, docs/SUMMARY.md, docs/images.
+---
+
+# FlatRedBall2 Docs Writing Reference
+
+FlatRedBall2's user docs live in **this repo's own `docs/` folder** — not the sibling `FlatRedBallDocs` repo (that's classic FlatRedBall's Glue/Editor-based docs, a different product), and not `.claude/skills/` (AI-facing, not user-facing). `docs/` is already connected to a live GitBook space — its git history has `GitBook:`/`GITBOOK-1` sync commits, so a push to `main` publishes.
+
+## Where FlatRedBall2 Docs Live
+
+- Nav: `docs/SUMMARY.md` — a flat list today (`Setup`, `Animation Editor`, `Your First Animation`), no nesting yet. A page not listed there is unreachable even if it exists on disk.
+- Every page in `docs/` today is an **Animation Editor tool doc** (the desktop app's UI — see `your-first-animation.md`). A runtime/code doc (loading a file format in a game, an engine API) is a different kind of page and needs its own new section in `SUMMARY.md` — mirrors Gum's own tool-docs-vs-code-docs split (`Gum/.claude/skills/gum-docs-writing/SKILL.md`, "Tool Docs vs Code Docs"). Don't fold a code doc into the Animation Editor section.
+- Images live in a flat `docs/images/`, referenced with a plain relative path (`images/foo.png`). There is no `.gitbook/assets/` folder or path convention here — that's specific to Gum/FlatRedBallDocs' GitBook setup; don't port it.
+
+## Match the Plain-Markdown Style Already In Use
+
+`docs/` uses plain GitHub-flavored markdown — no `{% hint %}`, `{% tabs %}`, or `<figure>` GitBook syntax appears anywhere in it yet. Don't introduce those unless the user asks for them. Heading levels nest normally (`#` → `##` → `###`, no skipped levels). For procedure style, match `your-first-animation.md`'s "Steps" section: numbered steps, bold UI element names, one action per step.
+
+## No Claudese
+
+Cut these when writing or reviewing docs prose:
+
+- **Em-dash restatement** — "X, not Y" or "X — the Y version" says the same thing twice. State it once.
+- **"It's not X, it's Y" framing** — say what it is, don't set up and knock down a strawman.
+- **Hedge/filler transitions** — "essentially," "in other words," "that said" — cut them, the next sentence works alone.
+
+## Imperative vs. Descriptive: Match the Sentence to the Job
+
+Two different jobs want two different moods, and mixing them up produces docs that either bury the actual click-through steps or bark commands where an explanation was needed:
+
+- **Procedural steps** (numbered how-to lists) → imperative mood, verb-first: "Click **Add Animation Chain**." "Set `SourceFile` to the `.achx` path."
+- **Explanatory prose** (what something does, why it matters) → subject-led, present tense, active voice, with the API/UI element as the grammatical subject: "The `AnimationChainList` stores every chain for an entity" — not "You should store your chains in an `AnimationChainList`." An imperative here hides the actual subject and reads as a command where a reader wanted a fact.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,3 +3,4 @@
 * [Setup](setup.md)
 * [Animation Editor](README.md)
 * [Your First Animation](your-first-animation.md)
+* [Loading and Drawing .achx/.achj Animations in MonoGame](loading-and-drawing-achx-animations.md)

--- a/docs/loading-and-drawing-achx-animations.md
+++ b/docs/loading-and-drawing-achx-animations.md
@@ -1,0 +1,132 @@
+# Loading and Drawing .achx/.achj Animations in MonoGame
+
+The Animation Editor saves animations as `.achx` (XML) or `.achj` (JSON) files. The `FlatRedBall.AnimationChain.MonoGame` NuGet package loads and plays these files in any MonoGame project. It has no dependency on the FlatRedBall2 engine or a game project structure — it works in a plain `Game` class.
+
+This page assumes you already have a `.achx` or `.achj` file and its spritesheet PNG, exported from Animation Editor.
+
+## Install the package
+
+```
+dotnet add package FlatRedBall.AnimationChain.MonoGame
+```
+
+Targeting KNI or Blazor WASM instead? Use `FlatRedBall.AnimationChain.KNI`.
+
+## Add your files to the project
+
+Copy the `.achx`/`.achj` file and its PNG into your project's `Content` folder, next to each other.
+
+Set both files' **Copy to Output Directory** property to **Copy if newer**. In the `.csproj`:
+
+```xml
+<ItemGroup>
+  <Content Include="Content\hero.achx">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </Content>
+  <Content Include="Content\AnimatedSpritesheet.png">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </Content>
+</ItemGroup>
+```
+
+Neither file goes through the MGCB content pipeline. `AchxLoader` reads the `.achx`/`.achj` as raw text and loads the PNG with `Texture2D.FromStream`, so don't add either one to `Content.mgcb`.
+
+## Load the animation in code
+
+`AchxLoader` reads the file and returns a ready-to-play `AnimationChainList<AnimationFrame>`. An `AnimationPlayer<AnimationFrame>` drives playback — it tracks the current chain and frame time.
+
+```csharp
+private AchxLoader _loader;
+private AnimationPlayer<AnimationFrame> _player;
+
+protected override void LoadContent()
+{
+    _loader = new AchxLoader(GraphicsDevice);
+    var animations = _loader.Load("Content/hero.achx");
+
+    _player = new AnimationPlayer<AnimationFrame>(animations);
+    _player.Play("Walk");
+}
+
+protected override void Update(GameTime gameTime)
+{
+    _player.Update(gameTime.ElapsedGameTime);
+    base.Update(gameTime);
+}
+```
+
+`Play` looks up the chain by the name given in Animation Editor. Calling `Play` with the currently-playing chain's name is a no-op, so it's safe to call every frame from gameplay code that hasn't changed animation state.
+
+## Draw the animation in code
+
+There are two ways to draw a frame: let the package draw it for you, or read the current frame yourself and draw it with your own `SpriteBatch.Draw` call.
+
+{% tabs %}
+{% tab title="DrawAnimation (quickest)" %}
+`SpriteBatchExtensions.DrawAnimation` draws the player's current frame with a regular `SpriteBatch`:
+
+```csharp
+protected override void Draw(GameTime gameTime)
+{
+    GraphicsDevice.Clear(Color.CornflowerBlue);
+
+    _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
+    _spriteBatch.DrawAnimation(_player, position: new Vector2(400, 300), scale: 4f);
+    _spriteBatch.End();
+
+    base.Draw(gameTime);
+}
+```
+
+`SamplerState.PointClamp` keeps pixel art sharp at a non-1x `scale`. The `position` argument is a screen-pixel anchor point; `DrawAnimation` centers the frame on it by default, matching Animation Editor's preview. It also applies flip flags, authored per-frame color/alpha, and `ColorOperation.Add` (via a pixel shader) automatically.
+{% endtab %}
+
+{% tab title="Manual SpriteBatch.Draw" %}
+`AnimationPlayer<AnimationFrame>.CurrentFrame` exposes the texture and source rectangle directly, so you can draw it with your own `SpriteBatch.Draw` call instead — useful when you need your own rotation, origin, blend state, or custom effect:
+
+```csharp
+protected override void Draw(GameTime gameTime)
+{
+    GraphicsDevice.Clear(Color.CornflowerBlue);
+
+    var frame = _player.CurrentFrame;
+    if (frame?.Texture != null)
+    {
+        var effects = SpriteEffects.None;
+        if (frame.FlipHorizontal) effects |= SpriteEffects.FlipHorizontally;
+        if (frame.FlipVertical) effects |= SpriteEffects.FlipVertically;
+
+        _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
+        _spriteBatch.Draw(
+            frame.Texture,
+            position: new Vector2(400, 300) + new Vector2(frame.RelativeX, frame.RelativeY),
+            sourceRectangle: frame.SourceRectangle?.ToXnaRectangle(),
+            color: Color.White,
+            rotation: 0f,
+            origin: Vector2.Zero,
+            scale: 4f,
+            effects: effects,
+            layerDepth: 0f);
+        _spriteBatch.End();
+    }
+
+    base.Draw(gameTime);
+}
+```
+
+`SourceRectangle` is a renderer-agnostic `PixelRectangle` — `ToXnaRectangle()` converts it to a MonoGame `Rectangle`. This path skips `DrawAnimation`'s extras: you apply flip flags yourself (shown above), and authored per-frame color/alpha and `ColorOperation.Add` aren't applied unless you read those fields (`frame.Red`/`Green`/`Blue`/`Alpha`/`ColorOperation`) and handle them yourself.
+{% endtab %}
+{% endtabs %}
+
+Release the loader's cached textures when you're done with it:
+
+```csharp
+protected override void UnloadContent()
+{
+    _loader.Dispose();
+}
+```
+
+## Next steps
+
+For frame origin/offset details (`RelativeX`/`RelativeY`), authored color and `ColorOperation.Add`, and loading from a byte stream in a browser (Blazor WASM/KNI) instead of the filesystem, see the package's own README: [FlatRedBall.AnimationChain.MonoGame on NuGet](https://www.nuget.org/packages/FlatRedBall.AnimationChain.MonoGame).


### PR DESCRIPTION
## Summary
- Adds the first FlatRedBall2 runtime/code doc: loading and drawing `.achx`/`.achj` animations in a plain MonoGame project via `FlatRedBall.AnimationChain.MonoGame`.
- Covers package install, adding content files with `Copy if newer` (no MGCB), loading via `AchxLoader`, and two drawing approaches (`DrawAnimation` vs. manual `SpriteBatch.Draw`).
- Adds a `docs-writing` skill documenting this repo's `docs/` folder conventions (plain markdown, flat `docs/images/`, no FlatRedBallDocs-style GitBook hint/figure syntax).

## Test plan
- [ ] Docs-only change, no code/behavior change — nothing to unit test.
- [ ] Visually review the rendered page on the GitBook site after merge (first use of `{% tabs %}` syntax in this repo's `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXy5nBjkxHHZ4rk4etZbAY
