### PR TITLE
Glue loader: map Line/PositionedObject, exempt lists from unbuildable warnings

### DIFF
--- a/src/Glue/GlueProjectLoader.cs
+++ b/src/Glue/GlueProjectLoader.cs
@@ -249,14 +249,16 @@ public static class GlueProjectLoader
             // unmapped — it is built from that element's own data.
             bool isKnownElement = elementNames.Contains(typeName.ToElementNameCandidate());
 
-            // Tile objects and collision relationships are not in GlueTypeMap because they are not
-            // constructed from a CLR type — a map comes from a file, a collection is derived from a
-            // map, and a relationship is registered rather than instantiated. Counting them as
-            // unmapped would report as missing the very things that now work.
+            // Tile objects, collision relationships, and lists are not in GlueTypeMap because they
+            // are not constructed from a CLR type — a map comes from a file, a collection is derived
+            // from a map, a relationship is registered rather than instantiated, and a list is a
+            // plain List<object> GlueElementBuilder builds directly. Counting them as unmapped would
+            // report as missing the very things that now work.
             bool isBuiltElsewhere =
                 GlueTileBuilder.IsTileObject(namedObject) ||
                 GlueCollisionBuilder.IsRelationship(namedObject) ||
-                GlueGumResolver.IsGumObject(namedObject);
+                GlueGumResolver.IsGumObject(namedObject) ||
+                namedObject.IsList;
 
             if (!isKnownElement && !isBuiltElsewhere && !GlueTypeMap.TryGetType(typeName, out _))
             {

--- a/src/Glue/GlueTypeMap.cs
+++ b/src/Glue/GlueTypeMap.cs
@@ -27,7 +27,11 @@ public static class GlueTypeMap
         ["FlatRedBall.Math.Geometry.AxisAlignedRectangle"] = static () => new Collision.AARect(),
         ["FlatRedBall.Math.Geometry.Circle"] = static () => new Collision.Circle(),
         ["FlatRedBall.Math.Geometry.Polygon"] = static () => new Collision.Polygon(),
+        ["FlatRedBall.Math.Geometry.Line"] = static () => new Collision.Line(),
         ["FlatRedBall.Entities.CameraControllingEntity"] = static () => new Entities.CameraControllingEntity(),
+        // A bare PositionedObject is an attachment anchor with no visual — Entity is the equivalent:
+        // position/attachment with no required shape or sprite.
+        ["FlatRedBall.PositionedObject"] = static () => new Entity(),
     };
 
     private static readonly Dictionary<string, Type> TypesByGlueName = new(StringComparer.Ordinal)
@@ -36,7 +40,9 @@ public static class GlueTypeMap
         ["FlatRedBall.Math.Geometry.AxisAlignedRectangle"] = typeof(Collision.AARect),
         ["FlatRedBall.Math.Geometry.Circle"] = typeof(Collision.Circle),
         ["FlatRedBall.Math.Geometry.Polygon"] = typeof(Collision.Polygon),
+        ["FlatRedBall.Math.Geometry.Line"] = typeof(Collision.Line),
         ["FlatRedBall.Entities.CameraControllingEntity"] = typeof(Entities.CameraControllingEntity),
+        ["FlatRedBall.PositionedObject"] = typeof(Entity),
     };
 
     /// <summary>

--- a/tests/FlatRedBall2.Tests/Glue/GlueProjectLoaderTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueProjectLoaderTests.cs
@@ -100,6 +100,36 @@ public class GlueProjectLoaderTests
     }
 
     [Fact]
+    public void Load_ListObject_IsExemptFromUnbuildableTypeWarning()
+    {
+        // A list's element type (Entities\Enemy) does not resolve to anything in this project, so
+        // without the IsList exemption the list itself would also be reported as unbuildable even
+        // though FlatRedBall.Math.PositionedObjectList<T> already builds fine.
+        var files = new Dictionary<string, string>
+        {
+            [@"C:\proj\Test.gluj"] = @"{
+                ""FileVersion"": 68,
+                ""ScreenReferences"": [ { ""Name"": ""Screens\\Level1"" } ]
+            }",
+            [@"C:\proj\Screens/Level1.glsj"] = @"{
+                ""Name"": ""Screens\\Level1"",
+                ""NamedObjects"": [
+                    {
+                        ""InstanceName"": ""EnemyList"",
+                        ""SourceClassType"": ""FlatRedBall.Math.PositionedObjectList<T>"",
+                        ""SourceType"": 2,
+                        ""SourceClassGenericType"": ""Entities\\Enemy""
+                    }
+                ]
+            }",
+        };
+
+        var result = GlueProjectLoader.Load(@"C:\proj\Test.gluj", InMemory(files));
+
+        result.Diagnostics.ShouldNotContain(d => d.Message.Contains("cannot be built by this build"));
+    }
+
+    [Fact]
     public void Load_MissingElementFile_WarnsAndKeepsLoadingTheRest()
     {
         var files = new Dictionary<string, string>

--- a/tests/FlatRedBall2.Tests/Glue/GlueTypeMapTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueTypeMapTests.cs
@@ -35,6 +35,24 @@ public class GlueTypeMapTests
     }
 
     [Fact]
+    public void TryGetType_Line_MapsToCollisionLine()
+    {
+        GlueTypeMap.TryGetType("FlatRedBall.Math.Geometry.Line", out var type).ShouldBeTrue();
+
+        type.ShouldBe(typeof(FlatRedBall2.Collision.Line));
+    }
+
+    [Fact]
+    public void TryGetType_PositionedObject_MapsToEntity()
+    {
+        // A bare PositionedObject is an attachment anchor with no visual — FRB2's Entity is the
+        // equivalent: it has position/attachment but no required shape or sprite.
+        GlueTypeMap.TryGetType("FlatRedBall.PositionedObject", out var type).ShouldBeTrue();
+
+        type.ShouldBe(typeof(FlatRedBall2.Entity));
+    }
+
+    [Fact]
     public void TryGetType_Sprite_MapsToRenderingSprite()
     {
         GlueTypeMap.TryGetType("FlatRedBall.Sprite", out var type).ShouldBeTrue();
@@ -54,21 +72,20 @@ public class GlueTypeMapTests
     }
 
     [Fact]
-    public void Load_DoorsDemo_ReportsUnmappedTypesAsWarningsAndNoErrors()
+    public void Load_DoorsDemo_HasNoUnmappedTypeWarningsAndNoErrors()
     {
-        // Most of this fixture belongs to later phases, so a pile of warnings is the expected,
-        // correct outcome. Pinning the count turns it into a progress metric: each phase that lands
-        // should drive it down. Under a fail-fast policy this project could not load at all.
-        // It went 13 -> 18 when inheritance landed, and that is progress rather than regression:
-        // Level1 previously declared four objects and now honestly carries all nine it inherits, so
-        // the unmapped ones are counted in both screens instead of only in the base.
+        // Pinning the count turns it into a progress metric: each phase that lands should drive it
+        // down. Under a fail-fast policy this project could not load at all.
+        // Dropped to 0 once #1073 exempted PositionedObjectList<T> from this report the same way tile
+        // and collision objects already were -- every "cannot be built" warning this fixture produced
+        // was a list, which already builds correctly.
         var glujPath = Path.Combine(
             AppContext.BaseDirectory, "Glue", "Fixtures", "DoorsDemo", "DoorsDemo.gluj");
 
         var result = GlueProjectLoader.Load(glujPath);
 
         result.HasErrors.ShouldBeFalse();
-        result.Diagnostics.Count(d => d.Message.Contains("cannot be built by this build")).ShouldBe(4);
+        result.Diagnostics.Count(d => d.Message.Contains("cannot be built by this build")).ShouldBe(0);
     }
 
     // FileVersion 54 projects write SourceClassType in short form, and mix both spellings inside one


### PR DESCRIPTION
Three quick-win Glue loader gaps from #838.

- **#1074**: `GlueTypeMap` maps `FlatRedBall.Math.Geometry.Line` to `FlatRedBall2.Collision.Line`.
- **#1075**: `GlueTypeMap` maps bare `FlatRedBall.PositionedObject` to `FlatRedBall2.Entity` (the attachment-anchor-with-no-visual equivalent).
- **#1073**: `GlueProjectLoader.ReportUnbuildableTypes` now exempts `NamedObjectSave.IsList` the same way it already exempts tile/collision/Gum objects. `PositionedObjectList<T>` already builds correctly via `GlueElementBuilder`; it was a false-positive warning. DoorsDemo's pinned unmapped-type count went from 4 to 0 as a result (every warning that fixture produced was a list).

Manual test: not needed — covered by unit tests against the headless loader.

Closes #1073
Closes #1074
Closes #1075
Part of #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox