### PR TITLE
Fix #1102: DeleteShapes resolves each shape's own owning frame

### DIFF
--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.App/MainWindow.axaml.cs
@@ -6577,18 +6577,16 @@ public partial class MainWindow : Window
             }
             case AARectSave rectToDel:
             {
-                var frame   = _selectedState.SelectedFrame!;
                 var rects   = _selectedState.SelectedRectangles;
                 var circles = _selectedState.SelectedCircles;
-                _appCommands.DeleteShapes(frame, rects.Count > 0 ? rects : new() { rectToDel }, circles);
+                _appCommands.DeleteShapes(rects.Count > 0 ? rects : new() { rectToDel }, circles);
                 break;
             }
             case CircleSave circleToDel:
             {
-                var frame   = _selectedState.SelectedFrame!;
                 var circles = _selectedState.SelectedCircles;
                 var rects   = _selectedState.SelectedRectangles;
-                _appCommands.DeleteShapes(frame, rects, circles.Count > 0 ? circles : new() { circleToDel });
+                _appCommands.DeleteShapes(rects, circles.Count > 0 ? circles : new() { circleToDel });
                 break;
             }
         }

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Browser/App.axaml.cs
@@ -750,10 +750,10 @@ public partial class App : Application
 
         deleteSelectedButton.Click += (_, _) =>
         {
-            if (selectedState.SelectedRectangle is { } rect && selectedState.SelectedFrame is { } rectFrame)
-                appCommands.DeleteShapes(rectFrame, new List<AARectSave> { rect }, new List<CircleSave>());
-            else if (selectedState.SelectedCircle is { } circle && selectedState.SelectedFrame is { } circleFrame)
-                appCommands.DeleteShapes(circleFrame, new List<AARectSave>(), new List<CircleSave> { circle });
+            if (selectedState.SelectedRectangle is { } rect)
+                appCommands.DeleteShapes(new List<AARectSave> { rect }, new List<CircleSave>());
+            else if (selectedState.SelectedCircle is { } circle)
+                appCommands.DeleteShapes(new List<AARectSave>(), new List<CircleSave> { circle });
             else if (selectedState.SelectedFrame is { } frame)
                 appCommands.DeleteFrames(new List<AnimationFrameSave> { frame });
             else if (selectedState.SelectedChain is { } selectedChain)

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/AppCommands.cs
@@ -663,15 +663,29 @@ namespace AnimationEditor.Core.CommandsAndState
             _undoManager.Execute(new DeleteAxisAlignedRectangleCommand(rectangle, owner, this, _events, _selectedState));
         }
 
-        public void DeleteShapes(AnimationFrameSave frame, List<AARectSave> rectangles, List<CircleSave> circles)
+        /// <summary>
+        /// Deletes a multi-selection of shapes. Each shape's own owning frame is resolved via
+        /// <see cref="ObjectFinder"/> rather than assuming a single shared frame, so a selection
+        /// spanning multiple frames (e.g. Ctrl+click across frames, then Delete) deletes correctly
+        /// instead of silently dropping shapes that don't belong to one caller-supplied frame
+        /// (#1102). A shape whose owning chain is locked is skipped; the rest of the batch still
+        /// proceeds -- mirrors <see cref="MatchRectanglesToFrames"/>.
+        /// </summary>
+        public void DeleteShapes(List<AARectSave> rectangles, List<CircleSave> circles)
         {
-            if (IsFrameLocked(frame)) return;
-
             var commands = new List<IUndoableCommand>();
             foreach (var rect in rectangles.ToArray())
-                commands.Add(new DeleteAxisAlignedRectangleCommand(rect, frame, this, _events, _selectedState));
+            {
+                var ownerFrame = _objectFinder.GetAnimationFrameContaining(rect);
+                if (ownerFrame is null || IsFrameLocked(ownerFrame)) continue;
+                commands.Add(new DeleteAxisAlignedRectangleCommand(rect, ownerFrame, this, _events, _selectedState));
+            }
             foreach (var circle in circles.ToArray())
-                commands.Add(new DeleteCircleCommand(circle, frame, this, _events, _selectedState));
+            {
+                var ownerFrame = _objectFinder.GetAnimationFrameContaining(circle);
+                if (ownerFrame is null || IsFrameLocked(ownerFrame)) continue;
+                commands.Add(new DeleteCircleCommand(circle, ownerFrame, this, _events, _selectedState));
+            }
             if (commands.Count == 0) return;
 
             int total = commands.Count;

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Core/CommandsAndState/IAppCommands.cs
@@ -132,7 +132,7 @@ namespace AnimationEditor.Core.CommandsAndState
         void MatchRectanglesToFrames(List<AARectSave> rectangles);
         void DeleteCircle(CircleSave circle, AnimationFrameSave owner);
         void DeleteAxisAlignedRectangle(AARectSave rectangle, AnimationFrameSave owner);
-        void DeleteShapes(AnimationFrameSave frame, List<AARectSave> rectangles, List<CircleSave> circles);
+        void DeleteShapes(List<AARectSave> rectangles, List<CircleSave> circles);
         void DeleteFrames(List<AnimationFrameSave> frames);
         Task AddAnimationChain();
         AnimationChainSave? AddAnimationChainWithName(string name);

--- a/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
+++ b/tools/AnimationEditorAvalonia/src/AnimationEditor.Views/Controls/AnimationTreeControl.axaml.cs
@@ -643,20 +643,18 @@ public partial class AnimationTreeControl : UserControl
             }
             case AARectSave rectToDel:
             {
-                var frame = _selectedState!.SelectedFrame!;
-                var rects = _selectedState.SelectedRectangles;
+                var rects = _selectedState!.SelectedRectangles;
                 var circles = _selectedState.SelectedCircles;
                 _appCommands!.DeleteShapes(
-                    frame, rects.Count > 0 ? rects : new List<AARectSave> { rectToDel }, circles);
+                    rects.Count > 0 ? rects : new List<AARectSave> { rectToDel }, circles);
                 break;
             }
             case CircleSave circleToDel:
             {
-                var frame = _selectedState!.SelectedFrame!;
-                var circles = _selectedState.SelectedCircles;
+                var circles = _selectedState!.SelectedCircles;
                 var rects = _selectedState.SelectedRectangles;
                 _appCommands!.DeleteShapes(
-                    frame, rects, circles.Count > 0 ? circles : new List<CircleSave> { circleToDel });
+                    rects, circles.Count > 0 ? circles : new List<CircleSave> { circleToDel });
                 break;
             }
         }

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainLockTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsChainLockTests.cs
@@ -115,6 +115,32 @@ public class AppCommandsChainLockTests
         Assert.True(ctx.UndoManager.CanUndo);
     }
 
+    /// <summary>
+    /// A multi-selection spanning a locked chain's frame and an unlocked chain's frame (e.g.
+    /// Ctrl+click a shape in each, then Delete) must skip only the locked chain's shape, not
+    /// veto the whole batch -- mirrors <see cref="DeleteFrames_CrossChainSelectionWithLockedChain_DeletesOnlyUnlockedChainFrames"/>.
+    /// </summary>
+    [Fact]
+    public void DeleteShapes_CrossChainSelectionWithLockedChain_DeletesOnlyUnlockedChainShape()
+    {
+        var ctx = TestHelpers.SetupFreshAcls();
+        var lockedChain = TestHelpers.MakeChain(ctx.Acls, "Walk", frameCount: 1);
+        lockedChain.IsLocked = true;
+        var unlockedChain = TestHelpers.MakeChain(ctx.Acls, "Run", frameCount: 1);
+        var lockedFrame = lockedChain.Frames[0];
+        var unlockedFrame = unlockedChain.Frames[0];
+        var lockedRect = new AARectSave { Name = "LockedRect" };
+        var unlockedCircle = new CircleSave { Name = "UnlockedCircle", Radius = 10 };
+        lockedFrame.ShapesSave!.Shapes.Add(lockedRect);
+        unlockedFrame.ShapesSave!.Shapes.Add(unlockedCircle);
+
+        ctx.AppCommands.DeleteShapes(new() { lockedRect }, new() { unlockedCircle });
+
+        Assert.Single(lockedFrame.ShapesSave!.Shapes);
+        Assert.Empty(unlockedFrame.ShapesSave!.Shapes);
+        Assert.True(ctx.UndoManager.CanUndo);
+    }
+
     [Fact]
     public void PasteShapes_TargetFrameChainLocked_IsNoOp()
     {

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/AppCommandsDeleteTests.cs
@@ -142,7 +142,7 @@ public class AppCommandsDeleteTests
         frame.ShapesSave!.Shapes.Add(rect);
         frame.ShapesSave!.Shapes.Add(circle);
 
-        ctx.AppCommands.DeleteShapes(frame,
+        ctx.AppCommands.DeleteShapes(
             new List<AARectSave> { rect }, new List<CircleSave> { circle });
 
         Assert.Empty(frame.ShapesSave!.AARectSaves);
@@ -151,6 +151,32 @@ public class AppCommandsDeleteTests
         ctx.UndoManager.Undo();
         Assert.Equal(new[] { rect }, frame.ShapesSave!.AARectSaves);
         Assert.Equal(new[] { circle }, frame.ShapesSave!.CircleSaves);
+        Assert.False(ctx.UndoManager.CanUndo);
+    }
+
+    [Fact]
+    public void DeleteShapes_CrossFrameSelection_DeletesFromEachShapesOwnFrame()
+    {
+        // Regression test for #1102: a multi-selection spanning two frames used to pass a
+        // single shared "owner" frame, so IndexOf silently failed (returned false, dropped
+        // the sub-command) for whichever shape didn't belong to that frame.
+        var ctx = TestHelpers.SetupFreshAcls();
+        var chain = TestHelpers.MakeChain(ctx.Acls, "Run", 2);
+        var frameA = chain.Frames[0];
+        var frameB = chain.Frames[1];
+        var rect = new AARectSave { Name = "RectInA" };
+        var circle = new CircleSave { Name = "CircleInB", Radius = 10 };
+        frameA.ShapesSave!.Shapes.Add(rect);
+        frameB.ShapesSave!.Shapes.Add(circle);
+
+        ctx.AppCommands.DeleteShapes(new List<AARectSave> { rect }, new List<CircleSave> { circle });
+
+        Assert.Empty(frameA.ShapesSave!.Shapes);
+        Assert.Empty(frameB.ShapesSave!.Shapes);
+
+        ctx.UndoManager.Undo();
+        Assert.Equal(new[] { rect }, frameA.ShapesSave!.AARectSaves);
+        Assert.Equal(new[] { circle }, frameB.ShapesSave!.CircleSaves);
         Assert.False(ctx.UndoManager.CanUndo);
     }
 
@@ -167,7 +193,7 @@ public class AppCommandsDeleteTests
         string? label = null;
         ctx.AppCommands.ItemsDeleted += l => label = l;
 
-        ctx.AppCommands.DeleteShapes(frame,
+        ctx.AppCommands.DeleteShapes(
             new List<AARectSave> { rect }, new List<CircleSave> { circle });
 
         Assert.Equal("2 shapes", label);
@@ -184,7 +210,7 @@ public class AppCommandsDeleteTests
         string? label = null;
         ctx.AppCommands.ItemsDeleted += l => label = l;
 
-        ctx.AppCommands.DeleteShapes(frame,
+        ctx.AppCommands.DeleteShapes(
             new List<AARectSave> { rect }, new List<CircleSave>());
 
         Assert.Equal("BodyCollision", label);

--- a/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
+++ b/tools/AnimationEditorAvalonia/tests/AnimationEditor.Core.Tests/UndoCoverageRosterTests.cs
@@ -224,7 +224,7 @@ public class UndoCoverageRosterTests
         yield return Row(nameof(IAppCommands.DeleteAxisAlignedRectangle),
             ctx => Sync(() => ctx.AppCommands.DeleteAxisAlignedRectangle(Rect(ctx), Zebra(ctx).Frames[0])));
         yield return Row(nameof(IAppCommands.DeleteShapes),
-            ctx => Sync(() => ctx.AppCommands.DeleteShapes(Zebra(ctx).Frames[0], new() { Rect(ctx) }, new() { Circle(ctx) })));
+            ctx => Sync(() => ctx.AppCommands.DeleteShapes(new() { Rect(ctx) }, new() { Circle(ctx) })));
         yield return Row(nameof(IAppCommands.DeleteFrames),
             ctx => Sync(() => ctx.AppCommands.DeleteFrames(new() { Zebra(ctx).Frames[1] })));
         yield return Row(nameof(IAppCommands.AddAnimationChain),


### PR DESCRIPTION
Closes #1102

`DeleteShapes` passed one shared `frame` as every selected shape's owner. A cross-frame multi-select (ctrl-click a rect in Frame A, a rect in Frame B, Delete) silently dropped whichever shape didn't belong to that frame: `DeleteAxisAlignedRectangleCommand`/`DeleteCircleCommand`'s `IndexOf` returned -1, `Do()` returned `false`, and `CompositeCommand` swallowed it with no error or undo entry. The same shared frame also vetoed the whole batch on one `IsFrameLocked` check even when only some shapes were in a locked chain.

Fix: dropped the `frame` parameter from `DeleteShapes`/`IAppCommands.DeleteShapes`; each shape now resolves its own owner via `ObjectFinder.GetAnimationFrameContaining` and is skipped individually if unowned or locked — the same per-item pattern `MatchRectanglesToFrames` already uses for the identical #567 problem. Updated all three call sites (`MainWindow`, `AnimationTreeControl`, and `AnimationEditor.Browser/App.axaml.cs`) to drop the now-unused `frame` local.

Manual test: not needed — covered by the new Core.Tests cases plus compilation.

Tests: `AnimationEditor.Core.Tests` 1986 → 1988 (all green), `AnimationEditor.App.Tests` 965 green, `AnimationEditor.Views.Tests` 134 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQCG3aabDzjuuYLYyYpBfT
