### PR TITLE
Fix #1088: named Glue lists get their own live collision membership

### DIFF
--- a/src/Glue/GlueCollisionBuilder.cs
+++ b/src/Glue/GlueCollisionBuilder.cs
@@ -79,7 +79,7 @@ internal static class GlueCollisionBuilder
             if (!IsRelationship(save) || string.IsNullOrEmpty(save.InstanceName) || save.IsDisabled)
                 continue;
 
-            var built = BuildOne(save, elementName, objects, diagnostics, project, screen, namedObjects);
+            var built = BuildOne(save, elementName, objects, diagnostics, project, screen);
 
             if (built is not null)
                 objects[save.InstanceName] = built;
@@ -92,8 +92,7 @@ internal static class GlueCollisionBuilder
         Dictionary<string, object> objects,
         List<GlueLoadDiagnostic> diagnostics,
         GlueProject? project,
-        Screen? screen,
-        List<NamedObjectSave> namedObjects)
+        Screen? screen)
     {
         var settings = GlueCollisionSettings.From(save);
 
@@ -123,7 +122,7 @@ internal static class GlueCollisionBuilder
             return null;
         }
 
-        var first = ResolveSide(settings.FirstCollisionName!, objects, project, namedObjects);
+        var first = ResolveSide(settings.FirstCollisionName!, objects, project);
 
         if (first is null)
         {
@@ -143,7 +142,7 @@ internal static class GlueCollisionBuilder
             return null;
         }
 
-        var second = ResolveSide(settings.SecondCollisionName, objects, project, namedObjects);
+        var second = ResolveSide(settings.SecondCollisionName, objects, project);
 
         if (second is null)
         {
@@ -162,16 +161,17 @@ internal static class GlueCollisionBuilder
     /// <remarks>
     /// A Glue list is built once, at load, into a plain snapshot (<see cref="GlueElementBuilder.Build"/>).
     /// Binding a relationship straight to that snapshot means an entity spawned afterwards — via
-    /// <see cref="GlueProject.CreateEntity(string, Screen)"/>, the Factory-equivalent path — is
-    /// invisible to it forever. <see cref="GlueProject.InstancesOf"/> is the live list every created
-    /// instance of an entity type is tracked in (Added on create, removed on destroy), so once the
-    /// list's element type is known this resolves to that instead of the snapshot.
+    /// <see cref="GlueProject.CreateEntity(string, Screen, string?)"/>, the Factory-equivalent path —
+    /// is invisible to it forever. <see cref="GlueProject.InstancesOfList"/> is the live list every
+    /// instance spawned into <paramref name="name"/> is tracked in (added on create, removed on
+    /// destroy), so this resolves to that instead of the snapshot.
+    /// <para>Keyed by the list's own instance name, not its element type — two differently-named
+    /// lists of the same entity type (e.g. two enemy waves) must stay distinct live views, not
+    /// collapse onto one shared list. An entity can still be live in both at once (G82): membership
+    /// is per list, not exclusive.</para>
     /// </remarks>
     private static object? ResolveSide(
-        string name,
-        Dictionary<string, object> objects,
-        GlueProject? project,
-        List<NamedObjectSave> namedObjects)
+        string name, Dictionary<string, object> objects, GlueProject? project)
     {
         if (!objects.TryGetValue(name, out object? side))
             return null;
@@ -183,12 +183,7 @@ internal static class GlueCollisionBuilder
             if (entities.Count != list.Count)
                 return null;
 
-            var entityTypeName = namedObjects
-                .FirstOrDefault(n => n.IsList && n.InstanceName == name)?.SourceClassGenericType;
-
-            return project is not null && !string.IsNullOrEmpty(entityTypeName)
-                ? (object)project.InstancesOf(entityTypeName)
-                : entities;
+            return project is not null ? (object)project.InstancesOfList(name) : entities;
         }
 
         return side;

--- a/src/Glue/GlueElementBuilder.cs
+++ b/src/Glue/GlueElementBuilder.cs
@@ -106,9 +106,10 @@ internal static class GlueElementBuilder
     /// and this phase does not need one.
     /// </summary>
     /// <remarks>
-    /// Members are built but not registered anywhere: a list in Glue is usually a spawn pool whose
-    /// contents an entity factory owns, which is Phase 8. Anything unbuildable — most commonly a
-    /// nested entity, which needs Phase 6 — is reported and skipped.
+    /// Members are built but not registered anywhere here. A nested entity member is the exception —
+    /// it is registered on its owning screen as a side effect of being created (see
+    /// <see cref="GlueObjectBuilder.Create"/>), and is told which list it joined so a collision
+    /// relationship bound to this list's name (<see cref="GlueProject.InstancesOfList"/>) sees it.
     /// </remarks>
     private static object BuildList(
         GlueObjectBuilder builder,
@@ -120,7 +121,7 @@ internal static class GlueElementBuilder
 
         foreach (var contained in save.ContainedObjects)
         {
-            object? item = builder.Create(contained, elementName);
+            object? item = builder.Create(contained, elementName, listName: save.InstanceName);
             if (item is not null)
                 items.Add(item);
         }

--- a/src/Glue/GlueObjectBuilder.cs
+++ b/src/Glue/GlueObjectBuilder.cs
@@ -45,8 +45,16 @@ public sealed class GlueObjectBuilder
     /// <summary>
     /// Constructs and configures an instance without attaching or registering it.
     /// </summary>
+    /// <param name="save">The object to build.</param>
+    /// <param name="elementName">The owning screen or entity's Glue name, for diagnostics.</param>
+    /// <param name="listName">
+    /// The Glue list <paramref name="save"/> is a member of, if any — threaded through to
+    /// <see cref="GlueProject.CreateEntity(string, Screen, string?)"/> when this builds a nested
+    /// entity, so a design-time-placed list member is as visible to a relationship bound to that
+    /// list's name as one spawned into it at runtime.
+    /// </param>
     /// <returns>The configured instance, or null if this build cannot construct that type.</returns>
-    public object? Create(NamedObjectSave save, string? elementName = null)
+    public object? Create(NamedObjectSave save, string? elementName = null, string? listName = null)
     {
         var typeName = GlueTypeName.Parse(save.SourceClassType);
 
@@ -58,7 +66,7 @@ public sealed class GlueObjectBuilder
         // An object whose type names another element is a nested entity — built from that element's
         // own data rather than constructed from a CLR type.
         if (typeName.IsElementReference)
-            return CreateNestedEntity(save, elementName);
+            return CreateNestedEntity(save, elementName, listName);
 
         if (!GlueTypeMap.TryCreate(typeName, out object? instance))
         {
@@ -286,7 +294,7 @@ public sealed class GlueObjectBuilder
     /// either, this reports and skips — which is what every build did before a project context
     /// existed.
     /// </remarks>
-    private object? CreateNestedEntity(NamedObjectSave save, string? elementName)
+    private object? CreateNestedEntity(NamedObjectSave save, string? elementName, string? listName)
     {
         if (_project is null || _owningScreen is null)
         {
@@ -311,7 +319,7 @@ public sealed class GlueObjectBuilder
             return null;
         }
 
-        var entity = _project.CreateEntity(referenced.Name!, _owningScreen);
+        var entity = _project.CreateEntity(referenced.Name!, _owningScreen, listName);
 
         // The instance's own instructions layer on top of the entity's authored values.
         ApplyInstructions(entity, save, elementName);

--- a/src/Glue/GlueProject.cs
+++ b/src/Glue/GlueProject.cs
@@ -22,6 +22,8 @@ public sealed class GlueProject
     private readonly Dictionary<string, ScreenSave> _screens = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, EntitySave> _entities = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<GlueEntity>> _instances = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<GlueEntity>> _listInstances = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<string>> _factoryListsByEntityType = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<GlueEntity>> _pool = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<GlueLoadDiagnostic> _diagnostics = new();
 
@@ -38,6 +40,39 @@ public sealed class GlueProject
             _entities[entity.Name!] = entity;
 
         content?.LoadGlobalFiles(result.Project.GlobalFiles, _diagnostics);
+
+        foreach (var screen in result.Project.Screens)
+            IndexFactoryLists(screen.NamedObjects);
+
+        foreach (var entity in result.Project.Entities)
+            IndexFactoryLists(entity.NamedObjects);
+    }
+
+    /// <summary>
+    /// Indexes every list whose author opted it into factory spawning
+    /// (<see cref="Model.NamedObjectSave.AssociateWithFactory"/>), keyed by the entity type it holds.
+    /// </summary>
+    /// <remarks>
+    /// Top-level only, matching where Glue actually declares lists — the same scope
+    /// <see cref="GlueElementBuilder"/> uses. A type can have any number of associated lists at once
+    /// (G82): a generic spawn (<see cref="CreateEntity(string, Screen, string?)"/> with no explicit
+    /// list) joins every one of them, mirroring FRB1's <c>ListsToAddTo</c>.
+    /// </remarks>
+    private void IndexFactoryLists(List<NamedObjectSave> namedObjects)
+    {
+        foreach (var save in namedObjects)
+        {
+            if (!save.IsList || !save.AssociateWithFactory ||
+                string.IsNullOrEmpty(save.SourceClassGenericType) || string.IsNullOrEmpty(save.InstanceName))
+            {
+                continue;
+            }
+
+            if (!_factoryListsByEntityType.TryGetValue(save.SourceClassGenericType, out var listNames))
+                _factoryListsByEntityType[save.SourceClassGenericType] = listNames = new List<string>();
+
+            listNames.Add(save.InstanceName);
+        }
     }
 
     /// <summary>The raw load result.</summary>
@@ -113,6 +148,28 @@ public sealed class GlueProject
         return list;
     }
 
+    /// <summary>Every live instance tracked under the named Glue list <paramref name="listName"/>.</summary>
+    /// <remarks>
+    /// Distinct from <see cref="InstancesOf"/>, which is keyed by entity type and so cannot tell two
+    /// differently-named lists of the same type apart. This is keyed by the list's own Glue instance
+    /// name instead — the identity a collision relationship actually binds to — so
+    /// <c>WaveOneEnemies</c> and <c>WaveTwoEnemies</c>, both <c>Entities\Enemy</c>, stay separate
+    /// collections even though they hold the same type.
+    /// <para>An entity can be live in more than one named list at once: one it was declared a member
+    /// of, and/or any list of its type that opted into
+    /// <see cref="Model.NamedObjectSave.AssociateWithFactory"/> — see
+    /// <see cref="CreateEntity(string, Screen, string?)"/>. Same lazy-create-and-cache behavior as
+    /// <see cref="InstancesOf"/>: a relationship can bind to a list name before anything has been
+    /// spawned into it.</para>
+    /// </remarks>
+    public IReadOnlyList<GlueEntity> InstancesOfList(string listName)
+    {
+        if (!_listInstances.TryGetValue(listName, out var list))
+            _listInstances[listName] = list = new List<GlueEntity>();
+
+        return list;
+    }
+
     /// <summary>
     /// The screen <paramref name="screen"/> names as the one to advance to, or null when it names
     /// none — Glue's own idiom for level progression.
@@ -148,14 +205,25 @@ public sealed class GlueProject
     /// entity. Registration order matches the engine's: the screen owns it, and destroying it
     /// removes it from this project's instance list.
     /// </remarks>
+    /// <param name="glueName">The entity's Glue name, e.g. <c>Entities\Enemy</c>.</param>
+    /// <param name="screen">The screen to register the entity on.</param>
+    /// <param name="listName">
+    /// The one Glue list this instance is already known to be a declared member of — used when
+    /// building a list's own authored member, whose placement is unambiguous. Leave this null for an
+    /// ordinary spawn (the call game code makes at runtime, mirroring FRB1's
+    /// <c>&lt;Entity&gt;Factory.CreateNew()</c>): the instance then joins every list of this entity
+    /// type that opted into <see cref="Model.NamedObjectSave.AssociateWithFactory"/> — none, one, or
+    /// several. Either way the entity is always tracked under <see cref="InstancesOf"/> by type. See
+    /// <see cref="InstancesOfList"/>.
+    /// </param>
     /// <exception cref="ArgumentException">No element has that name.</exception>
     /// <exception cref="InvalidOperationException">The element is abstract.</exception>
-    public GlueEntity CreateEntity(string glueName, Screen screen)
+    public GlueEntity CreateEntity(string glueName, Screen screen, string? listName = null)
     {
         var save = FindEntity(glueName)
             ?? throw UnknownName(glueName, "entity", _entities.Keys);
 
-        return CreateEntity(save, screen);
+        return CreateEntity(save, screen, listName);
     }
 
     /// <summary>
@@ -165,7 +233,7 @@ public sealed class GlueProject
     /// For callers already iterating the project's elements — looking the name back up would repeat
     /// work, and would fail outright for a save whose name no longer matches its dictionary key.
     /// </remarks>
-    internal GlueEntity CreateEntity(EntitySave save, Screen screen)
+    internal GlueEntity CreateEntity(EntitySave save, Screen screen, string? listName = null)
     {
         if (save.IsAbstract)
         {
@@ -189,7 +257,34 @@ public sealed class GlueProject
         entity._onDestroy = () => Release(entity);
 
         Track(save.Name!, entity);
+        JoinLists(save, entity, listName);
+
         return entity;
+    }
+
+    /// <summary>
+    /// Adds a newly created entity to the named list(s) it belongs to.
+    /// </summary>
+    /// <remarks>
+    /// A list's own declared member always names its list explicitly (threaded down from
+    /// <see cref="GlueElementBuilder"/>), so its placement is never inferred here. An ordinary spawn
+    /// gives no list — that is the signal to fall back to
+    /// <see cref="Model.NamedObjectSave.AssociateWithFactory"/> and join every associated list of this
+    /// type, which may be none, one, or several (G82).
+    /// </remarks>
+    private void JoinLists(EntitySave save, GlueEntity entity, string? listName)
+    {
+        if (listName is not null)
+        {
+            TrackInList(listName, entity);
+            return;
+        }
+
+        if (save.Name is not null && _factoryListsByEntityType.TryGetValue(save.Name, out var listNames))
+        {
+            foreach (var name in listNames)
+                TrackInList(name, entity);
+        }
     }
 
     /// <summary>
@@ -247,6 +342,14 @@ public sealed class GlueProject
         list.Add(entity);
     }
 
+    private void TrackInList(string listName, GlueEntity entity)
+    {
+        if (!_listInstances.TryGetValue(listName, out var list))
+            _listInstances[listName] = list = new List<GlueEntity>();
+
+        list.Add(entity);
+    }
+
     /// <summary>
     /// Drops a destroyed instance from the live list, and keeps its shell if the element is pooled.
     /// </summary>
@@ -267,10 +370,18 @@ public sealed class GlueProject
     }
 
     /// <summary>Forgets a destroyed instance, so a relationship does not keep collecting corpses.</summary>
+    /// <remarks>
+    /// Removed from every named list, not just its type-wide one — an entity can be live in several
+    /// lists at once (G82) and nothing records which, so this checks them all. Lists per project are
+    /// few, so the scan costs nothing worth avoiding.
+    /// </remarks>
     internal void Forget(GlueEntity entity)
     {
         if (entity.GlueName is not null && _instances.TryGetValue(entity.GlueName, out var list))
             list.Remove(entity);
+
+        foreach (var namedList in _listInstances.Values)
+            namedList.Remove(entity);
     }
 
     /// <summary>

--- a/src/Glue/GlueTileBuilder.cs
+++ b/src/Glue/GlueTileBuilder.cs
@@ -132,7 +132,7 @@ internal static class GlueTileBuilder
     /// Glue matches a tile's type against an entity's name, so a tile typed <c>Door</c> spawns
     /// <c>Entities\Door</c>. Tiles are located with the same by-class query collision uses, which is
     /// what keeps the two consistent.
-    /// <para>Spawning goes through <see cref="GlueProject.CreateEntity(EntitySave, Screen)"/> rather than
+    /// <para>Spawning goes through <see cref="GlueProject.CreateEntity(EntitySave, Screen, string?)"/> rather than
     /// <see cref="TileMap.CreateEntities{T}"/>: the latter needs a <c>Factory&lt;T&gt;</c>, and every
     /// loaded entity is a <see cref="GlueEntity"/>, so one factory could not tell a Door from a
     /// Player (Phase 8 G80).</para>

--- a/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Entities/Blob.glej
+++ b/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Entities/Blob.glej
@@ -1,0 +1,87 @@
+{
+  "Tags": [
+    "GLUE"
+  ],
+  "Source": "GLUE",
+  "CreatedByOtherEntities": true,
+  "Is2D": true,
+  "CustomVariables": [
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "X",
+      "SetByDerived": true
+    },
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "Y",
+      "SetByDerived": true
+    },
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "Z",
+      "SetByDerived": true
+    }
+  ],
+  "Properties": [
+    {
+      "Name": "ImplementsICollidable",
+      "Value": true,
+      "Type": "Boolean"
+    },
+    {
+      "Name": "InputDevice",
+      "Value": 0
+    }
+  ],
+  "NamedObjects": [
+    {
+      "InstanceName": "CircleInstance",
+      "SourceClassType": "FlatRedBall.Math.Geometry.Circle",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [
+        {
+          "Type": "float",
+          "Member": "Radius",
+          "Value": 6.0,
+          "Time": 0.0
+        }
+      ],
+      "SourceType": 2,
+      "SourceFile": "Circle",
+      "HasPublicProperty": true,
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true
+    }
+  ],
+  "Name": "Entities\\Blob",
+  "CustomClassesForExport": []
+}

--- a/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Entities/Target.glej
+++ b/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Entities/Target.glej
@@ -1,0 +1,87 @@
+{
+  "Tags": [
+    "GLUE"
+  ],
+  "Source": "GLUE",
+  "CreatedByOtherEntities": true,
+  "Is2D": true,
+  "CustomVariables": [
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "X",
+      "SetByDerived": true
+    },
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "Y",
+      "SetByDerived": true
+    },
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "float",
+          "Type": "String"
+        }
+      ],
+      "Name": "Z",
+      "SetByDerived": true
+    }
+  ],
+  "Properties": [
+    {
+      "Name": "ImplementsICollidable",
+      "Value": true,
+      "Type": "Boolean"
+    },
+    {
+      "Name": "InputDevice",
+      "Value": 0
+    }
+  ],
+  "NamedObjects": [
+    {
+      "InstanceName": "CircleInstance",
+      "SourceClassType": "FlatRedBall.Math.Geometry.Circle",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [
+        {
+          "Type": "float",
+          "Member": "Radius",
+          "Value": 6.0,
+          "Time": 0.0
+        }
+      ],
+      "SourceType": 2,
+      "SourceFile": "Circle",
+      "HasPublicProperty": true,
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true
+    }
+  ],
+  "Name": "Entities\\Target",
+  "CustomClassesForExport": []
+}

--- a/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Screens/GameScreen.glsj
+++ b/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/Screens/GameScreen.glsj
@@ -1,0 +1,275 @@
+{
+  "Tags": [
+    "GLUE"
+  ],
+  "Source": "GLUE",
+  "NamedObjects": [
+    {
+      "InstanceName": "ListA",
+      "SourceClassType": "FlatRedBall.Math.PositionedObjectList<T>",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [],
+      "SourceType": 2,
+      "SourceFile": "PositionedObjectList (Generic)",
+      "SourceClassGenericType": "Entities\\Blob",
+      "ExposedInDerived": true,
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true,
+      "ContainedObjects": [
+        {
+          "InstanceName": "BlobInA",
+          "SourceClassType": "Entities\\Blob",
+          "Properties": [
+            {
+              "Name": "AssociateWithFactory",
+              "Value": true,
+              "Type": "Boolean"
+            },
+            {
+              "Name": "SourceType",
+              "Value": 1,
+              "Type": "SourceType"
+            }
+          ],
+          "InstructionSaves": [
+            {
+              "Type": "float",
+              "Member": "X",
+              "Value": 0.0,
+              "Time": 0.0
+            },
+            {
+              "Type": "float",
+              "Member": "Y",
+              "Value": 0.0,
+              "Time": 0.0
+            }
+          ],
+          "SourceType": 1,
+          "SourceFile": "Entities\\Blob",
+          "AttachToContainer": true,
+          "GenerateTimedEmit": true
+        }
+      ]
+    },
+    {
+      "InstanceName": "ListB",
+      "SourceClassType": "FlatRedBall.Math.PositionedObjectList<T>",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": false,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [],
+      "SourceType": 2,
+      "SourceFile": "PositionedObjectList (Generic)",
+      "SourceClassGenericType": "Entities\\Blob",
+      "ExposedInDerived": true,
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true,
+      "ContainedObjects": [
+        {
+          "InstanceName": "BlobInB",
+          "SourceClassType": "Entities\\Blob",
+          "Properties": [
+            {
+              "Name": "AssociateWithFactory",
+              "Value": true,
+              "Type": "Boolean"
+            },
+            {
+              "Name": "SourceType",
+              "Value": 1,
+              "Type": "SourceType"
+            }
+          ],
+          "InstructionSaves": [
+            {
+              "Type": "float",
+              "Member": "X",
+              "Value": 0.0,
+              "Time": 0.0
+            },
+            {
+              "Type": "float",
+              "Member": "Y",
+              "Value": 0.0,
+              "Time": 0.0
+            }
+          ],
+          "SourceType": 1,
+          "SourceFile": "Entities\\Blob",
+          "AttachToContainer": true,
+          "GenerateTimedEmit": true
+        }
+      ]
+    },
+    {
+      "InstanceName": "ListC",
+      "SourceClassType": "FlatRedBall.Math.PositionedObjectList<T>",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [],
+      "SourceType": 2,
+      "SourceFile": "PositionedObjectList (Generic)",
+      "SourceClassGenericType": "Entities\\Blob",
+      "ExposedInDerived": true,
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true,
+      "ContainedObjects": []
+    },
+    {
+      "InstanceName": "Target",
+      "SourceClassType": "Entities\\Target",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 1,
+          "Type": "SourceType"
+        }
+      ],
+      "InstructionSaves": [
+        {
+          "Type": "float",
+          "Member": "X",
+          "Value": 0.0,
+          "Time": 0.0
+        },
+        {
+          "Type": "float",
+          "Member": "Y",
+          "Value": 0.0,
+          "Time": 0.0
+        }
+      ],
+      "SourceType": 1,
+      "SourceFile": "Entities\\Target",
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true
+    },
+    {
+      "InstanceName": "ListAVsTarget",
+      "SourceClassType": "FlatRedBall.Math.Collision.ListVsPositionedObjectRelationship<Entities.Blob, Entities.Target>",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        },
+        {
+          "Name": "IsAutoNameEnabled",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "FirstCollisionName",
+          "Value": "ListA",
+          "Type": "String"
+        },
+        {
+          "Name": "SecondCollisionName",
+          "Value": "Target",
+          "Type": "String"
+        },
+        {
+          "Name": "IsCollisionActive",
+          "Value": true
+        },
+        {
+          "Name": "CollisionType",
+          "Value": 0
+        }
+      ],
+      "InstructionSaves": [],
+      "SourceType": 2,
+      "SourceFile": "FlatRedBall.Math.Collision.ListVsPositionedObjectRelationship<Entities.Blob, Entities.Target>",
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true
+    },
+    {
+      "InstanceName": "ListBVsTarget",
+      "SourceClassType": "FlatRedBall.Math.Collision.ListVsPositionedObjectRelationship<Entities.Blob, Entities.Target>",
+      "Properties": [
+        {
+          "Name": "AssociateWithFactory",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "SourceType",
+          "Value": 2,
+          "Type": "SourceType"
+        },
+        {
+          "Name": "IsAutoNameEnabled",
+          "Value": true,
+          "Type": "Boolean"
+        },
+        {
+          "Name": "FirstCollisionName",
+          "Value": "ListB",
+          "Type": "String"
+        },
+        {
+          "Name": "SecondCollisionName",
+          "Value": "Target",
+          "Type": "String"
+        },
+        {
+          "Name": "IsCollisionActive",
+          "Value": true
+        },
+        {
+          "Name": "CollisionType",
+          "Value": 0
+        }
+      ],
+      "InstructionSaves": [],
+      "SourceType": 2,
+      "SourceFile": "FlatRedBall.Math.Collision.ListVsPositionedObjectRelationship<Entities.Blob, Entities.Target>",
+      "AttachToContainer": true,
+      "GenerateTimedEmit": true
+    }
+  ],
+  "Name": "Screens\\GameScreen",
+  "Events": [],
+  "CustomClassesForExport": []
+}

--- a/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/TwoLists.gluj
+++ b/tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/TwoLists.gluj
@@ -1,0 +1,52 @@
+{
+  "In2D": true,
+  "ResolutionWidth": 800,
+  "ResolutionHeight": 600,
+  "OrthogonalWidth": 800,
+  "OrthogonalHeight": 600,
+  "Screens": [],
+  "Entities": [],
+  "GlobalFiles": [],
+  "GlobalContentSettingsSave": {},
+  "SyncedProjects": [],
+  "StartUpScreen": "Screens\\GameScreen",
+  "ResolutionPresets": [],
+  "PerformanceSettingsSave": {},
+  "IgnoredDirectories": [],
+  "CustomClasses": [],
+  "ApplyToFixedResolutionPlatforms": true,
+  "ExternallyBuiltFileDirectory": "../../",
+  "FileVersion": 42,
+  "ScreenReferences": [
+    {
+      "Name": "Screens\\GameScreen"
+    }
+  ],
+  "EntityReferences": [
+    {
+      "Name": "Entities\\Blob"
+    },
+    {
+      "Name": "Entities\\Target"
+    }
+  ],
+  "Bookmarks": [],
+  "PluginData": {
+    "RequiredPlugins": []
+  },
+  "DisplaySettings": {
+    "Name": "Custom",
+    "GenerateDisplayCode": true,
+    "Is2D": true,
+    "ResolutionWidth": 800,
+    "ResolutionHeight": 600,
+    "AspectRatioWidth": 16.0,
+    "AspectRatioHeight": 9.0,
+    "SupportLandscape": true,
+    "Scale": 100,
+    "ScaleGum": 100,
+    "DominantInternalCoordinates": 1,
+    "TextureFilter": 1
+  },
+  "AllDisplaySettings": []
+}

--- a/tests/FlatRedBall2.Tests/Glue/GlueCollisionTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueCollisionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FlatRedBall2.Collision;
@@ -226,5 +227,36 @@ public class GlueCollisionTests
 
         screen.BuildDiagnostics.ShouldContain(d =>
             d.Severity == GlueDiagnosticSeverity.Warning && d.Message.Contains("GoneList"));
+    }
+
+    // ListA and ListB are both Entities\Blob, each with its own declared member (BlobInA/BlobInB).
+    // Binding by entity type (as opposed to the list's own name) would collapse them onto one shared
+    // live view, so ListA's relationship would wrongly see ListB's member too. ListB is also
+    // AssociateWithFactory=false, unlike ListA — a spawn with no explicit list must respect that and
+    // join only ListA.
+    [Fact]
+    public void BuildObjects_TwoListsOfSameEntityType_KeepSeparateCollisionMembership()
+    {
+        var engine = new FlatRedBallService();
+        var project = GlueProject.Load(Gluj("TwoLists"));
+        engine.GlueProject = project;
+        engine.Start<GlueScreen>(s => { s.Save = project.StartUpScreen; s.Project = project; });
+
+        var screen = (GlueScreen)engine.CurrentScreen;
+        var listAVsTarget =
+            (CollisionRelationship<GlueEntity, GlueEntity>)screen.Objects["ListAVsTarget"];
+        var blobInB = (GlueEntity)((List<object>)screen.Objects["ListB"]).Single();
+
+        // A spawn with no explicit list joins only lists opted into the factory (ListA), never ListB.
+        var spawned = project.CreateEntity(@"Entities\Blob", screen);
+        spawned.X = 0f;
+        spawned.Y = 0f;
+
+        var seenByListA = new List<GlueEntity>();
+        listAVsTarget.CollisionOccurred += (blob, _) => seenByListA.Add(blob);
+        listAVsTarget.RunCollisions();
+
+        seenByListA.ShouldNotContain(blobInB);
+        seenByListA.ShouldContain(spawned);
     }
 }

--- a/tests/FlatRedBall2.Tests/Glue/GlueFactoryTests.cs
+++ b/tests/FlatRedBall2.Tests/Glue/GlueFactoryTests.cs
@@ -128,4 +128,22 @@ public class GlueFactoryTests
         player.ShouldNotBeSameAs(door);
         player.GlueName.ShouldBe(playerName);
     }
+
+    // TwoLists' ListA and ListC are both Entities\Blob and both AssociateWithFactory=true (G82): a
+    // spawn naming no particular list is FRB1's ListsToAddTo, one instance feeding every associated
+    // list of its type at once, not a single owner.
+    [Fact]
+    public void CreateEntity_WithNoExplicitList_JoinsEveryAssociatedListOfItsType()
+    {
+        var engine = new FlatRedBallService();
+        var project = GlueProject.Load(Path.Combine(
+            AppContext.BaseDirectory, "Glue", "Fixtures", "TwoLists", "TwoLists.gluj"));
+        engine.GlueProject = project;
+        engine.Start<GlueScreen>(s => { s.Save = project.StartUpScreen; s.Project = project; });
+
+        var spawned = project.CreateEntity(@"Entities\Blob", engine.CurrentScreen);
+
+        project.InstancesOfList("ListA").ShouldContain(spawned);
+        project.InstancesOfList("ListC").ShouldContain(spawned);
+    }
 }


### PR DESCRIPTION
Closes #1088
Part of #838
Depends on #1082

Base branch note: opened against `main`, but this builds directly on #1078/#1082's live-list mechanism, so this diff includes `1078-glue-collision-live-list`'s commits until that PR merges — expected, not a mistake.

## Design

`GlueCollisionBuilder` bound a named list to `GlueProject.InstancesOf(entityTypeName)` - keyed only by entity type, so two differently-named lists of the same type collapsed onto the identical backing collection.

- `GlueProject` now owns one real backing `List<GlueEntity>` per **authored list name** (`InstancesOfList`), not per entity type.
- `AssociateWithFactory` is consulted for the first time (previously parsed and ignored). A generic spawn (`CreateEntity(glueName, screen)`, no explicit list) joins **every** list of that entity type opted into the factory - none, one, or several, mirroring FRB1's `ListsToAddTo` (G82).
- A list's own declared member (nested in its `ContainedObjects`) always names its list explicitly, threaded down through `GlueElementBuilder`/`GlueObjectBuilder` - its placement is never inferred from the type index.
- `GlueCollisionBuilder.ResolveSide` binds to the named list's own live collection instead of the type-wide bucket.

Full design writeup: `plan/804-glue-project-loader/phase-08-factories.md` §10 (PR #1098).

## Tests

- `GlueCollisionTests.BuildObjects_TwoListsOfSameEntityType_KeepSeparateCollisionMembership` - two lists of the same type (`ListA`/`ListB`), only `ListA` associated; a relationship bound to `ListA` never sees `ListB`'s declared member, and a generic spawn respects the `AssociateWithFactory` flag.
- `GlueFactoryTests.CreateEntity_WithNoExplicitList_JoinsEveryAssociatedListOfItsType` - two lists of the same type both associated (`ListA`/`ListC`); a generic spawn joins both simultaneously.
- `GlueCollisionTests.BuildObjects_EntitySpawnedAfterRegistration_ParticipatesInCollision` (Beefball, #1082) passes unchanged - no special-casing for "exactly one list"; it's just the one-associated-list case of the same general rule.

New fixture: `tests/FlatRedBall2.Tests/Glue/Fixtures/TwoLists/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2QCcvQFdGen5LJUdDoNox