### PR TITLE
Make TextRuntime.UseFontOversampling opt-in via EngineInitSettings

### DIFF
--- a/samples/Solitaire/Solitaire.Common/Game1.cs
+++ b/samples/Solitaire/Solitaire.Common/Game1.cs
@@ -43,10 +43,13 @@ public class Game1 : Game
         FlatRedBallService.Default.Initialize(this, new EngineInitSettings
         {
 #if GUM_BUNDLE
-            GumProjectFile = "GumProject/GumProject.gumpkg"
+            GumProjectFile = "GumProject/GumProject.gumpkg",
 #else
-            GumProjectFile = "GumProject/GumProject.gumj"
+            GumProjectFile = "GumProject/GumProject.gumj",
 #endif
+            // Solitaire's cards zoom with Camera.Zoom, so crisp re-rasterized text matters here —
+            // most FRB2 projects default this off (see EngineInitSettings.UseFontOversampling).
+            UseFontOversampling = true
         });
         FlatRedBallService.Default.Start<GameScreen>();
     }

--- a/src/EngineInitSettings.cs
+++ b/src/EngineInitSettings.cs
@@ -51,4 +51,16 @@ public class EngineInitSettings
     /// during startup or only produce a warning.
     /// </summary>
     public MissingGumFontFileBehavior MissingGumFontFileBehavior { get; init; } = MissingGumFontFileBehavior.Warn;
+
+    /// <summary>
+    /// Whether Gum text automatically rebuilds its font at a higher raster size under
+    /// <c>Camera.Zoom</c>, for crisper text instead of a stretched/blurry bitmap. Off by default,
+    /// matching Gum's own <c>TextRuntime.UseFontOversampling</c> default — pixel-art games want
+    /// blocky/nearest-neighbor text, and it's a project-wide call the game should make, not the
+    /// engine. Turning it on also means any <c>Font</c>/<c>FontFamily</c> left at Gum's system-font
+    /// default ("Arial") now needs KernSmith to resolve that family at runtime, which fails on
+    /// BlazorGL/WASM where there is no OS font store — set an explicit bundled font before opting in
+    /// on a web target.
+    /// </summary>
+    public bool UseFontOversampling { get; init; } = false;
 }

--- a/src/FlatRedBallService.cs
+++ b/src/FlatRedBallService.cs
@@ -349,6 +349,14 @@ public class FlatRedBallService
         isBrowser ? RasterizerBackend.StbTrueType : null;
 
     /// <summary>
+    /// Reads <see cref="EngineInitSettings.UseFontOversampling"/>, defaulting to <c>false</c> when no
+    /// settings were given. Extracted as a pure function so the opt-in default is testable without a
+    /// real <c>GraphicsDevice</c>.
+    /// </summary>
+    internal static bool ResolveUseFontOversampling(EngineInitSettings? settings) =>
+        settings?.UseFontOversampling ?? false;
+
+    /// <summary>
     /// Reads the <c>.gluj</c> and its element files from <see cref="OutputContentRoot"/> rather than
     /// the process working directory, which is the project folder under <c>dotnet run</c> and the
     /// output folder under a debugger — so the plain-relative read would find a different (stale)
@@ -547,12 +555,12 @@ public class FlatRedBallService
         CustomSetPropertyOnRenderable.InMemoryFontCreator =
             new KernSmithFontCreator(game.GraphicsDevice, fontRasterizerBackend);
         // Rebuilds each visible TextRuntime's font at its zoomed size instead of stretching the
-        // baked bitmap, fixing blur under Camera.Zoom and window resize (issue #1000). Safe to turn
-        // on unconditionally because it only acts on the Gum Camera.Zoom GumRenderBatch already
-        // drives from Camera.PixelsPerUnit — screen-space layers (Zoom == 1, e.g. AddOverlay) never
-        // trigger a rebuild — and the KernSmithFontCreator above is always present as the
-        // IInMemoryFontCreator oversampling needs to rasterize the new size.
-        TextRuntime.UseFontOversampling = true;
+        // baked bitmap, fixing blur under Camera.Zoom and window resize (issue #1000). Opt-in via
+        // EngineInitSettings.UseFontOversampling (default false, matching Gum's own default) rather
+        // than unconditional: it's a project-wide call the game should make (pixel-art games want
+        // blocky text), and turning it on for a Font left at Gum's "Arial" default requires KernSmith
+        // to resolve a system font, which fails on BlazorGL/WASM.
+        TextRuntime.UseFontOversampling = ResolveUseFontOversampling(settings);
 
         if ((settings?.GumProjectFile ?? ResolveGlueGumProjectFile(GlueProject, game.Content.RootDirectory))
             is string gumProjectFile)

--- a/tests/FlatRedBall2.Tests/FlatRedBallServiceFontOversamplingTests.cs
+++ b/tests/FlatRedBall2.Tests/FlatRedBallServiceFontOversamplingTests.cs
@@ -1,0 +1,27 @@
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests;
+
+public class FlatRedBallServiceFontOversamplingTests
+{
+    [Fact]
+    public void ResolveUseFontOversampling_NullSettings_ReturnsFalse()
+    {
+        FlatRedBallService.ResolveUseFontOversampling(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ResolveUseFontOversampling_DefaultSettings_ReturnsFalse()
+    {
+        FlatRedBallService.ResolveUseFontOversampling(new EngineInitSettings()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ResolveUseFontOversampling_OptedIn_ReturnsTrue()
+    {
+        var settings = new EngineInitSettings { UseFontOversampling = true };
+
+        FlatRedBallService.ResolveUseFontOversampling(settings).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- `FlatRedBallService.Initialize` hardcoded `TextRuntime.UseFontOversampling = true` for every project, contradicting Gum's own off-by-default rationale (pixel-art games want blocky text; it's a project-wide decision the game should make).
- Silent WASM breakage: oversampling re-rasterizes text at a size the embedded default-font resource doesn't cover, falling through to KernSmith resolving "Arial" as a *system* font — which BlazorGL/WASM has no OS font store to satisfy. Any FRB2 web project with unconfigured fonts (the common case) crashes at runtime.
- Added `EngineInitSettings.UseFontOversampling` (default `false`), routed through a new testable `FlatRedBallService.ResolveUseFontOversampling` helper. Solitaire opts in explicitly since its cards zoom with `Camera.Zoom`.

## Test plan
- [x] New unit tests (`FlatRedBallServiceFontOversamplingTests`) cover null settings, default settings, and opt-in — all pass
- [x] Full `dotnet test tests/FlatRedBall2.Tests/` passes (1697/1697)
- [x] `dotnet build src/FlatRedBall2.csproj` and Solitaire Desktop build clean
- [x] Verified against an external code-only sample project (BlazorGL/KNI target) wired to this branch via local `ProjectReference` — builds clean; dev server confirmed serving. Browser console check pending Chrome extension reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfYAJ3n9TFwKtSxvKuRYV8