### PR TITLE
AnimationEditor: snap collision-shape drag position to the pixel

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/PreviewControl.cs
@@ -913,15 +913,15 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
         {
             _shapeDragStartX = r.X;
             _shapeDragStartY = r.Y;
-            r.X += worldDx;
-            r.Y += worldDy;
+            r.X = SnapToPixel(r.X + worldDx);
+            r.Y = SnapToPixel(r.Y + worldDy);
         }
         else if (_draggingShape is CircleSave c)
         {
             _shapeDragStartX = c.X;
             _shapeDragStartY = c.Y;
-            c.X += worldDx;
-            c.Y += worldDy;
+            c.X = SnapToPixel(c.X + worldDx);
+            c.Y = SnapToPixel(c.Y + worldDy);
         }
         CommitShapeDrag();
     }
@@ -2288,8 +2288,8 @@ public class PreviewControl : Control, IZoomTarget, IPanScrollTarget
             float om = _appState!.OffsetMultiplier * _zoom;
             float dx = (float)(pos.X - _shapeDragAnchor.X) / om;
             float dy = -(float)(pos.Y - _shapeDragAnchor.Y) / om;
-            float newX = _shapeDragStartX + dx;
-            float newY = _shapeDragStartY + dy;
+            float newX = SnapToPixel(_shapeDragStartX + dx);
+            float newY = SnapToPixel(_shapeDragStartY + dy);
             if (_draggingShape is AARectSave r) { r.X = newX; r.Y = newY; }
             else if (_draggingShape is CircleSave c)          { c.X = newX; c.Y = newY; }
             InvalidateVisual();

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/PreviewShapeDragTests.cs
@@ -63,6 +63,22 @@ public class PreviewShapeDragTests
         Assert.Equal(-7f, circle.Y, precision: 3);
     }
 
+    [AvaloniaFact]
+    public void DragCircle_SubPixelDelta_SnapsPositionToPixel()
+    {
+        var ctx    = TestHelpers.BuildServices();
+        var circle = new CircleSave { X = 0f, Y = 0f, Radius = 10f };
+        var frame  = MakeFrame(circle: circle);
+        ctx.SelectedState.SelectedFrame  = frame;
+        ctx.SelectedState.SelectedCircle = circle;
+
+        var ctrl = ctx.CreatePreviewControl();
+        ctrl.SimulateShapeDrag(10.6f, -5.4f);
+
+        Assert.Equal(11f, circle.X, precision: 3);
+        Assert.Equal(-5f, circle.Y, precision: 3);
+    }
+
     // ── Rectangle drag ────────────────────────────────────────────────────────
 
     [AvaloniaFact]


### PR DESCRIPTION
Closes #1066.

Dragging a collision shape (Circle/AARect) in the Animation Editor's preview panel left its X/Y at raw sub-pixel values, unlike frame drag which already snaps via `SnapToPixel`. Applied the same snapping to shape position in `PreviewControl.OnPointerMoved` and its `SimulateShapeDrag` test helper.

Scoped to position only, per issue — resize/radius unaffected.

Manual test: not needed — covered by the headless `SimulateShapeDrag` drag-simulation path (`PreviewShapeDragTests`), same pattern already used for frame drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rznwJa6bx7QPXKK9dhX9K
