### PR TITLE
Fix dangling ProjectReferences missing from .slnx solution membership

### DIFF
--- a/diagnostics/MusicPitchWebSpike/MusicPitchWebSpike.slnx
+++ b/diagnostics/MusicPitchWebSpike/MusicPitchWebSpike.slnx
@@ -1,5 +1,7 @@
 <Solution>
-  <Project Path="../../../src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
+  <Project Path="../../src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
+  <Project Path="../../src/Kni/FlatRedBall2.Kni.csproj" />
+  <Project Path="../../src/AnimationChain.Common/AnimationChain.Common.csproj" />
   <Project Path="MusicPitchWebSpike.Common/MusicPitchWebSpike.Common.csproj" />
   <Project Path="MusicPitchWebSpike.BlazorGL/MusicPitchWebSpike.BlazorGL.csproj" />
 </Solution>

--- a/frb-skills/multiplatform-conversion/SKILL.md
+++ b/frb-skills/multiplatform-conversion/SKILL.md
@@ -42,6 +42,8 @@ Desktop and BlazorGL both now target `net10.0`, so a single Common project can n
 
 See `samples/Solitaire/Solitaire.Common/` for a working example, including how its Gum content-copy `<Content Include>` items pick up `Link` metadata once the source path (`..\Content\...`) no longer matches the project's own directory.
 
+**Landmine: list every `ProjectReference` target as its own `<Project Path>` in the `.slnx`.** Visual Studio's IDE-hosted NuGet restore only walks `ProjectReference`s among projects that are themselves listed as solution members — a project that exists on disk and is correctly referenced but missing from the `.slnx` builds fine via `dotnet build`/CLI `msbuild` (both walk the full reference closure regardless of solution membership) but fails with NU1105 ("not part of the current solution") the moment someone opens the `.slnx` in Visual Studio. So `GameName.slnx` needs `GameName.Common\Kni\GameName.Common.Kni.csproj` listed explicitly alongside `GameName.Common.csproj`, not just the projects a human would think of as "the heads." `tests/FlatRedBall2.Tests/Packaging/SolutionMembershipTests.cs` checks this for every `.slnx` in this repo; there's no equivalent check for a downstream game project, so verify it by hand when scaffolding one.
+
 No `Version` attribute — the repo uses NuGet Central Package Management, so versions are pinned once in `Directory.Packages.props`, not per `PackageReference`.
 
 Common must NOT add `MonoGame.Content.Builder.Task` — that belongs on the heads that drive content compilation. `Apos.Shapes` needs no content-pipeline wiring at all — its shader is embedded in the assembly.

--- a/samples/AnimationChainSample/AnimationChainSample.slnx
+++ b/samples/AnimationChainSample/AnimationChainSample.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="../../src/AnimationChain.MonoGame/AnimationChain.MonoGame.csproj" />
+  <Project Path="../../src/AnimationChain.Common/AnimationChain.Common.csproj" />
   <Project Path="AnimationChainSample.csproj" />
 </Solution>

--- a/samples/PlatformKing/PlatformKing.slnx
+++ b/samples/PlatformKing/PlatformKing.slnx
@@ -1,8 +1,10 @@
 <Solution>
   <Project Path="../../src/FlatRedBall2.csproj" />
   <Project Path="../../src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
+  <Project Path="../../src/Kni/FlatRedBall2.Kni.csproj" />
   <Project Path="../../src/AnimationChain.Common/AnimationChain.Common.csproj" />
   <Project Path="PlatformKing.Common/PlatformKing.Common.csproj" />
+  <Project Path="PlatformKing.Common/Kni/PlatformKing.Common.Kni.csproj" />
   <Project Path="PlatformKing.Desktop/PlatformKing.Desktop.csproj" />
   <Project Path="PlatformKing.BlazorGL/PlatformKing.BlazorGL.csproj" />
 </Solution>

--- a/samples/ShmupSpace/ShmupSpace.slnx
+++ b/samples/ShmupSpace/ShmupSpace.slnx
@@ -1,8 +1,10 @@
 <Solution>
   <Project Path="../../src/FlatRedBall2.csproj" />
   <Project Path="../../src/FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
+  <Project Path="../../src/Kni/FlatRedBall2.Kni.csproj" />
   <Project Path="../../src/AnimationChain.Common/AnimationChain.Common.csproj" />
   <Project Path="ShmupSpace.Common/ShmupSpace.Common.csproj" />
+  <Project Path="ShmupSpace.Common/Kni/ShmupSpace.Common.Kni.csproj" />
   <Project Path="ShmupSpace.Desktop/ShmupSpace.Desktop.csproj" />
   <Project Path="ShmupSpace.BlazorGL/ShmupSpace.BlazorGL.csproj" />
 </Solution>

--- a/src/FlatRedBall2.slnx
+++ b/src/FlatRedBall2.slnx
@@ -6,6 +6,7 @@
   <Project Path="FlatRedBall2.csproj" />
   <Project Path="AnimationChain.Common/AnimationChain.Common.csproj" />
   <Project Path="FlatRedBall2.BlazorGL/FlatRedBall2.BlazorGL.csproj" />
+  <Project Path="Kni/FlatRedBall2.Kni.csproj" />
   <Project Path="AnimationChain.MonoGame/AnimationChain.MonoGame.csproj" />
   <Project Path="AnimationChain.MonoGame/Kni/AnimationChain.KNI.csproj" />
 </Solution>

--- a/templates/frb2-multiplatform/MyGame.slnx
+++ b/templates/frb2-multiplatform/MyGame.slnx
@@ -2,4 +2,5 @@
   <Project Path="MyGame.Desktop/MyGame.Desktop.csproj" DefaultStartup="true" />
   <Project Path="MyGame.BlazorGL/MyGame.BlazorGL.csproj" />
   <Project Path="MyGame.Common/MyGame.Common.csproj" />
+  <Project Path="MyGame.Common/Kni/MyGame.Common.Kni.csproj" />
 </Solution>

--- a/tests/FlatRedBall2.Tests/Packaging/SolutionMembershipTests.cs
+++ b/tests/FlatRedBall2.Tests/Packaging/SolutionMembershipTests.cs
@@ -34,7 +34,7 @@ public class SolutionMembershipTests
         {
             var slnxDir = Path.GetDirectoryName(slnxPath)!;
             var listedProjectPaths = Regex.Matches(File.ReadAllText(slnxPath), @"<Project\s+Path=""([^""]+)""")
-                .Select(match => match.Groups[1].Value)
+                .Select(match => ToPortablePath(match.Groups[1].Value))
                 .ToList();
 
             var listedAbsolutePaths = listedProjectPaths
@@ -52,7 +52,7 @@ public class SolutionMembershipTests
                 var csprojDir = Path.GetDirectoryName(csprojPath)!;
                 var referencedPaths = Regex.Matches(
                         File.ReadAllText(csprojPath), @"<ProjectReference\s+Include=""([^""]+)""")
-                    .Select(match => match.Groups[1].Value);
+                    .Select(match => ToPortablePath(match.Groups[1].Value));
 
                 foreach (var referencedPath in referencedPaths)
                 {
@@ -78,4 +78,9 @@ public class SolutionMembershipTests
 
     private static string NormalizePath(string path) =>
         Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    // Project files in this repo use Windows-style '\' separators, which System.IO.Path treats as
+    // a literal character (not a separator) on Linux CI runners. Convert to '/' first so
+    // Path.Combine/GetFullPath resolve identically on every OS.
+    private static string ToPortablePath(string path) => path.Replace('\\', '/');
 }

--- a/tests/FlatRedBall2.Tests/Packaging/SolutionMembershipTests.cs
+++ b/tests/FlatRedBall2.Tests/Packaging/SolutionMembershipTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace FlatRedBall2.Tests.Packaging;
+
+// Visual Studio's IDE-hosted NuGet restore only walks ProjectReferences among projects that are
+// themselves listed as <Project Path="..."> members of the .slnx being restored. dotnet/msbuild
+// CLI restore walks the full reference closure regardless of solution membership, so a dangling
+// reference (a project references a .csproj that isn't listed in the same .slnx) builds fine on
+// the command line and in CI, but fails with NU1105 the moment a human opens the .slnx in Visual
+// Studio. This test catches the general condition (any dangling reference in any .slnx in the
+// repo), not one specific missing project.
+public class SolutionMembershipTests
+{
+    [Fact]
+    public void EverySlnxListsAllProjectReferencesOfItsMemberProjects()
+    {
+        var repoRoot = TemplatePackageReferenceTests.RepoRootForTests;
+        var slnxFiles = Directory.EnumerateFiles(repoRoot, "*.slnx", SearchOption.AllDirectories)
+            .Where(path => !ContainsExcludedSegment(path))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        slnxFiles.ShouldNotBeEmpty();
+
+        var violations = new List<string>();
+
+        foreach (var slnxPath in slnxFiles)
+        {
+            var slnxDir = Path.GetDirectoryName(slnxPath)!;
+            var listedProjectPaths = Regex.Matches(File.ReadAllText(slnxPath), @"<Project\s+Path=""([^""]+)""")
+                .Select(match => match.Groups[1].Value)
+                .ToList();
+
+            var listedAbsolutePaths = listedProjectPaths
+                .Select(relative => NormalizePath(Path.Combine(slnxDir, relative)))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var relativeProjectPath in listedProjectPaths)
+            {
+                var csprojPath = Path.Combine(slnxDir, relativeProjectPath);
+                if (!File.Exists(csprojPath))
+                {
+                    continue;
+                }
+
+                var csprojDir = Path.GetDirectoryName(csprojPath)!;
+                var referencedPaths = Regex.Matches(
+                        File.ReadAllText(csprojPath), @"<ProjectReference\s+Include=""([^""]+)""")
+                    .Select(match => match.Groups[1].Value);
+
+                foreach (var referencedPath in referencedPaths)
+                {
+                    var referencedAbsolute = NormalizePath(Path.Combine(csprojDir, referencedPath));
+                    if (!listedAbsolutePaths.Contains(referencedAbsolute))
+                    {
+                        violations.Add(
+                            $"{Path.GetRelativePath(repoRoot, slnxPath)}: " +
+                            $"{relativeProjectPath} references {referencedPath}, " +
+                            "which is not listed as a <Project Path> member of the same .slnx " +
+                            "(builds fine via dotnet/msbuild CLI, fails NU1105 in Visual Studio).");
+                    }
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(string.Join(Environment.NewLine, violations));
+    }
+
+    private static bool ContainsExcludedSegment(string path) =>
+        path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => segment is "obj" or "bin" or ".vs" or ".git");
+
+    private static string NormalizePath(string path) =>
+        Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+}


### PR DESCRIPTION
## Summary
- Several `.slnx` files reference projects (mostly Kni/BlazorGL backends) that aren't listed as solution members. Visual Studio's IDE restore only walks `ProjectReference`s among listed members, so these build clean via CLI/CI but fail NU1105 the moment a generated game project is opened in Visual Studio.
- Adds `SolutionMembershipTests` asserting every `.slnx` lists every `ProjectReference` of its member projects — a general invariant, not a point check. It found 8 real violations, including an unrelated wrong-path-depth bug in `MusicPitchWebSpike.slnx`.
- Fixes all 8, including the multiplatform template (root cause of a user-reported build failure) and 3 in-repo samples.
- Documents the landmine in the `multiplatform-conversion` skill.

## Test plan
- [x] New test proven red before the fix, green after (`dotnet test tests/FlatRedBall2.Tests/ --filter FullyQualifiedName~SolutionMembershipTests`)
- [x] Full suite green: 1739/1739 (`dotnet test tests/FlatRedBall2.Tests/`)
- [x] `dotnet build templates/frb2-multiplatform/MyGame.slnx` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb8ysCiPpAjJhLBVZMcagB