### PR TITLE
Bump Gum/KernSmith to 2026.9.11.1-preview.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,17 +41,17 @@
     <PackageVersion Include="NVorbis" Version="0.10.5" />
     <PackageVersion Include="Apos.Shapes" Version="$(AposShapesVersion)" />
     <PackageVersion Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
-    <PackageVersion Include="Gum.MonoGame" Version="2026.9.3.2-preview.1" />
-    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.9.3.2-preview.1" />
-    <PackageVersion Include="Gum.KNI" Version="2026.9.3.2-preview.1" />
-    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.9.3.2-preview.1" />
+    <PackageVersion Include="Gum.MonoGame" Version="2026.9.11.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.MonoGame" Version="2026.9.11.1-preview.1" />
+    <PackageVersion Include="Gum.KNI" Version="2026.9.11.1-preview.1" />
+    <PackageVersion Include="Gum.Shapes.KNI" Version="2026.9.11.1-preview.1" />
     <!-- KernSmith moved from a 0.x scheme to the same date-based versioning as Gum, tracking
          Gum's release cadence 1:1. 0.16.0 was its last 0.x release, so a floating "0.16.*" no
          longer matches anything published; pin exactly like the Gum.* packages above. -->
-    <PackageVersion Include="KernSmith.MonoGameGum" Version="2026.9.3.2-preview.1" />
-    <PackageVersion Include="KernSmith.KniGum" Version="2026.9.3.2-preview.1" />
+    <PackageVersion Include="KernSmith.MonoGameGum" Version="2026.9.11.1-preview.1" />
+    <PackageVersion Include="KernSmith.KniGum" Version="2026.9.11.1-preview.1" />
     <!-- Rasterizer backend package, pinned to the same version as the core KernSmith package
-         KernSmith.KniGum depends on transitively (2026.9.3.2-preview.1 -> KernSmith 0.21.0). -->
+         KernSmith.KniGum depends on transitively (2026.9.11.1-preview.1 -> KernSmith 0.21.0). -->
     <PackageVersion Include="KernSmith.Rasterizers.StbTrueType" Version="0.21.0" />
     <PackageVersion Include="MonoGame.Framework.DesktopGL" Version="3.8.5.1" />
     <PackageVersion Include="MonoGame.Content.Builder.Task" Version="3.8.5.1" />

--- a/samples/Solitaire/Solitaire.Common/.config/dotnet-tools.json
+++ b/samples/Solitaire/Solitaire.Common/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "gumcli": {
-      "version": "2026.9.3.2-preview.1",
+      "version": "2026.9.11.1-preview.1",
       "commands": ["gumcli"]
     }
   }


### PR DESCRIPTION
## Summary
- Bumps Gum.MonoGame/Shapes.MonoGame/KNI/Shapes.KNI and KernSmith.MonoGameGum/KniGum to 2026.9.11.1-preview.1, which fixes the default template referencing an Arial system font that broke web projects.
- Bumps Solitaire's `gumcli` tool pin to match.

## Test plan
- [x] `dotnet build src/FlatRedBall2.csproj` — clean
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1694 passed
- [x] `dotnet build samples/Solitaire/Solitaire.Desktop/Solitaire.Desktop.csproj` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQCmq462SNKDSAbJwcrDQE