### PR TITLE
Fix #1078: bind Glue collision relationships to the live instance list

### DIFF
--- a/src/Glue/GlueCollisionBuilder.cs
+++ b/src/Glue/GlueCollisionBuilder.cs
@@ -79,7 +79,7 @@ internal static class GlueCollisionBuilder
             if (!IsRelationship(save) || string.IsNullOrEmpty(save.InstanceName) || save.IsDisabled)
                 continue;
 
-            var built = BuildOne(save, elementName, objects, diagnostics, project, screen);
+            var built = BuildOne(save, elementName, objects, diagnostics, project, screen, namedObjects);
 
             if (built is not null)
                 objects[save.InstanceName] = built;
@@ -92,7 +92,8 @@ internal static class GlueCollisionBuilder
         Dictionary<string, object> objects,
         List<GlueLoadDiagnostic> diagnostics,
         GlueProject? project,
-        Screen? screen)
+        Screen? screen,
+        List<NamedObjectSave> namedObjects)
     {
         var settings = GlueCollisionSettings.From(save);
 
@@ -122,7 +123,7 @@ internal static class GlueCollisionBuilder
             return null;
         }
 
-        var first = ResolveSide(settings.FirstCollisionName!, objects, project);
+        var first = ResolveSide(settings.FirstCollisionName!, objects, project, namedObjects);
 
         if (first is null)
         {
@@ -142,7 +143,7 @@ internal static class GlueCollisionBuilder
             return null;
         }
 
-        var second = ResolveSide(settings.SecondCollisionName, objects, project);
+        var second = ResolveSide(settings.SecondCollisionName, objects, project, namedObjects);
 
         if (second is null)
         {
@@ -158,8 +159,19 @@ internal static class GlueCollisionBuilder
     /// <summary>
     /// Resolves one side to something collidable: an entity list, a single entity, or tile shapes.
     /// </summary>
+    /// <remarks>
+    /// A Glue list is built once, at load, into a plain snapshot (<see cref="GlueElementBuilder.Build"/>).
+    /// Binding a relationship straight to that snapshot means an entity spawned afterwards — via
+    /// <see cref="GlueProject.CreateEntity(string, Screen)"/>, the Factory-equivalent path — is
+    /// invisible to it forever. <see cref="GlueProject.InstancesOf"/> is the live list every created
+    /// instance of an entity type is tracked in (Added on create, removed on destroy), so once the
+    /// list's element type is known this resolves to that instead of the snapshot.
+    /// </remarks>
     private static object? ResolveSide(
-        string name, Dictionary<string, object> objects, GlueProject? project)
+        string name,
+        Dictionary<string, object> objects,
+        GlueProject? project,
+        List<NamedObjectSave> namedObjects)
     {
         if (!objects.TryGetValue(name, out object? side))
             return null;
@@ -168,7 +180,15 @@ internal static class GlueCollisionBuilder
         if (side is List<object> list)
         {
             var entities = list.OfType<GlueEntity>().ToList();
-            return entities.Count == list.Count ? entities : null;
+            if (entities.Count != list.Count)
+                return null;
+
+            var entityTypeName = namedObjects
+                .FirstOrDefault(n => n.IsList && n.InstanceName == name)?.SourceClassGenericType;
+
+            return project is not null && !string.IsNullOrEmpty(entityTypeName)
+                ? (object)project.InstancesOf(entityTypeName)
+                : entities;
         }
 
         return side;

--- a/src/Glue/GlueProject.cs
+++ b/src/Glue/GlueProject.cs
@@ -95,11 +95,21 @@ public sealed class GlueProject
     /// <remarks>
     /// Stands in for FRB1's per-entity factory list, and is what a collision relationship binds to.
     /// Pooling and spatial partitioning are <em>not</em> wired — see the Phase 8 notes.
+    /// <para>Returns the actual backing <c>List&lt;GlueEntity&gt;</c>, creating and caching an empty
+    /// one on first call for a name with no instances yet. This is load-bearing for a relationship
+    /// registered before any instance of that type exists (e.g. an enemy type spawned purely by a
+    /// runtime factory): the caller must get back the same live list every time, not a throwaway
+    /// empty array, or an instance created later has nothing to be added to.</para>
     /// </remarks>
-    public IReadOnlyList<GlueEntity> InstancesOf(string glueName) =>
-        _instances.TryGetValue(Normalize(glueName), out var list)
-            ? list
-            : Array.Empty<GlueEntity>();
+    public IReadOnlyList<GlueEntity> InstancesOf(string glueName)
+    {
+        string normalized = Normalize(glueName);
+
+        if (!_instances.TryGetValue(normalized, out var list))
+            _instances[normalized] = list = new List<GlueEntity>();
+
+        return list;
+    }
 
     /// <summary>
     /// The screen <paramref name="screen"/> names as the one to advance to, or null when it names

--- a/tests/FlatRedBall2.Tests/Glue/GlueCollisionTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueCollisionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using FlatRedBall2.Collision;
 using FlatRedBall2.Glue;
 using FlatRedBall2.Glue.Model;
 using Shouldly;
@@ -179,6 +180,35 @@ public class GlueCollisionTests
         var settings = GlueCollisionSettings.From(save);
 
         settings.FirstCollisionName.ShouldBe(settings.SecondCollisionName);
+    }
+
+    // The relationship binds "PlayerBallList" at build time. A ball a runtime Factory spawns
+    // afterwards must still be visible to it — not just the two balls placed in Glue.
+    [Fact]
+    public void BuildObjects_EntitySpawnedAfterRegistration_ParticipatesInCollision()
+    {
+        var engine = new FlatRedBallService();
+        var project = GlueProject.Load(Gluj("Beefball"));
+        engine.GlueProject = project;
+        engine.Start<GlueScreen>(s => { s.Save = project.StartUpScreen; s.Project = project; });
+
+        var screen = (GlueScreen)engine.CurrentScreen;
+        var relationship =
+            (CollisionRelationship<GlueEntity, GlueEntity>)screen.Objects["PlayerBallVsPuck"];
+
+        var puck = project.InstancesOf(@"Entities\Puck").Single();
+        puck.X = 0f;
+        puck.Y = 0f;
+
+        var spawnedBall = project.CreateEntity(@"Entities\PlayerBall", screen);
+        spawnedBall.X = 0f;
+        spawnedBall.Y = 0f;
+
+        GlueEntity? collidedBall = null;
+        relationship.CollisionOccurred += (ball, _) => collidedBall = ball;
+        relationship.RunCollisions();
+
+        collidedBall.ShouldBeSameAs(spawnedBall);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1078
Part of #838

`GlueCollisionBuilder.ResolveSide` copied a Glue-authored list into a new `List<GlueEntity>` once at build time, so any entity spawned into that list afterwards (Factory / `GlueProject.CreateEntity`) was invisible to the relationship — `ResolveSide` now binds to `GlueProject.InstancesOf(entityType)`, the actual live list new instances are added/removed from, and `InstancesOf` lazily creates and caches that list on first call so it's stable even before any instance exists.

Manual test: not needed. This is headless simulation logic — the new test uses the same `new FlatRedBallService()` + `Start<GlueScreen>()` pattern CLAUDE.md documents (~25 existing tests in `ScreenTests.cs` use it) to boot a real Glue project, spawn an entity, and directly assert on collision state; nothing here touches rendering or requires a display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox