### PR TITLE
Glue: map RotationZ and *TexturePixel edges onto Sprite properties

### DIFF
--- a/src/Glue/GlueMemberWriter.cs
+++ b/src/Glue/GlueMemberWriter.cs
@@ -26,6 +26,7 @@ internal static class GlueMemberWriter
     private static readonly Dictionary<string, string> MemberAliases = new(StringComparer.Ordinal)
     {
         ["Visible"] = "IsVisible",
+        ["RotationZ"] = "Rotation",
     };
 
     /// <summary>What the trimmer must keep: the properties assigned, and the constructor.</summary>

--- a/src/Glue/GlueObjectBuilder.cs
+++ b/src/Glue/GlueObjectBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using FlatRedBall2.Glue.Model;
 
@@ -251,6 +252,9 @@ public sealed class GlueObjectBuilder
             if (IsShiftMapToMoveGameplayLayerToZ0NoOp(instance, memberName))
                 continue;
 
+            if (TryApplyAsSourceRectangleEdge(instance, memberName, instruction, save, elementName))
+                continue;
+
             var property = GlueMemberWriter.FindProperty(instance, memberName);
 
             if (property is null || !property.CanWrite)
@@ -429,6 +433,50 @@ public sealed class GlueObjectBuilder
     /// <summary>Whether a property holds a loaded asset rather than a plain value.</summary>
     private static bool IsAssetType(Type type) =>
         type == typeof(Texture2D) || type == typeof(Animation.AnimationChainList);
+
+    /// <summary>
+    /// Applies one edge of a Sprite's <see cref="Rendering.Sprite.SourceRectangle"/> from a Glue
+    /// pixel-edge instruction (<c>LeftTexturePixel</c>, <c>RightTexturePixel</c>,
+    /// <c>TopTexturePixel</c>, <c>BottomTexturePixel</c>).
+    /// </summary>
+    /// <remarks>
+    /// FRB2 has no per-edge properties, only one <c>Rectangle?</c>, and Glue authors these four as
+    /// separate instructions in no guaranteed order — a sprite might set only Left+Right, or all
+    /// four. Each edge is computed from the <em>opposite</em> edge of whatever rectangle already
+    /// exists (defaulting to zero) rather than from the edge it shares an axis with, so the final
+    /// rectangle comes out the same no matter which edge instruction runs first.
+    /// </remarks>
+    private bool TryApplyAsSourceRectangleEdge(
+        object instance, string memberName, InstructionSave instruction,
+        NamedObjectSave save, string? elementName)
+    {
+        if (instance is not Rendering.Sprite sprite)
+            return false;
+
+        if (memberName is not ("LeftTexturePixel" or "RightTexturePixel" or "TopTexturePixel" or "BottomTexturePixel"))
+            return false;
+
+        if (!GlueValueConverter.TryConvert(instruction.Value, typeof(float), out object? converted) ||
+            converted is not float pixels)
+        {
+            Warn($"'{save.InstanceName}.{memberName}' could not take the authored value " +
+                 $"'{instruction.Value}' as a pixel edge; the default was kept.", elementName);
+            return true;
+        }
+
+        int edge = (int)MathF.Round(pixels);
+        Rectangle current = sprite.SourceRectangle ?? new Rectangle(0, 0, 0, 0);
+
+        sprite.SourceRectangle = memberName switch
+        {
+            "LeftTexturePixel" => new Rectangle(edge, current.Y, current.Right - edge, current.Height),
+            "RightTexturePixel" => new Rectangle(current.X, current.Y, edge - current.X, current.Height),
+            "TopTexturePixel" => new Rectangle(current.X, edge, current.Width, current.Bottom - edge),
+            _ /* BottomTexturePixel */ => new Rectangle(current.X, current.Y, current.Width, edge - current.Y),
+        };
+
+        return true;
+    }
 
     private void Warn(string message, string? elementName) =>
         _diagnostics.Add(new GlueLoadDiagnostic(GlueDiagnosticSeverity.Warning, message, elementName));

--- a/src/Glue/GlueValueConverter.cs
+++ b/src/Glue/GlueValueConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
+using FlatRedBall2.Math;
 using XnaColor = Microsoft.Xna.Framework.Color;
 
 namespace FlatRedBall2.Glue;
@@ -167,6 +168,13 @@ internal static class GlueValueConverter
         if (target == typeof(long) && value.TryGetInt64(out long l)) { converted = l; return true; }
         if (target == typeof(decimal) && value.TryGetDecimal(out decimal m)) { converted = m; return true; }
         if (target == typeof(byte) && value.TryGetByte(out byte b)) { converted = b; return true; }
+
+        // Glue authors RotationZ as a raw radian float; FRB2's Rotation is unit-safe Angle.
+        if (target == typeof(Angle) && value.TryGetSingle(out float radians))
+        {
+            converted = Angle.FromRadians(radians);
+            return true;
+        }
 
         return false;
     }

--- a/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueObjectBuilderTests.cs
@@ -8,6 +8,7 @@ using FlatRedBall2.Tiled;
 using Shouldly;
 using Xunit;
 using XnaColor = Microsoft.Xna.Framework.Color;
+using XnaRectangle = Microsoft.Xna.Framework.Rectangle;
 
 namespace FlatRedBall2.Tests.Glue;
 
@@ -91,6 +92,46 @@ public class GlueObjectBuilderTests
     }
 
     [Fact]
+    public void Create_AllFourTexturePixelInstructionsInReverseOrder_ProduceCombinedSourceRectangle()
+    {
+        // Right/Bottom are authored before Left/Top to confirm the edges combine into the same
+        // rectangle regardless of instruction order, since Glue does not guarantee ordering.
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [
+                { ""Type"": ""float"", ""Member"": ""RightTexturePixel"", ""Value"": 54.0 },
+                { ""Type"": ""float"", ""Member"": ""BottomTexturePixel"", ""Value"": 37.0 },
+                { ""Type"": ""float"", ""Member"": ""LeftTexturePixel"", ""Value"": 10.0 },
+                { ""Type"": ""float"", ""Member"": ""TopTexturePixel"", ""Value"": 5.0 }
+            ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.SourceRectangle.ShouldBe(new XnaRectangle(10, 5, 44, 32));
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Create_BottomTexturePixelInstruction_SetsSourceRectangleBottomEdge()
+    {
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [ { ""Type"": ""float"", ""Member"": ""BottomTexturePixel"", ""Value"": 37.0 } ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.SourceRectangle!.Value.Y.ShouldBe(0);
+        sprite.SourceRectangle!.Value.Height.ShouldBe(37);
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Create_Circle_ProducesARealCircle()
     {
         var (builder, _) = NewBuilder();
@@ -118,6 +159,22 @@ public class GlueObjectBuilderTests
     }
 
     [Fact]
+    public void Create_LeftTexturePixelInstruction_SetsSourceRectangleLeftEdge()
+    {
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [ { ""Type"": ""float"", ""Member"": ""LeftTexturePixel"", ""Value"": 10.0 } ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.SourceRectangle!.Value.X.ShouldBe(10);
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Create_RadiusInstruction_IsApplied()
     {
         var (builder, _) = NewBuilder();
@@ -133,6 +190,40 @@ public class GlueObjectBuilderTests
     }
 
     [Fact]
+    public void Create_RightTexturePixelInstruction_SetsSourceRectangleWidthFromOrigin()
+    {
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [ { ""Type"": ""float"", ""Member"": ""RightTexturePixel"", ""Value"": 54.0 } ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.SourceRectangle!.Value.X.ShouldBe(0);
+        sprite.SourceRectangle!.Value.Width.ShouldBe(54);
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Create_RotationZInstruction_MapsOntoRotationInRadians()
+    {
+        // Glue's member is "RotationZ" (a raw radian float); FRB2's is "Rotation" (an Angle).
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [ { ""Type"": ""float"", ""Member"": ""RotationZ"", ""Value"": 1.5707963267948966 } ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.Rotation.Radians.ShouldBe(1.5707963f, tolerance: 0.0001f);
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Create_Shape_IsVisibleByDefault()
     {
         // FRB2 shapes default to invisible because they are primarily collision volumes. A shape
@@ -145,6 +236,22 @@ public class GlueObjectBuilderTests
         }");
 
         ((AARect)builder.Create(save)!).IsVisible.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Create_TopTexturePixelInstruction_SetsSourceRectangleTopEdge()
+    {
+        var (builder, diagnostics) = NewBuilder();
+        var save = Save(@"{
+            ""InstanceName"": ""SpriteInstance"",
+            ""SourceClassType"": ""FlatRedBall.Sprite"",
+            ""InstructionSaves"": [ { ""Type"": ""float"", ""Member"": ""TopTexturePixel"", ""Value"": 5.0 } ]
+        }");
+
+        var sprite = (Sprite)builder.Create(save)!;
+
+        sprite.SourceRectangle!.Value.Y.ShouldBe(5);
+        diagnostics.ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1091
Part of #838

## Summary
- `RotationZ` (Glue's raw radian float) now aliases to `Rotation` (FRB2's `Angle`) via `GlueMemberWriter.MemberAliases` + a new `GlueValueConverter` case (`Angle.FromRadians`).
- `LeftTexturePixel`/`RightTexturePixel`/`TopTexturePixel`/`BottomTexturePixel` have no FRB2 equivalent property (only one `Sprite.SourceRectangle`), so each is applied as a partial edge update in a new `GlueObjectBuilder.TryApplyAsSourceRectangleEdge`: each edge is computed from the *opposite* edge of whatever rectangle already exists (defaulting to zero), so the final rectangle is the same regardless of which edge instruction Glue emits first.

## Test plan
- 6 new tests in `GlueObjectBuilderTests` (RotationZ mapping, each of the four edges individually, and all four combined in reverse order to prove order-independence).
- `dotnet build src/FlatRedBall2.csproj` clean.
- `dotnet test tests/FlatRedBall2.Tests/` — 1711 passed, 0 failed.
- Manual test: not needed — pure data-mapping change, fully covered by headless unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox