### PR TITLE
Fix #1099: paste a copied shape into every selected frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -6404,10 +6404,16 @@ public partial class MainWindow : Window
             if (completingCut && _pendingCutState.Kind != CopySelectionKind.Shape) return;
             var frame = _selectedState.SelectedFrame;
             if (frame is null) return;
+            // Cut/paste (same-document or cross-document) keeps a single-target destination
+            // (see #1099 follow-up); a plain paste applies to every selected frame, not just
+            // the last-clicked one.
+            IReadOnlyList<AnimationFrameSave> targetFrames = completingCut
+                ? new[] { frame }
+                : _selectedState.SelectedFrames;
 
             if (completingCutAcrossDocuments)
             {
-                _appCommands.PasteShapes(frame, rectangles ?? [], circles ?? []);
+                _appCommands.PasteShapes(targetFrames, rectangles ?? [], circles ?? []);
                 _pendingCutState.RemoveSourcesFrom(_pendingCutState.SourceDocument!);
             }
             else if (completingCut)
@@ -6424,9 +6430,10 @@ public partial class MainWindow : Window
             }
             else
             {
-                _appCommands.PasteShapes(frame, rectangles ?? [], circles ?? []);
+                _appCommands.PasteShapes(targetFrames, rectangles ?? [], circles ?? []);
             }
-            RefreshFrameNode(frame);
+            foreach (var targetFrame in targetFrames)
+                RefreshFrameNode(targetFrame);
             SyncTreeSelection();
         }
 

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -1920,13 +1920,40 @@ namespace AnimationEditor.Core.CommandsAndState
         public void PasteRectangle(AnimationFrameSave frame, AARectSave rectangle) =>
             PasteShapes(frame, new[] { rectangle }, Array.Empty<CircleSave>());
 
-        /// <inheritdoc cref="IAppCommands.PasteShapes"/>
+        /// <inheritdoc cref="IAppCommands.PasteShapes(AnimationFrameSave, IReadOnlyList{AARectSave}, IReadOnlyList{CircleSave})"/>
         public void PasteShapes(AnimationFrameSave frame, IReadOnlyList<AARectSave> rectangles,
             IReadOnlyList<CircleSave> circles)
         {
             var clones = BuildShapeClones(frame, rectangles, circles);
             if (clones.Count == 0) return;
             _undoManager.Execute(new PasteShapesCommand(frame, clones, this, _events, _selectedState));
+        }
+
+        /// <inheritdoc cref="IAppCommands.PasteShapes(IReadOnlyList{AnimationFrameSave}, IReadOnlyList{AARectSave}, IReadOnlyList{CircleSave})"/>
+        public void PasteShapes(IReadOnlyList<AnimationFrameSave> frames, IReadOnlyList<AARectSave> rectangles,
+            IReadOnlyList<CircleSave> circles)
+        {
+            if (frames.Count == 0) return;
+            if (frames.Count == 1)
+            {
+                PasteShapes(frames[0], rectangles, circles);
+                return;
+            }
+
+            var cmds = new List<IUndoableCommand>();
+            foreach (var frame in frames)
+            {
+                var clones = BuildShapeClones(frame, rectangles, circles);
+                if (clones.Count > 0)
+                    cmds.Add(new PasteShapesCommand(frame, clones, this, _events, _selectedState));
+            }
+            if (cmds.Count == 0) return;
+
+            int shapeCount = rectangles.Count + circles.Count;
+            string desc = shapeCount == 1
+                ? $"Paste {ShapeUndoLabel.Format((object?)rectangles.FirstOrDefault() ?? circles[0])} into {cmds.Count} Frames"
+                : $"Paste {shapeCount} Shapes into {cmds.Count} Frames";
+            _undoManager.Execute(new CompositeCommand(cmds, desc));
         }
 
         /// <inheritdoc cref="IAppCommands.PasteChainsCut"/>

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -427,6 +427,12 @@ namespace AnimationEditor.Core.CommandsAndState
         void PasteShapes(AnimationFrameSave frame, IReadOnlyList<AARectSave> rectangles,
             IReadOnlyList<CircleSave> circles);
 
+        /// <summary>Adds multiple clipboard shapes to every frame in <paramref name="frames"/> in one
+        /// undo step — each frame gets its own independent clone. Frames in a locked chain are
+        /// skipped (bulk skip-locked-entries), same as other multi-target paste/delete operations.</summary>
+        void PasteShapes(IReadOnlyList<AnimationFrameSave> frames, IReadOnlyList<AARectSave> rectangles,
+            IReadOnlyList<CircleSave> circles);
+
         /// <summary>Paste chains then remove <paramref name="sourcesToRemove"/> in one undo step.</summary>
         void PasteChainsCut(IReadOnlyList<AnimationChainSave> chains,
             IReadOnlyList<AnimationChainSave> sourcesToRemove);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
@@ -579,10 +579,16 @@ public partial class AnimationTreeControl : UserControl
             if (completingCut && pendingCut.Kind != CopySelectionKind.Shape) return;
             var frame = _selectedState!.SelectedFrame;
             if (frame is null) return;
+            // Cut/paste (same-document or cross-document) keeps a single-target destination
+            // (see #1099 follow-up); a plain paste applies to every selected frame, not just
+            // the last-clicked one.
+            IReadOnlyList<AnimationFrameSave> targetFrames = completingCut
+                ? new[] { frame }
+                : _selectedState.SelectedFrames;
 
             if (completingCutAcrossDocuments)
             {
-                _appCommands!.PasteShapes(frame, rectangles ?? new List<AARectSave>(), circles ?? new List<CircleSave>());
+                _appCommands!.PasteShapes(targetFrames, rectangles ?? new List<AARectSave>(), circles ?? new List<CircleSave>());
                 pendingCut.RemoveSourcesFrom(pendingCut.SourceDocument!);
             }
             else if (completingCut)
@@ -600,7 +606,7 @@ public partial class AnimationTreeControl : UserControl
             }
             else
             {
-                _appCommands!.PasteShapes(frame, rectangles ?? new List<AARectSave>(), circles ?? new List<CircleSave>());
+                _appCommands!.PasteShapes(targetFrames, rectangles ?? new List<AARectSave>(), circles ?? new List<CircleSave>());
             }
         }
 

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiCopyPasteAppTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/MultiCopyPasteAppTests.cs
@@ -249,6 +249,52 @@ public class MultiCopyPasteAppTests
         finally { window.Close(); }
     }
 
+    // #1099: copying a shape then multi-selecting frames and pasting must paste into every
+    // selected frame, not just one.
+    [AvaloniaFact]
+    public async Task Paste_ShapeIntoMultipleSelectedFrames_PastesIntoEveryFrame()
+    {
+        var (window, ctx) = CreateWindow();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var sourceFrame = new AnimationFrameSave { TextureName = "a.png", FrameLength = 0.1f };
+            sourceFrame.ShapesSave = new ShapesSave();
+            sourceFrame.ShapesSave.Shapes.Add(new AARectSave { Name = "Hit" });
+            var targetFrame1 = new AnimationFrameSave { TextureName = "b.png", FrameLength = 0.1f };
+            var targetFrame2 = new AnimationFrameSave { TextureName = "c.png", FrameLength = 0.1f };
+            chain.Frames.AddRange(new[] { sourceFrame, targetFrame1, targetFrame2 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+            RebuildTree(window);
+
+            var tree = window.FindControl<TreeView>("AnimTree")!;
+            var frameNodes = FirstChainNode(tree).Children;
+            var shapeNode = frameNodes[0].Children[0];
+
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(shapeNode);
+            FlushUi();
+            tree.Focus();
+            window.KeyPress(Key.C, RawInputModifiers.Control, PhysicalKey.None, null);
+            FlushUi();
+
+            tree.SelectedItems!.Clear();
+            tree.SelectedItems.Add(frameNodes[1]);
+            tree.SelectedItems.Add(frameNodes[2]);
+            FlushUi();
+            tree.Focus();
+            window.KeyPress(Key.V, RawInputModifiers.Control, PhysicalKey.None, null);
+            FlushUi();
+
+            Assert.Single(targetFrame1.ShapesSave!.Shapes);
+            Assert.Single(targetFrame2.ShapesSave!.Shapes);
+            Assert.NotSame(targetFrame1.ShapesSave.Shapes[0], targetFrame2.ShapesSave.Shapes[0]);
+            Assert.IsType<AARectSave>(targetFrame1.ShapesSave.Shapes[0]);
+            Assert.IsType<AARectSave>(targetFrame2.ShapesSave.Shapes[0]);
+        }
+        finally { window.Close(); }
+    }
+
     [AvaloniaFact]
     public void CtrlD_ThreeFrames_SelectsAllDuplicatesInTree()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MultiCopyPasteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/MultiCopyPasteTests.cs
@@ -72,6 +72,50 @@ public class MultiCopyPasteTests
     }
 
     [Fact]
+    public void PasteShapes_MultiFrame_PastesIntoEverySelectedFrame()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Walk", 3);
+        var f0 = chain.Frames[0];
+        var f1 = chain.Frames[1];
+        var f2 = chain.Frames[2];
+        var rect = new AARectSave { Name = "Hit" };
+        var circle = new CircleSave { Name = "Hurt", Radius = 2 };
+
+        ctx.AppCommands.PasteShapes(new[] { f0, f1, f2 }, new[] { rect }, new[] { circle });
+
+        Assert.Equal(2, f0.ShapesSave!.Shapes.Count);
+        Assert.Equal(2, f1.ShapesSave!.Shapes.Count);
+        Assert.Equal(2, f2.ShapesSave!.Shapes.Count);
+        // Each frame gets its own clone, not a shared reference to the same shape instance.
+        Assert.NotSame(f0.ShapesSave.Shapes[0], f1.ShapesSave.Shapes[0]);
+        Assert.NotSame(f1.ShapesSave.Shapes[0], f2.ShapesSave.Shapes[0]);
+
+        ctx.UndoManager.Undo();
+        Assert.Empty(f0.ShapesSave!.Shapes);
+        Assert.Empty(f1.ShapesSave!.Shapes);
+        Assert.Empty(f2.ShapesSave!.Shapes);
+    }
+
+    [Fact]
+    public void PasteShapes_MultiFrame_SkipsFramesInLockedChainButPastesRest()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var lockedChain = TestHelpers.MakeChain(ctx.Acls, "Locked", 1);
+        lockedChain.IsLocked = true;
+        var unlockedChain = TestHelpers.MakeChain(ctx.Acls, "Walk", 1);
+        var lockedFrame = lockedChain.Frames[0];
+        var unlockedFrame = unlockedChain.Frames[0];
+        var rect = new AARectSave { Name = "Hit" };
+
+        ctx.AppCommands.PasteShapes(new[] { lockedFrame, unlockedFrame }, new[] { rect }, []);
+
+        Assert.Empty(lockedFrame.ShapesSave!.Shapes);
+        Assert.Single(unlockedFrame.ShapesSave!.Shapes);
+        Assert.True(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
     public void DuplicateFrames_SameChain_AdjacentBlock_OneUndo()
     {
         var ctx = TestHelpers.SetupFreshAcls();


### PR DESCRIPTION
Closes #1099.

## Problem
Copying a shape, multi-selecting several frames, and pasting only pasted into one frame (the last-clicked one) instead of all selected frames.

## Fix
- Added `IAppCommands.PasteShapes(IReadOnlyList<AnimationFrameSave>, ...)` overload: clones the shapes independently per frame and composites the per-frame `PasteShapesCommand`s into one undo step. Locked-chain frames are skipped, matching existing bulk-paste behavior elsewhere.
- Switched the plain-paste branch in `MainWindow.axaml.cs` and `AnimationTreeControl.axaml.cs` from the singular `SelectedFrame` to the existing multi-select-aware `SelectedFrames`.
- Cut/paste (same-document and cross-document) intentionally keeps a single-target destination for now — out of scope here, noted as a follow-up.

## Manual test
Not needed — covered by a headless `[AvaloniaFact]` test that drives real tree selection and Ctrl+C/Ctrl+V through `MainWindow` (`MultiCopyPasteAppTests.Paste_ShapeIntoMultipleSelectedFrames_PastesIntoEveryFrame`), plus Core unit tests for the new command, plus compilation.

## Tests
- `AnimationEditor.Core.Tests`: 1988 passed
- `AnimationEditor.Views.Tests`: 134 passed
- `AnimationEditor.App.Tests`: 966 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQCG3aabDzjuuYLYyYpBfT
