### PR TITLE
Glue loader: build Layer named objects and honor LayerOn

### DIFF
--- a/src/Glue/GlueObjectBuilder.cs
+++ b/src/Glue/GlueObjectBuilder.cs
@@ -66,6 +66,11 @@ public sealed class GlueObjectBuilder
             return null;
         }
 
+        // A Layer's identity is its Glue instance name, not an authored instruction — the
+        // parameterless factory in GlueTypeMap has no way to see it, so it is set here instead.
+        if (instance is Rendering.Layer layer)
+            layer.Name = save.InstanceName ?? layer.Name;
+
         ApplyShapeVisibilityDefault(instance);
         ApplyInstructions(instance, save, elementName);
 
@@ -89,11 +94,16 @@ public sealed class GlueObjectBuilder
     {
         object? instance = Create(save, elementName);
 
+        if (instance is null)
+            return null;
+
+        var layer = ResolveLayerOn(_owningScreen, save, elementName);
+
         // A Gum visual is not IAttachable — it is parented through the entity's own Gum support,
         // which is what keeps it following the entity.
         if (instance is Gum.Wireframe.GraphicalUiElement visual)
         {
-            container.Add(visual);
+            container.Add(visual, layer);
             return instance;
         }
 
@@ -108,13 +118,13 @@ public sealed class GlueObjectBuilder
         {
             switch (instance)
             {
-                case Collision.AARect rect: container.Add(rect, isDefaultCollision: false); return instance;
-                case Collision.Circle circle: container.Add(circle, isDefaultCollision: false); return instance;
-                case Collision.Polygon polygon: container.Add(polygon, isDefaultCollision: false); return instance;
+                case Collision.AARect rect: container.Add(rect, isDefaultCollision: false, layer); return instance;
+                case Collision.Circle circle: container.Add(circle, isDefaultCollision: false, layer); return instance;
+                case Collision.Polygon polygon: container.Add(polygon, isDefaultCollision: false, layer); return instance;
             }
         }
 
-        container.Add(attachable);
+        container.Add(attachable, layer);
         return instance;
     }
 
@@ -127,6 +137,7 @@ public sealed class GlueObjectBuilder
     public object? AddTo(Screen container, NamedObjectSave save, string? elementName = null)
     {
         object? instance = Create(save, elementName);
+        var layer = instance is null ? null : ResolveLayerOn(container, save, elementName);
 
         switch (instance)
         {
@@ -140,6 +151,9 @@ public sealed class GlueObjectBuilder
             case Entity entity:
                 container.Register(entity);
 
+                if (layer is not null)
+                    entity.Layer = layer;
+
                 // Register wires the entity up but does not initialise it — the engine's own
                 // Factory does that as a separate step. Skipping it leaves an engine entity in a
                 // half-built state: a camera controller resolves its Camera in CustomInitialize and
@@ -151,16 +165,50 @@ public sealed class GlueObjectBuilder
 
                 break;
 
+            // A Layer itself joins the screen's layer registry rather than its render list — it is
+            // the bucket other objects render into, not a renderable of its own.
+            case Rendering.Layer newLayer:
+                container.Layers.Add(newLayer);
+                break;
+
             case Gum.Wireframe.GraphicalUiElement visual:
-                container.Add(visual);
+                container.Add(visual, layer);
                 break;
 
             case Rendering.IRenderable renderable:
-                container.Add(renderable);
+                container.Add(renderable, layer);
                 break;
         }
 
         return instance;
+    }
+
+    /// <summary>
+    /// Resolves an object's authored <see cref="NamedObjectSave.LayerOn"/> to the built
+    /// <see cref="Rendering.Layer"/> it names, so the caller can pass it to the layer-aware
+    /// <c>Add</c> overload instead of falling through to the container's default layer.
+    /// </summary>
+    /// <remarks>
+    /// Looked up by name on <paramref name="screen"/>'s <see cref="Screen.Layers"/> rather than a
+    /// builder-local table, because that is the same registry
+    /// <see cref="AddTo(Screen, NamedObjectSave, string?)"/> adds a built <c>Layer</c> object to — so
+    /// this depends on the Layer having already been built, which matches Glue's own authoring
+    /// convention of declaring layers before the objects placed on them.
+    /// </remarks>
+    private Rendering.Layer? ResolveLayerOn(Screen? screen, NamedObjectSave save, string? elementName)
+    {
+        if (string.IsNullOrEmpty(save.LayerOn))
+            return null;
+
+        var layer = screen?.Layers.Find(l => l.Name == save.LayerOn);
+
+        if (layer is null)
+        {
+            Warn($"'{save.InstanceName}' names the layer '{save.LayerOn}', which was not found; " +
+                 "it was added to the default layer instead.", elementName);
+        }
+
+        return layer;
     }
 
     /// <summary>

--- a/src/Glue/GlueTypeMap.cs
+++ b/src/Glue/GlueTypeMap.cs
@@ -32,6 +32,9 @@ public static class GlueTypeMap
         // A bare PositionedObject is an attachment anchor with no visual — Entity is the equivalent:
         // position/attachment with no required shape or sprite.
         ["FlatRedBall.PositionedObject"] = static () => new Entity(),
+        // Constructed with a placeholder name: GlueObjectBuilder.Create overwrites it with the
+        // object's own InstanceName once built, since a parameterless factory has no way to see it.
+        ["FlatRedBall.Graphics.Layer"] = static () => new Rendering.Layer(string.Empty),
     };
 
     private static readonly Dictionary<string, Type> TypesByGlueName = new(StringComparer.Ordinal)
@@ -43,6 +46,7 @@ public static class GlueTypeMap
         ["FlatRedBall.Math.Geometry.Line"] = typeof(Collision.Line),
         ["FlatRedBall.Entities.CameraControllingEntity"] = typeof(Entities.CameraControllingEntity),
         ["FlatRedBall.PositionedObject"] = typeof(Entity),
+        ["FlatRedBall.Graphics.Layer"] = typeof(Rendering.Layer),
     };
 
     /// <summary>
@@ -62,6 +66,7 @@ public static class GlueTypeMap
         ["AxisAlignedRectangle"] = "FlatRedBall.Math.Geometry.AxisAlignedRectangle",
         ["Circle"] = "FlatRedBall.Math.Geometry.Circle",
         ["Polygon"] = "FlatRedBall.Math.Geometry.Polygon",
+        ["Layer"] = "FlatRedBall.Graphics.Layer",
     };
 
     private static string Canonical(string openTypeName) =>

--- a/src/Rendering/Layer.cs
+++ b/src/Rendering/Layer.cs
@@ -6,9 +6,9 @@ namespace FlatRedBall2.Rendering;
 /// layer, regardless of <see cref="IRenderable.Z"/>; within a single layer, Z and the
 /// screen's <see cref="SortMode"/> determine ordering.
 /// <para>
-/// Create layers via <c>Screen.AddLayer(name)</c> and assign them by passing the layer
-/// to <c>Screen.Add(renderable, layer)</c> or <c>Entity.Add(child, layer)</c>, or by
-/// setting <see cref="IRenderable.Layer"/> directly.
+/// Create a layer with <c>new Layer(name)</c>, add it to <c>Screen.Layers</c> so it takes part in
+/// draw-order sorting, and assign it by passing the layer to <c>Screen.Add(renderable, layer)</c>
+/// or <c>Entity.Add(child, layer)</c>, or by setting <see cref="IRenderable.Layer"/> directly.
 /// </para>
 /// </summary>
 public class Layer
@@ -16,8 +16,12 @@ public class Layer
     /// <summary>Creates a new layer with the given diagnostic name.</summary>
     public Layer(string name) => Name = name;
 
-    /// <summary>Diagnostic name shown in tooling and <see cref="ToString"/>.</summary>
-    public string Name { get; }
+    /// <summary>
+    /// Diagnostic name shown in tooling and <see cref="ToString"/>. The setter is internal because
+    /// it exists only for the Glue loader, which builds a <see cref="Layer"/> before it knows the
+    /// authored instance name.
+    /// </summary>
+    public string Name { get; internal set; }
 
     /// <summary>
     /// When <c>true</c> and passed to <c>Camera.Add</c>/<c>Screen.Add</c>, the Gum visual is

--- a/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using FlatRedBall2.Collision;
 using FlatRedBall2.Glue;
 using FlatRedBall2.Glue.Model;
+using FlatRedBall2.Rendering;
 using Shouldly;
 using Xunit;
 using XnaColor = Microsoft.Xna.Framework.Color;
@@ -205,6 +206,46 @@ public class GlueObjectBuilderTests
         circle.X.ShouldBe(10f);
         circle.AbsoluteX.ShouldBe(110f);
         circle.AbsoluteY.ShouldBe(195f);
+    }
+
+    [Fact]
+    public void AddTo_LayerNamedObject_AddsToScreenLayers()
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+        var screen = new Screen();
+        var builder = new GlueObjectBuilder(diagnostics, owningScreen: screen);
+        var save = Save(@"{
+            ""InstanceName"": ""Foreground"",
+            ""SourceClassType"": ""FlatRedBall.Graphics.Layer""
+        }");
+
+        var layer = (Layer)builder.AddTo(screen, save)!;
+
+        screen.Layers.ShouldContain(layer);
+        layer.Name.ShouldBe("Foreground");
+    }
+
+    [Fact]
+    public void AddTo_ObjectWithLayerOn_PlacesItOnTheNamedLayer()
+    {
+        var diagnostics = new List<GlueLoadDiagnostic>();
+        var screen = new Screen();
+        var builder = new GlueObjectBuilder(diagnostics, owningScreen: screen);
+        var layerSave = Save(@"{
+            ""InstanceName"": ""Foreground"",
+            ""SourceClassType"": ""FlatRedBall.Graphics.Layer""
+        }");
+        var layer = (Layer)builder.AddTo(screen, layerSave)!;
+        layer.ShouldNotBeNull();
+        var spriteSave = Save(@"{
+            ""InstanceName"": ""Hero"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""LayerOn"": ""Foreground""
+        }");
+
+        var sprite = (FlatRedBall2.Rendering.Sprite)builder.AddTo(screen, spriteSave)!;
+
+        sprite.Layer.ShouldBe(layer);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1077
Part of #838

FRB2's `Layer` type and layer-aware `Add` overloads existed but the Glue loader never built a `Layer` from a `FlatRedBall.Graphics.Layer` named object or read `LayerOn` on other objects. `GlueTypeMap` now maps that type; `GlueObjectBuilder` sets the built `Layer`'s name from `InstanceName` (a parameterless factory can't see it), registers it on `Screen.Layers`, and resolves `LayerOn` by name on the owning screen so sprites/shapes/entities/Gum visuals route through the layer-aware `Add` overload instead of the container's default layer. Also fixed a stale XML doc on `Layer` referencing a `Screen.AddLayer(name)` method that doesn't exist.

Manual test: not needed — Layer construction and Add-to-layer routing are plain object/collection state, fully covered by the two new headless unit tests (`GlueObjectBuilderTests.AddTo_LayerNamedObject_AddsToScreenLayers`, `AddTo_ObjectWithLayerOn_PlacesItOnTheNamedLayer`), no rendering or pixel output involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox