### PR TITLE
Glue loader: recognize ShiftMapToMoveGameplayLayerToZ0 as a no-op

### DIFF
--- a/src/Glue/GlueObjectBuilder.cs
+++ b/src/Glue/GlueObjectBuilder.cs
@@ -248,6 +248,9 @@ public sealed class GlueObjectBuilder
             if (TryApplyAsAsset(instance, memberName, instruction, save, elementName))
                 continue;
 
+            if (IsShiftMapToMoveGameplayLayerToZ0NoOp(instance, memberName))
+                continue;
+
             var property = GlueMemberWriter.FindProperty(instance, memberName);
 
             if (property is null || !property.CanWrite)
@@ -411,6 +414,17 @@ public sealed class GlueObjectBuilder
         property.SetValue(instance, asset);
         return true;
     }
+
+    /// <summary>
+    /// FRB1's <c>ShiftMapToMoveGameplayLayerToZ0</c> generates code that shifts a map's Z so its
+    /// "GameplayLayer" sub-layer lands at Z = 0. FRB2's <see cref="Tiled.TileMap"/> does this
+    /// unconditionally on every load (see its <c>AssignDefaultZ</c>), and has no map-level Z to
+    /// shift in the first place — only per-layer Z exists. The flag's requested effect already
+    /// always holds, so recognize it on a map and consume it instead of warning about a missing
+    /// property.
+    /// </summary>
+    private static bool IsShiftMapToMoveGameplayLayerToZ0NoOp(object instance, string memberName) =>
+        memberName == "ShiftMapToMoveGameplayLayerToZ0" && instance is Tiled.TileMap;
 
     /// <summary>Whether a property holds a loaded asset rather than a plain value.</summary>
     private static bool IsAssetType(Type type) =>

--- a/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
@@ -4,6 +4,7 @@ using FlatRedBall2.Collision;
 using FlatRedBall2.Glue;
 using FlatRedBall2.Glue.Model;
 using FlatRedBall2.Rendering;
+using FlatRedBall2.Tiled;
 using Shouldly;
 using Xunit;
 using XnaColor = Microsoft.Xna.Framework.Color;
@@ -21,6 +22,49 @@ public class GlueObjectBuilderTests
     {
         var diagnostics = new List<GlueLoadDiagnostic>();
         return (new GlueObjectBuilder(diagnostics), diagnostics);
+    }
+
+    [Fact]
+    public void ApplyInstructions_ShiftMapToMoveGameplayLayerToZ0OnATileMap_DoesNotWarnAndLeavesGameplayLayerAtZ0()
+    {
+        // FRB1 generates code that shifts the whole map's Z so "GameplayLayer" lands at Z = 0.
+        // FRB2's TileMap does this unconditionally on every load (AssignDefaultZ), so the instruction
+        // has nothing to write to but nothing left to do either — it should be consumed, not warned
+        // about. "Background" ahead of it in TMX order gives GameplayLayer a nonzero index to shift
+        // away from, so the assertion is not trivially true regardless of the fix.
+        var (builder, diagnostics) = NewBuilder();
+        var layers = new List<TileMapLayer> { new("Background"), new("GameplayLayer") };
+        var map = new TileMap(width: 160f, height: 160f, tileWidth: 16, tileHeight: 16, layers);
+        var save = Save(@"{
+            ""InstanceName"": ""Map"",
+            ""InstructionSaves"": [
+                { ""Type"": ""bool"", ""Member"": ""ShiftMapToMoveGameplayLayerToZ0"", ""Value"": true }
+            ]
+        }");
+
+        builder.ApplyInstructions(map, save, elementName: null);
+
+        diagnostics.ShouldBeEmpty();
+        map.GetLayer("GameplayLayer").Z.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void ApplyInstructions_ShiftMapToMoveGameplayLayerToZ0OnANonTileMap_StillWarns()
+    {
+        // The no-op is scoped to TileMap specifically -- on any other instance the name is still an
+        // unrecognized member and should warn like any other, so a real typo elsewhere isn't masked.
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""CircleInstance"",
+            ""SourceClassType"": ""FlatRedBall.Math.Geometry.Circle"",
+            ""InstructionSaves"": [
+                { ""Type"": ""bool"", ""Member"": ""ShiftMapToMoveGameplayLayerToZ0"", ""Value"": true }
+            ]
+        }");
+
+        builder.Create(save).ShouldNotBeNull();
+
+        diagnostics.ShouldContain(d => d.Message.Contains("ShiftMapToMoveGameplayLayerToZ0"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1089
Part of #838

FRB1's `ShiftMapToMoveGameplayLayerToZ0` generates code that shifts a map's Z so its `GameplayLayer` sub-layer lands at Z = 0. FRB2's `TileMap` already does this unconditionally on every load (`AssignDefaultZ`) and has no map-level Z to shift in the first place — only per-layer Z exists. The instruction previously found no writable property and warned on every one of KidDefense's 47 usages (essentially every level); it's now recognized on a `TileMap` instance in `GlueObjectBuilder.ApplyInstructions` and consumed silently, since the effect it requests is always already true.

The no-op is scoped to `instance is TileMap` specifically, so the same member name on any other object type still warns as an unrecognized member (guards against masking real typos).

## Test plan
- [x] `ApplyInstructions_ShiftMapToMoveGameplayLayerToZ0OnATileMap_DoesNotWarnAndLeavesGameplayLayerAtZ0` — fails before the fix, passes after
- [x] `ApplyInstructions_ShiftMapToMoveGameplayLayerToZ0OnANonTileMap_StillWarns` — confirms the no-op doesn't leak to other instance types
- [x] `dotnet build src/FlatRedBall2.csproj` clean
- [x] `dotnet test tests/FlatRedBall2.Tests/` — 1707/1707 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox