### PR TITLE
Glue loader: CSV to typed dictionary (CreatesDictionary / CreationOptions: Dictionary)

### DIFF
--- a/src/Glue/GlueContentSource.cs
+++ b/src/Glue/GlueContentSource.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using FlatRedBall2.AnimationEditorCommon;
 using FlatRedBall2.Glue.Model;
+using FlatRedBall2.IO;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace FlatRedBall2.Glue;
@@ -218,7 +219,18 @@ public sealed class GlueContentSource
                     break;
 
                 case ".csv":
-                    _text[instanceName] = ReadAllText(path);
+                    string text = ReadAllText(path);
+                    _text[instanceName] = text;
+
+                    if (file.CreatesCsvDictionary)
+                    {
+                        _assets[instanceName] = CsvTable.Parse(text).ToDictionary(header =>
+                            Warn(diagnostics, elementName,
+                                $"'{file.Name}' column '{header.Name}' declares type " +
+                                $"'{header.Type}', which could not be resolved; its values are " +
+                                "kept as raw text."));
+                    }
+
                     break;
 
                 default:

--- a/src/Glue/Model/ReferencedFileSave.cs
+++ b/src/Glue/Model/ReferencedFileSave.cs
@@ -103,6 +103,17 @@ public class ReferencedFileSave
         TreatAsCsv ||
         (Name is not null && Name.EndsWith(".csv", System.StringComparison.OrdinalIgnoreCase));
 
+    /// <summary>
+    /// Whether a CSV should load as a dictionary keyed by its required column, rather than as plain
+    /// text. Glue writes this two ways depending on which UI authored the file: <see cref="CreatesDictionary"/>
+    /// directly, or a <c>CreationOptions</c> property. The property's value is the JSON string
+    /// <c>"\"Dictionary\""</c> — Glue double-quotes it, so the decoded string itself still has
+    /// literal quote characters around <c>Dictionary</c>.
+    /// </summary>
+    [JsonIgnore]
+    public bool CreatesCsvDictionary =>
+        CreatesDictionary || Properties.GetValue<string>("CreationOptions") == "\"Dictionary\"";
+
     /// <inheritdoc />
     public override string ToString() => Name ?? base.ToString()!;
 }

--- a/src/IO/CsvRow.cs
+++ b/src/IO/CsvRow.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace FlatRedBall2.IO;
+
+/// <summary>
+/// One row of a <see cref="CsvTable.ToDictionary"/> result, with each column already converted to
+/// the CLR type its header declared.
+/// </summary>
+/// <remarks>
+/// Not a generated class — nothing here is codegen'd per CSV. A column whose declared type could not
+/// be resolved keeps its raw text instead, so <see cref="Get{T}"/> with <c>string</c> still works
+/// even when a header names a type this library has never heard of.
+/// </remarks>
+public sealed class CsvRow
+{
+    private readonly IReadOnlyDictionary<string, object?> _values;
+
+    internal CsvRow(IReadOnlyDictionary<string, object?> values) => _values = values;
+
+    /// <summary>The column's converted value, untyped, or null when absent or empty.</summary>
+    public object? this[string columnName] =>
+        _values.TryGetValue(columnName, out object? value) ? value : null;
+
+    /// <summary>
+    /// The column's value as <typeparamref name="T"/>. Returns <c>default</c> when the column is
+    /// absent, its cell was empty, or the stored value does not match <typeparamref name="T"/> —
+    /// which happens when a header's declared type disagreed with what a cell actually held.
+    /// </summary>
+    public T? Get<T>(string columnName) => this[columnName] is T typed ? typed : default;
+}

--- a/src/IO/CsvTable.cs
+++ b/src/IO/CsvTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -118,6 +119,176 @@ public sealed class CsvTable
     /// <summary>Reads a bool, returning <paramref name="fallback"/> when absent or unparseable.</summary>
     public bool Bool(IReadOnlyList<string> row, string headerName, bool fallback = false) =>
         bool.TryParse(Value(row, headerName), out bool value) ? value : fallback;
+
+    /// <summary>
+    /// Resolves every header to a <see cref="CsvColumn"/> — its parsed name/type-text/required flag
+    /// plus the CLR type that text resolved to. This is the schema step: it parses headers and
+    /// resolves types, and nothing else, so a future consumer (e.g. generating a real class per CSV
+    /// instead of a runtime <see cref="CsvRow"/>) can reuse it without writing its own header parser
+    /// or type resolver. <see cref="ToDictionary"/> is one such consumer, not the only reason this
+    /// exists.
+    /// </summary>
+    /// <param name="onUnresolvedType">
+    /// Called once per column whose declared type is neither a C# builtin nor found by reflection
+    /// against currently loaded assemblies.
+    /// </param>
+    public IReadOnlyList<CsvColumn> ResolveSchema(Action<CsvHeader>? onUnresolvedType = null)
+    {
+        var columns = new CsvColumn[Headers.Count];
+
+        for (int i = 0; i < Headers.Count; i++)
+        {
+            Type? type = ResolveColumnType(Headers[i].Type);
+
+            if (type is null && Headers[i].Type.Length > 0)
+                onUnresolvedType?.Invoke(Headers[i]);
+
+            columns[i] = new CsvColumn(Headers[i], type);
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Converts every data row into a <see cref="CsvRow"/>, keyed by <see cref="KeyHeader"/>'s
+    /// value, using <see cref="ResolveSchema"/> to convert each cell to the CLR type its column
+    /// declares — a C# builtin (<c>bool</c>, <c>int</c>, <c>float?</c>, ...), or, for anything else,
+    /// a type resolved by name against every currently loaded assembly. That is how a header like
+    /// <c>WeaponUpgradeType (MyGame.Types.WeaponUpgradeType)</c> reaches a caller's own enum without
+    /// this library ever referencing it at compile time.
+    /// </summary>
+    /// <param name="onUnresolvedType">
+    /// Called once per column whose declared type is neither a builtin nor found by reflection.
+    /// That column's cells fall back to raw, unconverted text rather than being dropped.
+    /// </param>
+    /// <returns>Rows keyed by <see cref="KeyHeader"/>'s value. Empty when there is no required column.</returns>
+    public Dictionary<string, CsvRow> ToDictionary(Action<CsvHeader>? onUnresolvedType = null)
+    {
+        var result = new Dictionary<string, CsvRow>(StringComparer.OrdinalIgnoreCase);
+        var key = KeyHeader;
+
+        if (key is null)
+            return result;
+
+        var columns = ResolveSchema(onUnresolvedType);
+
+        foreach (var row in Rows)
+        {
+            string keyValue = Value(row, key.Value.Name) ?? string.Empty;
+
+            if (keyValue.Length == 0)
+                continue;
+
+            var values = new Dictionary<string, object?>(columns.Count, StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < columns.Count && i < row.Count; i++)
+                values[columns[i].Header.Name] = ConvertCell(row[i], columns[i].Type);
+
+            result[keyValue] = new CsvRow(values);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves a header's declared type text to a CLR type. An empty declaration (no parenthesized
+    /// type at all) is treated as <see cref="string"/> rather than unresolved — most CSVs have at
+    /// least one untyped column, and that is not the caller's own type Glue failed to find.
+    /// </summary>
+    /// <remarks>
+    /// Looking up a type by name is inherently trim/AOT-unsafe — the type is only known at CSV-load
+    /// time, so a trimmer has no reference to preserve it by. That is an accepted limitation of
+    /// resolving a caller's own type from data rather than a bug: a game publishing trimmed must
+    /// keep any type it names in a header, e.g. with a <c>DynamicDependency</c> attribute.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Deliberately dynamic: a header names a type only the caller's own " +
+            "assembly knows about, so there is nothing to reference statically.")]
+    private static Type? ResolveColumnType(string typeText)
+    {
+        if (typeText.Length == 0)
+            return typeof(string);
+
+        string bare = typeText[^1] == '?' ? typeText[..^1] : typeText;
+
+        Type? builtin = bare switch
+        {
+            "string" or "String" or "System.String" => typeof(string),
+            "bool" or "Boolean" or "System.Boolean" => typeof(bool),
+            "int" or "Int32" or "System.Int32" => typeof(int),
+            "long" or "Int64" or "System.Int64" => typeof(long),
+            "float" or "Single" or "System.Single" => typeof(float),
+            "double" or "Double" or "System.Double" => typeof(double),
+            "decimal" or "Decimal" or "System.Decimal" => typeof(decimal),
+            _ => null,
+        };
+
+        if (builtin is not null)
+            return builtin;
+
+        // Not a builtin — the type belongs to the caller's own compiled assembly, which this
+        // library cannot reference. Resolve it by name against everything already loaded instead.
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var found = assembly.GetType(bare, throwOnError: false, ignoreCase: false);
+
+            if (found is not null)
+                return found;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts one cell's raw text to <paramref name="type"/>. An empty cell is always <c>null</c>
+    /// — a nullable column's absence and a non-nullable column's absence are the same "no value"
+    /// here, since a CSV cell being blank does not distinguish the two. A cell that fails to parse
+    /// (the header's declared type disagreeing with what was actually written) keeps its raw text
+    /// rather than being dropped, matching the behavior for an unresolved column type.
+    /// </summary>
+    private static object? ConvertCell(string rawText, Type? type)
+    {
+        if (rawText.Length == 0)
+            return null;
+
+        if (type is null || type == typeof(string))
+            return rawText;
+
+        if (type.IsEnum)
+            return Enum.TryParse(type, rawText, ignoreCase: true, out object? enumValue)
+                ? enumValue
+                : rawText;
+
+        if (type == typeof(bool))
+            return bool.TryParse(rawText, out bool b) ? b : rawText;
+
+        if (type == typeof(int))
+            return int.TryParse(rawText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int i)
+                ? i
+                : rawText;
+
+        if (type == typeof(long))
+            return long.TryParse(rawText, NumberStyles.Integer, CultureInfo.InvariantCulture, out long l)
+                ? l
+                : rawText;
+
+        if (type == typeof(float))
+            return float.TryParse(rawText, NumberStyles.Float, CultureInfo.InvariantCulture, out float f)
+                ? f
+                : rawText;
+
+        if (type == typeof(double))
+            return double.TryParse(rawText, NumberStyles.Float, CultureInfo.InvariantCulture, out double d)
+                ? d
+                : rawText;
+
+        if (type == typeof(decimal))
+            return decimal.TryParse(rawText, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal m)
+                ? m
+                : rawText;
+
+        return rawText;
+    }
 
     /// <summary>Splits text into records, honouring quotes, doubled-quote escapes and comments.</summary>
     private static IEnumerable<List<string>> ReadRecords(string text)
@@ -276,4 +447,28 @@ public readonly struct CsvHeader
 
     /// <inheritdoc />
     public override string ToString() => OriginalText;
+}
+
+/// <summary>
+/// One column's header alongside the CLR type its declared type text resolved to. The output of
+/// <see cref="CsvTable.ResolveSchema"/> — the schema step shared by every consumer that needs a
+/// column's name, declared type, and required-ness, whether that consumer builds a runtime
+/// <see cref="CsvRow"/> or (in the future) generates a real class.
+/// </summary>
+public readonly struct CsvColumn
+{
+    internal CsvColumn(CsvHeader header, Type? type)
+    {
+        Header = header;
+        Type = type;
+    }
+
+    /// <summary>The column's parsed header — name, declared type text, and whether it is the key.</summary>
+    public CsvHeader Header { get; }
+
+    /// <summary>
+    /// The CLR type <see cref="Header"/>'s declared type text resolved to, or <c>null</c> when it
+    /// is neither a builtin nor found by reflection.
+    /// </summary>
+    public Type? Type { get; }
 }

--- a/tests/FlatRedBall2.Tests/Glue/GlueContentTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueContentTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using FlatRedBall2.Glue;
 using FlatRedBall2.Glue.Model;
+using FlatRedBall2.IO;
 using Microsoft.Xna.Framework.Graphics;
 using Shouldly;
 using Xunit;
@@ -37,6 +39,38 @@ public class GlueContentTests
             return null;
 
         return new GlueContentSource(_graphics.ContentLoader!, FixtureDirectory(project));
+    }
+
+    [Fact]
+    public void CreatesCsvDictionary_CreationOptionsPropertyIsTheQuotedStringDictionary_ReturnsTrue()
+    {
+        // Glue writes this flag two ways depending on which UI authored the file. Real projects
+        // (e.g. KidDefense's LocalizationDatabase.csv) use this one, and the property's JSON value
+        // is a string that itself contains literal quote characters: "\"Dictionary\"".
+        string json = @"{
+            ""Name"": ""GlobalContent/Localization.csv"",
+            ""Properties"": [ { ""Name"": ""CreationOptions"", ""Value"": ""\""Dictionary\"""" } ]
+        }";
+
+        var file = JsonSerializer.Deserialize(json, GlueJsonContext.Default.ReferencedFileSave)!;
+
+        file.CreatesCsvDictionary.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreatesCsvDictionary_CreatesDictionaryIsTrue_ReturnsTrue()
+    {
+        var file = new ReferencedFileSave { Name = "GlobalContent/TechTreeUnlocks.csv", CreatesDictionary = true };
+
+        file.CreatesCsvDictionary.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreatesCsvDictionary_NeitherFlagSet_ReturnsFalse()
+    {
+        var file = new ReferencedFileSave { Name = "GlobalContent/Plain.csv" };
+
+        file.CreatesCsvDictionary.ShouldBeFalse();
     }
 
     [Fact]
@@ -111,6 +145,32 @@ public class GlueContentTests
 
         csv.ShouldNotBeNull();
         csv.ShouldContain("MaxSpeedX");
+    }
+
+    [Fact]
+    public void Load_CsvReferencedFileWithCreatesDictionary_IsAddressableAsATypedRowDictionary()
+    {
+        // PlatformerValuesStatic.csv's ReferencedFileSave sets CreatesDictionary: true, so its rows
+        // should also be reachable as CsvRows keyed by the required "Name" column, each column
+        // converted per its header's declared type rather than left as text.
+        var source = SourceFor("DoorsDemo");
+        if (source is null)
+            return;
+
+        var entity = new GlueEntity
+        {
+            Save = LoadFixtureEntity("DoorsDemo", "Player.glej"),
+            Content = source,
+        };
+
+        entity.BuildObjects();
+
+        var rows = entity.Content!.Get<Dictionary<string, CsvRow>>("PlatformerValuesStatic");
+
+        rows.ShouldNotBeNull();
+        rows.ShouldContainKey("Ground");
+        rows["Ground"].Get<float>("MaxSpeedX").ShouldBe(100f);
+        rows["Ground"].Get<bool>("JumpApplyByButtonHold").ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/FlatRedBall2.Tests/IO/CsvTableTests.cs
+++ b/tests/FlatRedBall2.Tests/IO/CsvTableTests.cs
@@ -4,6 +4,14 @@ using Xunit;
 
 namespace FlatRedBall2.Tests.IO;
 
+// A type belonging to this assembly, standing in for a game's own compiled type that a CSV header
+// names by fully-qualified name (e.g. "WeaponUpgradeType (MyGame.Types.WeaponUpgradeType)").
+internal enum TestUpgradeType
+{
+    FireRate,
+    BulletSpeed,
+}
+
 // Covers the CSV dialect FlatRedBall's tooling produces: typed headers, a required key column,
 // comments, and rows that do not match the header width.
 public class CsvTableTests
@@ -71,5 +79,84 @@ public class CsvTableTests
 
         table.Float(new[] { "" }, "A", 16f).ShouldBe(16f);
         table.Float(new[] { "" }, "Missing", 3f).ShouldBe(3f);
+    }
+
+    [Fact]
+    public void ResolveSchema_TypedRequiredAndBuiltinHeaders_ReturnsHeaderAndResolvedTypeForEach()
+    {
+        // This is the schema step ToDictionary builds on, and the seam a future per-CSV codegen
+        // step (generating a real class instead of a runtime CsvRow) would reuse instead of
+        // re-parsing headers itself.
+        var table = CsvTable.Parse("\"Name (string, required)\",Speed (float)\nFast,100\n");
+
+        var columns = table.ResolveSchema();
+
+        columns[0].Header.Name.ShouldBe("Name");
+        columns[0].Header.IsRequired.ShouldBeTrue();
+        columns[0].Type.ShouldBe(typeof(string));
+        columns[1].Header.Name.ShouldBe("Speed");
+        columns[1].Type.ShouldBe(typeof(float));
+    }
+
+    [Fact]
+    public void ToDictionary_BuiltinTypedColumns_ConvertsEachCellToItsDeclaredType()
+    {
+        string csv = "\"Name (string, required)\",IsUnlock (bool),Bonus (float?)\n" +
+                     "UnlockFireball,TRUE,\n" +
+                     "FireRateBoost,FALSE,0.04\n";
+
+        var dictionary = CsvTable.Parse(csv).ToDictionary();
+
+        dictionary["UnlockFireball"].Get<bool>("IsUnlock").ShouldBeTrue();
+        dictionary["UnlockFireball"].Get<float?>("Bonus").ShouldBeNull();
+        dictionary["FireRateBoost"].Get<float?>("Bonus").ShouldBe(0.04f);
+    }
+
+    [Fact]
+    public void ToDictionary_ColumnTypeCannotBeResolved_KeepsRawTextAndReportsTheColumn()
+    {
+        string csv = "\"Name (string, required)\",Upgrade (Nonexistent.Made.Up.Type)\n" +
+                     "Row1,SomeValue\n";
+        CsvHeader? unresolved = null;
+
+        var dictionary = CsvTable.Parse(csv).ToDictionary(header => unresolved = header);
+
+        unresolved!.Value.Name.ShouldBe("Upgrade");
+        dictionary["Row1"].Get<string>("Upgrade").ShouldBe("SomeValue");
+    }
+
+    [Fact]
+    public void ToDictionary_ColumnTypeIsAnEnumInAnotherAssembly_ResolvesItByReflection()
+    {
+        // Stands in for a header naming a type in the game's own compiled assembly, which this
+        // library can never reference directly.
+        string csv = $"\"Name (string, required)\",Upgrade ({typeof(TestUpgradeType).FullName})\n" +
+                     "Row1,FireRate\n";
+
+        var dictionary = CsvTable.Parse(csv).ToDictionary();
+
+        dictionary["Row1"].Get<TestUpgradeType>("Upgrade").ShouldBe(TestUpgradeType.FireRate);
+    }
+
+    [Fact]
+    public void ToDictionary_CommentRow_IsNotIncluded()
+    {
+        string csv = "\"Name (string, required)\",Value (int)\n" +
+                     "// a comment row,1\n" +
+                     "Real,2\n";
+
+        var dictionary = CsvTable.Parse(csv).ToDictionary();
+
+        dictionary.Count.ShouldBe(1);
+        dictionary["Real"].Get<int>("Value").ShouldBe(2);
+    }
+
+    [Fact]
+    public void ToDictionary_KeyedByRequiredColumn_UsesItsValueAsTheDictionaryKey()
+    {
+        var dictionary = CsvTable.Parse("Other (int),\"Name (string, required)\"\n1,Foo\n").ToDictionary();
+
+        dictionary.ShouldContainKey("Foo");
+        dictionary["Foo"].Get<int>("Other").ShouldBe(1);
     }
 }


### PR DESCRIPTION
Closes #1087
Part of #838

## Design

`CsvTable.ResolveSchema()` resolves each header's declared type text to a CLR `Type` — builtin
(`bool`, `int`, `float?`, ...) or, for anything else, a type found by reflection against every
loaded assembly (how `WeaponUpgradeType (KidDefense.Types.WeaponUpgradeType)` reaches the game's
own enum without FRB2 referencing it at compile time). This is a standalone schema step returning
`IReadOnlyList<CsvColumn>` (header + resolved type), separate from row-building, so a future
per-CSV codegen feature (generating a real class instead of a runtime row) can reuse header
parsing and type resolution without writing its own.

`CsvTable.ToDictionary()` consumes that schema to build `Dictionary<string, CsvRow>` keyed by the
required column. `CsvRow` is a small `Dictionary<string, object?>`-backed wrapper with `Get<T>` and
an untyped indexer — not a generated class, per the "no codegen" constraint on this epic. A column
whose type can't be resolved keeps its raw string value rather than being dropped.

`ReferencedFileSave.CreatesCsvDictionary` ORs the `CreatesDictionary` bool with a `CreationOptions`
property check — the property's JSON value is the literal quoted string `"\"Dictionary\""`,
confirmed against KidDefense's own `.gluj`. `GlueContentSource` builds the dictionary for any CSV
where this is true, reachable via the existing `Get<Dictionary<string, CsvRow>>(instanceName)`.

## Tests

`CsvTableTests`: `ResolveSchema_...`, `ToDictionary_BuiltinTypedColumns_...`,
`ToDictionary_ColumnTypeCannotBeResolved_...` (warns, keeps raw text),
`ToDictionary_ColumnTypeIsAnEnumInAnotherAssembly_...` (reflection against a type in the test
assembly, standing in for a game's own type), `ToDictionary_CommentRow_IsNotIncluded`,
`ToDictionary_KeyedByRequiredColumn_...`.

`GlueContentTests`: `CreatesCsvDictionary_*` (both trigger paths), and an integration test against
the real `PlatformerValuesStatic.csv` fixture (already `CreatesDictionary: true`) confirming
`Get<Dictionary<string, CsvRow>>` returns typed rows.

`dotnet build src/FlatRedBall2.csproj` and `dotnet test tests/FlatRedBall2.Tests/` clean (1715
passed, no new warnings — the reflection lookup's IL2026 trim warning is suppressed with a
documented justification since it's inherent to resolving a caller's own type from data).

Manual test: not needed — headless engine change, fully covered by unit tests.

## Left for item 10 (localization)

`ReferencedFileSave` already exposes `IsDatabaseForLocalizing` isn't wired up here — item 10 needs
to build a lookup/translation layer on top of the `Dictionary<string, CsvRow>` this issue produces
(KidDefense's `LocalizationDatabase.csv` is one of these same dictionary CSVs, gated by
`CreationOptions: Dictionary` + a property this PR doesn't read). No engine work landed for it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox
