### PR TITLE
Fix #1104: Browse for Texture retextures every selected frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -4917,9 +4917,6 @@ public partial class MainWindow : Window
 
     private async Task BrowseForFrameTexture()
     {
-        var frame = _selectedState.SelectedFrame;
-        if (frame is null) return;
-
         var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
             Title = "Select Texture",
@@ -4933,6 +4930,19 @@ public partial class MainWindow : Window
 
         var pickedPath = files?.FirstOrDefault()?.TryGetLocalPath();
         if (string.IsNullOrEmpty(pickedPath)) return;
+
+        await ApplyPickedTextureAsync(pickedPath);
+    }
+
+    /// <summary>
+    /// Dialog-free core of <see cref="BrowseForFrameTexture"/>: applies <paramref name="pickedPath"/>
+    /// as the texture for every currently selected frame. Split out so tests can drive it directly
+    /// without going through the real OS file picker.
+    /// </summary>
+    internal async Task ApplyPickedTextureAsync(string pickedPath)
+    {
+        var frames = _selectedState.SelectedFrames;
+        if (frames.Count == 0) return;
 
         string achxFolder = string.IsNullOrEmpty(_projectManager.FileName)
             ? string.Empty
@@ -4963,7 +4973,7 @@ public partial class MainWindow : Window
                         try
                         {
                             File.Copy(capturedSource, capturedDest, overwrite: true);
-                            CommitFrameTexture(new[] { frame }, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
+                            CommitFrameTexture(frames, TexturePathHelper.ComputeStorePath(capturedDest, achxFolder), capturedDest);
                         }
                         catch (Exception retryEx)
                         {
@@ -4980,7 +4990,7 @@ public partial class MainWindow : Window
             ? resolvedAbsPath
             : TexturePathHelper.ComputeStorePath(resolvedAbsPath, achxFolder);
 
-        CommitFrameTexture(new[] { frame }, storePath, resolvedAbsPath);
+        CommitFrameTexture(frames, storePath, resolvedAbsPath);
     }
 
     private enum TextureCopyChoice { Copy, Keep, Cancel }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/BrowseTextureMultiSelectTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.App.Tests/BrowseTextureMultiSelectTests.cs
@@ -1,0 +1,78 @@
+using AnimationEditor.Core.IO;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FlatRedBall2.AnimationEditorCommon;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AnimationEditor.App.Tests;
+
+/// <summary>
+/// Issue #1104: "Browse for Texture" only retextured <c>_selectedState.SelectedFrame</c> (the
+/// primary frame), so committing a new texture with multiple frames selected silently left every
+/// other selected frame untouched. Same root cause as #1103 (texture combo box), different entry
+/// point. <c>ApplyPickedTextureAsync</c> is the extracted, dialog-free core of
+/// <c>BrowseForFrameTexture</c> — see that method for the untestable OS file-picker residue.
+/// </summary>
+public class BrowseTextureMultiSelectTests
+{
+    private static void WriteSolidPng(string path, SKColor color, int size = 16)
+    {
+        using var bm = new SKBitmap(size, size);
+        bm.Erase(color);
+        using var data = bm.Encode(SKEncodedImageFormat.Png, 100);
+        File.WriteAllBytes(path, data.ToArray());
+    }
+
+    [AvaloniaFact]
+    public async Task ApplyPickedTextureAsync_MultipleFramesSelected_AppliesToAll()
+    {
+        var ctx = TestHelpers.BuildServices();
+        ctx.ProjectManager.AnimationChainListSave = new AnimationChainListSave();
+        // Untitled in-memory project: ShouldPromptToCopyForProject short-circuits to false on an
+        // empty FileName, so the copy-prompt dialog branch (which itself needs a dialog) never runs.
+        ctx.ProjectManager.FileName = null;
+
+        var dir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var pickedPngPath = Path.Combine(dir, "new.png");
+        WriteSolidPng(pickedPngPath, SKColors.Green);
+
+        var window = ctx.CreateMainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            var chain = new AnimationChainSave { Name = "Walk" };
+            var f0 = new AnimationFrameSave
+            {
+                TextureName = "a.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            var f1 = new AnimationFrameSave
+            {
+                TextureName = "a.png", FrameLength = 0.1f,
+                LeftCoordinate = 0f, TopCoordinate = 0f, RightCoordinate = 1f, BottomCoordinate = 1f,
+                ShapesSave = new ShapesSave(),
+            };
+            chain.Frames.AddRange(new[] { f0, f1 });
+            ctx.ProjectManager.AnimationChainListSave!.AnimationChains.Add(chain);
+
+            ctx.SelectedState.SelectedChain = chain;
+            ctx.SelectedState.SelectedFrame = f0;
+            ctx.SelectedState.SelectedNodes = new List<object> { f0, f1 };
+            Dispatcher.UIThread.RunJobs();
+
+            await window.ApplyPickedTextureAsync(pickedPngPath);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(pickedPngPath, f0.TextureName);
+            Assert.Equal(pickedPngPath, f1.TextureName);
+        }
+        finally { window.Close(); Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
Closes #1104

`BrowseForFrameTexture` read the singular `_selectedState.SelectedFrame` and wrapped it `new[] { frame }` at both `CommitFrameTexture` call sites, so with multiple frames selected, only the primary frame got retextured. Same root cause as #1103 (texture combo box), different entry point.

Fix: extracted the dialog-free core into `internal Task ApplyPickedTextureAsync(string pickedPath)`, which reads `_selectedState.SelectedFrames` and passes it through unchanged to both `CommitFrameTexture` call sites. `BrowseForFrameTexture` is now a thin wrapper that only drives the real OS file picker.

**Manual test / TDD note:** `ApplyPickedTextureAsync` is covered by a new test (`BrowseTextureMultiSelectTests`), written failing-first (confirmed compile failure before the extraction existed), using an untitled in-memory project so the copy-prompt dialog branch never runs. `BrowseForFrameTexture`'s remaining lines (the `StorageProvider.OpenFilePickerAsync` call) are untested residue — a real modal OS dialog can't be driven headless and would hang the test run.

Verified: `AnimationEditor.App.Tests` 966 passed, `AnimationEditor.Core.Tests` 1986 passed, solution build 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQCG3aabDzjuuYLYyYpBfT
