### PR TITLE
Load Glue project GlobalFiles entries, not just the Gum project

### DIFF
--- a/src/Glue/GlueContentSource.cs
+++ b/src/Glue/GlueContentSource.cs
@@ -161,19 +161,35 @@ public sealed class GlueContentSource
         if (!_loaded.Add(element))
             return;
 
-        foreach (var file in element.ReferencedFiles)
+        LoadFiles(element.ReferencedFiles, element.Name, diagnostics);
+    }
+
+    /// <summary>
+    /// Loads a project's <c>GlobalFiles</c> — the same <see cref="ReferencedFileSave"/> shape as an
+    /// element's own <see cref="GlueElement.ReferencedFiles"/>, but declared at the project root
+    /// rather than under a screen or entity. <see cref="GlueGumResolver"/> already pulls the Gum
+    /// project out of this same list; this loads everything else in it the same way an element's
+    /// own referenced files are loaded.
+    /// </summary>
+    internal void LoadGlobalFiles(List<ReferencedFileSave> files, List<GlueLoadDiagnostic> diagnostics) =>
+        LoadFiles(files, elementName: null, diagnostics);
+
+    private void LoadFiles(
+        List<ReferencedFileSave> files, string? elementName, List<GlueLoadDiagnostic> diagnostics)
+    {
+        foreach (var file in files)
         {
             if (string.IsNullOrEmpty(file.Name) || !file.LoadedAtRuntime)
                 continue;
 
             if (file.Name.Contains('*'))
             {
-                Warn(diagnostics, element.Name,
+                Warn(diagnostics, elementName,
                     $"'{file.Name}' is a wildcard reference, which this loader does not expand.");
                 continue;
             }
 
-            LoadOne(file, element.Name, diagnostics);
+            LoadOne(file, elementName, diagnostics);
         }
     }
 

--- a/src/Glue/GlueProject.cs
+++ b/src/Glue/GlueProject.cs
@@ -36,6 +36,8 @@ public sealed class GlueProject
 
         foreach (var entity in result.Project.Entities.Where(e => !string.IsNullOrEmpty(e.Name)))
             _entities[entity.Name!] = entity;
+
+        content?.LoadGlobalFiles(result.Project.GlobalFiles, _diagnostics);
     }
 
     /// <summary>The raw load result.</summary>

--- a/tests/FlatRedBall2.Tests/Glue/Fixtures/DoorsDemo/DoorsDemo.gluj
+++ b/tests/FlatRedBall2.Tests/Glue/Fixtures/DoorsDemo/DoorsDemo.gluj
@@ -40,6 +40,9 @@
       "DestroyOnUnload": false,
       "HasPublicProperty": true,
       "ProjectsToExcludeFrom": []
+    },
+    {
+      "Name": "StandardTilesetIcons.png"
     }
   ],
   "GlobalContentSettingsSave": {

--- a/tests/FlatRedBall2.Tests/Glue/GlueContentTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueContentTests.cs
@@ -159,6 +159,24 @@ public class GlueContentTests
     }
 
     [Fact]
+    public void Load_ProjectGlobalFiles_LoadsEntriesOtherThanTheGumProjectToo()
+    {
+        // GlobalFiles is a project-level ReferencedFileSave list, same shape as an element's own
+        // ReferencedFiles. GlueGumResolver has always pulled the .gumx out of it; every other entry
+        // (DoorsDemo.gluj now also declares StandardTilesetIcons.png) needs the same loading an
+        // element's ReferencedFiles already gets.
+        if (!_graphics.IsAvailable)
+            return;
+
+        var project = FlatRedBall2.Glue.GlueProject.Load(
+            Path.Combine(AppContext.BaseDirectory, "Glue", "Fixtures", "DoorsDemo", "DoorsDemo.gluj"),
+            new GlueContentSource(
+                _graphics.ContentLoader!, FixtureDirectory("DoorsDemo"), _graphics.GraphicsDevice));
+
+        project.Content!.Get<Texture2D>("StandardTilesetIcons").ShouldNotBeNull();
+    }
+
+    [Fact]
     public void Load_ReferencedFileNotLoadedAtRuntime_IsSkipped()
     {
         var source = SourceFor("DoorsDemo");


### PR DESCRIPTION
Closes #1076
Part of #838

`GlueGumResolver` only ever pulled the `.gumx` out of a project's `GlobalFiles` list; every other `ReferencedFileSave` entry there was silently dropped. `GlueContentSource.LoadGlobalFiles` now loads that list through the same per-file loading an element's own `ReferencedFiles` already gets, called from `GlueProject`'s constructor. Test fixture: added a `StandardTilesetIcons.png` entry to `DoorsDemo.gluj`'s `GlobalFiles` and asserted it's reachable via `GlueProject.Content.Get<Texture2D>`.

Manual test: not needed — covered by `GlueContentTests.Load_ProjectGlobalFiles_LoadsEntriesOtherThanTheGumProjectToo`, no rendering or pixel output involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox