### PR TITLE
Fix #894: delete stray recovery file on normal AnimationEditor close

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -327,6 +327,9 @@ public partial class MainWindow : Window
             _appSettings.PreviewPaneHeight = AchxEditorPane.RowDefinitions[3].Height.Value;
             _appSettings.WindowMaximized = WindowState == WindowState.Maximized;
             SaveTabsToSettings();
+            // A normal close is not a crash -- clear any stray recovery file so the next
+            // launch doesn't falsely report "closed unexpectedly" (#894).
+            _appCommands.HandleApplicationClosing();
             _appCommands.HotReloadWatcher.Dispose();
             PreviewCtrl.Playback.FrameIndexChanged -= OnPreviewPlaybackFrameIndexChanged;
             PreviewCtrl.IsPlayingChanged -= UpdatePlayPauseIcon;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1670,6 +1670,9 @@ namespace AnimationEditor.Core.CommandsAndState
             RefreshTreeViewRequested?.Invoke();
         }
 
+        /// <inheritdoc cref="IAppCommands.HandleApplicationClosing"/>
+        public void HandleApplicationClosing() => _ioManager.DeleteRecoveryFile();
+
         // ── WF09: Create frame from magic-wand pixel bounds ───────────────────
 
         /// <summary>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -277,6 +277,16 @@ namespace AnimationEditor.Core.CommandsAndState
         /// separately.
         /// </summary>
         void CloseProject();
+
+        /// <summary>
+        /// Call when the application window is closing normally (not a crash). Deletes any
+        /// crash-recovery file for an unsaved document (<c>ProjectManager.FileName</c> is null) so
+        /// a clean close doesn't leave a stray recovery file that falsely triggers the "closed
+        /// unexpectedly" prompt on next launch (#894). A no-op once the document has a
+        /// <c>FileName</c>, since <see cref="AppCommands.SaveCurrentAnimationChainList"/> only ever
+        /// writes a recovery file for a nameless document.
+        /// </summary>
+        void HandleApplicationClosing();
         void AddFrameFromPixelBounds(AnimationChainSave chain, string textureName, int minX, int minY, int maxX, int maxY, int bitmapWidth, int bitmapHeight);
         void SetFrameTextureName(AnimationFrameSave frame, string? textureName);
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsRecoveryTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsRecoveryTests.cs
@@ -92,4 +92,31 @@ public class AppCommandsRecoveryTests : IDisposable
 
         Assert.True(ctx.IoManager.RecoveryFileExists(), "Recovery should be preserved when user cancels Save As");
     }
+
+    // ── Recovery deletion on a normal window close (#894) ────────────────────
+
+    [Fact]
+    public void HandleApplicationClosing_WhenFileNameIsNull_DeletesRecoveryFile()
+    {
+        // Simulates an unsaved document (FileName never set) that picked up a
+        // recovery file from an earlier edit, then closed normally rather than crashing.
+        ctx.ProjectManager.FileName = null;
+        ctx.IoManager.WriteRecoveryFile(new AnimationChainListSave());
+        Assert.True(ctx.IoManager.RecoveryFileExists());
+
+        ctx.AppCommands.HandleApplicationClosing();
+
+        Assert.False(ctx.IoManager.RecoveryFileExists(),
+            "A normal close should not leave a stray recovery file behind to falsely trigger the 'closed unexpectedly' prompt on next launch.");
+    }
+
+    [Fact]
+    public void HandleApplicationClosing_WhenFileNameIsSet_LeavesNoRecoveryFileBehind()
+    {
+        ctx.ProjectManager.FileName = _dir.Path + "/hero.achx";
+
+        ctx.AppCommands.HandleApplicationClosing();
+
+        Assert.False(ctx.IoManager.RecoveryFileExists());
+    }
 }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -52,6 +52,7 @@ public class UndoCoverageRosterTests
         [nameof(IAppCommands.SaveCurrentAnimationChainList)]      = Category.MutatingNotUndoable, // writes a file; no model change
         [nameof(IAppCommands.SaveCurrentAnimationChainListAsync)] = Category.MutatingNotUndoable, // writes a file; no model change
         [nameof(IAppCommands.ExportToPixiJsAsync)]                = Category.MutatingNotUndoable, // writes a PixiJS json; no model change
+        [nameof(IAppCommands.HandleApplicationClosing)]           = Category.MutatingNotUndoable, // deletes a recovery file; no model change
 
         // Non-mutating -----------------------------------------------------------
         [nameof(IAppCommands.RefreshTreeNode)]              = Category.NonMutating,


### PR DESCRIPTION
## Summary
Closes #894. `AppCommands.SaveCurrentAnimationChainList` writes a recovery file on every edit to an unsaved (`FileName == null`) document, but `MainWindow`'s `Closed` handler never deleted it on a normal close — so any scratch edit followed by a clean quit left the file behind and falsely triggered the "closed unexpectedly" prompt on next launch.

Adds `AppCommands.HandleApplicationClosing()` (deletes the recovery file), wired into `MainWindow.Closed`, mirroring the existing `CloseProject` cleanup pattern.

## Test plan
- [x] New failing test confirmed the bug (compile error before the method existed, since `IAppCommands` had no closing hook)
- [x] `dotnet test tests/AnimationEditor.Core.Tests --filter FullyQualifiedName~AppCommandsRecoveryTests` — 7/7 pass
- [x] `dotnet build src/AnimationEditor.App/AnimationEditor.App.csproj` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzYeKkxWoovafjfX8YAfKy