### PR TITLE
Verify ColorOperation.Add renders correctly on real GPU; fix test-fixture GL corruption

### DIFF
--- a/tests/FlatRedBall2.Tests/Rendering/SpriteAddColorRenderTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/SpriteAddColorRenderTests.cs
@@ -1,4 +1,5 @@
 using FlatRedBall2.Animation;
+using FlatRedBall2.Diagnostics;
 using FlatRedBall2.Rendering;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -88,5 +89,63 @@ public class SpriteAddColorRenderTests
 
         pixels[0].ShouldBe(new Color(50, 50, 50, 255));
         pixels[1].ShouldBe(new Color(0, 0, 0, 0));
+    }
+
+    // The two tests above each isolate a single Sprite in its own Begin/End pair. A real Screen
+    // draws every renderable in one pass and breaks/re-begins the batch only when Batch actually
+    // changes between neighbors (Screen.Draw) - normal -> Add -> normal forces the batch to swap
+    // to WorldSpaceAddColorBatch and back mid-frame. This proves that round-trip doesn't leak
+    // shader/blend state onto the sprites on either side of the Add-color one.
+    [Fact]
+    public void ScreenDraw_NormalAddNormalSpritesInOnePass_EachRendersCorrectly()
+    {
+        if (!_fixture.IsAvailable) return;
+        var device = _fixture.GraphicsDevice!;
+
+        Sprite MakeOneByOneSprite(float x, int? red)
+        {
+            var texture = new Texture2D(device, 1, 1);
+            texture.SetData(new[] { new Color(50, 50, 50, 255) });
+
+            var chain = new AnimationChain { Name = "Chain" };
+            chain.Add(new AnimationFrame
+            {
+                Texture = texture,
+                ColorOperation = red.HasValue ? ColorOperation.Add : null,
+                Red = red,
+                RelativeX = x, // Sprite.X is clobbered by RelativeX on PlayAnimation - set it here, not on the Sprite.
+            });
+            var sprite = new Sprite { AnimationChains = new AnimationChainList { chain } };
+            sprite.PlayAnimation("Chain");
+            return sprite;
+        }
+
+        var screen = new Screen();
+        screen.Add(MakeOneByOneSprite(x: 0.5f, red: null));  // normal
+        screen.Add(MakeOneByOneSprite(x: 1.5f, red: 200));   // Add - forces a batch break each way
+        screen.Add(MakeOneByOneSprite(x: 2.5f, red: null));  // normal again
+
+        using var target = new RenderTarget2D(device, 3, 1);
+        var camera = new Camera();
+        camera.X = 1.5f;
+        camera.ApplyToHostRect(new Viewport(0, 0, 3, 1), orthogonalHeight: 1);
+
+        using var spriteBatch = new SpriteBatch(device);
+        device.SetRenderTarget(target);
+        device.Clear(Color.Transparent);
+
+        screen.Draw(spriteBatch, new RenderDiagnostics(), camera);
+
+        device.SetRenderTarget(null);
+
+        var pixels = new Color[3];
+        target.GetData(pixels);
+
+        pixels.ShouldBe(new[]
+        {
+            new Color(50, 50, 50, 255),  // normal, before the Add sprite
+            new Color(250, 50, 50, 255), // Add: R += 200/255
+            new Color(50, 50, 50, 255),  // normal, after the Add sprite
+        });
     }
 }

--- a/tests/FlatRedBall2.Tests/Rendering/SpriteAddColorRenderTests.cs
+++ b/tests/FlatRedBall2.Tests/Rendering/SpriteAddColorRenderTests.cs
@@ -1,0 +1,92 @@
+using FlatRedBall2.Animation;
+using FlatRedBall2.Rendering;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Rendering;
+
+// Issue #1064. AddColorShaderMathTests and SpriteAddColorBatchTests each cover one half of this
+// path in isolation (shader formula in C#, batch-selection logic) but neither proves the GPU
+// actually produces the right pixels when Sprite, Camera, and WorldSpaceAddColorBatch run
+// together. This renders a real Sprite playing an Add-color AnimationChain frame to an offscreen
+// RenderTarget2D and reads the pixels back, on the one GraphicsDeviceFixture-backed machine that
+// has a display to create a device with.
+[Collection(GraphicsDeviceCollection.Name)]
+public class SpriteAddColorRenderTests
+{
+    private readonly GraphicsDeviceFixture _fixture;
+
+    public SpriteAddColorRenderTests(GraphicsDeviceFixture fixture) => _fixture = fixture;
+
+    // 2x1 texture: left texel opaque gray, right texel fully transparent. Camera and render
+    // target both 2x1 so the sprite covers exactly one world unit per texel with no filtering
+    // blur, and only X flips ever move between texels (Y-flip subtlety from Sprite's default
+    // batch doesn't come into play with a single row).
+    private static (Sprite sprite, RenderTarget2D target, Camera camera, SpriteBatch batch) MakeScene(
+        GraphicsDevice device, int? red)
+    {
+        var texture = new Texture2D(device, 2, 1);
+        texture.SetData(new[] { new Color(50, 50, 50, 255), new Color(0, 0, 0, 0) });
+
+        var chain = new AnimationChain { Name = "Chain" };
+        chain.Add(new AnimationFrame
+        {
+            Texture = texture,
+            ColorOperation = red.HasValue ? ColorOperation.Add : null,
+            Red = red,
+        });
+        var sprite = new Sprite { AnimationChains = new AnimationChainList { chain } };
+        sprite.PlayAnimation("Chain");
+
+        var target = new RenderTarget2D(device, 2, 1);
+        var camera = new Camera();
+        camera.ApplyToHostRect(new Viewport(0, 0, 2, 1), orthogonalHeight: 1);
+
+        return (sprite, target, camera, new SpriteBatch(device));
+    }
+
+    private static Color[] RenderAndReadBack(
+        GraphicsDevice device, Sprite sprite, RenderTarget2D target, Camera camera, SpriteBatch spriteBatch)
+    {
+        device.SetRenderTarget(target);
+        device.Clear(Color.Transparent);
+
+        sprite.Batch.Begin(spriteBatch, camera);
+        sprite.Draw(spriteBatch, camera);
+        sprite.Batch.End(spriteBatch);
+
+        device.SetRenderTarget(null);
+
+        var pixels = new Color[2];
+        target.GetData(pixels);
+        return pixels;
+    }
+
+    [Fact]
+    public void Draw_AddColorFrame_BoostsOpaqueTexelAndLeavesTransparentTexelUntouched()
+    {
+        if (!_fixture.IsAvailable) return;
+        var device = _fixture.GraphicsDevice!;
+
+        var (sprite, target, camera, batch) = MakeScene(device, red: 200);
+        var pixels = RenderAndReadBack(device, sprite, target, camera, batch);
+
+        pixels[0].ShouldBe(new Color(250, 50, 50, 255)); // opaque: R += 200/255, G/B untouched
+        pixels[1].ShouldBe(new Color(0, 0, 0, 0));        // transparent: Add must not leak color
+    }
+
+    [Fact]
+    public void Draw_NoColorOperation_RendersTextureUnmodified()
+    {
+        if (!_fixture.IsAvailable) return;
+        var device = _fixture.GraphicsDevice!;
+
+        var (sprite, target, camera, batch) = MakeScene(device, red: null);
+        var pixels = RenderAndReadBack(device, sprite, target, camera, batch);
+
+        pixels[0].ShouldBe(new Color(50, 50, 50, 255));
+        pixels[1].ShouldBe(new Color(0, 0, 0, 0));
+    }
+}

--- a/tests/FlatRedBall2.Tests/UI/DynamicFontGenerationTests.cs
+++ b/tests/FlatRedBall2.Tests/UI/DynamicFontGenerationTests.cs
@@ -44,7 +44,12 @@ public class DynamicFontGenerationTests
         if (GumIsOwnedElsewhere)
             return;
 
-        using var game = TryCreateGame();
+        // Deliberately not disposed: disposing this ad-hoc Game tears down process-wide GL/SDL
+        // state that the shared GraphicsDeviceFixture's device depends on, breaking shader
+        // compilation for every GraphicsDeviceFixture-based test that runs afterward in this
+        // process (see SpriteAddColorRenderTests, discovered while adding it). The process exits
+        // once the test run finishes, so leaking this one Game for the run's lifetime is fine.
+        var game = TryCreateGame();
         if (game is null)
             return;
 

--- a/tests/FlatRedBall2.Tests/UI/FontOversamplingTests.cs
+++ b/tests/FlatRedBall2.Tests/UI/FontOversamplingTests.cs
@@ -42,7 +42,12 @@ public class FontOversamplingTests
         if (GumIsOwnedElsewhere)
             return;
 
-        using var game = TryCreateGame();
+        // Deliberately not disposed: disposing this ad-hoc Game tears down process-wide GL/SDL
+        // state that the shared GraphicsDeviceFixture's device depends on, breaking shader
+        // compilation for every GraphicsDeviceFixture-based test that runs afterward in this
+        // process (see SpriteAddColorRenderTests, discovered while adding it). The process exits
+        // once the test run finishes, so leaking this one Game for the run's lifetime is fine.
+        var game = TryCreateGame();
         if (game is null)
             return;
 


### PR DESCRIPTION
## Summary
- Adds `SpriteAddColorRenderTests`: renders a real `Sprite` playing an Add-color `AnimationChain` frame through `Camera` + `WorldSpaceAddColorBatch` into an offscreen `RenderTarget2D` and reads pixels back. Confirms the shader boosts an opaque texel by the authored offset and leaves a transparent texel untouched, and that a plain frame renders unmodified.
- Verdict on #1064: the feature already works correctly on real hardware. No `src/` change needed.
- Fixes a real bug found while adding the test: `FontOversamplingTests`/`DynamicFontGenerationTests` each `using`-dispose their own ad-hoc `Game`/`GraphicsDeviceManager`, and disposing it corrupts process-wide GL/SDL state, deterministically breaking shader compilation for any `GraphicsDeviceFixture`-based test that runs afterward in the same process. Fix: stop disposing it (leaked for the run's lifetime, which is fine — the process exits when the run finishes).

## Test plan
- `dotnet test tests/FlatRedBall2.Tests/` — full suite green (1693 passed), run 3x to rule out flakiness.
- New test's pixel assertions verified against the real GPU output (temporarily broke an expected value to confirm the assertion actually executes, not silently skipped for lack of a display).

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xUMyn3o5eujR5dEUM22pk
